### PR TITLE
JSON parser (Spec types) + benchmark CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .lake
+.vscode/

--- a/Leanr/JsonParser.lean
+++ b/Leanr/JsonParser.lean
@@ -1,32 +1,52 @@
 import Lean.Data.Json
-import Leanr.Legacy.Solver
-import Leanr.Legacy.Expression
+import Leanr.Spec
+import Leanr.OpenVM.Semantics
 
--- `JsonParser` is intentionally kept out of the `Legacy` namespace: the JSON
--- parsing logic is expected to stay useful. It still targets the legacy
--- `System`/`Expression` types via `open Legacy` for now.
-open Legacy
+/-!
+# JSON parser for powdr `SymbolicMachine` exports
 
-variable {p : ℕ} [Fact (Nat.Prime p)]
+Parses the `ApcWithBusMap` JSON that powdr's APC export writes (see
+`autoprecompiles/src/export.rs` in powdr): the `machine` key holds constraints (expression
+trees, asserted zero) and bus interactions (`{id, mult, args}`), the `bus_map.bus_ids` key
+maps bus ids to bus types. Adapted from the `main`-branch parser to target the `Spec.lean`
+types (`ConstraintSystem`, `Nat` bus ids) and the structured `OpenVmBusType`.
 
-private def parseBusType (j : Lean.Json) : Except String BusType :=
+Parsing needs no primality: everything lands in `ZMod p` verbatim.
+-/
+
+set_option autoImplicit false
+
+open Leanr.OpenVM (OpenVmBusType BusMapList)
+
+variable {p : ℕ}
+
+private def parseBusType (j : Lean.Json) : Except String OpenVmBusType :=
   match j with
   | Lean.Json.str "ExecutionBridge" => .ok .executionBridge
   | Lean.Json.str "Memory" => .ok .memory
   | Lean.Json.str "PcLookup" => .ok .pcLookup
-  | Lean.Json.str s => .ok (.other s)
   | Lean.Json.obj obj =>
     match obj.toList.head? with
-    | some ("Other", Lean.Json.str name) => .ok (.other name)
+    | some ("Other", Lean.Json.str "VariableRangeChecker") => .ok .variableRangeChecker
+    | some ("Other", Lean.Json.str "BitwiseLookup") => .ok .bitwiseLookup
     | some ("Other", Lean.Json.obj inner) =>
       match inner.toList.head? with
-      | some (name, val) => .ok (.other s!"{name}:{val}")
+      | some ("TupleRangeChecker", Lean.Json.arr sizes) =>
+        if h : sizes.size = 2 then do
+          let s1 ← sizes[0].getNat?
+          let s2 ← sizes[1].getNat?
+          .ok (.tupleRangeChecker s1 s2)
+        else .error s!"TupleRangeChecker expects 2 sizes, got {sizes.size}"
+      | some (name, _) => .error s!"unknown bus type: Other.{name}"
       | none => .error "empty Other object in bus_map"
-    | some (k, _) => .ok (.other k)
+    -- An unknown bus type would be modeled as a no-op bus (never stateful, never
+    -- violating), silently licensing unsound drops — so fail loudly instead.
+    | some ("Other", Lean.Json.str name) => .error s!"unknown bus type: Other.{name}"
+    | some (k, _) => .error s!"unknown bus type: {k}"
     | none => .error "empty object in bus_map"
   | _ => .error s!"unexpected bus type: {j}"
 
-private def parseBusMap (j : Lean.Json) : Except String BusMap := do
+private def parseBusMap (j : Lean.Json) : Except String BusMapList := do
   let obj ← j.getObjVal? "bus_ids"
   let entries ← match obj with
     | Lean.Json.obj kvs => pure kvs.toList
@@ -42,6 +62,7 @@ private def parseBusMap (j : Lean.Json) : Except String BusMap := do
 partial def parseJsonExpr (j : Lean.Json) : Except String (Expression p) :=
   match j with
   | Lean.Json.num n =>
+    -- All constants in powdr exports are integers (exponent 0).
     let z := n.mantissa * (10 ^ n.exponent)
     .ok (.const (z : ZMod p))
   | Lean.Json.str s => .ok (.var s)
@@ -80,9 +101,10 @@ partial def parseJsonExpr (j : Lean.Json) : Except String (Expression p) :=
 private def parseConstraint (j : Lean.Json) : Except String (Expression p) :=
   parseJsonExpr j
 
