### PR TITLE
CI: fail on sorry / new axioms

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: leanprover/lean-action@v1
+      - name: Proof integrity (no sorry / new axioms)
+        run: ./Scripts/check-proof-integrity.sh

--- a/Scripts/CheckAxioms.lean
+++ b/Scripts/CheckAxioms.lean
@@ -1,0 +1,9 @@
+import Leanr.Optimizer
+
+/-! CI helper: print the axiom dependencies of the top-level correctness theorems.
+    `Scripts/check-proof-integrity.sh` asserts the output mentions no forbidden axiom
+    (`sorryAx`, `native_decide`'s `ofReduceBool`, …) — i.e. the proofs are fully checked
+    and rest only on Lean's three standard axioms. -/
+
+#print axioms optimizer_maintainsCorrectness
+#print axioms optimizer_respectsDegreeBound

--- a/Scripts/check-proof-integrity.sh
+++ b/Scripts/check-proof-integrity.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fails if the optimizer's correctness proof is not fully machine-checked:
+#   1. no `sorry` / `admit` / `native_decide` / `axiom` in the Lean sources, and
+#   2. the top-level correctness theorems depend only on Lean's three standard axioms.
+# Run from the repo root (CI runs it after `lake build`).
+set -euo pipefail
+
+echo "==> Checking sources for forbidden tactics/axioms"
+if grep -rnE '\b(sorry|admit|native_decide)\b|^[[:space:]]*axiom[[:space:]]' \
+     Leanr Main.lean Leanr.lean; then
+  echo "ERROR: found sorry/admit/native_decide/axiom above." >&2
+  exit 1
+fi
+
+echo "==> Checking axiom dependencies of the correctness theorems"
+out=$(lake env lean Scripts/CheckAxioms.lean 2>&1)
+echo "$out"
+if echo "$out" | grep -qE 'sorryAx|ofReduceBool|trustCompiler'; then
+  echo "ERROR: a correctness theorem depends on a forbidden axiom." >&2
+  exit 1
+fi
+
+echo "OK: proof integrity checks passed."


### PR DESCRIPTION
`lake build` exits 0 on a `sorry` (it is only a warning), so today CI would green-light an unproven optimizer. Since the whole guarantee rests on the proof being fully checked, add an explicit gate.

New `Scripts/check-proof-integrity.sh` (run after `lake build` in CI, also runnable locally):
1. greps the Lean sources for `sorry` / `admit` / `native_decide` / `axiom`;
2. runs `Scripts/CheckAxioms.lean` and fails if `optimizer_maintainsCorrectness` / `optimizer_respectsDegreeBound` depend on any forbidden axiom (`sorryAx`, `ofReduceBool`, …).

Verified locally: passes on `main`, and fails (exit 1) when a `sorry` is injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)