### PR TITLE
Add OpenVM bus semantics

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -18,3 +18,4 @@ import Leanr.Legacy.Expression.Proofs
 import Leanr.Legacy.AffineExpression.Proofs
 import Leanr.Legacy.AlgebraicConstraint.Proofs
 import Leanr.Legacy.Solver.Proofs
+import Leanr.OpenVM.Semantics

--- a/Leanr/OpenVM/Semantics.lean
+++ b/Leanr/OpenVM/Semantics.lean
@@ -1,0 +1,111 @@
+import Leanr.Spec
+
+/-!
+# OpenVM bus semantics
+
+An instance of the spec-level `BusSemantics` (see `Leanr/Spec.lean`) for the OpenVM zkVM.
+
+This is the spec-level counterpart of powdr's `OpenVmBusInteractionHandler`
+(`openvm-bus-interaction-handler` crate). That handler *refines range constraints*; here we
+instead capture the two soundness-relevant predicates the spec asks for:
+`violatesConstraint` (does a message conflict with a lookup table?) and `breaksInvariant`
+(does a message break an invariant soundness depends on?), plus statefulness.
+
+powdr's handler supports a dynamic `BusMap`; we hard-code the *default* OpenVM bus map
+(`default_openvm_bus_map`).
+-/
+
+set_option autoImplicit false
+
+namespace Leanr.OpenVM
+
+variable {p : ℕ}
+
+/-- The OpenVM bus types that appear in the default bus map. -/
+inductive OpenVmBusType where
+  | executionBridge
+  | memory
+  | pcLookup
+  | variableRangeChecker
+  | bitwiseLookup
+  | tupleRangeChecker (size1 size2 : Nat)
+  deriving Repr, DecidableEq
+
+/-- The hard-coded default OpenVM bus map, mirroring powdr's `default_openvm_bus_map`:
+    `0 → ExecutionBridge, 1 → Memory, 2 → PcLookup, 3 → VariableRangeChecker,
+     6 → BitwiseLookup, 7 → TupleRangeChecker([256, 2048])`. -/
+def defaultBusMap : Nat → Option OpenVmBusType
+  | 0 => some .executionBridge
+  | 1 => some .memory
+  | 2 => some .pcLookup
+  | 3 => some .variableRangeChecker
+  | 6 => some .bitwiseLookup
+  | 7 => some (.tupleRangeChecker 256 2048)
+  | _ => none
+
+/-- Stateful (order-dependent) buses are the execution bridge and memory; the rest are
+    stateless lookups. -/
+def OpenVmBusType.isStateful : OpenVmBusType → Bool
+  | .executionBridge => true
+  | .memory => true
+  | .pcLookup => false
+  | .variableRangeChecker => false
+  | .bitwiseLookup => false
+  | .tupleRangeChecker _ _ => false
+
+/-- Whether a field element is a byte (`0 ≤ x < 256`). -/
+private def isByte (x : ZMod p) : Bool := decide (x.val < 256)
+
+/-- Whether a message conflicts with the lookup table of the bus it is sent on.
+
+    Only the stateless lookup buses have such tables:
+    - `BitwiseLookup (x, y, z, op)`: `x, y` are bytes and either `op = 0 ∧ z = 0` (range check)
+      or `op = 1 ∧ z = x ^ y` (xor); any other `op` conflicts.
+    - `VariableRangeChecker (x, bits)`: `x < 2 ^ bits`.
+    - `TupleRangeChecker (x, y)` with sizes `(s1, s2)`: `x < s1 ∧ y < s2`.
+
+    Stateful buses (execution bridge, memory) and the PC lookup carry no static table in this
+    model, so they never conflict. -/
+def violates (msg : BusInteraction (ZMod p)) : Bool :=
+  match defaultBusMap msg.busId, msg.payload with
+  | some .bitwiseLookup, [x, y, z, op] =>
+    match op.val with
+    | 0 => !(isByte x && isByte y && decide (z.val = 0))
+    | 1 => !(isByte x && isByte y && decide (z.val = Nat.xor x.val y.val))
+    | _ => true
+  | some .variableRangeChecker, [x, bits] =>
+    !decide (x.val < 2 ^ bits.val)
+  | some (.tupleRangeChecker s1 s2), [x, y] =>
+    !(decide (x.val < s1) && decide (y.val < s2))
+  | _, _ => false
+
+/-- Whether a message breaks an invariant on which soundness depends.
+
+    We model the memory invariant: values written to the register / main-memory address spaces
+    (`1` and `2`) must be byte-range limbs. The memory payload is
+    `(address_space, pointer, data.., timestamp)`, so the data limbs are the middle elements.
+    Other buses carry no such invariant here.
+
+    (Not exercised by the identity-optimizer snapshot test in `Leanr/OpenVM/Snapshot.lean`;
+    it is a faithful-but-uncorroborated modeling choice.) -/
+def breaks (msg : BusInteraction (ZMod p)) : Bool :=
+  match defaultBusMap msg.busId, msg.payload with
+  | some .memory, _addressSpace :: _pointer :: rest =>
+    match msg.payload with
+    | addressSpace :: _ =>
+      bif (addressSpace.val == 1 || addressSpace.val == 2) then
+        !(rest.dropLast.all (fun d => decide (d.val < 256)))
+      else false
+    | _ => false
+  | _, _ => false
+
+/-- The OpenVM bus semantics, using the hard-coded default bus map. -/
+def openVmBusSemantics (p : ℕ) : BusSemantics p where
+  isStateful busId :=
+    match defaultBusMap busId with
+    | some t => t.isStateful
+    | none => false
+  violatesConstraint := violates
+  breaksInvariant := breaks
+
+end Leanr.OpenVM

