### PR TITLE
Semantics: variable range checker rejects lookups over 25 bits

### DIFF
--- a/Leanr/OpenVM/Facts.lean
+++ b/Leanr/OpenVM/Facts.lean
@@ -27,7 +27,7 @@ private def slotBoundImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat)
   | some .bitwiseLookup, [_, _, _, some op], 0 => if op.val ≤ 1 then some 256 else none
   | some .bitwiseLookup, [_, _, _, some op], 1 => if op.val ≤ 1 then some 256 else none
   | some .variableRangeChecker, [_, some bits], 0 =>
-      if bits.val ≤ 30 then some (2 ^ bits.val) else none
+      if bits.val ≤ 25 then some (2 ^ bits.val) else none
   | some (.tupleRangeChecker s1 _), [_, _], 0 => some s1
   | some (.tupleRangeChecker _ s2), [_, _], 1 => some s2
   | _, _, _ => none
@@ -137,7 +137,8 @@ def openVmFacts (p : ℕ) [NeZero p]
       subst hx hb
       unfold violates at hok'
       rw [hbus, hpay] at hok'
-      simpa using hok'
+      rw [Bool.not_eq_false', Bool.and_eq_true] at hok'
+      exact of_decide_eq_true hok'.2
     · -- tuple range checker, slot 0
       rename_i s1 s2 q0 q1 hbus
       simp only [Option.some.injEq] at hfact

--- a/Leanr/OpenVM/Semantics.lean
+++ b/Leanr/OpenVM/Semantics.lean
@@ -88,8 +88,9 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
     | _ => true
 
   | some .variableRangeChecker, [x, bits] =>
-    -- Check that x < 2^bits.
-    !decide (x.val < 2 ^ bits.val)
+    -- Check that x < 2^bits, and that the number of bits requested is one the checker
+    -- supports: OpenVM's variable range checker rejects any lookup of more than 25 bits.
+    !(decide (bits.val ≤ 25) && decide (x.val < 2 ^ bits.val))
 
   | some (.tupleRangeChecker s1 s2), [x, y] =>
     -- Range check that x < s1 and y < s2.


### PR DESCRIPTION
OpenVM's variable range checker only supports up to 25 bits, so a lookup requesting more has no table entry and must be modeled as a violation.

Previously `violates` for `variableRangeChecker` checked only `x.val < 2^bits.val`, accepting arbitrarily large `bits` (and accepting *everything* once `2^bits` exceeds the field). This makes the audited semantics unfaithful at the high end.

- `Semantics.lean`: add `bits.val ≤ 25` to the accept condition.
- `Facts.lean`: cap `slotBound` at the same 25-bit range; adjust the one proof step that now extracts the value bound from a two-conjunct condition.

`lake build` green; `optimizer_maintainsCorrectness` still depends only on `[propext, Classical.choice, Quot.sound]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)