### PR TITLE
Self-contained Spec of optimizer correctness

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -7,6 +7,7 @@ import Leanr.Legacy.AlgebraicConstraint
 import Leanr.Legacy.BusInteraction
 import Leanr.Legacy.System
 import Leanr.Legacy.Solver
+import Leanr.Spec
 import Leanr.Legacy.StringParser
 import Leanr.JsonParser
 import Leanr.Legacy.OpenVM

--- a/Leanr.lean
+++ b/Leanr.lean
@@ -8,6 +8,7 @@ import Leanr.Legacy.BusInteraction
 import Leanr.Legacy.System
 import Leanr.Legacy.Solver
 import Leanr.Spec
+import Leanr.IdentityOptimizer
 import Leanr.Legacy.StringParser
 import Leanr.JsonParser
 import Leanr.Legacy.OpenVM

--- a/Leanr/IdentityOptimizer.lean
+++ b/Leanr/IdentityOptimizer.lean
@@ -1,0 +1,35 @@
+import Leanr.Spec
+
+set_option autoImplicit false
+
+variable {p : ℕ} [Fact p.Prime]
+
+-- None of the proofs below need `p` to be prime; they are purely structural.
+omit [Fact p.Prime]
+
+/-- The identity optimizer: it returns the constraint system unchanged.
+    This is the trivial optimizer that does nothing, serving as a baseline. -/
+def identityOptimizer (cs : ConstraintSystem p) (_ : BusSemantics p) : ConstraintSystem p :=
+  cs
+
+/-- `≈` on `BusState` is reflexive: every message trivially has the same net
+    multiplicity in a state as in itself. -/
+theorem BusState.equiv_refl (s : BusState p) : s ≈ s :=
+  fun _ => rfl
+
+/-- Any constraint system implies itself: the same satisfying assignment works
+    and its side effects are (reflexively) equal. -/
+theorem ConstraintSystem.implies_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    cs.implies cs busSemantics :=
+  fun env hsat => ⟨env, hsat, BusState.equiv_refl _⟩
+
+/-- Any constraint system is equivalent to itself. -/
+theorem ConstraintSystem.equivalentTo_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    cs.equivalentTo cs busSemantics :=
+  ⟨cs.implies_refl busSemantics, cs.implies_refl busSemantics⟩
+
+/-- The identity optimizer maintains correctness. -/
+theorem identityOptimizer_maintainsCorrectness :
+    optimizerMaintainsCorrectness (p := p) identityOptimizer :=
+  fun cs busSemantics =>
+    ⟨cs.equivalentTo_refl busSemantics, id⟩

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -6,6 +6,8 @@ set_option autoImplicit false
 -- `p` is the field characteristic; a prime, so `ZMod p` is a field.
 variable {p : ℕ} [Fact p.Prime]
 
+--------- Expressions ---------
+
 /-- An arithmetic expression over variables (identified by `String`) and field constants. -/
 inductive Expression (p : ℕ) where
   | const (n : ZMod p)
@@ -21,47 +23,82 @@ def Expression.eval (e : Expression p) (env : String → ZMod p) : ZMod p :=
   | .add e1 e2 => e1.eval env + e2.eval env
   | .mul e1 e2 => e1.eval env * e2.eval env
 
+--------- Bus Interactions ---------
+
+/-- A bus interaction. Typically, α is
+    - an expression (=> symbolic bus interaction), or
+    - a field element (=> bus interaction message). -/
 structure BusInteraction (α : Type) where
   busId : Nat
   multiplicity : α
   payload : List α
 
+/-- Evaluate a bus interaction under an assignment `env`, turning a symbolic bus
+    interaction into a bus interaction message. -/
 def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : String → ZMod p) :
     BusInteraction (ZMod p) :=
   { busId := bi.busId,
     multiplicity := bi.multiplicity.eval env,
     payload := bi.payload.map (fun e => e.eval env) }
 
+/-- The bus semantics of the zkVM. -/
 structure BusSemantics (p : ℕ) where
