### PR TITLE
Task 2: derived columns in Leanr (represented, threaded, emitted, serialized)

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -1,5 +1,6 @@
 -- Root of the `Leanr` library.
 import Leanr.Optimizer
 import Leanr.Implementation.JsonParser
+import Leanr.Implementation.JsonSerializer
 import Leanr.Utils.Dsl
 import Leanr.Utils.Size

--- a/Leanr/Implementation/JsonParser.lean
+++ b/Leanr/Implementation/JsonParser.lean
@@ -101,6 +101,48 @@ partial def parseJsonExpr (j : Lean.Json) : Except String (Expression p) :=
 private def parseConstraint (j : Lean.Json) : Except String (Expression p) :=
   parseJsonExpr j
 
+/-- Parse a powdr `ComputationMethod`, serialized as an externally-tagged enum:
+    `{"Constant": <field>}`, `{"QuotientOrZero": [num, den]}`, or
+    `{"IfEqZero": [cond, then, else]}` (the last two arms are recursive). -/
+partial def parseComputationMethod (j : Lean.Json) : Except String (ComputationMethod p) :=
+  match j with
+  | Lean.Json.obj obj =>
+    match obj.toList with
+    | [("Constant", v)] => do
+      let e ← parseJsonExpr (p := p) v
+      match e with
+      | .const n => .ok (.constant n)
+      | _ => .error s!"Constant expects a field element, got: {v}"
+    | [("QuotientOrZero", Lean.Json.arr args)] =>
+      if h : args.size = 2 then do
+        let num ← parseJsonExpr (p := p) args[0]
+        let den ← parseJsonExpr (p := p) args[1]
+        .ok (.quotientOrZero num den)
+      else .error s!"QuotientOrZero expects 2 args, got {args.size}"
+    | [("IfEqZero", Lean.Json.arr args)] =>
+      if h : args.size = 3 then do
+        let cond ← parseJsonExpr (p := p) args[0]
+        let thenM ← parseComputationMethod args[1]
+        let elseM ← parseComputationMethod args[2]
+        .ok (.ifEqZero cond thenM elseM)
+      else .error s!"IfEqZero expects 3 args, got {args.size}"
+    | [(k, _)] => .error s!"unknown computation method: {k}"
+    | _ => .error s!"unexpected computation method object: {j}"
+  | _ => .error s!"unexpected computation method: {j}"
+
+/-- Parse a powdr `DerivedVariable`, serialized as a 3-tuple
+    `[is_new, "name@id", computation_method]`. -/
+def parseDerivedVariable (j : Lean.Json) : Except String (DerivedVariable p) :=
+  match j with
+  | Lean.Json.arr items =>
+    if h : items.size = 3 then do
+      let isNew ← items[0].getBool?
+      let name ← items[1].getStr?
+      let computation ← parseComputationMethod (p := p) items[2]
+      .ok { isNew := isNew, name := name, computation := computation }
+    else .error s!"DerivedVariable expects a 3-tuple, got {items.size} elements"
+  | _ => .error s!"unexpected derived variable: {j}"
+
 private def parseBusInteraction (j : Lean.Json) :
     Except String (BusInteraction (Expression p)) := do
   let id ← j.getObjVal? "id"
@@ -140,13 +182,25 @@ def parseJsonSystem (jsonStr : String) : Except String (ConstraintSystem p × Bu
   let busInteractions : List (BusInteraction (Expression p)) ←
     busArr.toList.mapM (parseBusInteraction (p := p))
 
+  -- Parse derived columns (witgen hints). Optional: older exports omit the key entirely,
+  -- so a missing `derived_columns` field defaults to no derived columns.
+  let derivedColumns : List (DerivedVariable p) ←
+    match machine.getObjVal? "derived_columns" with
+    | .error _ => pure []
+    | .ok derivedJson =>
+      match derivedJson with
+      | Lean.Json.arr a => a.toList.mapM (parseDerivedVariable (p := p))
+      | Lean.Json.null => pure []
+      | _ => .error "derived_columns is not an array"
+
   -- Parse bus_map
   let busMapJson ← json.getObjVal? "bus_map"
   let busMap ← parseBusMap busMapJson
 
   let system : ConstraintSystem p := {
     algebraicConstraints := constraints,
-    busInteractions := busInteractions
+    busInteractions := busInteractions,
+    derivedColumns := derivedColumns
   }
   pure (system, busMap)
 

--- a/Leanr/Implementation/JsonSerializer.lean
+++ b/Leanr/Implementation/JsonSerializer.lean
@@ -1,0 +1,75 @@
+import Lean.Data.Json
+import Leanr.Spec
+import Leanr.Implementation.JsonParser
+
+/-!
+# JSON serializer for derived columns
+
+Serializes `DerivedVariable`/`ComputationMethod` (and the `Expression`s they contain) to the exact
+JSON shape powdr's serde emits, so that Leanr's derived-column representation round-trips against
+powdr (`autoprecompiles`/`constraint-solver`):
+
+- an `Expression` is a JSON tree — `Number` → a bare number, `Reference` → the `"name@id"` string,
+  a binary op → `[lhs, "+"/"-"/"*", rhs]` (Leanr only produces `+`/`*`);
+- a `ComputationMethod` is an externally-tagged enum — `{"Constant": <field>}`,
+  `{"QuotientOrZero": [num, den]}`, `{"IfEqZero": [cond, then, else]}`;
+- a `DerivedVariable` is the 3-tuple `[is_new, "name@id", computation_method]`.
+
+This mirrors `parseComputationMethod` / `parseDerivedVariable` in `JsonParser.lean`; the two are
+tested to round-trip below. Leanr has no full circuit serializer yet (a separate task); this file
+covers the derived-column portion required to emit hints.
+
+Serialization needs no primality: field elements are written as their canonical `ZMod.val`.
+-/
+
+set_option autoImplicit false
+
+variable {p : ℕ}
+
+/-- Serialize a field element as its canonical natural-number representative. -/
+private def serializeField (n : ZMod p) : Lean.Json :=
+  Lean.Json.num (Lean.JsonNumber.fromNat n.val)
+
+/-- Serialize an `Expression` to powdr's JSON expression tree. -/
+def serializeExpr : Expression p → Lean.Json
+  | .const n => serializeField n
+  | .var x => Lean.Json.str x
+  | .add e1 e2 => Lean.Json.arr #[serializeExpr e1, Lean.Json.str "+", serializeExpr e2]
+  | .mul e1 e2 => Lean.Json.arr #[serializeExpr e1, Lean.Json.str "*", serializeExpr e2]
+
+/-- Serialize a `ComputationMethod` as powdr's externally-tagged enum. -/
+def serializeComputationMethod : ComputationMethod p → Lean.Json
+  | .constant n => Lean.Json.mkObj [("Constant", serializeField n)]
+  | .quotientOrZero num den =>
+      Lean.Json.mkObj [("QuotientOrZero", Lean.Json.arr #[serializeExpr num, serializeExpr den])]
+  | .ifEqZero cond thenM elseM =>
+      Lean.Json.mkObj [("IfEqZero",
+        Lean.Json.arr #[serializeExpr cond,
+          serializeComputationMethod thenM, serializeComputationMethod elseM])]
+
+/-- Serialize a `DerivedVariable` as powdr's 3-tuple `[is_new, variable, computation_method]`. -/
+def serializeDerivedVariable (dc : DerivedVariable p) : Lean.Json :=
+  Lean.Json.arr #[Lean.Json.bool dc.isNew, Lean.Json.str dc.name,
+    serializeComputationMethod dc.computation]
+
+/-- Serialize a list of derived columns as a JSON array (powdr's `derived_columns`). -/
+def serializeDerivedColumns (dcs : List (DerivedVariable p)) : Lean.Json :=
+  Lean.Json.arr (dcs.map serializeDerivedVariable).toArray
+
+-- Round-trip check: serializing derived columns, parsing them back, and re-serializing yields
+-- the identical JSON (so `serialize`/`parse` agree and match powdr's shape).
+#guard
+  (let dcs : List (DerivedVariable 2013265921) :=
+    [ { isNew := true, name := "a@1", computation := .constant 7 },
+      { isNew := false, name := "b@2",
+        computation := .quotientOrZero (.var "a@1") (.add (.var "c@3") (.const 1)) },
+      { isNew := true, name := "d@4",
+        computation := .ifEqZero (.var "e@5")
+          (.constant 0) (.quotientOrZero (.const 1) (.var "e@5")) } ]
+   let json := serializeDerivedColumns dcs
+   match json with
+   | Lean.Json.arr items =>
+     match items.toList.mapM (parseDerivedVariable (p := 2013265921)) with
+     | .ok parsed => (serializeDerivedColumns parsed).compress = json.compress
+     | .error _ => false
+   | _ => false)

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -92,30 +92,32 @@ def pipeline : VerifiedPassW p := pipelineIters 32
     more than the snapshot default). -/
 def optimizerWithBusFacts {bs : BusSemantics p} (facts : BusFacts p bs) (iters : Nat := 32)
     (cs : ConstraintSystem p) : ConstraintSystem p :=
-  -- The pipeline passes operate on the algebraic/bus part only and reset `derivedColumns` to the
-  -- default `[]`; reattach the input's derived columns verbatim. Since `refines`,
-  -- `guaranteesInvariants` and `withinDegree` read only `algebraicConstraints`/`busInteractions`,
-  -- this reattachment is invisible to all correctness properties.
-  { (pipelineIters iters cs bs facts).val with derivedColumns := cs.derivedColumns }
+  -- The output is exactly the pipeline's result: any derived columns a pass emitted (the terminal
+  -- re-encoding pass emits `isNew = false` hints for the variables it eliminates) flow straight to
+  -- the output. No reattachment — with the strengthened `refines`, the emitted hints' consistency
+  -- under the completeness witness is carried by the pipeline's own `PassCorrect` proof.
+  (pipelineIters iters cs bs facts).val
 
 /-- The fact-aware optimizer is correct: its output `refines` its input (sound, and complete for
-    the input's intended executions) and preserves invariants — the same two clauses
-    `optimizerMaintainsCorrectness` demands, stated per instance because nontrivial facts are tied
-    to one semantics. -/
+    the input's intended executions — now including consistency of the output's derived columns
+    under the completeness witness) and preserves invariants. -/
 theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (facts : BusFacts p bs)
     (iters : Nat := 32) (cs : ConstraintSystem p) :
     ((optimizerWithBusFacts facts iters cs).refines cs bs) ∧
       (cs.guaranteesInvariants bs → (optimizerWithBusFacts facts iters cs).guaranteesInvariants bs) :=
-  -- `refines` and `guaranteesInvariants` read only `algebraicConstraints`/`busInteractions`, which
-  -- the `with derivedColumns := …` update leaves untouched, so the pipeline's proof applies as-is.
   (pipelineIters iters cs bs facts).property
 
-/-- The fact-aware optimizer carries derived columns through verbatim: it reattaches the input's
-    derived columns after running the (derived-column-agnostic) pipeline. -/
-theorem optimizerWithBusFacts_preservesDerived {bs : BusSemantics p} (facts : BusFacts p bs)
-    (iters : Nat := 32) (cs : ConstraintSystem p) :
-    (optimizerWithBusFacts facts iters cs).derivedColumns = cs.derivedColumns :=
-  rfl
+/-- The fact-aware optimizer's output derived columns are consistent under the completeness witness:
+    for every admissible, satisfying, hint-consistent input assignment there is an output-satisfying
+    `env'` under which every emitted hint computes its assigned value. A projection of the
+    `refines` completeness direction (`impliesAdmissible`), which now carries this. -/
+theorem optimizerWithBusFacts_derivedConsistent {bs : BusSemantics p} (facts : BusFacts p bs)
+    (iters : Nat := 32) (cs : ConstraintSystem p) (env : String → ZMod p)
+    (hadm : cs.admissible bs env) (hsat : cs.satisfies bs env) (hdc : cs.derivedConsistent env) :
+    ∃ env', (optimizerWithBusFacts facts iters cs).satisfies bs env' ∧
+      (optimizerWithBusFacts facts iters cs).derivedConsistent env' :=
+  let ⟨env', hsat', _, _, hdc'⟩ := (pipelineIters iters cs bs facts).property.1.2 env hadm hsat hdc
+  ⟨env', hsat', hdc'⟩
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -92,7 +92,11 @@ def pipeline : VerifiedPassW p := pipelineIters 32
     more than the snapshot default). -/
 def optimizerWithBusFacts {bs : BusSemantics p} (facts : BusFacts p bs) (iters : Nat := 32)
     (cs : ConstraintSystem p) : ConstraintSystem p :=
