### PR TITLE
Tidy the library root into a complete index

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -1,8 +1,4 @@
--- Root of the `Leanr` library: importing it builds the whole public surface.
--- `Leanr.Optimizer` transitively pulls in the framework and every pipelined pass;
--- the rest are the OpenVM instantiation, the powdr-export parser, and the CLI utilities.
--- A pass intentionally not (yet) in the pipeline should be imported here too, so
--- `lake build` still checks it.
+-- Root of the `Leanr` library.
 import Leanr.Optimizer
 import Leanr.OpenVM.Facts
 import Leanr.JsonParser

--- a/Leanr.lean
+++ b/Leanr.lean
@@ -1,16 +1,10 @@
--- This module serves as the root of the `Leanr` library.
--- Import modules here that should be built as part of the library.
-import Leanr.Spec
-import Leanr.MemoryBus
+-- Root of the `Leanr` library: importing it builds the whole public surface.
+-- `Leanr.Optimizer` transitively pulls in the framework and every pipelined pass;
+-- the rest are the OpenVM instantiation, the powdr-export parser, and the CLI utilities.
+-- A pass intentionally not (yet) in the pipeline should be imported here too, so
+-- `lake build` still checks it.
+import Leanr.Optimizer
+import Leanr.OpenVM.Facts
+import Leanr.JsonParser
 import Leanr.Utils.Dsl
 import Leanr.Utils.Size
-import Leanr.OptimizerPasses.Subst
-import Leanr.OptimizerPasses.Rewrite
-import Leanr.OptimizerPasses.ConstantFold
-import Leanr.OptimizerPasses.TrivialConstraint
-import Leanr.OptimizerPasses.ZeroMultBus
-import Leanr.OptimizerPasses.Affine
-import Leanr.OptimizerPasses.Normalize
-import Leanr.Optimizer
-import Leanr.OpenVM.Semantics
-import Leanr.JsonParser


### PR DESCRIPTION
`Leanr.lean` imported some passes individually while omitting others (and `OpenVM.Facts`), relying on transitive imports — an inconsistent index.

Replace with the module roots that cover the whole tree:
- `Leanr.Optimizer` — framework + every pipelined pass (+ Spec, MemoryBus, BusFacts),
- `Leanr.OpenVM.Facts` — OpenVM semantics + proven facts,
- `Leanr.JsonParser`, `Leanr.Utils.{Dsl,Size}`.

Now `import Leanr` gives the full public surface. The comment documents the convention that a not-yet-pipelined pass should still be imported here so `lake build` checks it. Build unchanged (2368 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)