-  isStateful : Nat → Bool
-  accepts : BusInteraction (ZMod p) → Bool
+  /-- Whether the bus of the given ID changes the state of the VM.
+      Stateless bus interactions are typically lookups. -/
+  isStateful (busId : Nat) : Bool
+  /-- Whether the bus interaction message is accepted by the rest of the system.
+      If this returns `false`, it *must* be that there is a constraint violation
+      somewhere in the zkVM that caused the message to be rejected.
+      For example, if the bus implements a lookup, this function would check
+      whether the bus interaction message exists in the lookup table. -/
+  accepts (busInteractionMessage : BusInteraction (ZMod p)) : Bool
 
+--------- Constraint System ---------
+
+/-- A constraint system representing a single zkVM chip. -/
 structure ConstraintSystem (p : ℕ) where
   algebraicConstraints : List (Expression p)
   busInteractions : List (BusInteraction (Expression p))
 
+/-- The side effects of a constraint system under a given environment and bus semantics.
+    The side effects are the tuples sent to the *stateful* buses.-/
 noncomputable def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
     (busSemantics : BusSemantics p) (env : String → ZMod p) : (Nat × List (ZMod p)) →₀ ZMod p :=
-  (cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId) |>.map (fun bi =>
-    let m := bi.eval env
-    Finsupp.single (m.busId, m.payload) m.multiplicity)).sum
+  (cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
+    |>.map (fun bi =>
+      let m := bi.eval env
+      Finsupp.single (m.busId, m.payload) m.multiplicity)
+  ).sum
 
+/-- Whether a constraint system is satisfied under a given environment and bus semantics. -/
 def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSemantics p)
     (env : String → ZMod p) : Prop :=
   (∀ c ∈ s.algebraicConstraints, c.eval env = 0) ∧
   (∀ bi ∈ s.busInteractions, busSemantics.accepts (bi.eval env))
 
+/-- Whether a constraint system implies another under a given bus semantics.
+    Informally, a constraint system `self` implies a system `other` if for every
+    satisfying assignment of `self`:
+    1. There exists a satisfying assignment of `other`
+    2. The side effects of `self` under the given environment and bus semantics
+       are equal to the side effects of `other` under the corresponding environment.
+-/
 def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
     Prop :=
   ∀ env, self.satisfies busSemantics env →
     ∃ env', other.satisfies busSemantics env' ∧
       self.sideEffects busSemantics env = other.sideEffects busSemantics env'
 
+/-- Whether two constraint systems are equivalent under a given bus semantics.
+    Two constraint systems are equivalent if each implies the other. -/
 def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
     Prop :=
   self.implies other busSemantics ∧ other.implies self busSemantics
 
-def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → ConstraintSystem p) :
+/-- Whether an optimizer maintains circuit equivalence.
+    An optimizer maintains circuit equivalence if, for every constraint system and bus semantics,
+    the optimized constraint system is equivalent to the original. -/
+def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → BusSemantics p → ConstraintSystem p) :
     Prop :=
   ∀ constraintSystem busSemantics,
-    (optimizer constraintSystem).equivalentTo constraintSystem busSemantics
+    (optimizer constraintSystem busSemantics).equivalentTo constraintSystem busSemantics

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -1,0 +1,53 @@
+import Mathlib.Data.ZMod.Basic
+
+set_option autoImplicit false
+
+-- `p` is the field characteristic; a prime, so `ZMod p` is a field.
+variable {p : ℕ} [Fact p.Prime]
+
+/-- An arithmetic expression over variables (identified by `String`) and field constants. -/
+inductive Expression (p : ℕ) where
+  | const (n : ZMod p)
+  | var (x : String)
+  | add (e1 e2 : Expression p)
+  | mul (e1 e2 : Expression p)
+
+/-- Evaluate an expression under an assignment `env` of variables to field elements. -/
+def Expression.eval (e : Expression p) (env : String → ZMod p) : ZMod p :=
+  match e with
+  | .const n => n
+  | .var x => env x
+  | .add e1 e2 => e1.eval env + e2.eval env
+  | .mul e1 e2 => e1.eval env * e2.eval env
+
+/-- A bus interaction, consisting of a bus ID, a multiplicity, and a payload. -/
+structure BusInteraction (α : Type) where
+  busId : Nat
+  multiplicity : α
+  payload : List α
+
+/-- Evaluates a bus interaction under an assignment `env` of variables to a bus interaction message. -/
+def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : String → ZMod p) : BusInteraction (ZMod p) :=
+  { busId := bi.busId,
+    multiplicity := bi.multiplicity.eval env,
+    payload := bi.payload.map (fun e => e.eval env) }
+
+/-- A constraint system. -/
+structure ConstraintSystem (p : ℕ) where
+  algebraicConstraints : List (Expression p)
+  busInteractions : List (BusInteraction (Expression p))
+
+/-- `env` satisfies all constraints in `s` -/
+def ConstraintSystem.satisfies (s : ConstraintSystem p) (env : String → ZMod p) : Prop :=
+  ∀ c ∈ s.algebraicConstraints, c.eval env = 0
+
+/-- The satisfiability of `self` implies the satisfiability of `other` -/
+def ConstraintSystem.impliesSatisfiabilityOf (self other : ConstraintSystem p) : Prop :=
+  ∀ env, (self.satisfies env → ∃ env', other.satisfies env')
+
+/-- `self` and `other` are equivalent if they imply each other's satisfiability -/
+def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) : Prop :=
+  self.impliesSatisfiabilityOf other ∧ other.impliesSatisfiabilityOf self
+
+def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
+  ∀ s, (optimizer s).equivalentTo s

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -53,6 +53,12 @@ structure BusSemantics (p : ℕ) where
       whether the bus interaction message exists in the lookup table. -/
   accepts (busInteractionMessage : BusInteraction (ZMod p)) : Bool
 
