### PR TITLE
Move legacy code into Legacy module

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -1,18 +1,18 @@
 -- This module serves as the root of the `Leanr` library.
 -- Import modules here that should be built as part of the library.
-import Leanr.Basic
-import Leanr.Expression
-import Leanr.AffineExpression
-import Leanr.AlgebraicConstraint
-import Leanr.BusInteraction
-import Leanr.System
-import Leanr.Solver
-import Leanr.StringParser
+import Leanr.Legacy.Basic
+import Leanr.Legacy.Expression
+import Leanr.Legacy.AffineExpression
+import Leanr.Legacy.AlgebraicConstraint
+import Leanr.Legacy.BusInteraction
+import Leanr.Legacy.System
+import Leanr.Legacy.Solver
+import Leanr.Legacy.StringParser
 import Leanr.JsonParser
-import Leanr.OpenVM
-import Leanr.RangeConstraint
-import Leanr.RangeConstraint.Proofs
-import Leanr.Expression.Proofs
-import Leanr.AffineExpression.Proofs
-import Leanr.AlgebraicConstraint.Proofs
-import Leanr.Solver.Proofs
+import Leanr.Legacy.OpenVM
+import Leanr.Legacy.RangeConstraint
+import Leanr.Legacy.RangeConstraint.Proofs
+import Leanr.Legacy.Expression.Proofs
+import Leanr.Legacy.AffineExpression.Proofs
+import Leanr.Legacy.AlgebraicConstraint.Proofs
+import Leanr.Legacy.Solver.Proofs

--- a/Leanr/Basic.lean
+++ b/Leanr/Basic.lean
@@ -1,1 +1,0 @@
-import Leanr.RangeConstraint

--- a/Leanr/JsonParser.lean
+++ b/Leanr/JsonParser.lean
@@ -1,6 +1,11 @@
 import Lean.Data.Json
-import Leanr.Solver
-import Leanr.Expression
+import Leanr.Legacy.Solver
+import Leanr.Legacy.Expression
+
+-- `JsonParser` is intentionally kept out of the `Legacy` namespace: the JSON
+-- parsing logic is expected to stay useful. It still targets the legacy
+-- `System`/`Expression` types via `open Legacy` for now.
+open Legacy
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 

--- a/Leanr/Legacy/AffineExpression.lean
+++ b/Leanr/Legacy/AffineExpression.lean
@@ -4,7 +4,10 @@ import Std.Data.TreeMap.Lemmas
 import Std
 import Mathlib
 
-import Leanr.Expression
+import Leanr.Legacy.Expression
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -110,3 +113,5 @@ def AffineExpression.solvedRangeConstraint
       e.affine.foldl (fun (acc : RangeConstraint p) k (v : ZMod p) =>
         if k == x then acc else acc + (↑v) * env k) init
     some (rest_rc.multiple inv_neg_coeff)
+
+end Legacy

--- a/Leanr/Legacy/AffineExpression/Proofs.lean
+++ b/Leanr/Legacy/AffineExpression/Proofs.lean
@@ -1,5 +1,8 @@
-import Leanr.AffineExpression
-import Leanr.RangeConstraint.Proofs
+import Leanr.Legacy.AffineExpression
+import Leanr.Legacy.RangeConstraint.Proofs
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -84,7 +87,7 @@ private theorem foldl_alter_get?
             a.impl a.balanced_impl).toBalancedTree)
         init l).impl k =
     match Std.DTreeMap.Internal.Impl.Const.get? init.impl k,
-          l.findValue? compare k with
+          List.findValue? compare k l with
     | some v1, some v2 => some (f k v1 v2)
     | some v1, none => some v1
     | none, some v2 => some v2
@@ -663,3 +666,5 @@ theorem AffineExpression.deduce_variable_sound
   show (field_rc.multiple coeff⁻¹ + rc).allowsValue (val_env x) = true
   rw [h_val_eq, show field_rc.multiple coeff⁻¹ + rc = (field_rc.multiple coeff⁻¹).add rc from rfl]
   exact h_sum
+
+end Legacy

--- a/Leanr/Legacy/AlgebraicConstraint.lean
+++ b/Leanr/Legacy/AlgebraicConstraint.lean
@@ -1,5 +1,8 @@
-import Leanr.AffineExpression
-import Leanr.Expression
+import Leanr.Legacy.AffineExpression
+import Leanr.Legacy.Expression
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -89,3 +92,5 @@ def AlgebraicConstraint.solve? {p : ℕ}
       else
         some { var := x, value := -c⁻¹ * e.offset }
     | _ => none -- more than one variable
+
+end Legacy

--- a/Leanr/Legacy/AlgebraicConstraint/Proofs.lean
+++ b/Leanr/Legacy/AlgebraicConstraint/Proofs.lean
@@ -1,6 +1,9 @@
-import Leanr.AlgebraicConstraint
-import Leanr.AffineExpression.Proofs
-import Leanr.Expression.Proofs
+import Leanr.Legacy.AlgebraicConstraint
+import Leanr.Legacy.AffineExpression.Proofs
+import Leanr.Legacy.Expression.Proofs
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -48,3 +51,5 @@ theorem AlgebraicConstraint.solve?_sound {p : ℕ} [Fact (Nat.Prime p)]
           rw [h1]; ring
         rw [← ha]; simp [key]
     | _ :: _ :: _ => simp [h_list] at h_solve