-private def parseBusInteraction (j : Lean.Json) : Except String (BusInteraction (Expression p)) := do
+private def parseBusInteraction (j : Lean.Json) :
+    Except String (BusInteraction (Expression p)) := do
   let id ← j.getObjVal? "id"
-  let busId ← parseJsonExpr (p := p) id
+  let busId ← id.getNat?
   let mult ← j.getObjVal? "mult"
   let multiplicity ← parseJsonExpr mult
   let argsJson ← j.getObjVal? "args"
@@ -93,11 +115,12 @@ private def parseBusInteraction (j : Lean.Json) : Except String (BusInteraction 
   pure {
     busId := busId,
     multiplicity := multiplicity,
-    payload := payload.toArray
+    payload := payload
   }
 
-/-- Parse a JSON string into a `System` and `BusMap`, starting at the `machine` key. -/
-def parseJsonSystem (jsonStr : String) : Except String (System p × BusMap) := do
+/-- Parse a JSON string into a `ConstraintSystem` and `BusMap`, starting at the `machine`
+    key. Constraints are assert-zero expressions. -/
+def parseJsonSystem (jsonStr : String) : Except String (ConstraintSystem p × BusMapList) := do
   let json ← Lean.Json.parse jsonStr
   let machine ← json.getObjVal? "machine"
 
@@ -106,9 +129,8 @@ def parseJsonSystem (jsonStr : String) : Except String (System p × BusMap) := d
   let constraintArr ← match constraintsJson with
     | Lean.Json.arr a => pure a
     | _ => .error "constraints is not an array"
-  let constraints : List (AlgebraicConstraint p) ←
-    constraintArr.toList.mapM fun c =>
-      (parseConstraint (p := p) c).map AlgebraicConstraint.assertZero
+  let constraints : List (Expression p) ←
+    constraintArr.toList.mapM fun c => parseConstraint (p := p) c
 
   -- Parse bus interactions
   let busJson ← machine.getObjVal? "bus_interactions"
@@ -122,16 +144,11 @@ def parseJsonSystem (jsonStr : String) : Except String (System p × BusMap) := d
   let busMapJson ← json.getObjVal? "bus_map"
   let busMap ← parseBusMap busMapJson
 
-  let system : System p := {
-    constraints := constraints.toArray,
-    bus_interactions := busInteractions.toArray,
-    assignments := #[]
+  let system : ConstraintSystem p := {
+    algebraicConstraints := constraints,
+    busInteractions := busInteractions
   }
   pure (system, busMap)
-
--- BabyBear prime
-instance instFactPrimeBabyBear : Fact (Nat.Prime 2013265921) where
-  out := by native_decide
 
 /-- info: Parsed 9168 constraints, 3117 bus interactions, 6 bus types -/
 #guard_msgs in
@@ -139,6 +156,6 @@ instance instFactPrimeBabyBear : Fact (Nat.Prime 2013265921) where
   let contents ← IO.FS.readFile "apc_reth_op_bug.json"
   match parseJsonSystem (p := 2013265921) contents with
   | .ok (system, busMap) =>
-    IO.println s!"Parsed {system.constraints.size} constraints, {system.bus_interactions.size} bus interactions, {busMap.length} bus types"
+    IO.println s!"Parsed {system.algebraicConstraints.length} constraints, {system.busInteractions.length} bus interactions, {busMap.length} bus types"
   | .error e =>
     IO.println s!"Error: {e}"

--- a/Main.lean
+++ b/Main.lean
@@ -1,45 +1,183 @@
-import Leanr
-import Leanr.Legacy.StringParser
 import Leanr.JsonParser
-import Leanr.Legacy.Solver
+import Leanr.Optimizer
+import Leanr.Utils.Size
+import Leanr.Utils.Dsl
+import Leanr.OpenVM.Facts
 
-open Legacy
+/-!
+# The leanr CLI
 
-def main (args: List String) : IO Unit := do
-  let p := 0x1dffff
-  match args with
-  | [] =>
-    let stdin ← IO.getStdin
-    let input ← stdin.readToEnd
-    match parseSystem (p := p) input with
-    | .error err => IO.eprintln s!"Error: {err}"; IO.Process.exit 1
-    | .ok system =>
-      let result ← solve system (log := true)
-      IO.println s!"{result}"
-  | (fileName :: _) =>
-    if fileName.endsWith ".json.gz" then
-      let result ← IO.Process.output { cmd := "gunzip", args := #["-c", fileName] }
-      if result.exitCode ≠ 0 then
-        IO.eprintln s!"Error: gunzip failed: {result.stderr}"
-        IO.Process.exit 1
-      match parseJsonSystem (p := p) result.stdout with
-      | .error err => IO.eprintln s!"Error: {err}"; IO.Process.exit 1
-      | .ok (system, busMap) =>
-        IO.println s!"{busMap}"
-        let result ← solve system (log := true)
-        IO.println s!"{result}"
-    else if fileName.endsWith ".json" then
-      let input ← IO.FS.readFile fileName
-      match parseJsonSystem (p := p) input with
-      | .error err => IO.eprintln s!"Error: {err}"; IO.Process.exit 1
-      | .ok (system, busMap) =>
-        IO.println s!"{busMap}"
-        let result ← solve system (log := true)
-        IO.println s!"{result}"
-    else
-      let input ← IO.FS.readFile fileName
-      match parseSystem (p := p) input with
-      | .error err => IO.eprintln s!"Error: {err}"; IO.Process.exit 1
-      | .ok system =>
-        let result ← solve system (log := true)
-        IO.println s!"{result}"
+Benchmark harness for the optimizer on powdr `SymbolicMachine` exports
+(`OpenVm/Benchmark/*.json.gz`, or any file in the same format — see `Leanr/JsonParser.lean`):
+
+- `leanr run [--iters N] <file.json[.gz]>` — parse, run the leanr optimizer with the file's
+  own bus map, report sizes and effectiveness.
+- `leanr powdr <unopt.json[.gz]> <opt.json[.gz]>` — report powdr's effectiveness from its
+  serialized optimizer output (no leanr optimizer run).
+- `leanr compare [--iters N] <unopt.json[.gz]> <opt.json[.gz]>` — both, side by side.
+-/
+
+open Leanr.OpenVM
+
+/-- Read a benchmark file: `.json.gz` via `gunzip -c` (like the powdr test fixtures),
+    `.json` directly. -/
+def readInput (fileName : String) : IO String := do
+  if fileName.endsWith ".json.gz" then
+    let result ← IO.Process.output { cmd := "gunzip", args := #["-c", fileName] }
+    if result.exitCode ≠ 0 then
+      IO.eprintln s!"Error: gunzip failed: {result.stderr}"
+      IO.Process.exit 1
+    pure result.stdout
+  else if fileName.endsWith ".json" then
+    IO.FS.readFile fileName
+  else
+    IO.eprintln s!"Error: expected a .json or .json.gz file, got {fileName}"
+    IO.Process.exit 1
+
+/-- Parse a benchmark file into a constraint system over BabyBear plus its bus map.
+    Rejects systems with bus ids missing from the map: an unmapped bus would be modeled as a
+    no-op bus (stateless, never violating), silently licensing unsound optimizations. -/
+def parseFile (fileName : String) : IO (ConstraintSystem babyBear × BusMapList) := do
+  let contents ← readInput fileName
+  match parseJsonSystem (p := babyBear) contents with
+  | .error err =>
+    IO.eprintln s!"Error parsing {fileName}: {err}"
+    IO.Process.exit 1
+  | .ok (system, busMap) =>
+    let unmapped :=
+      ((system.busInteractions.map (·.busId)).eraseDups).filter
+        (fun busId => (busMap.toBusMap busId).isNone)
+    unless unmapped.isEmpty do
+      IO.eprintln s!"Error: {fileName} uses bus ids {unmapped} that are not in its bus_map"
+      IO.Process.exit 1
+    pure (system, busMap)
+
+/-- Size measures of a constraint system, as reported by the CLI. -/
+structure Stats where
+  vars : Nat
+  constraints : Nat
+  busInteractions : Nat
+
+/-- Same count as `ConstraintSystem.size` (distinct variables), but via a hash set —
+    `List.dedup` is quadratic and benchmark machines have ~10⁵ variable occurrences. -/
+def distinctVarCount (cs : ConstraintSystem babyBear) : Nat :=
+  let occurrences := cs.algebraicConstraints.flatMap Expression.vars ++
+    cs.busInteractions.flatMap BusInteraction.vars
+  (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).size
+
+def statsOf (cs : ConstraintSystem babyBear) : Stats :=
+  { vars := distinctVarCount cs,
+    constraints := cs.algebraicConstraints.length,
+    busInteractions := cs.busInteractions.length }
+
+def printStats (label : String) (stats : Stats) : IO Unit :=
+  IO.println s!"  {label}: {stats.vars} vars, {stats.constraints} constraints, \
+    {stats.busInteractions} bus interactions"
+
+/-- Effectiveness = vars before / vars after (the `Leanr/Utils/Size.lean` metric), as an exact
+    rational and a decimal approximation. -/
+def printEffectiveness (label : String) (before after : Stats) : IO Unit := do
+  let eff : ℚ := (before.vars : ℚ) / (after.vars : ℚ)
+  IO.println s!"{label} effectiveness (vars before / after): \
+    {eff} ≈ {before.vars.toFloat / after.vars.toFloat}"
+
+def cmdRun (fileName : String) (iters : Nat) : IO Unit := do
+  let (cs, busMap) ← parseFile fileName
+  IO.println s!"Parsed {cs.algebraicConstraints.length} constraints, \
+    {cs.busInteractions.length} bus interactions, {busMap.length} bus types"
+  let before := statsOf cs
+  let t0 ← IO.monoMsNow
+  -- IO.lazyPure sequences the pure optimizer run between the clock reads (the compiler is
+  -- free to float a plain `let` across IO actions, which breaks the measurement).
+  let optimized ← IO.lazyPure (fun _ => optimizerWith (cs := cs)
+    (bs := openVmBusSemantics babyBear busMap.toBusMap)
+    (facts := openVmFacts babyBear busMap.toBusMap)
+    (iters := iters))
+  let after ← IO.lazyPure (fun _ => statsOf optimized)
+  let t1 ← IO.monoMsNow
+  printStats (label := "before") (stats := before)
+  printStats (label := "leanr ") (stats := after)
+  printEffectiveness (label := "leanr") (before := before) (after := after)
+  let bound := (openVmBusSemantics babyBear busMap.toBusMap).degreeBound
+  IO.println s!"  degree bound (identities {bound.identities}, bus {bound.busInteractions}): \
+    input {if cs.withinDegreeB bound then "ok" else "EXCEEDED"}, \
+    output {if optimized.withinDegreeB bound then "ok" else "EXCEEDED"}"
+  IO.println s!"  ({iters} iters, {t1 - t0} ms)"
+
+/-- Like `cmdRun`, but also dump the distinct variables remaining after optimization (for
+    diagnosing which variable classes the optimizer misses). -/
+def cmdVars (fileName : String) (iters : Nat) : IO Unit := do
+  let (cs, busMap) ← parseFile fileName
+  let optimized ← IO.lazyPure (fun _ => optimizerWith (cs := cs)
+    (bs := openVmBusSemantics babyBear busMap.toBusMap)
+    (facts := openVmFacts babyBear busMap.toBusMap)
+    (iters := iters))
+  let occurrences := optimized.algebraicConstraints.flatMap Expression.vars ++
+    optimized.busInteractions.flatMap BusInteraction.vars
+  let distinct := (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList
+  for v in distinct.mergeSort (· ≤ ·) do
+    IO.println v
+
+/-- Render the optimized system (for diagnosing residual constraints/interactions). -/
+def cmdRender (fileName : String) (iters : Nat) : IO Unit := do
+  let (cs, busMap) ← parseFile fileName
+  let optimized ← IO.lazyPure (fun _ => optimizerWith (cs := cs)
+    (bs := openVmBusSemantics babyBear busMap.toBusMap)
+    (facts := openVmFacts babyBear busMap.toBusMap)
+    (iters := iters))
+  IO.println (Leanr.Spec.Dsl.render optimized)
+
+def cmdPowdr (unoptFile : String) (optFile : String) : IO Unit := do
+  let (csBefore, _) ← parseFile unoptFile
+  let (csAfter, _) ← parseFile optFile
+  let before := statsOf csBefore
+  let after := statsOf csAfter
+  printStats (label := "before") (stats := before)
+  printStats (label := "powdr ") (stats := after)
+  printEffectiveness (label := "powdr") (before := before) (after := after)
+
+def cmdCompare (unoptFile : String) (optFile : String) (iters : Nat) : IO Unit := do
+  cmdRun (fileName := unoptFile) (iters := iters)
+  let (csBefore, _) ← parseFile unoptFile
+  let (csAfter, _) ← parseFile optFile
+  printStats (label := "powdr ") (stats := statsOf csAfter)
+  printEffectiveness (label := "powdr") (before := statsOf csBefore) (after := statsOf csAfter)
+
+def usage : String :=
+  "usage: leanr run [--iters N] <file.json[.gz]>\n" ++
+  "       leanr powdr <unopt.json[.gz]> <opt.json[.gz]>\n" ++
+  "       leanr compare [--iters N] <unopt.json[.gz]> <opt.json[.gz]>\n\n" ++
+  "Files are powdr SymbolicMachine exports (ApcWithBusMap), e.g. OpenVm/Benchmark/*.json.gz.\n" ++
+  "--iters bounds the optimizer's cleanup cycles (default 32)."
+
+/-- Extract a `--iters N` flag (anywhere in the argument list). -/
+def splitIters : List String → Except String (Option Nat × List String)
+  | [] => .ok (none, [])
+  | "--iters" :: [] => .error "--iters expects a number"
+  | "--iters" :: n :: rest =>
+    match n.toNat? with
+    | some k => do
+      let (_, others) ← splitIters rest
+      .ok (some k, others)
+    | none => .error s!"--iters expects a number, got {n}"
+  | arg :: rest => do
+    let (k, others) ← splitIters rest
+    .ok (k, arg :: others)
+
+def main (args : List String) : IO Unit := do
+  match splitIters args with
+  | .error err =>
+    IO.eprintln s!"Error: {err}"
+    IO.Process.exit 1
+  | .ok (itersOpt, positional) =>
+    let iters := itersOpt.getD 32
+    match positional with
+    | ["run", fileName] => cmdRun (fileName := fileName) (iters := iters)
+    | ["vars", fileName] => cmdVars (fileName := fileName) (iters := iters)
+    | ["render", fileName] => cmdRender (fileName := fileName) (iters := iters)
+    | ["powdr", unoptFile, optFile] => cmdPowdr (unoptFile := unoptFile) (optFile := optFile)
+    | ["compare", unoptFile, optFile] =>
+      cmdCompare (unoptFile := unoptFile) (optFile := optFile) (iters := iters)
+    | _ =>
+      IO.eprintln usage
+      IO.Process.exit 1

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ Leanr is designed to have a small auditing surface. To audit Leanr, it should be
 2. [`Leanr/OpenVM/Semantics.lean`](./Leanr/OpenVM/Semantics.lean): The OpenVM-specific semantics. These are needed for our OpenVM-specific optimizations. If you are instead interested in a different VM, you can skip this file, but must provide semantics for your VM in order to use Leanr.
 3. [`Leanr/MemoryBus.lean`](./Leanr/MemoryBus.lean): Utility used in the OpenVM semantics above (and likely useful for other VMs as well).
 4. The `optimizer_maintainsCorrectness` theorem in [`Leanr/Optimizer.lean`](./Leanr/Optimizer.lean): Audit the statement and check that the proof is correct by running `lake build`.
+
+## Usage
+
+The `leanr` executable runs the optimizer on powdr `SymbolicMachine` exports (`ApcWithBusMap` JSON, plain or gzipped) and reports effectiveness — distinct variables before / after (see [`Leanr/Utils/Size.lean`](./Leanr/Utils/Size.lean)):
+
+```bash
+lake build
+
+# Optimize one case and report effectiveness
+lake exe leanr run [--iters N] Leanr/OpenVM/Benchmark/apc_001_pc3647036.json.gz
+
+# powdr's own effectiveness, from its serialized optimizer output
+lake exe leanr powdr <unopt>.json.gz <unopt>.powdr_opt.json.gz
+
+# Both, side by side
+lake exe leanr compare [--iters N] <unopt>.json.gz <unopt>.powdr_opt.json.gz
+```
+
+`--iters` bounds the optimizer's cleanup cycles (default 32); large machines need more to converge. The top-100 openvm-eth benchmark set lives in `Leanr/OpenVM/Benchmark/` — `apc_<rank>_pc<pc>.json.gz` inputs paired with `.powdr_opt.json.gz` powdr outputs; iterate over it with a shell loop.

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "leanr"
 version = "0.1.0"
-defaultTargets = ["leanr"]
+defaultTargets = ["Leanr", "leanr"]
 
 [[require]]
 name = "mathlib"


### PR DESCRIPTION
Stacked on #27 (base `pr2-optimizer-passes`).

Retargets `JsonParser` from the Legacy types to the Spec `ConstraintSystem`, and hard-errors on unknown bus types (an unmapped bus would otherwise be modeled as an unsound no-op). Rewrites `Main` into the benchmark CLI (`run` / `vars` / `render` / `powdr` / `compare`): parse an export, run `optimizerWith` with the file's own bus map + facts, and report vars/constraints/bus-interactions before/after plus effectiveness.

`lakefile` builds the whole library by default; `README` documents the CLI.

`lake build` green (parser regression: 9168 constraints / 3117 bus interactions / 6 bus types).
