### PR TITLE
Strip witness-column disambiguator from variable names in display

### DIFF
--- a/Leanr/Utils/Dsl.lean
+++ b/Leanr/Utils/Dsl.lean
@@ -35,7 +35,20 @@ def V (x : String) : Expression p := .var x
 The renderer simplifies the *display* of an expression (it never rewrites the expression itself):
 constant folding of numeric factors, dropping `+ 0` / `* 1` / `* 0`, and showing constants in the
 upper half of `[0, p)` as negatives — so `x + (p-1) * y` prints as `x - y` and `(p-1) * 2` as `-2`.
-Parentheses are emitted only around sum factors of a product, where precedence requires them. -/
+Parentheses are emitted only around sum factors of a product, where precedence requires them.
+
+Variable names carry a trailing `@<id>` witness-column disambiguator (e.g. `opcode_add_flag_0@31`)
+that is stripped for display by `displayVar`; within a single circuit the names are already unique
+without it. -/
+
+/-- Strip a trailing `@<id>` suffix from a variable name for display, e.g. `opcode_add_flag_0@31`
+    renders as `opcode_add_flag_0`. The suffix is a witness-column disambiguator and the names are
+    already unique without it within a single circuit, so this loses no information. A name without
+    such a suffix (no `@`, or a non-numeric one) is returned unchanged. -/
+def displayVar (name : String) : String :=
+  match name.splitOn "@" with
+  | [base, id] => if id ≠ "" && id.all Char.isDigit then base else name
+  | _ => name
 
 /-- Split a field constant into a sign and magnitude: constants in the upper half of `[0, p)`
     are shown as negatives (e.g. `p - 1` renders as `-1`, `p - 2` as `-2`). -/
@@ -49,7 +62,7 @@ mutual
   private partial def prodFold : Expression p → ZMod p × List String
     | .mul a b => let (ca, fa) := prodFold a; let (cb, fb) := prodFold b; (ca * cb, fa ++ fb)
     | .const n => (n, [])
-    | .var x => (1, [x])
+    | .var x => (1, [displayVar x])
     | e =>                                                 -- an additive factor
       match collectSummands e with
       | [(neg, body)] => (if neg then -1 else 1, [body])   -- single term: splice in, no parens

--- a/Main.lean
+++ b/Main.lean
@@ -65,12 +65,15 @@ def distinctVarCount (cs : ConstraintSystem babyBear) : Nat :=
     cs.busInteractions.flatMap BusInteraction.vars
   (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).size
 
-/-- The distinct variable names of a constraint system, sorted. The report uses these to map
-    variables between the original and optimized circuits (removed / added). -/
+/-- The distinct variable names of a constraint system, sorted and rendered for display (the
+    `@<id>` witness-column suffix stripped via `Leanr.Spec.Dsl.displayVar`). The report uses these
+    to map variables between the original and optimized circuits (removed / added). Since names are
+    unique without the suffix within a circuit, this stays one-to-one with `distinctVarCount`. -/
 def distinctVars (cs : ConstraintSystem babyBear) : List String :=
   let occurrences := cs.algebraicConstraints.flatMap Expression.vars ++
     cs.busInteractions.flatMap BusInteraction.vars
-  (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList.mergeSort (· ≤ ·)
+  ((occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList.map
+    Leanr.Spec.Dsl.displayVar).mergeSort (· ≤ ·)
 
 def statsOf (cs : ConstraintSystem babyBear) : Stats :=
   { vars := distinctVarCount cs,
@@ -130,7 +133,7 @@ def cmdVars (fileName : String) (iters : Nat) : IO Unit := do
   let occurrences := optimized.algebraicConstraints.flatMap Expression.vars ++
     optimized.busInteractions.flatMap BusInteraction.vars
   let distinct := (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList
-  for v in distinct.mergeSort (· ≤ ·) do
+  for v in (distinct.map Leanr.Spec.Dsl.displayVar).mergeSort (· ≤ ·) do
     IO.println v
 
 /-- Render the optimized system (for diagnosing residual constraints/interactions). -/


### PR DESCRIPTION
## Summary

Variable names in the constraint system carry a trailing `@<id>` suffix as a witness-column disambiguator (e.g., `opcode_add_flag_0@31`). This suffix is internal to the circuit representation and should not appear in user-facing output. This PR adds a `displayVar` function to strip these suffixes for display purposes, and applies it consistently across the renderer and reporting functions.

## Key Changes

- **Added `displayVar` function** in `Leanr/Utils/Dsl.lean`: Strips trailing `@<numeric-id>` suffixes from variable names. Names without such a suffix (or with non-numeric suffixes) are returned unchanged.

- **Updated expression renderer** in `Dsl.lean`: The `prodFold` function now applies `displayVar` when rendering variable names in products, ensuring the rendered output shows clean variable names.

- **Updated variable reporting** in `Main.lean`:
  - `distinctVars`: Now applies `displayVar` to all variable names before sorting and returning them for the report
  - `cmdVars`: Similarly applies `displayVar` when listing distinct variables in the CLI output

- **Updated documentation**: Clarified in comments that the `@<id>` suffix is a witness-column disambiguator that is stripped for display, and that this loses no information since names are already unique within a single circuit without the suffix.

## Implementation Details

The `displayVar` function uses `String.splitOn "@"` to check for the suffix pattern. It only strips the suffix if:
1. The string contains exactly one `@` character (splitting into exactly 2 parts)
2. The part after `@` is non-empty and contains only digits

This conservative approach ensures that variable names with legitimate `@` characters in other contexts are not accidentally modified.

https://claude.ai/code/session_01G8o8ecwFMCepcP6kFFvmVp