### PR TITLE
docs: correct CLAUDE.md equivalence wording; note on log entry 41

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,10 @@ Over a finite field, a circuit has **algebraic constraints** (expressions that m
 zero) and **bus interactions** (tuples sent to a global bus with a multiplicity; globally the bus
 must balance). Buses are either **stateless lookups** (range/table checks — a chip sends with
 multiplicity 0/1 and a table chip receives) or **stateful** (memory, execution bridge — they carry
-state such as timestamp/PC). Two circuits are **equivalent** when each implies the other's
-satisfiability *and* they have the same effect on stateful buses; an optimization must preserve
-this.
+state such as timestamp/PC). An optimization must **refine** the circuit: *sound* — every
+satisfying assignment of the output maps to one of the input with the same effect on stateful
+buses — and *complete for real traces* — every intended (real-trace) satisfying assignment of the
+input is reproduced by the output. The precise relation is `refines` in `Leanr/Spec.lean`.
 
 ## Layout
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -955,6 +955,10 @@ attributable to powdr passes we don't have (`autoprecompiles/src/optimizer.rs`):
    statically sound**. powdr's headline number includes some of these; we deliberately don't (this
    is the honest-vs-optimistic gap, a spec decision, out of scope).
 
+> *Note (added later): the claim that these benchmark exports include `optimistic_constraints` is
+> unverified and, per Georg, incorrect — they are produced without the optimistic pass. The
+> leanr-vs-powdr var gap is accounted for by the sound items (1)–(3) above.*
+
 **What closing the remaining sound gap would take:** a degree-aware inlining pass (subst-like, but
 inlining any below-degree-bound column, not just pinned vars) + a dead-column sweep (a `filterBus`/
 constraint-filter over provably-unused witnesses). Both are sound and mechanical; together they'd


### PR DESCRIPTION
Two small documentation-accuracy fixes:

- **CLAUDE.md** described the contract as symmetric "equivalence" (*each implies the other's satisfiability*). The spec is the asymmetric `refines`: sound for all assignments, complete only for real traces. Reworded to match, pointing at `Leanr/Spec.lean`.
- **docs/log.md** entry 41 attributed part of the leanr-vs-powdr gap to powdr's `optimistic_constraints`. Per Georg the benchmark exports are produced *without* the optimistic pass, so this is incorrect. Added an inline correction note (the historical entry is otherwise left as-is).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)