-  (pipelineIters iters cs bs facts).val
+  -- The pipeline passes operate on the algebraic/bus part only and reset `derivedColumns` to the
+  -- default `[]`; reattach the input's derived columns verbatim. Since `refines`,
+  -- `guaranteesInvariants` and `withinDegree` read only `algebraicConstraints`/`busInteractions`,
+  -- this reattachment is invisible to all correctness properties.
+  { (pipelineIters iters cs bs facts).val with derivedColumns := cs.derivedColumns }
 
 /-- The fact-aware optimizer is correct: its output `refines` its input (sound, and complete for
     the input's intended executions) and preserves invariants — the same two clauses
@@ -102,7 +106,16 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (facts : BusFacts p 
     (iters : Nat := 32) (cs : ConstraintSystem p) :
     ((optimizerWithBusFacts facts iters cs).refines cs bs) ∧
       (cs.guaranteesInvariants bs → (optimizerWithBusFacts facts iters cs).guaranteesInvariants bs) :=
+  -- `refines` and `guaranteesInvariants` read only `algebraicConstraints`/`busInteractions`, which
+  -- the `with derivedColumns := …` update leaves untouched, so the pipeline's proof applies as-is.
   (pipelineIters iters cs bs facts).property
+
+/-- The fact-aware optimizer carries derived columns through verbatim: it reattaches the input's
+    derived columns after running the (derived-column-agnostic) pipeline. -/
+theorem optimizerWithBusFacts_preservesDerived {bs : BusSemantics p} (facts : BusFacts p bs)
+    (iters : Nat := 32) (cs : ConstraintSystem p) :
+    (optimizerWithBusFacts facts iters cs).derivedColumns = cs.derivedColumns :=
+  rfl
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/

--- a/Leanr/Implementation/OptimizerPasses/Basic.lean
+++ b/Leanr/Implementation/OptimizerPasses/Basic.lean
@@ -24,6 +24,14 @@ This module provides:
 
 These proofs are purely structural; none of them need `p` to be prime. -/
 
+/-! ## Derived-column consistency helpers -/
+
+/-- A system with no derived columns is (vacuously) derived-consistent under any assignment. Used
+    by every pass that constructs its output without derived columns (the default `[]`). -/
+theorem ConstraintSystem.derivedConsistent_of_nil {p : ℕ} {s : ConstraintSystem p}
+    (env : String → ZMod p) (h : s.derivedColumns = []) : s.derivedConsistent env := by
+  intro dc hdc; rw [h] at hdc; simp at hdc
+
 /-! ## Equivalence is an equivalence relation -/
 
 /-- `≈` on `BusState` is reflexive: every message trivially has the same net multiplicity in a
@@ -53,21 +61,22 @@ theorem ConstraintSystem.implies_trans {a b c : ConstraintSystem p} {busSemantic
     let ⟨env'', hc, hbc⟩ := h2 env' hb
     ⟨env'', hc, BusState.equiv_trans hab hbc⟩
 
-/-- Any constraint system admissibly-implies itself: the same admissible assignment works. -/
+/-- Any constraint system admissibly-implies itself: the same admissible assignment works. The
+    derived-column consistency delivered is exactly the one assumed (`env' = env`). -/
 theorem ConstraintSystem.impliesAdmissible_refl (cs : ConstraintSystem p)
     (busSemantics : BusSemantics p) : cs.impliesAdmissible cs busSemantics :=
-  fun env hadm hsat => ⟨env, hsat, hadm, BusState.equiv_refl _⟩
+  fun env hadm hsat hdc => ⟨env, hsat, hadm, BusState.equiv_refl _, hdc⟩
 
 /-- `impliesAdmissible` is transitive: chain the admissible witnesses and the side-effect
-    equalities. The middle witness is admissible (delivered by the first step), so the second
-    step applies. -/
+    equalities. The middle witness is admissible *and derived-consistent* (delivered by the first
+    step), so the second step applies; its delivered derived-consistency becomes the result's. -/
 theorem ConstraintSystem.impliesAdmissible_trans {a b c : ConstraintSystem p}
     {busSemantics : BusSemantics p} (h1 : a.impliesAdmissible b busSemantics)
     (h2 : b.impliesAdmissible c busSemantics) : a.impliesAdmissible c busSemantics :=
-  fun env hadm hsat =>
-    let ⟨env', hb, hbadm, hab⟩ := h1 env hadm hsat
-    let ⟨env'', hc, hcadm, hbc⟩ := h2 env' hbadm hb
-    ⟨env'', hc, hcadm, BusState.equiv_trans hab hbc⟩
+  fun env hadm hsat hdc =>
+    let ⟨env', hb, hbadm, hab, hbdc⟩ := h1 env hadm hsat hdc
+    let ⟨env'', hc, hcadm, hbc, hcdc⟩ := h2 env' hbadm hb hbdc
+    ⟨env'', hc, hcadm, BusState.equiv_trans hab hbc, hcdc⟩
 
 /-- Any constraint system refines itself. -/
 theorem ConstraintSystem.refines_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :

--- a/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -86,7 +86,8 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (hBstateless : ∀ bi ∈ cs.busInteractions, keepBi bi = false → bs.isStateful bi.busId = false)
     (hBkeep : ∀ bi ∈ cs.busInteractions, keepBi bi = true → ∀ x ∈ bi.vars, remV x = false) :
     PassCorrect cs { algebraicConstraints := cs.algebraicConstraints.filter keepCon,
-                     busInteractions := cs.busInteractions.filter keepBi } bs := by
+                     busInteractions := cs.busInteractions.filter keepBi,
+                     derivedColumns := cs.derivedColumns } bs := by
   -- the merge: keep `env` on kept variables, use the witness on removed ones
   set m : (String → ZMod p) → (String → ZMod p) :=
     fun env x => if remV x = true then w x else env x with hm
@@ -137,23 +138,24 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     refine ⟨m env, keySat env hsat.1 hsat.2, ?_⟩
     -- side effects: out under env = cs under (m env)
     have hse : ({ algebraicConstraints := cs.algebraicConstraints.filter keepCon,
-                  busInteractions := cs.busInteractions.filter keepBi } :
+                  busInteractions := cs.busInteractions.filter keepBi,
+                  derivedColumns := cs.derivedColumns } :
                   ConstraintSystem p).sideEffects bs env = cs.sideEffects bs (m env) :=
       sideEffects_drop_eq bs keepBi env (m env) cs.busInteractions
         (fun bi hbi hkf => hBstateless bi hbi hkf)
         (fun bi hbi hstate => hmeB env bi (hBkeep bi hbi (hstKeep bi hbi hstate)))
     rw [hse]; exact BusState.equiv_refl _
   · -- completeness: cs.impliesAdmissible out
-    intro env hadm hsat _hdc
+    intro env hadm hsat hdc
     refine ⟨env, ⟨fun c hc => hsat.1 c (List.mem_filter.1 hc).1,
-                  fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_,
-                  ConstraintSystem.derivedConsistent_of_nil env rfl⟩
+                  fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_, hdc⟩
     · -- admissibility carries over (dropped interactions are stateless)
       exact (cs.admissible_filterBus bs keepBi env
         (fun bi hbi hkf => Or.inr (hBstateless bi hbi hkf))).2 hadm
     · -- side effects: cs under env = out under env
       have hse : ({ algebraicConstraints := cs.algebraicConstraints.filter keepCon,
-                    busInteractions := cs.busInteractions.filter keepBi } :
+                    busInteractions := cs.busInteractions.filter keepBi,
+                    derivedColumns := cs.derivedColumns } :
                     ConstraintSystem p).sideEffects bs env = cs.sideEffects bs env :=
         sideEffects_drop_eq bs keepBi env env cs.busInteractions
           (fun bi hbi hkf => hBstateless bi hbi hkf) (fun _ _ _ => rfl)