+
+end Legacy

--- a/Leanr/Legacy/Basic.lean
+++ b/Leanr/Legacy/Basic.lean
@@ -1,0 +1,5 @@
+import Leanr.Legacy.RangeConstraint
+
+namespace Legacy
+
+end Legacy

--- a/Leanr/Legacy/BusInteraction.lean
+++ b/Leanr/Legacy/BusInteraction.lean
@@ -1,5 +1,8 @@
-import Leanr.Expression
-import Leanr.RangeConstraint
+import Leanr.Legacy.Expression
+import Leanr.Legacy.RangeConstraint
+
+namespace Legacy
+
 
 structure BusInteraction (e : Type) where
   busId : e
@@ -70,3 +73,5 @@ instance : ToString BusMap where
   toString bm :=
     let entries := bm.map fun (id, ty) => s!"  {id}: {ty}"
     "BusMap:\n" ++ String.intercalate "\n" entries
+
+end Legacy

--- a/Leanr/Legacy/Expression.lean
+++ b/Leanr/Legacy/Expression.lean
@@ -1,7 +1,10 @@
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Tactic.Ring
 import Init.Data.ToString.Basic
-import Leanr.RangeConstraint
+import Leanr.Legacy.RangeConstraint
+
+namespace Legacy
+
 
 -- TODO could use generic Field instead of ZMod p
 
@@ -107,3 +110,5 @@ def Expression.rangeConstraint {p : ℕ}
   | .var x => env x
   | .add e1 e2 => e1.rangeConstraint env + e2.rangeConstraint env
   | .mul e1 e2 => e1.rangeConstraint env * e2.rangeConstraint env
+
+end Legacy

--- a/Leanr/Legacy/Expression/Proofs.lean
+++ b/Leanr/Legacy/Expression/Proofs.lean
@@ -1,4 +1,7 @@
-import Leanr.Expression
+import Leanr.Legacy.Expression
+
+namespace Legacy
+
 
 theorem simplifying_add_eval {p : ℕ} (e1 e2 : Expression p) (env : String → ZMod p) :
     (Expression.simplifying_add e1 e2).eval env = e1.eval env + e2.eval env := by
@@ -96,3 +99,5 @@ theorem Expression.substitute_eval {p : ℕ} (e : Expression p)
   | mul e1 e2 ih1 ih2 =>
     unfold substitute
     rw [simplifying_mul_eval, ih1, ih2]; rfl
+
+end Legacy

--- a/Leanr/Legacy/OpenVM.lean
+++ b/Leanr/Legacy/OpenVM.lean
@@ -1,6 +1,9 @@
-import Leanr.RangeConstraint
-import Leanr.BusInteraction
+import Leanr.Legacy.RangeConstraint
+import Leanr.Legacy.BusInteraction
 import Lean.Data.Json
+
+namespace Legacy
+
 
 namespace OpenVM
 
@@ -186,3 +189,5 @@ def openVMBusInteractionHandler (busMap : BusMap) : BusInteractionHandler babyBe
   }
 
 end OpenVM
+
+end Legacy

--- a/Leanr/Legacy/Parser.lean
+++ b/Leanr/Legacy/Parser.lean
@@ -1,6 +1,9 @@
 import Init.Data.ToString
 
-import Leanr.Expression
+import Leanr.Legacy.Expression
+
+namespace Legacy
+
 
 declare_syntax_cat expr
 
@@ -30,3 +33,5 @@ macro_rules
 /-- info: (((2 * x) + (3 * y)) + 0) -/
 #guard_msgs in
 #eval ((expr { 2 * x + 3 * y + 4 }) : Expression 4)
+
+end Legacy

--- a/Leanr/Legacy/RangeConstraint.lean
+++ b/Leanr/Legacy/RangeConstraint.lean
@@ -1,6 +1,9 @@
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Data.Nat.Bitwise
 
+namespace Legacy
+
+
 structure RangeConstraint (p : ℕ) where
   mask : Nat
   min : ZMod p
@@ -191,3 +194,5 @@ instance {p : ℕ} : Add (RangeConstraint p) where add := RangeConstraint.add
 instance {p : ℕ} : Sub (RangeConstraint p) where sub := RangeConstraint.sub
 instance {p : ℕ} : Mul (RangeConstraint p) where mul := RangeConstraint.mul
 instance {p : ℕ} : Neg (RangeConstraint p) where neg := RangeConstraint.neg
+
+end Legacy

--- a/Leanr/Legacy/RangeConstraint/Proofs.lean
+++ b/Leanr/Legacy/RangeConstraint/Proofs.lean
@@ -1,5 +1,8 @@
-import Leanr.RangeConstraint
+import Leanr.Legacy.RangeConstraint
 import Mathlib.Tactic.Ring
+
+namespace Legacy
+
 
 -- ===== Bitwise helper lemmas =====
 
