### PR TITLE
Optimizer framework: VerifiedPass scaffolding + trivial optimizer

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -9,6 +9,10 @@ import Leanr.Legacy.System
 import Leanr.Legacy.Solver
 import Leanr.Spec
 import Leanr.MemoryBus
+import Leanr.BusFacts
+import Leanr.OptimizerPasses.Basic
+import Leanr.OptimizerPasses.FactPass
+import Leanr.OptimizerPasses.Identity
 import Leanr.Optimizer
 import Leanr.Legacy.StringParser
 import Leanr.JsonParser

--- a/Leanr/BusFacts.lean
+++ b/Leanr/BusFacts.lean
@@ -1,0 +1,90 @@
+import Leanr.MemoryBus
+
+set_option autoImplicit false
+
+/-! # Proven auxiliary knowledge about a bus semantics
+
+`BusSemantics` exposes its lookup tables only through the opaque `violatesConstraint`, so a
+generic optimizer cannot learn facts like "this bus range-checks its first payload entry"
+without probing the whole field. `BusFacts` is the sound channel for that knowledge: a
+structure *dependent on the semantics* in which every claim carries a proof against it — the
+kernel checks the facts, so supplying them adds **nothing** to the audit surface, and a pass
+consuming them stays correct for arbitrary semantics (with `BusFacts.trivial` it degrades to
+the fact-free behavior).
+
+A *pattern* is a payload template: `some c` entries must equal the evaluated message's entry,
+`none` entries are free. Passes build patterns from the constant entries of a concrete
+interaction, so facts can be conditional on e.g. an op-selector slot (see `Leanr/OpenVM/Facts.lean`).
+-/
+
+variable {p : ℕ}
+
+/-- Does a payload match a pattern? Same length, and every constant pattern entry agrees. -/
+def Matches (payload : List (ZMod p)) (pattern : List (Option (ZMod p))) : Prop :=
+  payload.length = pattern.length ∧
+  ∀ (slot : Nat) (c : ZMod p), pattern[slot]? = some (some c) → payload[slot]? = some c
+
+/-- Proven, pass-consumable knowledge about the bus semantics `bs`. -/
+structure BusFacts (p : ℕ) (bs : BusSemantics p) where
+  /-- Accepted-value bound for one payload slot of messages matching a pattern:
+      `slotBound busId pattern slot = some bound` means every *accepted* message on `busId`
+      matching `pattern` has `payload[slot].val < bound`. -/
+  slotBound : (busId : Nat) → (pattern : List (Option (ZMod p))) → (slot : Nat) → Option Nat
+  slotBound_sound :
+    ∀ (m : BusInteraction (ZMod p)) (pattern : List (Option (ZMod p))) (slot bound : Nat)
+      (x : ZMod p),
+      slotBound m.busId pattern slot = some bound →
+      Matches m.payload pattern →
+      bs.violatesConstraint m = false →
+      m.payload[slot]? = some x →
+      x.val < bound
+  /-- Functional dependence: for accepted messages matching the pattern, the value in
+      `outSlot` is determined by the rest of the payload via the computable `f`. `f` receives
+      the payload with `outSlot` zeroed out, so it provably cannot depend on the value it
+      determines — which is what lets a pass *probe* `f` on candidate inputs. -/
+  slotFun : (busId : Nat) → (pattern : List (Option (ZMod p))) → (outSlot : Nat) →
+    Option (List (ZMod p) → ZMod p)
+  slotFun_sound :
+    ∀ (m : BusInteraction (ZMod p)) (pattern : List (Option (ZMod p))) (outSlot : Nat)
+      (f : List (ZMod p) → ZMod p) (z : ZMod p),
+      slotFun m.busId pattern outSlot = some f →
+      Matches m.payload pattern →
+      bs.violatesConstraint m = false →
+      m.payload[outSlot]? = some z →
+      z = f (m.payload.set outSlot 0)
+  /-- Buses whose messages never violate a constraint (e.g. stateful buses with no table). -/
+  neverViolates : (busId : Nat) → Bool
+  neverViolates_sound :
+    ∀ (m : BusInteraction (ZMod p)),
+      neverViolates m.busId = true → bs.violatesConstraint m = false
+  /-- The last-write-wins shape declared for a bus, or `none`. Passes read `addressFields` to
+      group same-address accesses; this is the VM-side memory knowledge (`Leanr/MemoryBus.lean`)
+      the spec's abstract `admissible` predicate deliberately omits. -/
+  memShape : (busId : Nat) → Option MemoryBusShape
+  /-- Every bus with a declared shape is stateful — so its messages survive the active∧stateful
+      filter that `ConstraintSystem.admissible` applies before consulting `bs.admissible`. -/
+  memShape_stateful : ∀ (busId : Nat) (shape : MemoryBusShape),
+    memShape busId = some shape → bs.isStateful busId = true
+  /-- The VM's abstract `admissible` predicate entails the concrete consecutive-match discipline
+      (`admissibleMemoryBus`) on each declared bus's active messages. For a VM whose `admissible` *is*
+      that per-bus conjunction (see `Leanr/OpenVM/`) this is essentially definitional. -/
+  admissible_sound :
+    ∀ (msgs : List (BusInteraction (ZMod p))),
+      bs.admissible (msgs.filter
+        (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)) →
+      ∀ (busId : Nat) (shape : MemoryBusShape), memShape busId = some shape →
+        admissibleMemoryBus shape ((msgs.filter (fun m => m.busId = busId)).filter
+          (fun m => decide (m.multiplicity ≠ 0)))
+
+/-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
+    shapes, so the memory/exec unify passes degrade to no-ops. -/
+def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
+  slotBound _ _ _ := none
+  slotBound_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
+  slotFun _ _ _ := none
+  slotFun_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
+  neverViolates _ := false
+  neverViolates_sound := by intro _ h; exact absurd h (by simp)
+  memShape _ := none
+  memShape_stateful := by intro _ _ h; exact absurd h (by simp)
+  admissible_sound := by intro _ _ _ _ h; exact absurd h (by simp)