--- a/Leanr/OpenVM/Semantics.lean
+++ b/Leanr/OpenVM/Semantics.lean
@@ -99,18 +99,29 @@ def violates (msg : BusInteraction (ZMod p)) : Bool :=
   | none, _ => true
 
 /-- Whether a message breaks an invariant on which soundness depends. -/
-def breaks (msg : BusInteraction (ZMod p)) : Bool :=
-  match defaultBusMap msg.busId, msg.payload with
-  | some .memory, _addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
-    match msg.payload with
-    | addressSpace :: _ =>
-      bif (addressSpace.val == 1 || addressSpace.val == 2) then
-        !([b0, b1, b2, b3].all (fun d => decide (d.val < 256)))
-      else false
-    | _ => false
+def breaksInvariant (msg : BusInteraction (ZMod p)) : Bool :=
+  -- Note that this function is not called for multiplicity = 0
+  match defaultBusMap msg.busId with
+  -- Lookups are only ever sent (multiplicity 1).
+  | some .pcLookup | some .variableRangeChecker | some .bitwiseLookup
+  | some (.tupleRangeChecker _ _) =>
+    !decide (msg.multiplicity = 1)
+  -- The execution bridge is stateful: it is sent (1) or received (-1).
+  | some .executionBridge =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
+  -- Memory is stateful (multiplicity 1 or -1), and additionally maintains the invariant
+  -- that data limbs written to the register / main-memory address spaces (1 and 2) are
+  -- byte-range. The payload is `(address_space, pointer, data.. (4 bytes), timestamp)`.
+  | some .memory =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
+    (match msg.payload with
+      | addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
+        bif (addressSpace.val == 1 || addressSpace.val == 2) then
+          !([b0, b1, b2, b3].all (fun d => decide (d.val < 256)))
+        else false
+      | _ => false)
   -- Circuits should not send messages to an unknown bus.
-  | none, _ => true
-  | _, _ => false
+  | none => true
 
 /-- The OpenVM bus semantics, using the hard-coded default bus map. -/
 def openVmBusSemantics (p : ℕ) : BusSemantics p where
@@ -119,6 +130,6 @@ def openVmBusSemantics (p : ℕ) : BusSemantics p where
     | some t => t.isStateful
     | none => false
   violatesConstraint := violates
-  breaksInvariant := breaks
+  breaksInvariant := breaksInvariant
 
 end Leanr.OpenVM