@@ -250,7 +252,8 @@ def disconnectedComponentPass : VerifiedPass p := fun cs bs =>
         !keepBiWith bs remV bi || bi.vars.all (fun x => !remV x))
     ) = true then
     ⟨{ algebraicConstraints := cs.algebraicConstraints.filter (keepConWith remV),
-       busInteractions := cs.busInteractions.filter (keepBiWith bs remV) },
+       busInteractions := cs.busInteractions.filter (keepBiWith bs remV),
+       derivedColumns := cs.derivedColumns },
      by
        simp only [Bool.and_eq_true, and_assoc] at hchk
        obtain ⟨_hne, hcz, hbz, hck, hbk⟩ := hchk

--- a/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -144,9 +144,10 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
         (fun bi hbi hstate => hmeB env bi (hBkeep bi hbi (hstKeep bi hbi hstate)))
     rw [hse]; exact BusState.equiv_refl _
   · -- completeness: cs.impliesAdmissible out
-    intro env hadm hsat
+    intro env hadm hsat _hdc
     refine ⟨env, ⟨fun c hc => hsat.1 c (List.mem_filter.1 hc).1,
-                  fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_⟩
+                  fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_,
+                  ConstraintSystem.derivedConsistent_of_nil env rfl⟩
     · -- admissibility carries over (dropped interactions are stateless)
       exact (cs.admissible_filterBus bs keepBi env
         (fun bi hbi hkf => Or.inr (hBstateless bi hbi hkf))).2 hadm

--- a/Leanr/Implementation/OptimizerPasses/FactPass.lean
+++ b/Leanr/Implementation/OptimizerPasses/FactPass.lean
@@ -36,6 +36,8 @@ def VerifiedPassW.iterate (f : VerifiedPassW p) : Nat → VerifiedPassW p
   | n + 1 => (f.iterate n).andThen f
 
 deriving instance DecidableEq for Expression
+deriving instance DecidableEq for ComputationMethod
+deriving instance DecidableEq for DerivedVariable
 deriving instance DecidableEq for BusInteraction
 deriving instance DecidableEq for ConstraintSystem
 

--- a/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
@@ -48,9 +48,9 @@ theorem ConstraintSystem.addConstraints_correct (cs : ConstraintSystem p) (bs : 
     intro env hsat
     exact ⟨env, hfwd env hsat, BusState.equiv_refl _⟩
   · -- completeness (uses the discipline to discharge the added constraints)
-    intro env hint hsat
+    intro env hint hsat hdc
     obtain ⟨hc, hb⟩ := hsat
-    refine ⟨env, ⟨fun c hcm => ?_, hb⟩, hint, BusState.equiv_refl _⟩
+    refine ⟨env, ⟨fun c hcm => ?_, hb⟩, hint, BusState.equiv_refl _, hdc⟩
     rcases List.mem_append.1 hcm with h | h
     · exact hc c h
     · exact H env hint ⟨hc, hb⟩ c h

--- a/Leanr/Implementation/OptimizerPasses/MonicScale.lean
+++ b/Leanr/Implementation/OptimizerPasses/MonicScale.lean
@@ -150,9 +150,9 @@ theorem ConstraintSystem.mapConstraintsIff_correct (cs : ConstraintSystem p)
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
-    -- `mapConstraints` leaves bus interactions untouched, so `isIntended` is definitionally `cs`'s
-    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro env hint hsat hdc
+    -- `mapConstraints` leaves bus interactions and derived columns untouched
+    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _, hdc⟩
   · intro hinv env hsat bi hbi
     exact hinv env ((hiff env).1 hsat) bi hbi
 

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -89,6 +89,33 @@ theorem mentions_false_not_mem_vars (x : String) (e : Expression p)
       · exact iha h.1 hx
       · exact ihb h.2 hx
 
+/-! ## Derived-column (witgen-hint) helpers -/
+
+/-- All variables occurring in a computation method. -/
+def ComputationMethod.vars : ComputationMethod p → List String
+  | .constant _ => []
+  | .quotientOrZero num den => num.vars ++ den.vars
+  | .ifEqZero cond thenM elseM => cond.vars ++ ComputationMethod.vars thenM ++ ComputationMethod.vars elseM
+
+/-- A computation method evaluates equally under environments agreeing on its variables. -/
+theorem ComputationMethod.eval_congr (env₀ env₁ : String → ZMod p) :
+    ∀ (m : ComputationMethod p), (∀ y ∈ m.vars, env₀ y = env₁ y) → m.eval env₀ = m.eval env₁
+  | .constant _ => fun _ => rfl
+  | .quotientOrZero num den => fun h => by
+      simp only [ComputationMethod.eval,
+        Expression.eval_congr num env₀ env₁ (fun y hy => h y (by
+          simp only [ComputationMethod.vars, List.mem_append]; exact Or.inl hy)),
+        Expression.eval_congr den env₀ env₁ (fun y hy => h y (by
+          simp only [ComputationMethod.vars, List.mem_append]; exact Or.inr hy))]
+  | .ifEqZero cond thenM elseM => fun h => by
+      have hc := Expression.eval_congr cond env₀ env₁ (fun y hy => h y (by
+        simp only [ComputationMethod.vars, List.mem_append]; exact Or.inl (Or.inl hy)))
+      have ht := ComputationMethod.eval_congr env₀ env₁ thenM (fun y hy => h y (by
+        simp only [ComputationMethod.vars, List.mem_append]; exact Or.inl (Or.inr hy)))
+      have he := ComputationMethod.eval_congr env₀ env₁ elseM (fun y hy => h y (by
+        simp only [ComputationMethod.vars, List.mem_append]; exact Or.inr hy))
+      simp only [ComputationMethod.eval, hc, ht, he]
+
 /-! ## The transport core -/
 
 /-- **Re-encoding correctness.** `out` replaces every expression `e` by `e.substF σ`, keeps
@@ -99,11 +126,12 @@ theorem mentions_false_not_mem_vars (x : String) (e : Expression p)
     generic witness-transport principle. -/
 theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusSemantics p)
     (rw : Expression p → Expression p) (keep : Expression p → Bool)
-    (newCs : List (Expression p))
-    (hfwd : ∀ env, cs.satisfies bsem env → ∃ env',
+    (newCs : List (Expression p)) (dcs : List (DerivedVariable p))
+    (hfwd : ∀ env, cs.satisfies bsem env → cs.derivedConsistent env → ∃ env',
       (∀ c ∈ cs.algebraicConstraints, (rw c).eval env' = c.eval env) ∧
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) ∧
-      (∀ c ∈ newCs, c.eval env' = 0))
+      (∀ c ∈ newCs, c.eval env' = 0) ∧
+      (∀ dc ∈ dcs, env' dc.name = dc.computation.eval env'))
     (hbwd : ∀ env',
       (ConstraintSystem.satisfies
         { algebraicConstraints :=
@@ -115,11 +143,13 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     PassCorrect cs
       { algebraicConstraints :=
           ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
-        busInteractions := cs.busInteractions.map (·.mapExpr rw) } bsem := by
+        busInteractions := cs.busInteractions.map (·.mapExpr rw),
+        derivedColumns := dcs } bsem := by
   set out : ConstraintSystem p :=
     { algebraicConstraints :=
         ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
-      busInteractions := cs.busInteractions.map (·.mapExpr rw) } with hout
+      busInteractions := cs.busInteractions.map (·.mapExpr rw),
+      derivedColumns := dcs } with hout
   -- message-list equality under expression-wise agreement
   have hmsgs : ∀ (env env' : String → ZMod p),
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
@@ -184,10 +214,9 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     · rw [hside env env' hB]
       exact BusState.equiv_refl _
   · -- completeness: cs intended-implies out
-    intro env hint hsat _hdc
-    obtain ⟨env', hA, hB, hnew⟩ := hfwd env hsat
-    refine ⟨env', ⟨?_, ?_⟩, (hdisc env env' hB).2 hint, ?_,
-      ConstraintSystem.derivedConsistent_of_nil env' (by rw [hout])⟩
+    intro env hint hsat hdc
+    obtain ⟨env', hA, hB, hnew, hdcs⟩ := hfwd env hsat hdc
+    refine ⟨env', ⟨?_, ?_⟩, (hdisc env env' hB).2 hint, ?_, hdcs⟩
     · intro c hc
       rcases List.mem_append.1 hc with h | h
       · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 h
@@ -607,14 +636,29 @@ theorem groupRewrite_bi_agree (xs bits : List String)
     exact groupRewrite_agree xs bits σfn patts hσnone env₀ env₁ aβ haβ hbitsagree
       hpolyvars hpoint e (hfreshP e he)
 
+/-- The `isNew = false` witgen hint re-encoding emits for an eliminated group variable `x`: it
+    records that `x` equals the interpolation polynomial `x` was substituted by (over the fresh
+    bits). `quotientOrZero e (const 1)` is powdr's `ComputationMethod::expression e` (`e / 1 = e`). -/
+def groupHint (xs : List String) (hm : Std.HashMap String (Expression p)) (x : String) :
+    DerivedVariable p :=
+  { isNew := false, name := x,
+    computation := .quotientOrZero ((Expression.var x).substF (groupSubst xs hm)) (.const 1) }
+
+/-- The hints emitted for one re-encoding step: one `isNew = false` hint per eliminated group var. -/
+def groupHints (xs : List String) (hm : Std.HashMap String (Expression p)) :
+    List (DerivedVariable p) :=
+  xs.map (groupHint xs hm)
+
 /-- The re-encoded system: substitute the group everywhere, keep only uncovered constraints,
-    add booleanity for the bits. -/
+    add booleanity for the bits, and emit a witgen hint for each eliminated group variable
+    (accumulating onto any already-present derived columns). -/
 def reencodeOut (cs : ConstraintSystem p) (xs bits : List String)
     (hm : Std.HashMap String (Expression p)) : ConstraintSystem p :=
   { algebraicConstraints :=
       ((cs.algebraicConstraints.filter (fun c => !coveredBy xs c)).map
         (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))) ++ bits.map boolConstraint,
-    busInteractions := cs.busInteractions.map (·.mapExpr (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))) }
+    busInteractions := cs.busInteractions.map (·.mapExpr (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))),
+    derivedColumns := cs.derivedColumns ++ groupHints xs hm }
 
 /-- The group's covered constraints. -/
 def coveredCsOf (cs : ConstraintSystem p) (xs : List String) : List (Expression p) :=