--- a/Leanr/Optimizer.lean
+++ b/Leanr/Optimizer.lean
@@ -1,42 +1,75 @@
-import Leanr.Spec
+import Leanr.OptimizerPasses.Basic
+import Leanr.OptimizerPasses.FactPass
+import Leanr.OptimizerPasses.Identity
 
 set_option autoImplicit false
 
-variable {p : ℕ} [Fact p.Prime]
+variable {p : ℕ}
 
--- None of the proofs below need `p` to be prime; they are purely structural.
-omit [Fact p.Prime]
+/-! # The circuit optimizer
 
-/-- The identity optimizer: it returns the constraint system unchanged.
-    This is the trivial optimizer that does nothing, serving as a baseline. -/
-def identityOptimizer (cs : ConstraintSystem p) (_ : BusSemantics p) : ConstraintSystem p :=
-  cs
+Assembles the optimization passes (from `Leanr/OptimizerPasses/`) into the public `optimizer`,
+using the scaffolding in `Leanr/OptimizerPasses/Basic.lean` and `FactPass.lean`. The fact-free
+`optimizer` keeps the signature `ConstraintSystem p → BusSemantics p → ConstraintSystem p` so the
+size/effectiveness tooling can use it directly; `optimizerWith` additionally consumes proven
+`BusFacts` about the given semantics (see `Leanr/BusFacts.lean`) — correctness is identical
+(`optimizerWith_correct` states the same two clauses per instance), the facts only widen what
+the passes can decide.
 
-/-- `≈` on `BusState` is reflexive: every message trivially has the same net
-    multiplicity in a state as in itself. -/
-theorem BusState.equiv_refl (s : BusState p) : s ≈ s :=
-  fun _ => rfl
+**Trivial baseline.** No optimization is wired in yet: `pipeline` is the identity pass, so the
+optimizer returns its input unchanged. Correctness (`optimizer_maintainsCorrectness`) and
+degree-safety (`optimizer_respectsDegreeBound`) are nevertheless established here through the
+framework — this is the "prove the trivial optimizer correct" milestone, and the fixed target
+that every real pass added later must preserve.
 
-/-- Any constraint system implies itself: the same satisfying assignment works
-    and its side effects are (reflexively) equal. -/
-theorem ConstraintSystem.implies_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
-    cs.implies cs busSemantics :=
-  fun env hsat => ⟨env, hsat, BusState.equiv_refl _⟩
+**To add an optimization:** write a `VerifiedPass` (or fact-aware `VerifiedPassW`) in a new file
+under `Leanr/OptimizerPasses/`, import it here, and `.andThen` it into `pipeline` below. That is
+the only edit needed here; the correctness proof follows automatically from the pass's own
+`PassCorrect`. -/
 