@@ -1074,3 +1077,5 @@ theorem RangeConstraint.conjunction_sound {p : ℕ} [NeZero p]
         exact post_loop_allows (rc1.mask &&& rc2.mask) _ _ x hmask
           (show (RangeConstraint.mk 0 rc2.min rc2.max).inRange x from by
             simp only [RangeConstraint.inRange]; exact h2r)
+
+end Legacy

--- a/Leanr/Legacy/Solver.lean
+++ b/Leanr/Legacy/Solver.lean
@@ -1,6 +1,9 @@
-import Leanr.System
-import Leanr.Parser
+import Leanr.Legacy.System
+import Leanr.Legacy.Parser
 import Std.Data.HashMap
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -171,3 +174,5 @@ def solve (system : System (p := p))
     return new_state.system
   termination_by system.constraints.size
   decreasing_by omega
+
+end Legacy

--- a/Leanr/Legacy/Solver/Proofs.lean
+++ b/Leanr/Legacy/Solver/Proofs.lean
@@ -1,5 +1,8 @@
-import Leanr.Solver
-import Leanr.AlgebraicConstraint.Proofs
+import Leanr.Legacy.Solver
+import Leanr.Legacy.AlgebraicConstraint.Proofs
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -220,3 +223,5 @@ theorem solve_sound (state : SolverState p) (handler : BusInteractionHandler p)
   · exact h_round
   termination_by state.system.constraints.size
   decreasing_by omega
+
+end Legacy

--- a/Leanr/Legacy/Solver/RangeProofs.lean
+++ b/Leanr/Legacy/Solver/RangeProofs.lean
@@ -1,6 +1,9 @@
-import Leanr.Solver
-import Leanr.AffineExpression.Proofs
-import Leanr.RangeConstraint.Proofs
+import Leanr.Legacy.Solver
+import Leanr.Legacy.AffineExpression.Proofs
+import Leanr.Legacy.RangeConstraint.Proofs
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -97,3 +100,5 @@ theorem updateRangeConstraint_sound
   · exact h_cur
   · simp only [SolverState.getRangeConstraint, Std.HashMap.getElem?_insert, beq_self_eq_true, ite_true, Option.getD]
     exact RangeConstraint.conjunction_sound _ _ _ h_cur h_new
+
+end Legacy

--- a/Leanr/Legacy/StringParser.lean
+++ b/Leanr/Legacy/StringParser.lean
@@ -1,7 +1,10 @@
-import Leanr.Solver
-import Leanr.Expression
+import Leanr.Legacy.Solver
+import Leanr.Legacy.Expression
 
 import Init.Data.ToString.Basic
+
+namespace Legacy
+
 
 
 /--
@@ -334,3 +337,5 @@ BusInteraction { bus_id: 3, multiplicity: (is_valid * 1), payload: [(((15360 * w
   match parseSystem (p := 0x1dffff) input with
   | .ok system => system
   | .error _ => System.fromConstraints []
+
+end Legacy

--- a/Leanr/Legacy/System.lean
+++ b/Leanr/Legacy/System.lean
@@ -1,5 +1,8 @@
-import Leanr.AlgebraicConstraint
-import Leanr.BusInteraction
+import Leanr.Legacy.AlgebraicConstraint
+import Leanr.Legacy.BusInteraction
+
+namespace Legacy
+
 
 variable {p : ℕ} [Fact (Nat.Prime p)]
 
@@ -24,3 +27,5 @@ def System.fromConstraints {p : ℕ}
 /-- A system's constraints are all satisfied by `env`. -/
 def System.satisfies (s : System p) (env : String → ZMod p) : Prop :=
   ∀ c ∈ s.constraints.toList, AlgebraicConstraint.eval c env = 0
+
+end Legacy

--- a/Leanr/Legacy/Talk.lean
+++ b/Leanr/Legacy/Talk.lean
@@ -1,5 +1,8 @@
 import Mathlib
 
+namespace Legacy
+
+
 variable {α : Type}
 
 inductive MyList (α : Type) : Type where
@@ -65,3 +68,5 @@ def square (n : ℕ) : ℕ := n * n
 def is_square (n : ℕ) : Prop := ∃ m, n = square m
 
 theorem sixteen_is_square : is_square 16 := by use 4; simp [square]
+
+end Legacy

--- a/Main.lean
+++ b/Main.lean
@@ -1,7 +1,9 @@
 import Leanr
-import Leanr.StringParser
+import Leanr.Legacy.StringParser
 import Leanr.JsonParser
-import Leanr.Solver
+import Leanr.Legacy.Solver
+
+open Legacy
 
 def main (args: List String) : IO Unit := do
   let p := 0x1dffff


### PR DESCRIPTION
Moves most of the current code into a `Legacy` module.

In #16, I want to add a minimal and complete spec of what it means for a circuit optimizer to be correct. Some of the names (`Expression`, `BusInteraction`) clash with the existing code. In the [`autoopt`](https://github.com/powdr-labs/leanr/tree/autoopt) branch, there is a pretty effective optimizer that's proven correct under the spec introduced in #16. So it seems plausible that we'll be able to replace the current optimizer. Will leave the current one in the code base for now, for inspiration for future passes.