@@ -637,11 +681,14 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List String)
     decide (2 ≤ (groupSurvivors cs xs doms).length) &&
     decide (bits.length < xs.length) &&
     decide (bits.Nodup) &&
-    -- freshness: no bit occurs anywhere in the system
+    -- freshness: no bit occurs anywhere in the system — constraints, bus interactions, the group
+    -- variables being eliminated, or any already-present derived column (name or computation)
     bits.all (fun b =>
       cs.algebraicConstraints.all (fun c => !c.mentions b) &&
       cs.busInteractions.all (fun bi =>
-        !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b))) &&
+        !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b)) &&
+      !xs.contains b &&
+      cs.derivedColumns.all (fun dc => !decide (dc.name = b) && !dc.computation.vars.contains b)) &&
     -- the substituted group variables only mention bits
     xs.all (fun x =>
       ((Expression.var x).substF (groupSubst xs hm)).vars.all (fun v => bits.contains v)) &&
@@ -669,18 +716,25 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
     unfold bitBox
     rw [List.map_map]
     simp [Function.comp_def]
-  -- per-expression freshness, unpacked
+  -- per-expression freshness, unpacked (the freshness clause is a 4-way `&&` per bit)
+  have hfreshAll : ∀ b ∈ bits,
+      (cs.algebraicConstraints.all (fun c => !c.mentions b) = true) ∧
+      (cs.busInteractions.all (fun bi =>
+        !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b)) = true) ∧
+      ((!xs.contains b) = true) ∧
+      (cs.derivedColumns.all (fun dc =>
+        !decide (dc.name = b) && !dc.computation.vars.contains b) = true) := by
+    intro b hb
+    have h1 := List.all_eq_true.mp hfreshB b hb
+    simp only [Bool.and_eq_true] at h1
+    exact ⟨h1.1.1.1, h1.1.1.2, h1.1.2, h1.2⟩
   have hfreshC : ∀ b ∈ bits, ∀ c ∈ cs.algebraicConstraints, b ∉ c.vars := by
     intro b hb c hc
-    have h1 := List.all_eq_true.mp hfreshB b hb
-    rw [Bool.and_eq_true] at h1
-    have := List.all_eq_true.mp h1.1 c hc
-    exact mentions_false_not_mem_vars b c (by simpa using this)
+    exact mentions_false_not_mem_vars b c
+      (by simpa using List.all_eq_true.mp (hfreshAll b hb).1 c hc)
   have hfreshBi : ∀ b ∈ bits, ∀ bi ∈ cs.busInteractions, b ∉ bi.vars := by
     intro b hb bi hbi
-    have h1 := List.all_eq_true.mp hfreshB b hb
-    rw [Bool.and_eq_true] at h1
-    have h2 := List.all_eq_true.mp h1.2 bi hbi
+    have h2 := List.all_eq_true.mp (hfreshAll b hb).2.1 bi hbi
     rw [Bool.and_eq_true] at h2
     intro hmem
     unfold BusInteraction.vars at hmem
@@ -700,33 +754,42 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
     simp [groupSubst, hy]
   have hfreshCm : ∀ c ∈ cs.algebraicConstraints, ∀ b ∈ bits, c.mentions b = false := by
     intro c hc b hb
-    have h1 := List.all_eq_true.mp hfreshB b hb
-    rw [Bool.and_eq_true] at h1
-    simpa using List.all_eq_true.mp h1.1 c hc
+    simpa using List.all_eq_true.mp (hfreshAll b hb).1 c hc
   have hfreshMm : ∀ bi ∈ cs.busInteractions, ∀ b ∈ bits,
       bi.multiplicity.mentions b = false := by
     intro bi hbi b hb
-    have h1 := List.all_eq_true.mp hfreshB b hb
-    rw [Bool.and_eq_true] at h1
-    have h2 := List.all_eq_true.mp h1.2 bi hbi
+    have h2 := List.all_eq_true.mp (hfreshAll b hb).2.1 bi hbi
     rw [Bool.and_eq_true] at h2
     simpa using h2.1
   have hfreshPm : ∀ bi ∈ cs.busInteractions, ∀ e ∈ bi.payload, ∀ b ∈ bits,
       e.mentions b = false := by
     intro bi hbi e he b hb
-    have h1 := List.all_eq_true.mp hfreshB b hb
-    rw [Bool.and_eq_true] at h1
-    have h2 := List.all_eq_true.mp h1.2 bi hbi
+    have h2 := List.all_eq_true.mp (hfreshAll b hb).2.1 bi hbi
     rw [Bool.and_eq_true] at h2
     simpa using List.all_eq_true.mp h2.2 e he
+  -- bits are disjoint from the eliminated group variables
+  have hbitNotXs : ∀ b ∈ bits, b ∉ xs := by
+    intro b hb
+    simpa using (hfreshAll b hb).2.2.1
+  -- bits are fresh for every already-present derived column (name and computation)
+  have hfreshDC : ∀ b ∈ bits, ∀ dc ∈ cs.derivedColumns,
+      dc.name ≠ b ∧ b ∉ dc.computation.vars := by
+    intro b hb dc hdc
+    have h := List.all_eq_true.mp (hfreshAll b hb).2.2.2 dc hdc
+    rw [Bool.and_eq_true] at h
+    refine ⟨?_, ?_⟩
+    · simpa using h.1
+    · simpa using h.2
   -- FORWARD
-  have hfwd : ∀ env, cs.satisfies bsem env → ∃ env',
+  have hfwd : ∀ env, cs.satisfies bsem env → cs.derivedConsistent env → ∃ env',
       (∀ c ∈ cs.algebraicConstraints,
         ((groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits))) c).eval env' = c.eval env) ∧
       (∀ bi ∈ cs.busInteractions,
         (bi.mapExpr (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))).eval env' = bi.eval env) ∧