+/-- A concrete bus interaction message: which bus, and the tuple sent. -/
+abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
+
+/-- Net effect on the stateful buses: each message mapped to its summed multiplicity. -/
+abbrev BusEffect (p : ℕ) := BusMessage p →₀ ZMod p
+
 --------- Constraint System ---------
 
 /-- A constraint system representing a single zkVM chip. -/
@@ -63,7 +69,7 @@ structure ConstraintSystem (p : ℕ) where
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
 noncomputable def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
-    (busSemantics : BusSemantics p) (env : String → ZMod p) : (Nat × List (ZMod p)) →₀ ZMod p :=
+    (busSemantics : BusSemantics p) (env : String → ZMod p) : BusEffect p :=
   (cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
     |>.map (fun bi =>
       let m := bi.eval env

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -1,4 +1,5 @@
 import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Finsupp.Basic
 
 set_option autoImplicit false
 
@@ -20,34 +21,47 @@ def Expression.eval (e : Expression p) (env : String → ZMod p) : ZMod p :=
   | .add e1 e2 => e1.eval env + e2.eval env
   | .mul e1 e2 => e1.eval env * e2.eval env
 
-/-- A bus interaction, consisting of a bus ID, a multiplicity, and a payload. -/
 structure BusInteraction (α : Type) where
   busId : Nat
   multiplicity : α
   payload : List α
 
-/-- Evaluates a bus interaction under an assignment `env` of variables to a bus interaction message. -/
-def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : String → ZMod p) : BusInteraction (ZMod p) :=
+def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : String → ZMod p) :
+    BusInteraction (ZMod p) :=
   { busId := bi.busId,
     multiplicity := bi.multiplicity.eval env,
     payload := bi.payload.map (fun e => e.eval env) }
 
-/-- A constraint system. -/
+structure BusSemantics (p : ℕ) where
+  isStateful : Nat → Bool
+  accepts : BusInteraction (ZMod p) → Bool
+
 structure ConstraintSystem (p : ℕ) where
   algebraicConstraints : List (Expression p)
   busInteractions : List (BusInteraction (Expression p))
 
-/-- `env` satisfies all constraints in `s` -/
-def ConstraintSystem.satisfies (s : ConstraintSystem p) (env : String → ZMod p) : Prop :=
-  ∀ c ∈ s.algebraicConstraints, c.eval env = 0
+noncomputable def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
+    (busSemantics : BusSemantics p) (env : String → ZMod p) : (Nat × List (ZMod p)) →₀ ZMod p :=
+  (cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId) |>.map (fun bi =>
+    let m := bi.eval env
+    Finsupp.single (m.busId, m.payload) m.multiplicity)).sum
 