-/-- Any constraint system admissibly-implies itself: the same admissible assignment works. -/
-theorem ConstraintSystem.impliesAdmissible_refl (cs : ConstraintSystem p)
-    (busSemantics : BusSemantics p) : cs.impliesAdmissible cs busSemantics :=
-  fun env hadm hsat => ⟨env, hsat, hadm, BusState.equiv_refl _⟩
+/-- The optimization pipeline: the sequence of verified passes that make up the optimizer.
+    Trivial for now — the identity pass. Extend it by composing passes with `.andThen`. -/
+def pipeline : VerifiedPassW p := identityPass.withFacts
 
-/-- Any constraint system refines itself (sound + admissible-complete, both reflexively). -/
-theorem ConstraintSystem.refines_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
-    cs.refines cs busSemantics :=
-  ⟨cs.implies_refl busSemantics, cs.impliesAdmissible_refl busSemantics⟩
+theorem pipeline_respectsDeg : RespectsDeg (pipeline (p := p)) :=
+  fun _ _ _ h => h
 
-/-- The identity optimizer maintains correctness: it returns the system unchanged, so it
-    `refines` the input, preserves invariants, and (leaving every expression as-is) never
-    changes any degree — hence trivially respects the degree bound. -/
+/-- The fact-aware circuit optimizer: run the pipeline with proven knowledge about the bus
+    semantics and project out the resulting constraint system. `iters` bounds the number of
+    cleanup cycles once real passes are wired in; the trivial pipeline ignores it. -/
+def optimizerWith (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (_iters : Nat := 32) : ConstraintSystem p :=
+  (pipeline cs bs facts).val
+
+/-- The fact-aware optimizer is correct: its output `refines` its input (sound, and complete for
+    the input's intended executions) and preserves invariants — the same two clauses
+    `optimizerMaintainsCorrectness` demands, stated per instance because nontrivial facts are tied
+    to one semantics. -/
+theorem optimizerWith_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (iters : Nat := 32) :
+    ((optimizerWith cs bs facts iters).refines cs bs) ∧
+      (cs.guaranteesInvariants bs → (optimizerWith cs bs facts iters).guaranteesInvariants bs) :=
+  (pipeline cs bs facts).property
+
+/-- The fact-free circuit optimizer (public signature fixed for the tooling/snapshot). -/
+def optimizer (cs : ConstraintSystem p) (busSemantics : BusSemantics p) : ConstraintSystem p :=
+  optimizerWith cs busSemantics (BusFacts.trivial busSemantics)
+
+/-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
+    bound (every pass is degree-guarded). -/
+theorem optimizerWith_respectsDegree (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (iters : Nat := 32)
+    (h : cs.withinDegree bs.degreeBound) :
+    (optimizerWith cs bs facts iters).withinDegree bs.degreeBound :=
+  pipeline_respectsDeg cs bs facts h
+
+/-- The optimizer respects the zkVM's degree bound. -/
+theorem optimizer_respectsDegreeBound : optimizerRespectsDegreeBound (p := p) optimizer :=
+  fun cs bs h => pipeline_respectsDeg cs bs (BusFacts.trivial bs) h
+
+/-- The optimizer maintains correctness: its output refines the input and preserves invariants
+    (both carried by `pipeline`), and it respects the degree bound. -/
 theorem optimizer_maintainsCorrectness :
-    optimizerMaintainsCorrectness (p := p) identityOptimizer :=
-  ⟨fun cs busSemantics => ⟨cs.refines_refl busSemantics, id⟩,
-   fun _ _ h => h⟩
+    optimizerMaintainsCorrectness (p := p) optimizer :=
+  ⟨fun cs busSemantics => (pipeline cs busSemantics (BusFacts.trivial busSemantics)).property,
+   optimizer_respectsDegreeBound⟩

--- a/Leanr/OptimizerPasses/Basic.lean
+++ b/Leanr/OptimizerPasses/Basic.lean
@@ -1,0 +1,159 @@
+import Leanr.Spec
+
+set_option autoImplicit false
+
+variable {p : ℕ}
+
+/-! # Optimizer scaffolding
+
+The reusable framework for building the circuit optimizer out of small, individually-proven
+optimization *passes*. Nothing here is specific to a particular optimization; concrete passes
+live in `Leanr/OptimizerPasses/`, and the pipeline that assembles them into the public
+`optimizer` lives in `Leanr/Optimizer.lean`.
+
+This module provides:
+
+* the relation glue for the spec's notions (`≈` on `BusState`, `ConstraintSystem.implies`,
+  `ConstraintSystem.impliesAdmissible`, `ConstraintSystem.refines`) — reflexivity and transitivity
+  — which is what lets passes *compose* without re-proving a growing monolith;
+* `PassCorrect`, the per-step correctness obligation;
+* `VerifiedPass`, a pass bundled with its own `PassCorrect` proof (so a pass cannot be written
+  without discharging its obligations), and `VerifiedPass.andThen`/`VerifiedPass.id` to compose
+  and seed pipelines.
+
+These proofs are purely structural; none of them need `p` to be prime. -/
+
+/-! ## Equivalence is an equivalence relation -/
+
+/-- `≈` on `BusState` is reflexive: every message trivially has the same net multiplicity in a
+    state as in itself. -/
+theorem BusState.equiv_refl (s : BusState p) : s ≈ s :=
+  fun _ => rfl
+
+/-- `≈` on `BusState` is symmetric. -/
+theorem BusState.equiv_symm {s t : BusState p} (h : s ≈ t) : t ≈ s :=
+  fun message => (h message).symm
+
+/-- `≈` on `BusState` is transitive. -/
+theorem BusState.equiv_trans {s t u : BusState p} (h1 : s ≈ t) (h2 : t ≈ u) : s ≈ u :=
+  fun message => (h1 message).trans (h2 message)
+
+/-- Any constraint system implies itself: the same satisfying assignment works and its side
+    effects are (reflexively) equal. -/
+theorem ConstraintSystem.implies_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    cs.implies cs busSemantics :=
+  fun env hsat => ⟨env, hsat, BusState.equiv_refl _⟩
+
+/-- `implies` is transitive: chain the witness assignments and the side-effect equalities. -/
+theorem ConstraintSystem.implies_trans {a b c : ConstraintSystem p} {busSemantics : BusSemantics p}
+    (h1 : a.implies b busSemantics) (h2 : b.implies c busSemantics) : a.implies c busSemantics :=
+  fun env hsat =>
+    let ⟨env', hb, hab⟩ := h1 env hsat
+    let ⟨env'', hc, hbc⟩ := h2 env' hb
+    ⟨env'', hc, BusState.equiv_trans hab hbc⟩
+
+/-- Any constraint system admissibly-implies itself: the same admissible assignment works. -/
+theorem ConstraintSystem.impliesAdmissible_refl (cs : ConstraintSystem p)
+    (busSemantics : BusSemantics p) : cs.impliesAdmissible cs busSemantics :=
+  fun env hadm hsat => ⟨env, hsat, hadm, BusState.equiv_refl _⟩
+
+/-- `impliesAdmissible` is transitive: chain the admissible witnesses and the side-effect
+    equalities. The middle witness is admissible (delivered by the first step), so the second
+    step applies. -/
+theorem ConstraintSystem.impliesAdmissible_trans {a b c : ConstraintSystem p}
+    {busSemantics : BusSemantics p} (h1 : a.impliesAdmissible b busSemantics)
+    (h2 : b.impliesAdmissible c busSemantics) : a.impliesAdmissible c busSemantics :=
+  fun env hadm hsat =>
+    let ⟨env', hb, hbadm, hab⟩ := h1 env hadm hsat
+    let ⟨env'', hc, hcadm, hbc⟩ := h2 env' hbadm hb
+    ⟨env'', hc, hcadm, BusState.equiv_trans hab hbc⟩
+
+/-- Any constraint system refines itself. -/
+theorem ConstraintSystem.refines_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    cs.refines cs busSemantics :=
+  ⟨cs.implies_refl busSemantics, cs.impliesAdmissible_refl busSemantics⟩
+
+/-- `refines` is transitive: soundness chains through `implies_trans`, completeness through
+    `impliesAdmissible_trans`. (It is *not* symmetric — see `ConstraintSystem.refines`.) -/
+theorem ConstraintSystem.refines_trans {a b c : ConstraintSystem p} {busSemantics : BusSemantics p}
+    (h1 : a.refines b busSemantics) (h2 : b.refines c busSemantics) :
+    a.refines c busSemantics :=
+  ⟨ConstraintSystem.implies_trans h1.1 h2.1, ConstraintSystem.impliesAdmissible_trans h2.2 h1.2⟩
+
+/-! ## Verified passes
+
+A single optimization step, packaged with its correctness proof. `VerifiedPass` is a function
+that, given a constraint system and bus semantics, returns a new constraint system **together
+with a proof** that it (a) `refines` the input and (b) preserves invariants. Because the
+proof is part of the return value, there is no separate theorem to weaken: a pass simply cannot
+be written down without discharging its obligations.
+
+Passes compose with `VerifiedPass.andThen` (run one, then the next), which threads the two proofs
+through `refines_trans` and the composition of invariant-preservation.
+
+**To add an optimization:** create a `VerifiedPass` for it in a new file under
+`Leanr/OptimizerPasses/`, then `.andThen` it into `pipeline` in `Leanr/Optimizer.lean`. Prove
+`PassCorrect` for your transformation; do not change `Spec.lean` or the glue above. -/
+
+/-- The per-pass correctness obligation: `out` `refines` the input `cs` (sound, and complete for
+    `cs`'s intended executions), and if `cs` guarantees the system's invariants then so does
+    `out`. This is exactly the two-part contract of `optimizerMaintainsCorrectness`, stated for a
+    single step. -/
+def PassCorrect (cs out : ConstraintSystem p) (busSemantics : BusSemantics p) : Prop :=
+  out.refines cs busSemantics ∧
+    (cs.guaranteesInvariants busSemantics → out.guaranteesInvariants busSemantics)
+
+/-- A proof-carrying optimization pass: maps a constraint system to a new one, bundled with a
+    proof that the step is correct (`PassCorrect`). -/
+abbrev VerifiedPass (p : ℕ) :=
+  (cs : ConstraintSystem p) → (busSemantics : BusSemantics p) →
+    { out : ConstraintSystem p // PassCorrect cs out busSemantics }
+
+/-- The identity pass: returns the system unchanged, correct by reflexivity. -/
+def VerifiedPass.id : VerifiedPass p :=
+  fun cs busSemantics => ⟨cs, cs.refines_refl busSemantics, _root_.id⟩
+
+/-- Sequential composition: run `f`, then run `g` on its output. The result is correct by
+    transitivity of `refines` and composition of the invariant-preservation implications. -/
+def VerifiedPass.andThen (f g : VerifiedPass p) : VerifiedPass p :=
+  fun cs busSemantics =>
+    let r1 := f cs busSemantics
+    let r2 := g r1.val busSemantics
+    ⟨r2.val,
+     ConstraintSystem.refines_trans r2.property.1 r1.property.1,
+     fun h => r2.property.2 (r1.property.2 h)⟩
+
+/-- Iterate a pass `n` times. Used to run local, one-step passes (e.g. "substitute one variable")
+    to a fixpoint: each application is a `VerifiedPass`, so the composite is correct by construction.
+    A pass that finds nothing to do returns its input unchanged, so extra iterations are harmless. -/
+def VerifiedPass.iterate (f : VerifiedPass p) : Nat → VerifiedPass p
+  | 0 => VerifiedPass.id
+  | n + 1 => (f.iterate n).andThen f
+
+/-! ## Decidable degree-bound check
+
+`ConstraintSystem.withinDegree` (the spec's degree-bound property) is a `Prop`; the degree-guard
+machinery needs a `Bool` twin to branch on. This is optimizer infrastructure, not part of the
+audited spec, so it lives here rather than in `Spec.lean`. -/
+
+/-- Decidable twin of `ConstraintSystem.withinDegree`. -/
+def ConstraintSystem.withinDegreeB (s : ConstraintSystem p) (b : DegreeBound) : Bool :=
+  s.algebraicConstraints.all (fun c => c.degree ≤ b.identities) &&
+  s.busInteractions.all (fun bi =>
+    decide (bi.multiplicity.degree ≤ b.busInteractions) &&
+      bi.payload.all (fun e => e.degree ≤ b.busInteractions))
+
+theorem ConstraintSystem.withinDegreeB_iff (s : ConstraintSystem p) (b : DegreeBound) :
+    s.withinDegreeB b = true ↔ s.withinDegree b := by
+  unfold ConstraintSystem.withinDegreeB ConstraintSystem.withinDegree
+  rw [Bool.and_eq_true, List.all_eq_true, List.all_eq_true]
+  constructor
+  · rintro ⟨hc, hb⟩
+    refine ⟨fun c hcm => by simpa using hc c hcm, fun bi hbm => ?_⟩
+    have := hb bi hbm
+    rw [Bool.and_eq_true, List.all_eq_true] at this
+    exact ⟨by simpa using this.1, fun e he => by simpa using this.2 e he⟩
+  · rintro ⟨hc, hb⟩
+    refine ⟨fun c hcm => by simpa using hc c hcm, fun bi hbm => ?_⟩
+    rw [Bool.and_eq_true, List.all_eq_true]
+    exact ⟨by simpa using (hb bi hbm).1, fun e he => by simpa using (hb bi hbm).2 e he⟩

--- a/Leanr/OptimizerPasses/FactPass.lean
+++ b/Leanr/OptimizerPasses/FactPass.lean
@@ -1,0 +1,106 @@
+import Leanr.OptimizerPasses.Basic
+import Leanr.BusFacts
+
+set_option autoImplicit false
+
+/-! # Fact-aware verified passes
+
+A `VerifiedPassW` is a `VerifiedPass` that may additionally consult proven `BusFacts` about the
+bus semantics it is given (see `Leanr/BusFacts.lean`). The correctness obligation is unchanged —
+`PassCorrect` against the *semantics* — the facts only widen what a pass can decide, never what
+it may claim: with `BusFacts.trivial` every fact-aware pass degrades to fact-free behavior. -/
+
+variable {p : ℕ}
+
+/-- A proof-carrying pass that may consult proven facts about the bus semantics. -/
+abbrev VerifiedPassW (p : ℕ) :=
+  (cs : ConstraintSystem p) → (bs : BusSemantics p) → (facts : BusFacts p bs) →
+    { out : ConstraintSystem p // PassCorrect cs out bs }
+
+/-- Any fact-free pass is a fact-aware pass that ignores the facts. -/
+def VerifiedPass.withFacts (f : VerifiedPass p) : VerifiedPassW p :=
+  fun cs bs _ => f cs bs
+
+/-- Sequential composition (same proof shape as `VerifiedPass.andThen`). -/
+def VerifiedPassW.andThen (f g : VerifiedPassW p) : VerifiedPassW p :=
+  fun cs bs facts =>
+    let r1 := f cs bs facts
+    let r2 := g r1.val bs facts
+    ⟨r2.val,
+     ConstraintSystem.refines_trans r2.property.1 r1.property.1,
+     fun h => r2.property.2 (r1.property.2 h)⟩
+
+/-- Iterate a fact-aware pass `n` times. -/
+def VerifiedPassW.iterate (f : VerifiedPassW p) : Nat → VerifiedPassW p
+  | 0 => fun cs bs _ => ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | n + 1 => (f.iterate n).andThen f
+
+deriving instance DecidableEq for Expression
+deriving instance DecidableEq for BusInteraction
+deriving instance DecidableEq for ConstraintSystem
+
+/-- Iterate a fact-aware pass at most `n` times, stopping as soon as a whole application is a
+    (structural) no-op — from then on every further application would be too, so the result is
+    the same as `iterate n`'s but without paying for the remaining cycles. Makes a generous
+    iteration budget free for inputs that converge early. -/
+def VerifiedPassW.iterateStable (f : VerifiedPassW p) : Nat → VerifiedPassW p
+  | 0 => fun cs bs _ => ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | n + 1 => fun cs bs facts =>
+      let r := f cs bs facts
+      if r.val = cs then r
+      else
+        let r2 := (f.iterateStable n) r.val bs facts
+        ⟨r2.val,
+         ConstraintSystem.refines_trans r2.property.1 r.property.1,
+         fun h => r2.property.2 (r.property.2 h)⟩
+
+/-! ## Degree guarding
+
+`optimizerRespectsDegreeBound` is enforced compositionally with **zero** per-pass proof burden:
+every pass is wrapped in a checked guard that falls back to its (unchanged) input if the
+output would exceed the semantics' degree bound. `RespectsDeg` then propagates through
+composition and iteration. -/
+
+/-- A pass never pushes a within-bound system past the semantics' degree bound. -/
+def RespectsDeg (f : VerifiedPassW p) : Prop :=
+  ∀ (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs),
+    cs.withinDegree bs.degreeBound → (f cs bs facts).val.withinDegree bs.degreeBound
+
+/-- Wrap a pass with a degree guard: if the output would exceed the bound, keep the input. -/
+def VerifiedPassW.guardDegree (f : VerifiedPassW p) : VerifiedPassW p :=
+  fun cs bs facts =>
+    let r := f cs bs facts
+    if r.val.withinDegreeB bs.degreeBound then r
+    else ⟨cs, cs.refines_refl bs, _root_.id⟩
+
+theorem VerifiedPassW.guardDegree_respectsDeg (f : VerifiedPassW p) :
+    RespectsDeg f.guardDegree := by
+  intro cs bs facts h
+  by_cases hok : (f cs bs facts).val.withinDegreeB bs.degreeBound = true
+  · simp only [VerifiedPassW.guardDegree, hok, if_true]
+    exact (ConstraintSystem.withinDegreeB_iff _ _).1 hok
+  · simp only [VerifiedPassW.guardDegree, hok]
+    exact h
+
+theorem VerifiedPassW.andThen_respectsDeg {f g : VerifiedPassW p}
+    (hf : RespectsDeg f) (hg : RespectsDeg g) : RespectsDeg (f.andThen g) := by
+  intro cs bs facts h
+  exact hg _ bs facts (hf cs bs facts h)
+
+theorem VerifiedPassW.iterate_respectsDeg {f : VerifiedPassW p} (hf : RespectsDeg f) :
+    ∀ n, RespectsDeg (f.iterate n)
+  | 0 => fun _ _ _ h => h
+  | n + 1 => VerifiedPassW.andThen_respectsDeg (iterate_respectsDeg hf n) hf
+
+theorem VerifiedPassW.iterateStable_respectsDeg {f : VerifiedPassW p} (hf : RespectsDeg f) :
+    ∀ n, RespectsDeg (f.iterateStable n) := by
+  intro n
+  induction n with
+  | zero => exact fun _ _ _ h => h
+  | succ n ih =>
+    intro cs bs facts h
+    by_cases heq : (f cs bs facts).val = cs
+    · simp only [VerifiedPassW.iterateStable, heq, if_true]
+      exact h
+    · simp only [VerifiedPassW.iterateStable, heq, if_false]
+      exact ih _ bs facts (hf cs bs facts h)

--- a/Leanr/OptimizerPasses/Identity.lean
+++ b/Leanr/OptimizerPasses/Identity.lean
@@ -1,0 +1,16 @@
+import Leanr.OptimizerPasses.Basic
+
+set_option autoImplicit false
+
+variable {p : ℕ}
+
+/-! # The identity pass
+
+The trivial optimization pass: it returns the constraint system unchanged. It exists as the
+template for real passes and as the seed of the pipeline while no optimization is implemented
+yet. A real pass looks just like this — a `VerifiedPass p` — but transforms the system and
+proves the transformation `PassCorrect` instead of leaning on `VerifiedPass.id`. -/
+
+/-- The identity optimization pass. -/
+def identityPass : VerifiedPass p :=
+  VerifiedPass.id


### PR DESCRIPTION
First of 4 stacked PRs splitting the autoopt branch (#25). Lands the **trust boundary** — the pass framework — with the optimizer still trivial (identity).

**Review concentrates here** (everything is machine-checked; no `sorry`/`axiom`/`native_decide`):
- `OptimizerPasses/Basic.lean` — `PassCorrect` + `VerifiedPass`: a pass carries its own correctness proof as its return value, so it cannot be written without discharging the obligation.
- `OptimizerPasses/FactPass.lean` — the fact-aware twin `VerifiedPassW`, composition, and the degree guard.
- `Optimizer.lean` — the two headline theorems `optimizer_maintainsCorrectness` / `optimizer_respectsDegreeBound`. Their **statements** are the fixed public contract; the later PRs only fill in `pipeline` and never change them.
- `BusFacts.lean` — the proof-carrying knowledge channel.

`pipeline := identityPass.withFacts` for now — the "trivial optimizer proven correct" milestone. `lake build` green.