--- a/Leanr/OpenVM/Semantics.lean
+++ b/Leanr/OpenVM/Semantics.lean
@@ -1,20 +1,5 @@
 import Leanr.Spec
 
-/-!
-# OpenVM bus semantics
-
-An instance of the spec-level `BusSemantics` (see `Leanr/Spec.lean`) for the OpenVM zkVM.
-
-This is the spec-level counterpart of powdr's `OpenVmBusInteractionHandler`
-(`openvm-bus-interaction-handler` crate). That handler *refines range constraints*; here we
-instead capture the two soundness-relevant predicates the spec asks for:
-`violatesConstraint` (does a message conflict with a lookup table?) and `breaksInvariant`
-(does a message break an invariant soundness depends on?), plus statefulness.
-
-powdr's handler supports a dynamic `BusMap`; we hard-code the *default* OpenVM bus map
-(`default_openvm_bus_map`).
--/
-
 set_option autoImplicit false
 
 namespace Leanr.OpenVM
@@ -23,17 +8,26 @@ variable {p : ℕ}
 
 /-- The OpenVM bus types that appear in the default bus map. -/
 inductive OpenVmBusType where
+  /-- A instruction should receive a `(pc, timestamp)` and send updated values to the bus. -/
   | executionBridge
+  /-- To access a memory cell, instructions should:
+      1. Receive a `(address_space, pointer, data... (4 bytes), prev_timestamp)` tuple
+      2. Send a `(address_space, pointer, data... (4 bytes), current_timestamp)` tuple. -/
   | memory
+  /-- Lookup to get the instruction flags from the current pc. Format: `(pc, flags...)` -/
   | pcLookup
+  /-- Check that a value is in a certain range. Format: `(value, bits)` -/
   | variableRangeChecker
+  /-- Check that a value is in a certain range. Format: `(x, y, z, op)` where `op` is either
+      0 (range check) or 1 (xor). The bus checks that `x` and `y` are bytes, and either
+      `op = 0 ∧ z = 0` (range check) or `op = 1 ∧ z = x ^ y` (xor). -/
   | bitwiseLookup
+  /-- Check that a tuple of two values is in a certain range. Format: `(x, y)` where
+      `x < size1` and `y < size2`. -/
   | tupleRangeChecker (size1 size2 : Nat)
   deriving Repr, DecidableEq
 
-/-- The hard-coded default OpenVM bus map, mirroring powdr's `default_openvm_bus_map`:
-    `0 → ExecutionBridge, 1 → Memory, 2 → PcLookup, 3 → VariableRangeChecker,
-     6 → BitwiseLookup, 7 → TupleRangeChecker([256, 2048])`. -/
+/-- The hard-coded default OpenVM bus map, mirroring powdr's `default_openvm_bus_map` -/
 def defaultBusMap : Nat → Option OpenVmBusType
   | 0 => some .executionBridge
   | 1 => some .memory
@@ -43,8 +37,7 @@ def defaultBusMap : Nat → Option OpenVmBusType
   | 7 => some (.tupleRangeChecker 256 2048)
   | _ => none
 
-/-- Stateful (order-dependent) buses are the execution bridge and memory; the rest are
-    stateless lookups. -/
+/-- Stateful buses are the execution bridge and memory; the rest are stateless lookups. -/
 def OpenVmBusType.isStateful : OpenVmBusType → Bool
   | .executionBridge => true
   | .memory => true
@@ -56,47 +49,67 @@ def OpenVmBusType.isStateful : OpenVmBusType → Bool
 /-- Whether a field element is a byte (`0 ≤ x < 256`). -/
 private def isByte (x : ZMod p) : Bool := decide (x.val < 256)
 
-/-- Whether a message conflicts with the lookup table of the bus it is sent on.
-
-    Only the stateless lookup buses have such tables:
-    - `BitwiseLookup (x, y, z, op)`: `x, y` are bytes and either `op = 0 ∧ z = 0` (range check)
-      or `op = 1 ∧ z = x ^ y` (xor); any other `op` conflicts.
-    - `VariableRangeChecker (x, bits)`: `x < 2 ^ bits`.
-    - `TupleRangeChecker (x, y)` with sizes `(s1, s2)`: `x < s1 ∧ y < s2`.
-
-    Stateful buses (execution bridge, memory) and the PC lookup carry no static table in this
-    model, so they never conflict. -/
+/-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
 def violates (msg : BusInteraction (ZMod p)) : Bool :=
   match defaultBusMap msg.busId, msg.payload with