-/-- The satisfiability of `self` implies the satisfiability of `other` -/
-def ConstraintSystem.impliesSatisfiabilityOf (self other : ConstraintSystem p) : Prop :=
-  ∀ env, (self.satisfies env → ∃ env', other.satisfies env')
+def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSemantics p)
+    (env : String → ZMod p) : Prop :=
+  (∀ c ∈ s.algebraicConstraints, c.eval env = 0) ∧
+  (∀ bi ∈ s.busInteractions, busSemantics.accepts (bi.eval env))
 
-/-- `self` and `other` are equivalent if they imply each other's satisfiability -/
-def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) : Prop :=
-  self.impliesSatisfiabilityOf other ∧ other.impliesSatisfiabilityOf self
+def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    Prop :=
+  ∀ env, self.satisfies busSemantics env →
+    ∃ env', other.satisfies busSemantics env' ∧
+      self.sideEffects busSemantics env = other.sideEffects busSemantics env'
 
-def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
-  ∀ s, (optimizer s).equivalentTo s
+def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    Prop :=
+  self.implies other busSemantics ∧ other.implies self busSemantics
+
+def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → ConstraintSystem p) :
+    Prop :=
+  ∀ constraintSystem busSemantics,
+    (optimizer constraintSystem).equivalentTo constraintSystem busSemantics

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -46,12 +46,14 @@ structure BusSemantics (p : ℕ) where
   /-- Whether the bus of the given ID changes the state of the VM.
       Stateless bus interactions are typically lookups. -/
   isStateful (busId : Nat) : Bool
-  /-- Whether the bus interaction message is accepted by the rest of the system.
-      If this returns `false`, it *must* be that there is a constraint violation
-      somewhere in the zkVM that caused the message to be rejected.
-      For example, if the bus implements a lookup, this function would check
-      whether the bus interaction message exists in the lookup table. -/
-  accepts (busInteractionMessage : BusInteraction (ZMod p)) : Bool
+  /-- Whether sending this bus interaction message violates a constraint in *another* chip.
+      An example of this is sending a message that conflicts with a lookup table entry. -/
+  violatesConstraint (busInteractionMessage : BusInteraction (ZMod p)) : Bool
+  /-- Whether sending this bus interaction message breaks an invariant on which soundness
+      of the system depends.
+      For example, a memory bus might have the invariant that all sent values must be in
+      a certain range. -/
+  breaksInvariant (busInteractionMessage : BusInteraction (ZMod p)) : Bool
 
 /-- A concrete bus interaction message: which bus, and the tuple sent. -/
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
@@ -80,15 +82,22 @@ noncomputable def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
 def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSemantics p)
     (env : String → ZMod p) : Prop :=
   (∀ c ∈ s.algebraicConstraints, c.eval env = 0) ∧
-  (∀ bi ∈ s.busInteractions, busSemantics.accepts (bi.eval env))
+  (∀ bi ∈ s.busInteractions,
+    let message := bi.eval env
+    message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false)
+
+/-- Whether a constraint system guarantees that all invariants are maintained under a given bus semantics. -/
+def ConstraintSystem.guaranteesInvariants (s : ConstraintSystem p) (busSemantics : BusSemantics p) : Prop :=
+  ∀ env, s.satisfies busSemantics env → ∀ bi ∈ s.busInteractions,
+    let message := bi.eval env
+    message.multiplicity ≠ 0 → busSemantics.breaksInvariant message = false
 
 /-- Whether a constraint system implies another under a given bus semantics.
     Informally, a constraint system `self` implies a system `other` if for every
     satisfying assignment of `self`:
     1. There exists a satisfying assignment of `other`
     2. The side effects of `self` under the given environment and bus semantics
-       are equal to the side effects of `other` under the corresponding environment.
--/
+       are equal to the side effects of `other` under the corresponding environment. -/
 def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
     Prop :=
   ∀ env, self.satisfies busSemantics env →