-      (∀ c ∈ bits.map boolConstraint, c.eval env' = 0) := by
-    intro env hsat
+      (∀ c ∈ bits.map boolConstraint, c.eval env' = 0) ∧
+      (∀ dc ∈ cs.derivedColumns ++ groupHints xs hm,
+        env' dc.name = dc.computation.eval env') := by
+    intro env hsat hdc
     have hallES : ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 := fun c hc =>
       hsat.1 c (List.mem_of_mem_filter hc)
     have hdsound := groupDoms_sound (coveredCsOf cs xs) xs doms hdoms env hallES
@@ -771,7 +834,7 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
         exact envExt_eq_env_of_notmem aβ env y (hkeysβ ▸ hyb)
     have hbitsagree : ∀ b ∈ bits, envExt aβ env b = envOf aβ b := fun b hb =>
       envExt_eq_envOf_of_mem aβ env b (hkeysβ ▸ hb)
-    refine ⟨envExt aβ env, ?_, ?_, ?_⟩
+    refine ⟨envExt aβ env, ?_, ?_, ?_, ?_⟩
     · intro c hc
       exact groupRewrite_agree xs bits (groupSubst xs hm) (assignments (bitBox bits))
         hσnone (envExt aβ env) env aβ haβ hbitsagree hpolyVars hpoint c (hfreshCm c hc)
@@ -788,6 +851,26 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
         (by rw [hbitKeys]; exact hnodup') aβ haβ
         (b, ([0, 1] : List (ZMod p))) (List.mem_map.2 ⟨b, hb, rfl⟩)
       simpa using hmem
+    · -- derived-column consistency at the forward witness `envExt aβ env`
+      intro dc hdcmem
+      rcases List.mem_append.1 hdcmem with h | h
+      · -- carried column: `env'` agrees with `env` off the (fresh) bits, so consistency transfers
+        have hname : dc.name ∉ bits := fun hmem => (hfreshDC dc.name hmem dc h).1 rfl
+        have hcomp : dc.computation.eval (envExt aβ env) = dc.computation.eval env :=
+          ComputationMethod.eval_congr _ _ dc.computation (fun y hy =>
+            envExt_eq_env_of_notmem aβ env y
+              (hkeysβ ▸ (fun hmem => (hfreshDC y hmem dc h).2 hy)))
+        rw [envExt_eq_env_of_notmem aβ env dc.name (hkeysβ ▸ hname), hcomp]
+        exact hdc dc h
+      · -- emitted group hint: `x = interpolation(x)`, discharged by `hpoint`
+        obtain ⟨x, hx, rfl⟩ := List.mem_map.1 h
+        have hxb : x ∉ bits := fun hmem => hbitNotXs x hmem hx
+        show envExt aβ env (groupHint xs hm x).name
+            = (groupHint xs hm x).computation.eval (envExt aβ env)
+        simp only [groupHint, ComputationMethod.eval, Expression.eval]
+        rw [envExt_eq_env_of_notmem aβ env x (hkeysβ ▸ hxb), if_neg one_ne_zero, inv_one,
+          mul_one, ← envF_eq_varSubst]
+        exact (hpoint x hxb).symm
   -- BACKWARD
   have hbwd : ∀ env',
       (ConstraintSystem.satisfies
@@ -879,7 +962,7 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
   show PassCorrect cs (reencodeOut cs xs bits hm) bsem
   unfold reencodeOut
   exact cs.reencode_correct bsem (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits))) (fun c => !coveredBy xs c)
-    (bits.map boolConstraint) hfwd hbwd
+    (bits.map boolConstraint) (cs.derivedColumns ++ groupHints xs hm) hfwd hbwd
 
 /-! ## Building the interpolation (proof-free) and the pass -/
 

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -184,9 +184,10 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     · rw [hside env env' hB]
       exact BusState.equiv_refl _
   · -- completeness: cs intended-implies out
-    intro env hint hsat
+    intro env hint hsat _hdc
     obtain ⟨env', hA, hB, hnew⟩ := hfwd env hsat
-    refine ⟨env', ⟨?_, ?_⟩, (hdisc env env' hB).2 hint, ?_⟩
+    refine ⟨env', ⟨?_, ?_⟩, (hdisc env env' hB).2 hint, ?_,
+      ConstraintSystem.derivedConsistent_of_nil env' (by rw [hout])⟩
     · intro c hc
       rcases List.mem_append.1 hc with h | h
       · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 h

--- a/Leanr/Implementation/OptimizerPasses/Rewrite.lean
+++ b/Leanr/Implementation/OptimizerPasses/Rewrite.lean
@@ -109,9 +109,9 @@ theorem ConstraintSystem.mapExpr_correct (cs : ConstraintSystem p) (bs : BusSema
   · intro env hsat
     refine ⟨env, (cs.satisfies_mapExpr hg bs env).1 hsat, ?_⟩
     rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
-  · intro env hint hsat
+  · intro env hint hsat _hdc
     refine ⟨env, (cs.satisfies_mapExpr hg bs env).2 hsat,
-      (cs.admissible_mapExpr hg bs env).2 hint, ?_⟩
+      (cs.admissible_mapExpr hg bs env).2 hint, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
     rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
   · intro hinv env hsat bi hbi
     have hsatcs : cs.satisfies bs env := (cs.satisfies_mapExpr hg bs env).1 hsat
@@ -151,9 +151,9 @@ theorem ConstraintSystem.filterConstraints_correct (cs : ConstraintSystem p) (bs
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
-    -- `filterConstraints` leaves bus interactions untouched, so `isIntended` is definitionally `cs`'s
-    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro env hint hsat hdc
+    -- `filterConstraints` leaves bus interactions and derived columns untouched
+    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _, hdc⟩
   · intro hinv env hsat bi hbi
     exact hinv env ((hiff env).1 hsat) bi hbi
 
@@ -270,10 +270,10 @@ theorem ConstraintSystem.filterBus_correct (cs : ConstraintSystem p) (bs : BusSe
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, BusState.equiv_symm (hside env)⟩
-  · intro env hint hsat
+  · intro env hint hsat hdc
     exact ⟨env, (hiff env).2 hsat,
       (cs.admissible_filterBus bs keep env
-        (fun bi hbi hkf => Or.inl (h bi hbi hkf env))).2 hint, hside env⟩
+        (fun bi hbi hkf => Or.inl (h bi hbi hkf env))).2 hint, hside env, hdc⟩
   · intro hinv env hsat bi hbi
     have hbimem : bi ∈ cs.busInteractions :=
       (List.mem_filter.1 (by simpa only [ConstraintSystem.filterBus] using hbi)).1

--- a/Leanr/Implementation/OptimizerPasses/Rewrite.lean
+++ b/Leanr/Implementation/OptimizerPasses/Rewrite.lean
@@ -33,7 +33,8 @@ def BusInteraction.mapExpr (bi : BusInteraction (Expression p)) (g : Expression 
 def ConstraintSystem.mapExpr (cs : ConstraintSystem p) (g : Expression p → Expression p) :
     ConstraintSystem p :=
   { algebraicConstraints := cs.algebraicConstraints.map g,
-    busInteractions := cs.busInteractions.map (·.mapExpr g) }
+    busInteractions := cs.busInteractions.map (·.mapExpr g),
+    derivedColumns := cs.derivedColumns }
 
 section EvalPreserving
 variable {g : Expression p → Expression p} (hg : ∀ e (env : String → ZMod p), (g e).eval env = e.eval env)
@@ -109,9 +110,9 @@ theorem ConstraintSystem.mapExpr_correct (cs : ConstraintSystem p) (bs : BusSema
   · intro env hsat
     refine ⟨env, (cs.satisfies_mapExpr hg bs env).1 hsat, ?_⟩
     rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
-  · intro env hint hsat _hdc
+  · intro env hint hsat hdc
     refine ⟨env, (cs.satisfies_mapExpr hg bs env).2 hsat,
-      (cs.admissible_mapExpr hg bs env).2 hint, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
+      (cs.admissible_mapExpr hg bs env).2 hint, ?_, hdc⟩
     rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
   · intro hinv env hsat bi hbi
     have hsatcs : cs.satisfies bs env := (cs.satisfies_mapExpr hg bs env).1 hsat

--- a/Leanr/Implementation/OptimizerPasses/Subst.lean
+++ b/Leanr/Implementation/OptimizerPasses/Subst.lean
@@ -152,11 +152,11 @@ theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : String) (t
     rw [cs.sideEffects_subst]
     exact BusState.equiv_refl _
   · -- completeness: cs intended-implies (cs.subst x t)
-    intro env hint hsat
+    intro env hint hsat _hdc
     have hx : env x = t.eval env := H env hsat
     have hupd : Function.update env x (t.eval env) = env := by
       rw [← hx]; exact Function.update_eq_self x env
-    refine ⟨env, ?_, ?_, ?_⟩
+    refine ⟨env, ?_, ?_, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
     · rw [cs.satisfies_subst, hupd]; exact hsat
     · rw [cs.admissible_subst, hupd]; exact hint
     · rw [cs.sideEffects_subst, hupd]; exact BusState.equiv_refl _

--- a/Leanr/Implementation/OptimizerPasses/Subst.lean
+++ b/Leanr/Implementation/OptimizerPasses/Subst.lean
@@ -72,7 +72,8 @@ theorem BusInteraction.eval_subst (bi : BusInteraction (Expression p)) (x : Stri
 def ConstraintSystem.subst (cs : ConstraintSystem p) (x : String) (t : Expression p) :
     ConstraintSystem p :=
   { algebraicConstraints := cs.algebraicConstraints.map (·.subst x t),
-    busInteractions := cs.busInteractions.map (·.subst x t) }
+    busInteractions := cs.busInteractions.map (·.subst x t),
+    derivedColumns := cs.derivedColumns }
 
 /-- The evaluated interactions of a substituted system, restricted to one bus, are those of the
     original under the rebound environment (substitution never changes a bus id). -/
@@ -152,11 +153,11 @@ theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : String) (t
     rw [cs.sideEffects_subst]
     exact BusState.equiv_refl _
   · -- completeness: cs intended-implies (cs.subst x t)
-    intro env hint hsat _hdc
+    intro env hint hsat hdc
     have hx : env x = t.eval env := H env hsat
     have hupd : Function.update env x (t.eval env) = env := by
       rw [← hx]; exact Function.update_eq_self x env
-    refine ⟨env, ?_, ?_, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
+    refine ⟨env, ?_, ?_, ?_, hdc⟩
     · rw [cs.satisfies_subst, hupd]; exact hsat
     · rw [cs.admissible_subst, hupd]; exact hint
     · rw [cs.sideEffects_subst, hupd]; exact BusState.equiv_refl _

--- a/Leanr/Implementation/OptimizerPasses/SubstMap.lean
+++ b/Leanr/Implementation/OptimizerPasses/SubstMap.lean
@@ -157,9 +157,9 @@ theorem ConstraintSystem.substF_correct (cs : ConstraintSystem p)
     rw [cs.sideEffects_substF]
     exact BusState.equiv_refl _
   · -- completeness: cs intended-implies (cs.substF f)
-    intro env hint hsat
+    intro env hint hsat _hdc
     have henv : envF f env = env := envF_eq_self f env (H env hsat)
-    refine ⟨env, ?_, ?_, ?_⟩
+    refine ⟨env, ?_, ?_, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
     · rw [cs.satisfies_substF, henv]; exact hsat
     · rw [cs.admissible_substF, henv]; exact hint
     · rw [cs.sideEffects_substF, henv]; exact BusState.equiv_refl _

--- a/Leanr/Implementation/OptimizerPasses/SubstMap.lean
+++ b/Leanr/Implementation/OptimizerPasses/SubstMap.lean
@@ -78,7 +78,8 @@ theorem BusInteraction.eval_substF (bi : BusInteraction (Expression p))
 def ConstraintSystem.substF (cs : ConstraintSystem p) (f : String → Option (Expression p)) :
     ConstraintSystem p :=
   { algebraicConstraints := cs.algebraicConstraints.map (·.substF f),
-    busInteractions := cs.busInteractions.map (·.substF f) }
+    busInteractions := cs.busInteractions.map (·.substF f),
+    derivedColumns := cs.derivedColumns }
 
 /-- The evaluated interactions of a substituted system, restricted to one bus, are those of
     the original under the rebound environment (substitution never changes a bus id). -/
@@ -157,9 +158,9 @@ theorem ConstraintSystem.substF_correct (cs : ConstraintSystem p)
     rw [cs.sideEffects_substF]
     exact BusState.equiv_refl _
   · -- completeness: cs intended-implies (cs.substF f)
-    intro env hint hsat _hdc
+    intro env hint hsat hdc
     have henv : envF f env = env := envF_eq_self f env (H env hsat)
-    refine ⟨env, ?_, ?_, ?_, ConstraintSystem.derivedConsistent_of_nil env rfl⟩
+    refine ⟨env, ?_, ?_, ?_, hdc⟩
     · rw [cs.satisfies_substF, henv]; exact hsat
     · rw [cs.admissible_substF, henv]; exact hint
     · rw [cs.sideEffects_substF, henv]; exact BusState.equiv_refl _

--- a/Leanr/Implementation/OptimizerPasses/TautoBus.lean
+++ b/Leanr/Implementation/OptimizerPasses/TautoBus.lean
@@ -144,11 +144,11 @@ theorem ConstraintSystem.filterBusStateless_correct (cs : ConstraintSystem p)
   refine ⟨⟨?_, ?_⟩, ?_⟩
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
+  · intro env hint hsat hdc
     exact ⟨env, (hiff env).2 hsat,
       (cs.admissible_filterBus bs keep env
         (fun bi hbi hkf => Or.inr (hstateless bi hbi hkf))).2 hint,
-      by rw [hside]; exact BusState.equiv_refl _⟩
+      by rw [hside]; exact BusState.equiv_refl _, hdc⟩
   · intro hinv env hsat bi hbi
     have hbimem : bi ∈ cs.busInteractions :=
       (List.mem_filter.1 (by simpa only [ConstraintSystem.filterBus] using hbi)).1

--- a/Leanr/Optimizer.lean
+++ b/Leanr/Optimizer.lean
@@ -37,7 +37,8 @@ theorem optimizerWithBusFacts_maintainsCorrectness (bs : BusSemantics p) (facts 
     (iters : Nat) :
     optimizerMaintainsCorrectness bs (optimizerWithBusFacts facts iters) :=
   ⟨fun cs => optimizerWithBusFacts_correct facts iters cs,
-   fun cs => optimizerWithBusFacts_respectsDegree facts iters cs⟩
+   fun cs => optimizerWithBusFacts_respectsDegree facts iters cs,
+   fun cs => optimizerWithBusFacts_preservesDerived facts iters cs⟩
 
 theorem simpleOptimizer_maintainsCorrectness (bs : BusSemantics p) (iters : Nat) :
     optimizerMaintainsCorrectness bs (simpleOptimizer bs iters) :=

--- a/Leanr/Optimizer.lean
+++ b/Leanr/Optimizer.lean
@@ -38,7 +38,8 @@ theorem optimizerWithBusFacts_maintainsCorrectness (bs : BusSemantics p) (facts 
     optimizerMaintainsCorrectness bs (optimizerWithBusFacts facts iters) :=
   ⟨fun cs => optimizerWithBusFacts_correct facts iters cs,
    fun cs => optimizerWithBusFacts_respectsDegree facts iters cs,
-   fun cs => optimizerWithBusFacts_preservesDerived facts iters cs⟩
+   fun cs env hadm hsat hdc =>
+     optimizerWithBusFacts_derivedConsistent facts iters cs env hadm hsat hdc⟩
 
 theorem simpleOptimizer_maintainsCorrectness (bs : BusSemantics p) (iters : Nat) :
     optimizerMaintainsCorrectness bs (simpleOptimizer bs iters) :=

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -29,6 +29,47 @@ def Expression.degree : Expression p → Nat
   | .add e1 e2 => max e1.degree e2.degree
   | .mul e1 e2 => e1.degree + e2.degree
 
+--------- Derived Columns (witgen hints) ---------
+
+/-- A *method for computing* the value of a derived column from an assignment, mirroring powdr's
+    `ComputationMethod`. These are witness-generation hints: they do **not** constrain the circuit
+    (they are not checked by the verifier), they instruct witgen how to fill a column. -/
+inductive ComputationMethod (p : ℕ) where
+  /-- A constant field value. -/
+  | constant (n : ZMod p)
+  /-- The quotient `num / den` using field inversion, or `0` when `den` evaluates to `0`. -/
+  | quotientOrZero (num den : Expression p)
+  /-- If `cond` evaluates to `0`, compute via `thenM`, otherwise via `elseM`. -/
+  | ifEqZero (cond : Expression p) (thenM elseM : ComputationMethod p)
+
+/-- Evaluate a computation method under an assignment. Reproduces powdr's
+    `evaluate_computation_method`: `quotientOrZero` uses the field inverse and yields `0` on a
+    zero divisor (matching powdr's explicit guard; note the `if` makes the result independent of
+    mathlib's convention `0⁻¹ = 0`). -/
+def ComputationMethod.eval (m : ComputationMethod p) (env : String → ZMod p) : ZMod p :=
+  match m with
+  | .constant n => n
+  | .quotientOrZero num den =>
+      let d := den.eval env
+      if d = 0 then 0 else num.eval env * d⁻¹
+  | .ifEqZero cond thenM elseM =>
+      if cond.eval env = 0 then thenM.eval env else elseM.eval env
+
+/-- A derived column, mirroring powdr's `DerivedVariable`. `isNew` distinguishes a genuinely new
+    column the optimizer created (witgen must compute it) from a hint for a pre-existing/removed
+    variable (`isNew = false`). `name` is the variable identifier (powdr's `"name@id"`). -/
+structure DerivedVariable (p : ℕ) where
+  isNew : Bool
+  name : String
+  computation : ComputationMethod p
+
+/-- A derived column is *consistent* under an assignment when the variable it names already holds
+    the value its computation method produces from that same assignment — the intended witgen
+    semantics `variable := computation(other columns)`. This is a **declarative** definition of
+    the hint's meaning; it is not enforced by any pass (see `docs/design/architecture.md`). -/
+def DerivedVariable.consistent (dc : DerivedVariable p) (env : String → ZMod p) : Prop :=
+  env dc.name = dc.computation.eval env
+
 --------- Bus Interactions ---------
 
 /-- A bus interaction. Typically, α is
@@ -96,6 +137,10 @@ instance : HasEquiv (BusState p) :=
 structure ConstraintSystem (p : ℕ) where
   algebraicConstraints : List (Expression p)
   busInteractions : List (BusInteraction (Expression p))
+  /-- Derived columns (witgen hints), mirroring powdr's `SymbolicMachine.derived_columns`. These
+      are metadata: they do not participate in `satisfies`/`refines` (see below). Defaulted to
+      `[]` so that constructions that do not care about derived columns are unaffected. -/
+  derivedColumns : List (DerivedVariable p) := []
 
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
@@ -120,6 +165,19 @@ def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSeman
   (∀ bi ∈ s.busInteractions,
     let message := bi.eval env
     message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false)
+
+/-- All of a system's derived columns are consistent under `env`. -/
+def ConstraintSystem.derivedConsistent (s : ConstraintSystem p) (env : String → ZMod p) : Prop :=
+  ∀ dc ∈ s.derivedColumns, dc.consistent env
+
+/-- A system's derived columns are *entailed* by the system when every satisfying assignment makes
+    them consistent — i.e. the hints are provably correct against the circuit itself. This is the
+    semantic notion of a valid derived column. It is provided declaratively (an emitting pass would
+    establish it for the columns it adds); the current optimizer emits no columns and instead
+    carries them verbatim (see `optimizerPreservesDerivedColumns`). -/
+def ConstraintSystem.derivedColumnsEntailed (s : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    Prop :=
+  ∀ env, s.satisfies busSemantics env → s.derivedConsistent env
 
 /-- Whether a constraint system guarantees that all invariants are maintained under a given bus semantics. -/
 def ConstraintSystem.guaranteesInvariants (s : ConstraintSystem p) (busSemantics : BusSemantics p) : Prop :=
@@ -173,6 +231,16 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
     constraintSystem.withinDegree busSemantics.degreeBound →
     (optimizer constraintSystem).withinDegree busSemantics.degreeBound
 
+/-- Whether an optimizer carries derived columns (witgen hints) through verbatim: the output's
+    derived columns equal the input's. Derived columns are trusted metadata, not constraints, so
+    the optimizer must neither fabricate a new (possibly bogus) hint nor silently drop one. Since
+    the columns are preserved identically, the output's hints are exactly as valid as the input's
+    (in particular `derivedColumnsEntailed` transfers when the columns are unchanged). -/
+def optimizerPreservesDerivedColumns
+    (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
+  ∀ constraintSystem : ConstraintSystem p,
+    (optimizer constraintSystem).derivedColumns = constraintSystem.derivedColumns
+
 /-- Whether an optimizer maintains correctness *with respect to a given `busSemantics`*. This
     means that, for all constraint systems:
     1. The optimized constraint system `refines` the original: it is sound (every satisfying
@@ -180,6 +248,8 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
        the input's intended (real-trace) executions.
     2. Assuming the original constraint system guarantees invariants, so does the optimized one.
     3. The optimizer respects the zkVM's degree bound.
+    4. The optimizer preserves derived columns verbatim
+       (`optimizerPreservesDerivedColumns`).
 
     The bus semantics is a *parameter*: quantifying over it (`∀ bs, optimizerMaintainsCorrectness
     bs opt`) recovers the "correct for every semantics" reading, while leaving it fixed lets a
@@ -192,3 +262,4 @@ def optimizerMaintainsCorrectness (busSemantics : BusSemantics p)
     (constraintSystem.guaranteesInvariants busSemantics →
       (optimizer constraintSystem).guaranteesInvariants busSemantics))
   ∧ optimizerRespectsDegreeBound busSemantics optimizer
+  ∧ optimizerPreservesDerivedColumns optimizer

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -171,10 +171,11 @@ def ConstraintSystem.derivedConsistent (s : ConstraintSystem p) (env : String �
   ∀ dc ∈ s.derivedColumns, dc.consistent env
 
 /-- A system's derived columns are *entailed* by the system when every satisfying assignment makes
-    them consistent — i.e. the hints are provably correct against the circuit itself. This is the
-    semantic notion of a valid derived column. It is provided declaratively (an emitting pass would
-    establish it for the columns it adds); the current optimizer emits no columns and instead
-    carries them verbatim (see `optimizerPreservesDerivedColumns`). -/
+    them consistent — i.e. the hints are provably correct against the circuit itself. This is a
+    stronger (env-universal) notion than the completeness-witness consistency carried by
+    `impliesAdmissible`; it holds for hints of columns still pinned by the constraints, but not for
+    hints of *eliminated* variables (which are free in the output), so the optimizer's guarantee is
+    the witness-level `optimizerDerivedColumnsConsistent`, not entailment. Kept as documentation. -/
 def ConstraintSystem.derivedColumnsEntailed (s : ConstraintSystem p) (busSemantics : BusSemantics p) :
     Prop :=
   ∀ env, s.satisfies busSemantics env → s.derivedConsistent env
@@ -201,12 +202,25 @@ def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : B
     assignments, and the produced witness is itself admissible. This is the *completeness*
     direction of an optimization: the optimizer must reproduce every real trace, but may drop
     spurious (non-trace) satisfying assignments. Delivering an admissible witness is what makes
-    `refines` transitive. -/
+    `refines` transitive.
+
+    **Derived columns (witgen hints).** The obligation additionally *assumes* `self`'s derived
+    columns are consistent under `env` and *delivers* a witness `env'` under which `other`'s derived
+    columns are consistent. This threads witness-generation semantics through the same completeness
+    witness the optimizer already constructs: a real trace of `self` is hint-consistent (witgen
+    filled the hint columns per their computation methods), and the optimizer must produce a real
+    trace of `other` that is likewise hint-consistent. The assume/deliver symmetry is exactly what
+    keeps the relation reflexive (`env' = env` re-delivers the assumption) and transitive (the
+    middle witness carries the hypothesis the next step needs). At the audited boundary the input
+    has no derived columns, so the hypothesis is vacuous and the conclusion is the real guarantee:
+    the optimizer's *output* hints are reconstructible on every real trace. -/
 def ConstraintSystem.impliesAdmissible (self other : ConstraintSystem p)
     (busSemantics : BusSemantics p) : Prop :=
   ∀ env, self.admissible busSemantics env → self.satisfies busSemantics env →
+    self.derivedConsistent env →
     ∃ env', other.satisfies busSemantics env' ∧ other.admissible busSemantics env' ∧
-      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
+      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env' ∧
+      other.derivedConsistent env'
 
 /-- Whether `self` is a valid **optimization** of `other` under a given bus semantics:
     * **sound** — `self.implies other`: A satisfying assignment of `self` implies that there exists
@@ -231,15 +245,20 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
     constraintSystem.withinDegree busSemantics.degreeBound →
     (optimizer constraintSystem).withinDegree busSemantics.degreeBound
 
-/-- Whether an optimizer carries derived columns (witgen hints) through verbatim: the output's
-    derived columns equal the input's. Derived columns are trusted metadata, not constraints, so
-    the optimizer must neither fabricate a new (possibly bogus) hint nor silently drop one. Since
-    the columns are preserved identically, the output's hints are exactly as valid as the input's
-    (in particular `derivedColumnsEntailed` transfers when the columns are unchanged). -/
-def optimizerPreservesDerivedColumns
+/-- Whether an optimizer's *output* derived columns (witgen hints) are consistent under the
+    completeness witness it constructs: for every admissible, satisfying, hint-consistent input
+    assignment there is an output-satisfying `env'` under which every output derived column computes
+    the value it is assigned. This is the meaningful correctness of an emitted hint — witgen,
+    following the hints on a real trace, obtains a consistent assignment — and it forbids
+    fabricating a hint that cannot be reconstructed. It is a direct projection of the `refines`
+    completeness direction (`impliesAdmissible`), which now carries derived-column consistency. -/
+def optimizerDerivedColumnsConsistent (busSemantics : BusSemantics p)
     (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
-  ∀ constraintSystem : ConstraintSystem p,
-    (optimizer constraintSystem).derivedColumns = constraintSystem.derivedColumns
+  ∀ (constraintSystem : ConstraintSystem p) (env : String → ZMod p),
+    constraintSystem.admissible busSemantics env → constraintSystem.satisfies busSemantics env →
+    constraintSystem.derivedConsistent env →
+    ∃ env', (optimizer constraintSystem).satisfies busSemantics env' ∧
+      (optimizer constraintSystem).derivedConsistent env'
 
 /-- Whether an optimizer maintains correctness *with respect to a given `busSemantics`*. This
     means that, for all constraint systems:
@@ -248,8 +267,8 @@ def optimizerPreservesDerivedColumns
        the input's intended (real-trace) executions.
     2. Assuming the original constraint system guarantees invariants, so does the optimized one.
     3. The optimizer respects the zkVM's degree bound.
-    4. The optimizer preserves derived columns verbatim
-       (`optimizerPreservesDerivedColumns`).
+    4. The optimizer's output derived columns (witgen hints) are consistent under the constructed
+       completeness witness (`optimizerDerivedColumnsConsistent`).
 
     The bus semantics is a *parameter*: quantifying over it (`∀ bs, optimizerMaintainsCorrectness
     bs opt`) recovers the "correct for every semantics" reading, while leaving it fixed lets a
@@ -262,4 +281,4 @@ def optimizerMaintainsCorrectness (busSemantics : BusSemantics p)
     (constraintSystem.guaranteesInvariants busSemantics →
       (optimizer constraintSystem).guaranteesInvariants busSemantics))
   ∧ optimizerRespectsDegreeBound busSemantics optimizer
-  ∧ optimizerPreservesDerivedColumns optimizer
+  ∧ optimizerDerivedColumnsConsistent busSemantics optimizer

--- a/Main.lean
+++ b/Main.lean
@@ -1,4 +1,5 @@
 import Leanr.Implementation.JsonParser
+import Leanr.Implementation.JsonSerializer
 import Leanr.Optimizer
 import Leanr.Utils.Size
 import Leanr.Utils.Dsl
@@ -123,6 +124,9 @@ def cmdRun (fileName : String) (iters : Nat) : IO Unit := do
   IO.println s!"  degree bound (identities {bound.identities}, bus {bound.busInteractions}): \
     input {if cs.withinDegreeB bound then "ok" else "EXCEEDED"}, \
     output {if optimized.withinDegreeB bound then "ok" else "EXCEEDED"}"
+  IO.println s!"  derived columns (witgen hints) emitted: {optimized.derivedColumns.length}"
+  if h : optimized.derivedColumns.length > 0 then
+    IO.println s!"    sample: {(serializeDerivedVariable optimized.derivedColumns[0]).compress}"
   IO.println s!"  ({iters} iters, {t1 - t0} ms)"
 
 /-- Like `cmdRun`, but also dump the distinct variables remaining after optimization (for

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -90,28 +90,42 @@ evaluator. These are **witness-generation hints, not constraints**: they are not
 verifier and are deliberately kept out of `satisfies`/`refines`/`withinDegree`, all of which read
 only `algebraicConstraints`/`busInteractions`. Consequently every existing pass proof is unaffected.
 
-- **Audited definitions.** `DerivedVariable.consistent` (a hint holds when the variable already
-  equals its computed value) and `ConstraintSystem.derivedColumnsEntailed` (every satisfying
-  assignment makes the hints consistent) are *declarative* — they state the intended semantics of a
-  hint for future emitting passes and for cross-tool round-tripping. They are **not** enforced by
-  any pass today.
-- **The correctness guarantee.** `optimizerMaintainsCorrectness` gains a fourth clause,
-  `optimizerPreservesDerivedColumns` (`(opt cs).derivedColumns = cs.derivedColumns`): the optimizer
-  carries hints through verbatim, neither fabricating nor dropping them. This is *not* semantic
-  entailment-preservation, which is **unprovable generically**: `refines` maps a satisfying
-  assignment of the output to a possibly-different one of the input (substitution passes rebind
-  eliminated variables), so output-consistency at `env` cannot be derived from input-consistency at
-  the rebound `env'`. Verbatim preservation is the strongest guarantee provable without per-pass
-  coupling, and is exactly what powdr witgen needs (an `isNew=false` hint is precisely how a removed
-  column is recomputed). The optimizer reattaches `cs.derivedColumns` after the
-  (derived-column-agnostic) pipeline, so the clause holds by `rfl`.
-- **Deferred.** No pass yet *emits* a hint; emission needs a pass-level entailment obligation, out
-  of scope here. Because hints are carried verbatim while substitution passes eliminate variables, a
-  preserved `computation` may reference a variable no longer present in the output constraints —
-  benign for representation/parse/serialize, but reconciling hints with variable elimination (drop
-  or rewrite dead references) is left to the powdr-integration task. Parsing (`JsonParser.lean`) and
-  serialization (`JsonSerializer.lean`) match powdr's serde (3-tuple, externally-tagged
-  `ComputationMethod`); a missing `derived_columns` key parses to `[]`.
+- **Correctness lives in `refines`.** `impliesAdmissible` (the completeness direction) now
+  *assumes* `self.derivedConsistent env` and *delivers* a witness `env'` with
+  `other.derivedConsistent env'`. This assume/deliver symmetry is what keeps the relation reflexive
+  (`env' = env` re-delivers the assumption) and transitive (the middle witness carries the
+  hypothesis the next step needs), so all pass composition (`refines_trans`) is unchanged. Soundness
+  (`implies`) is deliberately left untouched: an adversarial output-satisfying assignment cannot be
+  made hint-consistent, nor needs to be — hints are witgen instructions, not verifier constraints.
+  `optimizerMaintainsCorrectness`'s fourth clause, `optimizerDerivedColumnsConsistent`, is the
+  projection: for every admissible, satisfying, hint-consistent input there is an output-satisfying
+  `env'` under which every emitted hint computes its assigned value.
+- **Why this and not env-universal entailment.** `derivedColumnsEntailed` (every satisfying
+  assignment makes the hints consistent) is kept as documentation but is *not* the guarantee: it
+  fails for hints of *eliminated* variables, which are free in the output, so no output constraint
+  pins them. Consistency under the *constructed completeness witness* is the right, provable notion —
+  and is exactly what witgen needs (following the hints on a real trace yields a consistent
+  assignment).
+- **Emission.** The re-encoding pass (`Reencode.lean`) emits an `isNew = false` hint
+  `QuotientOrZero(interpolation-over-fresh-bits, 1)` (= powdr's `ComputationMethod::expression`) for
+  each group variable it eliminates, accumulating onto any hints already present. Its freshness
+  certificate (`checkReencode`) requires the fresh bits to avoid the eliminated group vars and every
+  existing derived column (name + computation), so accumulated hints transport across each step. The
+  emitted-hint consistency is discharged from the pass's own forward witness.
+- **Preservation.** Every *non-emitting* pass preserves derived columns unchanged. Because each
+  such pass's completeness witness is `env' = env`, consistency transfers for free (the pass reuses
+  its `derivedConsistent` hypothesis). This lets the emitting re-encoding pass stay inside the
+  iterated cleanup cycle — so effectiveness (variables/bus/constraints) is byte-identical to the
+  hint-free pipeline — while its hints survive verbatim to the optimizer output.
+- **Serialization.** Parsing (`JsonParser.lean`) and serialization (`JsonSerializer.lean`) match
+  powdr's serde exactly (3-tuple `[is_new, "name@id", method]`, externally-tagged `ComputationMethod`,
+  field elements as bare numbers); a missing `derived_columns` key parses to `[]`.
+- **Deferred.** Re-encoding does *not* yet emit `isNew = true` hints for the fresh bit columns it
+  creates (witgen must compute those): the bit value is a function of the eliminated group values,
+  expressible only via Lagrange interpolation over the non-boolean group-value domains (the existing
+  `indicatorExpr` machinery is boolean-only) — a substantial addition left for later. Parser-provided
+  *input* hints are dropped by substitution passes rather than rewritten under substitution (the
+  benchmark inputs carry none); rewriting them is future work.
 
 ## Adding a pass
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -80,6 +80,39 @@ proven facts, and iteration count) and derives its instances `simpleOptimizer_ma
 and the OpenVM `openVmOptimizer` (with
 `openVmOptimizer_maintainsCorrectness`) as one-liners.
 
+## Derived columns (witgen hints)
+
+`ConstraintSystem` carries a `derivedColumns : List (DerivedVariable p)` field (defaulted to `[]`),
+mirroring powdr's `SymbolicMachine.derived_columns`. A `DerivedVariable` is `{ isNew, name,
+computation }`, and a `ComputationMethod` is `constant` / `quotientOrZero` (field-inverse quotient,
+`0` on a zero divisor) / `ifEqZero` — reproducing powdr's `ComputationMethod` and its witgen
+evaluator. These are **witness-generation hints, not constraints**: they are not checked by the
+verifier and are deliberately kept out of `satisfies`/`refines`/`withinDegree`, all of which read
+only `algebraicConstraints`/`busInteractions`. Consequently every existing pass proof is unaffected.
+
+- **Audited definitions.** `DerivedVariable.consistent` (a hint holds when the variable already
+  equals its computed value) and `ConstraintSystem.derivedColumnsEntailed` (every satisfying
+  assignment makes the hints consistent) are *declarative* — they state the intended semantics of a
+  hint for future emitting passes and for cross-tool round-tripping. They are **not** enforced by
+  any pass today.
+- **The correctness guarantee.** `optimizerMaintainsCorrectness` gains a fourth clause,
+  `optimizerPreservesDerivedColumns` (`(opt cs).derivedColumns = cs.derivedColumns`): the optimizer
+  carries hints through verbatim, neither fabricating nor dropping them. This is *not* semantic
+  entailment-preservation, which is **unprovable generically**: `refines` maps a satisfying
+  assignment of the output to a possibly-different one of the input (substitution passes rebind
+  eliminated variables), so output-consistency at `env` cannot be derived from input-consistency at
+  the rebound `env'`. Verbatim preservation is the strongest guarantee provable without per-pass
+  coupling, and is exactly what powdr witgen needs (an `isNew=false` hint is precisely how a removed
+  column is recomputed). The optimizer reattaches `cs.derivedColumns` after the
+  (derived-column-agnostic) pipeline, so the clause holds by `rfl`.
+- **Deferred.** No pass yet *emits* a hint; emission needs a pass-level entailment obligation, out
+  of scope here. Because hints are carried verbatim while substitution passes eliminate variables, a
+  preserved `computation` may reference a variable no longer present in the output constraints —
+  benign for representation/parse/serialize, but reconciling hints with variable elimination (drop
+  or rewrite dead references) is left to the powdr-integration task. Parsing (`JsonParser.lean`) and
+  serialization (`JsonSerializer.lean`) match powdr's serde (3-tuple, externally-tagged
+  `ComputationMethod`); a missing `derived_columns` key parses to `[]`.
+
 ## Adding a pass
 
 Write a `VerifiedPass` (or `VerifiedPassW`) in a new `Leanr/Implementation/OptimizerPasses/` file,


### PR DESCRIPTION
## Summary

Represents powdr's **derived columns** (witgen hints) in Leanr, threads them through the pipeline,
**emits them from the re-encoding pass**, and serializes them in powdr's exact format — with all
correctness proofs closed (**no `sorry`, no `admit`, no new axiom**). `lake build` is fully green;
`openVmOptimizer_maintainsCorrectness` depends only on `[propext, Classical.choice, Quot.sound]`.

⚠️ **Touches the audited surface** (`Leanr/Spec.lean` `refines`/`impliesAdmissible`,
`Leanr/Optimizer.lean`). Per `CLAUDE.md` this is a correctness-spec change and warrants human review
(not a merge-without-review effectiveness PR). Effectiveness (variables/bus/constraints) is
**byte-identical** to the hint-free pipeline.

## Data model (mirrors powdr)

- `ComputationMethod p` = `constant (ZMod p)` | `quotientOrZero (num den)` (field-inverse, `0` on
  zero divisor) | `ifEqZero (cond) (thenM elseM)`; `eval` reproduces powdr's
  `evaluate_computation_method`.
- `DerivedVariable p = { isNew : Bool, name : String, computation : ComputationMethod p }`.
- `ConstraintSystem` gains `derivedColumns : List (DerivedVariable p) := []`.

## Spec strengthening (why it stays sound)

Derived columns are witgen hints, not verifier constraints — `satisfies`/`implies`/`withinDegree`
ignore them. The **completeness** direction of `refines` (`impliesAdmissible`) is strengthened to
*assume* `self.derivedConsistent env` and *deliver* a witness `env'` with
`other.derivedConsistent env'`. The assume/deliver symmetry keeps `refl` (env'=env re-delivers the
assumption) and `trans` (middle witness carries the next hypothesis) closing, so **all pass
composition is unchanged**. Soundness (`implies`) is untouched: an adversarial output assignment
can't be made hint-consistent and needn't be. The 4th clause of `optimizerMaintainsCorrectness` is
now `optimizerDerivedColumnsConsistent` — a projection of the strengthened `refines`: for every
admissible/satisfying/hint-consistent input there's an output-satisfying `env'` making every emitted
hint consistent (exactly what witgen needs following the hints on a real trace).

This is *not* env-universal entailment, which is **unprovable** for hints of eliminated variables
(free in the output). Consistency under the *constructed completeness witness* is the provable,
correct notion.

## Emission (the re-encoding pass)

`reencodePass` eliminates a variable group `xs` by substituting each `x` with an interpolation
polynomial over fresh boolean bits. It now **emits** an `isNew = false` hint per eliminated `x`:
`QuotientOrZero((var x).substF (groupSubst xs hm), const 1)` = powdr's `ComputationMethod::expression`.
Discharge uses the pass's own forward witness (`hpoint`). Hints **accumulate** across the multi-group
loop; the freshness certificate now also requires fresh bits to avoid the group vars and every
existing hint (name + computation), so carried hints transport across each step
(`ComputationMethod.eval_congr`).

**Propagation.** Every non-emitting pass now *preserves* derived columns; since each such pass's
completeness witness is `env' = env`, consistency transfers for free (reuse the hypothesis). So the
emitting re-encoding pass stays in the cleanup loop (no effectiveness change) and its hints survive
verbatim to the output, then serialize.

## Evidence emission works

`lake exe leanr run` reports emitted-hint counts. Example (`apc_002`):
```
derived columns (witgen hints) emitted: 11
  sample: [false,"flags__0_0@23",{"QuotientOrZero":[[[1,"+",[2013265920,"*","rnc36_44_3_0"]],"*",[1,"+",[2013265920,"*","rnc36_44_3_1"]]],1]}]
```
`apc_005` emits 640 hints. Effectiveness unchanged: `apc_001` 42/18/44, `apc_002` 49/13/38,
`apc_003` 133/45/150 (identical to the hint-free build).

## Parser / serializer

- Parser reads optional `machine.derived_columns` (3-tuple, externally-tagged); missing → `[]`
  (backward-compatible).
- `JsonSerializer.lean` emits Expression trees, externally-tagged `ComputationMethod`, and the
  `[is_new, "name@id", method]` tuple, matching powdr serde (field elements = bare numbers). Includes
  a `#guard` round-trip test.

## Files changed

`Leanr/Spec.lean`, `Leanr/Optimizer.lean` (audited); `Leanr/Implementation/Optimizer.lean`,
`OptimizerPasses/{Basic,Rewrite,Subst,SubstMap,MemoryUnify,MonicScale,TautoBus,DisconnectedComponent,Reencode,FactPass}.lean`,
`Leanr/Implementation/{JsonParser,JsonSerializer}.lean`, `Leanr.lean`, `Main.lean`,
`docs/design/architecture.md`.

## Deferred (documented)

- `isNew = true` hints for the fresh bit columns (needs Lagrange interpolation over non-boolean
  group-value domains; the existing indicator machinery is boolean-only).
- Rewriting parser-provided *input* hints under substitution (benchmark inputs carry none; they are
  currently dropped by substitution passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)