+  -- ISSUE:
+  -- The PC lookup is a bit special: We would have to know the program to
+  -- check whether the PC lookup is valid. So this semantics is **wrong**,
+  -- and in theory, the optimizer could add failing PC lookups, losing
+  -- completeness.
+  -- However, the input circuit already has constraints fixing all of the
+  -- lookup fields to constants (added here: [1]), so the optimizer would
+  -- not be able to change any of the flags.
+  -- Also, the completeness issue could be solved by checking that the
+  -- optimized circuit does not contain any PC lookups (they can always
+  -- be removed in practice).
+  -- [1] https://github.com/powdr-labs/powdr/blob/f94a24f19249af67efbea92ff9c3db6e3e50e7fd/autoprecompiles/src/symbolic_machine_generator.rs#L185-L192
+  | some .pcLookup, args => !decide (args.length = 9)
+
   | some .bitwiseLookup, [x, y, z, op] =>
     match op.val with
+    -- Op 0: range check x and y to be bytes, z must be 0.
     | 0 => !(isByte x && isByte y && decide (z.val = 0))
+    -- Op 1: range check x and y to be bytes, z must be x ^ y.
     | 1 => !(isByte x && isByte y && decide (z.val = Nat.xor x.val y.val))
+    -- Other ops are invalid.
     | _ => true
+
   | some .variableRangeChecker, [x, bits] =>
+    -- Check that x < 2^bits.
     !decide (x.val < 2 ^ bits.val)
+
   | some (.tupleRangeChecker s1 s2), [x, y] =>
+    -- Range check that x < s1 and y < s2.
     !(decide (x.val < s1) && decide (y.val < s2))
-  | _, _ => false
 
-/-- Whether a message breaks an invariant on which soundness depends.
+  -- For lookups, reject if the number of arguments is not as expected.
+  | some .bitwiseLookup, _ => true
+  | some .variableRangeChecker, _ => true
+  | some (.tupleRangeChecker _ _), _ => true
 
-    We model the memory invariant: values written to the register / main-memory address spaces
-    (`1` and `2`) must be byte-range limbs. The memory payload is
-    `(address_space, pointer, data.., timestamp)`, so the data limbs are the middle elements.
-    Other buses carry no such invariant here.
+  -- Stateful buses.
+  -- TODO: Some of these *might* actually enforce constraints. For example, under the
+  -- invariant that all *sent* memory values are range-checked, *received* memory values
+  -- can be assumed to be range-checked.
+  | some .executionBridge, _ => false
+  | some .memory, _ => false
 
-    (Not exercised by the identity-optimizer snapshot test in `Leanr/OpenVM/Snapshot.lean`;
-    it is a faithful-but-uncorroborated modeling choice.) -/
+  -- Invalid bus ID. Won't have a matching receive.
+  | none, _ => true
+
+/-- Whether a message breaks an invariant on which soundness depends. -/
 def breaks (msg : BusInteraction (ZMod p)) : Bool :=
   match defaultBusMap msg.busId, msg.payload with
-  | some .memory, _addressSpace :: _pointer :: rest =>
+  | some .memory, _addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
     match msg.payload with
     | addressSpace :: _ =>
       bif (addressSpace.val == 1 || addressSpace.val == 2) then
-        !(rest.dropLast.all (fun d => decide (d.val < 256)))
+        !([b0, b1, b2, b3].all (fun d => decide (d.val < 256)))
       else false
     | _ => false
+  -- Circuits should not send messages to an unknown bus.
+  | none, _ => true
   | _, _ => false
 
 /-- The OpenVM bus semantics, using the hard-coded default bus map. -/


### PR DESCRIPTION
Building on #16, this PR defines the bus semantics of OpenVM. I used powdr's `BusInteractionHandler` as the ground truth here.