@@ -101,10 +110,14 @@ def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) (busSemantic
     Prop :=
   self.implies other busSemantics ∧ other.implies self busSemantics
 
-/-- Whether an optimizer maintains circuit equivalence.
-    An optimizer maintains circuit equivalence if, for every constraint system and bus semantics,
-    the optimized constraint system is equivalent to the original. -/
-def optimizerMaintainsCircuitEquivalence (optimizer : ConstraintSystem p → BusSemantics p → ConstraintSystem p) :
+/-- Whether an optimizer maintains correctness. This means that, for all constraint systems
+    and bus semantics:
+    1. The optimized constraint system is equivalent to the original, i.e. it has a satisfying
+       witness iff the original does.
+    2. Assuming the original constraint system guarantees invariants, so does the optimized one. -/
+def optimizerMaintainsCorrectness (optimizer : ConstraintSystem p → BusSemantics p → ConstraintSystem p) :
     Prop :=
   ∀ constraintSystem busSemantics,
-    (optimizer constraintSystem busSemantics).equivalentTo constraintSystem busSemantics
+    ((optimizer constraintSystem busSemantics).equivalentTo constraintSystem busSemantics) ∧
+    (constraintSystem.guaranteesInvariants busSemantics →
+      (optimizer constraintSystem busSemantics).guaranteesInvariants busSemantics)

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -1,5 +1,4 @@
 import Mathlib.Data.ZMod.Basic
-import Mathlib.Data.Finsupp.Basic
 
 set_option autoImplicit false
 
@@ -58,8 +57,18 @@ structure BusSemantics (p : ℕ) where
 /-- A concrete bus interaction message: which bus, and the tuple sent. -/
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
 
-/-- Net effect on the stateful buses: each message mapped to its summed multiplicity. -/
-abbrev BusEffect (p : ℕ) := BusMessage p →₀ ZMod p
+/-- The effect on the stateful buses: the messages sent, each with a multiplicity. -/
+abbrev BusState (p : ℕ) := List (BusMessage p × ZMod p)
+
+/-- The net multiplicity with which `message` is sent in `state`. -/
+def multiplicitySum (message : BusMessage p) (state : BusState p) : ZMod p :=
+  match state with
+  | [] => 0
+  | (msg, mult) :: tl => (if msg = message then mult else 0) + multiplicitySum message tl
+
+/-- Two bus states are equal when every message is sent with the same net multiplicity. -/
+instance : HasEquiv (BusState p) :=
+  ⟨fun s t => ∀ message, multiplicitySum message s = multiplicitySum message t⟩
 
 --------- Constraint System ---------
 
@@ -70,13 +79,12 @@ structure ConstraintSystem (p : ℕ) where
 
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
-noncomputable def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
-    (busSemantics : BusSemantics p) (env : String → ZMod p) : BusEffect p :=
-  (cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
+def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
+    (busSemantics : BusSemantics p) (env : String → ZMod p) : BusState p :=
+  cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
     |>.map (fun bi =>
       let m := bi.eval env
-      Finsupp.single (m.busId, m.payload) m.multiplicity)
-  ).sum
+      ((m.busId, m.payload), m.multiplicity))
 
 /-- Whether a constraint system is satisfied under a given environment and bus semantics. -/
 def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSemantics p)
@@ -102,7 +110,7 @@ def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : B
     Prop :=
   ∀ env, self.satisfies busSemantics env →
     ∃ env', other.satisfies busSemantics env' ∧
-      self.sideEffects busSemantics env = other.sideEffects busSemantics env'
+      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
 
 /-- Whether two constraint systems are equivalent under a given bus semantics.
     Two constraint systems are equivalent if each implies the other. -/
@@ -113,7 +121,7 @@ def ConstraintSystem.equivalentTo (self other : ConstraintSystem p) (busSemantic
 /-- Whether an optimizer maintains correctness. This means that, for all constraint systems
     and bus semantics:
     1. The optimized constraint system is equivalent to the original, i.e. it has a satisfying
-       witness iff the original does.
+       witness iff the original does **and** the side effects are the same.
     2. Assuming the original constraint system guarantees invariants, so does the optimized one. -/
 def optimizerMaintainsCorrectness (optimizer : ConstraintSystem p → BusSemantics p → ConstraintSystem p) :
     Prop :=


### PR DESCRIPTION
*Builds on #19*

This PR adds a self-contained `Spec.lean`, specifying what it means for a circuit optimizer to be correct. The intention is that it should be easy to audit, minimal, and complete. The idea here is that in the end all files that humans need to review is:
- `Spec.lean`
- A zkVM-specific instantiation of `BusSemantics`
- Performance benchmarks

Everything else can be managed autonomously by AI.