### PR TITLE
Introduce structured `Variable` type and propagate through spec & optimizer

### DIFF
--- a/Leanr/Implementation/JsonParser.lean
+++ b/Leanr/Implementation/JsonParser.lean
@@ -65,7 +65,7 @@ partial def parseJsonExpr (j : Lean.Json) : Except String (Expression p) :=
     -- All constants in powdr exports are integers (exponent 0).
     let z := n.mantissa * (10 ^ n.exponent)
     .ok (.const (z : ZMod p))
-  | Lean.Json.str s => .ok (.var s)
+  | Lean.Json.str s => .ok (.var (Variable.ofPowdrName s))
   | Lean.Json.arr items =>
     if h3 : items.size = 3 then
       let lhs := items[0]

--- a/Leanr/Implementation/JsonParser.lean
+++ b/Leanr/Implementation/JsonParser.lean
@@ -1,5 +1,6 @@
 import Lean.Data.Json
 import Leanr.Spec
+import Leanr.Implementation.Variable
 import Leanr.OpenVmSemantics
 
 /-!

--- a/Leanr/Implementation/OptimizerPasses/Affine.lean
+++ b/Leanr/Implementation/OptimizerPasses/Affine.lean
@@ -30,22 +30,22 @@ variable {p : ℕ}
 /-- A linear (affine) form: a constant plus a list of `(variable, coefficient)` terms. -/
 structure LinExpr (p : ℕ) where
   const : ZMod p
-  terms : List (String × ZMod p)
+  terms : List (Variable × ZMod p)
 
 /-- Evaluate a linear form. -/
-def LinExpr.eval (l : LinExpr p) (env : String → ZMod p) : ZMod p :=
+def LinExpr.eval (l : LinExpr p) (env : Variable → ZMod p) : ZMod p :=
   l.const + (l.terms.map (fun t => t.2 * env t.1)).sum
 
 def LinExpr.add (a b : LinExpr p) : LinExpr p := ⟨a.const + b.const, a.terms ++ b.terms⟩
 def LinExpr.scale (k : ZMod p) (a : LinExpr p) : LinExpr p :=
   ⟨k * a.const, a.terms.map (fun t => (t.1, k * t.2))⟩
 
-theorem LinExpr.add_eval (a b : LinExpr p) (env : String → ZMod p) :
+theorem LinExpr.add_eval (a b : LinExpr p) (env : Variable → ZMod p) :
     (a.add b).eval env = a.eval env + b.eval env := by
   simp only [LinExpr.add, LinExpr.eval, List.map_append, List.sum_append]
   ring
 
-theorem LinExpr.scale_eval (k : ZMod p) (a : LinExpr p) (env : String → ZMod p) :
+theorem LinExpr.scale_eval (k : ZMod p) (a : LinExpr p) (env : Variable → ZMod p) :
     (a.scale k).eval env = k * a.eval env := by
   simp only [LinExpr.scale, LinExpr.eval, List.map_map, mul_add]
   congr 1
@@ -70,7 +70,7 @@ def linearize : Expression p → Option (LinExpr p)
       | _, _ => none
 
 theorem linearize_eval (e : Expression p) (l : LinExpr p) (h : linearize e = some l)
-    (env : String → ZMod p) : e.eval env = l.eval env := by
+    (env : Variable → ZMod p) : e.eval env = l.eval env := by
   induction e generalizing l with
   | const n => simp only [linearize, Option.some.injEq] at h; subst h; simp [LinExpr.eval, Expression.eval]
   | var x => simp only [linearize, Option.some.injEq] at h; subst h; simp [LinExpr.eval, Expression.eval]
@@ -110,8 +110,8 @@ theorem linearize_eval (e : Expression p) (l : LinExpr p) (h : linearize e = som
               exact absurd h (by simp)
 
 /-- Partition the evaluation of a term list by whether the variable is `x`. -/
-theorem eval_terms_split (x : String) (env : String → ZMod p)
-    (terms : List (String × ZMod p)) :
+theorem eval_terms_split (x : Variable) (env : Variable → ZMod p)
+    (terms : List (Variable × ZMod p)) :
     (terms.map (fun t => t.2 * env t.1)).sum
     = ((terms.filter (fun t => t.1 = x)).map Prod.snd).sum * env x
       + ((terms.filter (fun t => t.1 ≠ x)).map (fun t => t.2 * env t.1)).sum := by
@@ -129,14 +129,14 @@ theorem eval_terms_split (x : String) (env : String → ZMod p)
         ring
 
 /-- Total coefficient of `x` in a linear form. -/
-def LinExpr.coeff (l : LinExpr p) (x : String) : ZMod p :=
+def LinExpr.coeff (l : LinExpr p) (x : Variable) : ZMod p :=
   ((l.terms.filter (fun t => t.1 = x)).map Prod.snd).sum
 
 /-- The linear form with all `x` terms removed. -/
-def LinExpr.others (l : LinExpr p) (x : String) : LinExpr p :=
+def LinExpr.others (l : LinExpr p) (x : Variable) : LinExpr p :=
   ⟨l.const, l.terms.filter (fun t => t.1 ≠ x)⟩
 
-theorem LinExpr.eval_split (l : LinExpr p) (x : String) (env : String → ZMod p) :
+theorem LinExpr.eval_split (l : LinExpr p) (x : Variable) (env : Variable → ZMod p) :
     l.eval env = l.coeff x * env x + (l.others x).eval env := by
   simp only [LinExpr.eval, LinExpr.coeff, LinExpr.others, eval_terms_split x env l.terms]
   ring
@@ -145,7 +145,7 @@ theorem LinExpr.eval_split (l : LinExpr p) (x : String) (env : String → ZMod p
 def LinExpr.toExpr (l : LinExpr p) : Expression p :=
   l.terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) (.const l.const)
 
-theorem toExpr_foldl_eval (env : String → ZMod p) (terms : List (String × ZMod p)) :
+theorem toExpr_foldl_eval (env : Variable → ZMod p) (terms : List (Variable × ZMod p)) :
     ∀ init : Expression p,
       (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).eval env
       = init.eval env + (terms.map (fun t => t.2 * env t.1)).sum := by
@@ -157,18 +157,18 @@ theorem toExpr_foldl_eval (env : String → ZMod p) (terms : List (String × ZMo
       simp only [Expression.eval]
       ring
 
-theorem LinExpr.toExpr_eval (l : LinExpr p) (env : String → ZMod p) :
+theorem LinExpr.toExpr_eval (l : LinExpr p) (env : Variable → ZMod p) :
     l.toExpr.eval env = l.eval env := by
   simp only [LinExpr.toExpr, LinExpr.eval, toExpr_foldl_eval, Expression.eval]
 
 /-- Try to solve the linear form `= 0` for variable `v`, when `v` has coefficient `±1`. -/
-def LinExpr.trySolve (l : LinExpr p) (v : String) : Option (String × Expression p) :=
+def LinExpr.trySolve (l : LinExpr p) (v : Variable) : Option (Variable × Expression p) :=
   if l.coeff v = 1 then some (v, ((l.others v).scale (-1)).toExpr)
   else if l.coeff v = -1 then some (v, (l.others v).toExpr)
   else none
 
-theorem LinExpr.trySolve_sound (l : LinExpr p) (v x : String) (t : Expression p)
-    (h : l.trySolve v = some (x, t)) (env : String → ZMod p) (hl : l.eval env = 0) :
+theorem LinExpr.trySolve_sound (l : LinExpr p) (v x : Variable) (t : Expression p)
+    (h : l.trySolve v = some (x, t)) (env : Variable → ZMod p) (hl : l.eval env = 0) :
     env x = t.eval env := by
   unfold LinExpr.trySolve at h
   split_ifs at h with h1 h2
@@ -190,13 +190,13 @@ theorem LinExpr.trySolve_sound (l : LinExpr p) (v x : String) (t : Expression p)
     inversion behaving well): over a prime field every nonzero coefficient qualifies, over
     `ZMod n` exactly the residues coprime to `n`. Generalizes `trySolve`; kept separate so the
     solver can *prefer* `±1` pivots, which substitute without rescaling the other coefficients. -/
-def LinExpr.trySolveUnit (l : LinExpr p) (v : String) : Option (String × Expression p) :=
+def LinExpr.trySolveUnit (l : LinExpr p) (v : Variable) : Option (Variable × Expression p) :=
   if l.coeff v * (l.coeff v)⁻¹ = 1 then
     some (v, ((l.others v).scale (-(l.coeff v)⁻¹)).toExpr)
   else none
 
-theorem LinExpr.trySolveUnit_sound (l : LinExpr p) (v x : String) (t : Expression p)
-    (h : l.trySolveUnit v = some (x, t)) (env : String → ZMod p) (hl : l.eval env = 0) :
+theorem LinExpr.trySolveUnit_sound (l : LinExpr p) (v x : Variable) (t : Expression p)
+    (h : l.trySolveUnit v = some (x, t)) (env : Variable → ZMod p) (hl : l.eval env = 0) :
     env x = t.eval env := by
   unfold LinExpr.trySolveUnit at h
   split_ifs at h with h1
@@ -209,7 +209,7 @@ theorem LinExpr.trySolveUnit_sound (l : LinExpr p) (v x : String) (t : Expressio
 
 /-- Solve the linear form for the first `±1`-coefficient variable; failing that, for the first
     variable whose coefficient is a unit. -/
-def solveAffineLin (l : LinExpr p) : Option (String × Expression p) :=
+def solveAffineLin (l : LinExpr p) : Option (Variable × Expression p) :=
   match (l.terms.map Prod.fst).find? (fun v => (l.trySolve v).isSome) with
   | some v => l.trySolve v
   | none =>
@@ -217,8 +217,8 @@ def solveAffineLin (l : LinExpr p) : Option (String × Expression p) :=
     | some v => l.trySolveUnit v
     | none => none
 
-theorem solveAffineLin_sound (l : LinExpr p) (x : String) (t : Expression p)
-    (h : solveAffineLin l = some (x, t)) (env : String → ZMod p) (hl : l.eval env = 0) :
+theorem solveAffineLin_sound (l : LinExpr p) (x : Variable) (t : Expression p)
+    (h : solveAffineLin l = some (x, t)) (env : Variable → ZMod p) (hl : l.eval env = 0) :
     env x = t.eval env := by
   unfold solveAffineLin at h
   split at h
@@ -230,11 +230,11 @@ theorem solveAffineLin_sound (l : LinExpr p) (x : String) (t : Expression p)
     · exact absurd h (by simp)
 
 /-- Solve a constraint expression for a unit-coefficient variable, if it is affine. -/
-def solveAffine (c : Expression p) : Option (String × Expression p) :=
+def solveAffine (c : Expression p) : Option (Variable × Expression p) :=
   (linearize c).bind solveAffineLin
 
-theorem solveAffine_sound (c : Expression p) (x : String) (t : Expression p)
-    (h : solveAffine c = some (x, t)) (env : String → ZMod p) (hc : c.eval env = 0) :
+theorem solveAffine_sound (c : Expression p) (x : Variable) (t : Expression p)
+    (h : solveAffine c = some (x, t)) (env : Variable → ZMod p) (hc : c.eval env = 0) :
     env x = t.eval env := by
   simp only [solveAffine, Option.bind_eq_some_iff] at h
   obtain ⟨l, hlin, hsl⟩ := h
@@ -250,13 +250,13 @@ the one minimizing an expression-duplication cost. Soundness is per-pivot (each 
 with the same entailment as before), so the choice heuristic itself carries no proof burden. -/
 
 /-- All `±1`-coefficient pivots of one constraint. -/
-def pm1PivotsOf (c : Expression p) : List (String × Expression p) :=
+def pm1PivotsOf (c : Expression p) : List (Variable × Expression p) :=
   match linearize c with
   | none => []
   | some l => (l.terms.map Prod.fst).filterMap l.trySolve
 
-theorem pm1PivotsOf_sound (c : Expression p) (x : String) (t : Expression p)
-    (h : (x, t) ∈ pm1PivotsOf c) (env : String → ZMod p) (hc : c.eval env = 0) :
+theorem pm1PivotsOf_sound (c : Expression p) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ pm1PivotsOf c) (env : Variable → ZMod p) (hc : c.eval env = 0) :
     env x = t.eval env := by
   unfold pm1PivotsOf at h
   split at h
@@ -267,7 +267,7 @@ theorem pm1PivotsOf_sound (c : Expression p) (x : String) (t : Expression p)
     exact l.trySolve_sound v x t hv env hl
 
 /-- Unit-coefficient pivots of one constraint, for variables with no `±1` solution. -/
-def unitPivotsOf (c : Expression p) : List (String × Expression p) :=
+def unitPivotsOf (c : Expression p) : List (Variable × Expression p) :=
   match linearize c with
   | none => []
   | some l =>
@@ -276,8 +276,8 @@ def unitPivotsOf (c : Expression p) : List (String × Expression p) :=
       | some _ => none
       | none => l.trySolveUnit v)
 
-theorem unitPivotsOf_sound (c : Expression p) (x : String) (t : Expression p)
-    (h : (x, t) ∈ unitPivotsOf c) (env : String → ZMod p) (hc : c.eval env = 0) :
+theorem unitPivotsOf_sound (c : Expression p) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ unitPivotsOf c) (env : Variable → ZMod p) (hc : c.eval env = 0) :
     env x = t.eval env := by
   unfold unitPivotsOf at h
   split at h
@@ -294,11 +294,11 @@ theorem unitPivotsOf_sound (c : Expression p) (x : String) (t : Expression p)
 /-- All solvable pivots across a constraint list, `±1` pivots first: `List.argmin` keeps the
     *first* minimum, so on a cost tie a `±1` pivot (which substitutes without rescaling the
     remaining coefficients into inverse constants) beats a general unit pivot. -/
-def solvableFrom (all : List (Expression p)) : List (String × Expression p) :=
+def solvableFrom (all : List (Expression p)) : List (Variable × Expression p) :=
   all.flatMap pm1PivotsOf ++ all.flatMap unitPivotsOf
 
-theorem solvableFrom_sound (all : List (Expression p)) (x : String) (t : Expression p)
-    (h : (x, t) ∈ solvableFrom all) (env : String → ZMod p)
+theorem solvableFrom_sound (all : List (Expression p)) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ solvableFrom all) (env : Variable → ZMod p)
     (hall : ∀ c ∈ all, c.eval env = 0) : env x = t.eval env := by
   rcases List.mem_append.1 h with h' | h' <;> obtain ⟨c, hc, hp⟩ := List.mem_flatMap.1 h'
   · exact pm1PivotsOf_sound c x t hp env (hall c hc)
@@ -306,11 +306,11 @@ theorem solvableFrom_sound (all : List (Expression p)) (x : String) (t : Express
 
 /-- The duplication cost of substituting `x := t`: every *other* occurrence of `x` is replaced
     by a copy of `t`. A variable occurring only in its defining constraint costs `0`. -/
-def pivotCost (cs : ConstraintSystem p) (x : String) (t : Expression p) : Nat :=
+def pivotCost (cs : ConstraintSystem p) (x : Variable) (t : Expression p) : Nat :=
   (cs.occurrences x - 1) * (1 + t.vars.length)
 
 /-- The cheapest solvable pivot of the whole system, if any. -/
-def bestAffinePivot (cs : ConstraintSystem p) : Option (String × Expression p) :=
+def bestAffinePivot (cs : ConstraintSystem p) : Option (Variable × Expression p) :=
   (solvableFrom cs.algebraicConstraints).argmin (fun xt => pivotCost cs xt.1 xt.2)
 
 /-- The affine-substitution pass: eliminate one variable pinned by a linear constraint (unit

--- a/Leanr/Implementation/OptimizerPasses/Basic.lean
+++ b/Leanr/Implementation/OptimizerPasses/Basic.lean
@@ -1,4 +1,5 @@
 import Leanr.Spec
+import Leanr.Implementation.Variable
 
 set_option autoImplicit false
 

--- a/Leanr/Implementation/OptimizerPasses/BusUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusUnify.lean
@@ -33,7 +33,7 @@ def addrConstsNeq (shape : MemoryBusShape) (S bi : BusInteraction (Expression p)
     | _, _ => false)
 
 theorem addrConstsNeq_sound (shape : MemoryBusShape) (S bi : BusInteraction (Expression p))
-    (h : addrConstsNeq shape S bi = true) (env : String → ZMod p) :
+    (h : addrConstsNeq shape S bi = true) (env : Variable → ZMod p) :
     shape.address (S.eval env) ≠ shape.address (bi.eval env) := by
   obtain ⟨slot, hslot, hcond⟩ := List.any_eq_true.1 h
   intro heq
@@ -73,7 +73,7 @@ theorem addrConstsNeq_sound (shape : MemoryBusShape) (S bi : BusInteraction (Exp
 /-- Filtering evaluated messages by bus id equals evaluating the bus-filtered interactions
     (evaluation preserves the bus id). -/
 theorem map_eval_filter_busId (l : List (BusInteraction (Expression p))) (busId : Nat)
-    (env : String → ZMod p) :
+    (env : Variable → ZMod p) :
     (l.map (fun bi => bi.eval env)).filter (fun m => m.busId = busId)
     = (l.filter (fun bi => bi.busId = busId)).map (fun bi => bi.eval env) := by
   induction l with
@@ -89,7 +89,7 @@ theorem map_eval_filter_busId (l : List (BusInteraction (Expression p))) (busId 
     address in the bus's interaction list, with no active same-address message strictly between,
     have equal evaluated payloads (`admissibleMemoryBus.consecutive`). -/
 theorem consecutivePayloadEq (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) (env : String → ZMod p)
+    (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) (env : Variable → ZMod p)
     (hadm : cs.admissible bs env)
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
     (pre mid post : List (BusInteraction (Expression p)))
@@ -136,7 +136,7 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (post : List (BusInteraction (Expression p)))
     (hchk : checkPair shape (cs.busInteractions.filter (fun bi => bi.busId = busId))
       pre S mid R post = true)
-    (env : String → ZMod p) (hadm : cs.admissible bs env) :
+    (env : Variable → ZMod p) (hadm : cs.admissible bs env) :
     ∀ c ∈ memEqConstraints shape S R, c.eval env = 0 := by
   unfold checkPair at hchk
   simp only [Bool.and_eq_true] at hchk

--- a/Leanr/Implementation/OptimizerPasses/ConstantFold.lean
+++ b/Leanr/Implementation/OptimizerPasses/ConstantFold.lean
@@ -39,12 +39,12 @@ def Expression.foldMul (a b : Expression p) : Expression p :=
   | a, .const n => if n = 0 then .const 0 else if n = 1 then a else .mul a (.const n)
   | a, b => .mul a b
 
-theorem Expression.foldAdd_eval (a b : Expression p) (env : String → ZMod p) :
+theorem Expression.foldAdd_eval (a b : Expression p) (env : Variable → ZMod p) :
     (a.foldAdd b).eval env = a.eval env + b.eval env := by
   unfold Expression.foldAdd
   split <;> (try split_ifs) <;> simp_all [Expression.eval]
 
-theorem Expression.foldMul_eval (a b : Expression p) (env : String → ZMod p) :
+theorem Expression.foldMul_eval (a b : Expression p) (env : Variable → ZMod p) :
     (a.foldMul b).eval env = a.eval env * b.eval env := by
   unfold Expression.foldMul
   split <;> (try split_ifs) <;> simp_all [Expression.eval]
@@ -57,7 +57,7 @@ def Expression.fold : Expression p → Expression p
   | .add a b => a.fold.foldAdd b.fold
   | .mul a b => a.fold.foldMul b.fold
 
-theorem Expression.fold_eval (e : Expression p) (env : String → ZMod p) :
+theorem Expression.fold_eval (e : Expression p) (env : Variable → ZMod p) :
     e.fold.eval env = e.eval env := by
   induction e with
   | const n => rfl

--- a/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -34,7 +34,7 @@ The evaluated stateful interactions of the filtered system (under `e1`) equal th
 (under `e2`), given that every dropped interaction is stateless and every *stateful* interaction
 evaluates the same under `e1` and `e2`. -/
 theorem sideEffects_drop_eq (bs : BusSemantics p) (keepBi : BusInteraction (Expression p) → Bool)
-    (e1 e2 : String → ZMod p) (L : List (BusInteraction (Expression p)))
+    (e1 e2 : Variable → ZMod p) (L : List (BusInteraction (Expression p)))
     (hst : ∀ bi ∈ L, keepBi bi = false → bs.isStateful bi.busId = false)
     (heq : ∀ bi ∈ L, bs.isStateful bi.busId = true → bi.eval e2 = bi.eval e1) :
     ((L.filter keepBi).filter (fun bi => bs.isStateful bi.busId)).map
@@ -75,7 +75,7 @@ say: every removed item's variables are all "removed" variables (`remV`), the wi
 every removed constraint and makes every removed interaction non-violating, every removed
 interaction is stateless, and every kept item uses only kept variables. -/
 theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (w : String → ZMod p) (remV : String → Bool)
+    (w : Variable → ZMod p) (remV : Variable → Bool)
     (keepCon : Expression p → Bool) (keepBi : BusInteraction (Expression p) → Bool)
     (hCrem : ∀ c ∈ cs.algebraicConstraints, keepCon c = false → ∀ x ∈ c.vars, remV x = true)
     (hCsat : ∀ c ∈ cs.algebraicConstraints, keepCon c = false → c.eval w = 0)
@@ -88,7 +88,7 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     PassCorrect cs { algebraicConstraints := cs.algebraicConstraints.filter keepCon,
                      busInteractions := cs.busInteractions.filter keepBi } bs := by
   -- the merge: keep `env` on kept variables, use the witness on removed ones
-  set m : (String → ZMod p) → (String → ZMod p) :=
+  set m : (Variable → ZMod p) → (Variable → ZMod p) :=
     fun env x => if remV x = true then w x else env x with hm
   -- evaluation of a "removed" expression / interaction under the merge is the witness value
   have hmwC : ∀ env (e : Expression p), (∀ x ∈ e.vars, remV x = true) →
@@ -173,9 +173,9 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     interaction (`groups` = the variable lists; `v2g` = variable → group indices). This only *finds*
     a candidate component — correctness never depends on it, since the pass re-checks the partition
     the result induces. -/
-partial def bfsClosure (groups : Array (List String)) (v2g : Std.HashMap String (List Nat))
-    (visited : Std.HashSet String) (procGroups : Std.HashSet Nat) (stack : List String) :
-    Std.HashSet String :=
+partial def bfsClosure (groups : Array (List Variable)) (v2g : Std.HashMap Variable (List Nat))
+    (visited : Std.HashSet Variable) (procGroups : Std.HashSet Nat) (stack : List Variable) :
+    Std.HashSet Variable :=
   match stack with
   | [] => visited
   | x :: rest =>
@@ -190,21 +190,21 @@ partial def bfsClosure (groups : Array (List String)) (v2g : Std.HashMap String 
     variables (`groups`), and a map from each variable to the indices of the items it occurs in
     (`v2g`). Both `bfsClosure` seeds run over this graph. -/
 def buildGraph (cs : ConstraintSystem p) :
-    Array (List String) × Std.HashMap String (List Nat) :=
-  let groups : Array (List String) :=
+    Array (List Variable) × Std.HashMap Variable (List Nat) :=
+  let groups : Array (List Variable) :=
     (cs.algebraicConstraints.map Expression.vars ++
       cs.busInteractions.map BusInteraction.vars).toArray
-  let v2g : Std.HashMap String (List Nat) :=
+  let v2g : Std.HashMap Variable (List Nat) :=
     (List.range groups.size).foldl
       (fun mp i => (groups.getD i []).foldl (fun mp x => mp.insert x (i :: mp.getD x [])) mp) ∅
   (groups, v2g)
 
 /-- Keep a constraint unless *all* of its variables are removable (and it has at least one). -/
-def keepConWith (remV : String → Bool) (c : Expression p) : Bool :=
+def keepConWith (remV : Variable → Bool) (c : Expression p) : Bool :=
   c.vars.isEmpty || !(c.vars.all remV)
 
 /-- Keep an interaction if it is stateful or has a non-removable variable (or no variables). -/
-def keepBiWith (bs : BusSemantics p) (remV : String → Bool)
+def keepBiWith (bs : BusSemantics p) (remV : Variable → Bool)
     (bi : BusInteraction (Expression p)) : Bool :=
   bs.isStateful bi.busId || bi.vars.isEmpty || !(bi.vars.all remV)
 
@@ -225,9 +225,9 @@ def disconnectedComponentPass : VerifiedPass p := fun cs bs =>
   let conn := bfsClosure groups v2g ∅ ∅
     (cs.busInteractions.foldl (fun acc bi =>
       if bs.isStateful bi.busId then bi.vars ++ acc else acc) [])
-  let disc : String → Bool := fun x => !conn.contains x
+  let disc : Variable → Bool := fun x => !conn.contains x
   -- variables of a disconnected item the all-zero witness fails on: keep its whole component
-  let badSeeds : List String :=
+  let badSeeds : List Variable :=
     cs.algebraicConstraints.foldl (fun acc c =>
         if !c.vars.isEmpty && c.vars.all disc && !decide (c.eval (fun _ => 0) = 0)
         then c.vars ++ acc else acc)
@@ -236,7 +236,7 @@ def disconnectedComponentPass : VerifiedPass p := fun cs bs =>
             && bs.violatesConstraint (bi.eval (fun _ => 0))
         then bi.vars ++ acc else acc) [])
   let bad := bfsClosure groups v2g ∅ ∅ badSeeds
-  let remV : String → Bool := fun x => !conn.contains x && !bad.contains x
+  let remV : Variable → Bool := fun x => !conn.contains x && !bad.contains x
   if hchk : (
       (cs.algebraicConstraints.any (fun c => !keepConWith remV c) ||
         cs.busInteractions.any (fun bi => !keepBiWith bs remV bi)) &&

--- a/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
@@ -292,13 +292,13 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable 
 
 /-- Canonical key of a variable set, for target deduplication. -/
 def varSetKey (xs : List Variable) : String :=
-  String.intercalate "\x00" ((xs.mergeSort (fun a b => compare a b != .gt)).map toString)
+  String.intercalate "\x00" ((xs.mergeSort (fun a b => compare a b != .gt)).map (fun x => x.name))
 
 /-- Collect forced constants from joint enumerations of the given targets' variable sets,
     skipping variable sets already enumerated. -/
 def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p}
     (T : DomainTable p cs bs) :
-    List (List Variable) → Std.HashSet Variable → Solved p cs bs → Solved p cs bs
+    List (List Variable) → Std.HashSet String → Solved p cs bs → Solved p cs bs
   | [], _, σ => σ
   | xs :: rest, seen, σ =>
     let key := varSetKey xs

--- a/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
@@ -28,7 +28,7 @@ variable {p : ℕ}
 
 /-- Finite domains for variables, each entailed by every satisfying assignment of `cs`. -/
 structure DomainTable (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
-  map : Std.HashMap String (List (ZMod p))
+  map : Std.HashMap Variable (List (ZMod p))
   sound : ∀ env, cs.satisfies bs env → ∀ x d, map[x]? = some d → env x ∈ d
 
 namespace DomainTable
@@ -43,7 +43,7 @@ def empty : DomainTable p cs bs where
     exact absurd h (by simp)
 
 /-- Insert an entailed domain, keeping the smaller of two candidate domains for a variable. -/
-def insertEntry (T : DomainTable p cs bs) (x : String) (d : List (ZMod p))
+def insertEntry (T : DomainTable p cs bs) (x : Variable) (d : List (ZMod p))
     (h : ∀ env, cs.satisfies bs env → env x ∈ d) : DomainTable p cs bs :=
   let keep : Bool := match T.map[x]? with
     | some d0 => decide (d.length < d0.length)
@@ -64,15 +64,15 @@ def insertEntry (T : DomainTable p cs bs) (x : String) (d : List (ZMod p))
   else T
 
 /-- The table's domains for a variable list, all-or-nothing (mirrors `buildDoms`). -/
-def doms (T : DomainTable p cs bs) : List String → Option (List (String × List (ZMod p)))
+def doms (T : DomainTable p cs bs) : List Variable → Option (List (Variable × List (ZMod p)))
   | [] => some []
   | x :: xs =>
     match T.map[x]?, T.doms xs with
     | some d, some rest => some ((x, d) :: rest)
     | _, _ => none
 
-theorem doms_fst (T : DomainTable p cs bs) (xs : List String)
-    (ds : List (String × List (ZMod p))) (h : T.doms xs = some ds) : ds.map Prod.fst = xs := by
+theorem doms_fst (T : DomainTable p cs bs) (xs : List Variable)
+    (ds : List (Variable × List (ZMod p))) (h : T.doms xs = some ds) : ds.map Prod.fst = xs := by
   induction xs generalizing ds with
   | nil => simp only [doms, Option.some.injEq] at h; subst h; rfl
   | cons x rest ih =>
@@ -88,8 +88,8 @@ theorem doms_fst (T : DomainTable p cs bs) (xs : List String)
         subst h
         simp [ih ds' hr]
 
-theorem doms_sound (T : DomainTable p cs bs) (xs : List String)
-    (ds : List (String × List (ZMod p))) (h : T.doms xs = some ds) (env : String → ZMod p)
+theorem doms_sound (T : DomainTable p cs bs) (xs : List Variable)
+    (ds : List (Variable × List (ZMod p))) (h : T.doms xs = some ds) (env : Variable → ZMod p)
     (hsat : cs.satisfies bs env) : ∀ yd ∈ ds, env yd.1 ∈ yd.2 := by
   induction xs generalizing ds with
   | nil => simp only [doms, Option.some.injEq] at h; subst h; simp
@@ -122,7 +122,7 @@ def addConstraintDoms [Fact p.Prime] {cs : ConstraintSystem p} {bs : BusSemantic
   | c :: rest, hmem, T =>
     let hc := hmem c (List.mem_cons_self ..)
     let hrest := fun c' h => hmem c' (List.mem_cons_of_mem _ h)
-    let rec addVars (xs : List String) (T : DomainTable p cs bs) : DomainTable p cs bs :=
+    let rec addVars (xs : List Variable) (T : DomainTable p cs bs) : DomainTable p cs bs :=
       match xs with
       | [] => T
       | x :: xs =>
@@ -135,7 +135,7 @@ def addConstraintDoms [Fact p.Prime] {cs : ConstraintSystem p} {bs : BusSemantic
     addConstraintDoms rest hrest (if vs.length ≤ 3 then addVars vs T else T)
 
 /-- The raw-variable payload entries of an interaction. -/
-def payloadRawVars (bi : BusInteraction (Expression p)) : List String :=
+def payloadRawVars (bi : BusInteraction (Expression p)) : List Variable :=
   bi.payload.filterMap (fun e => match e with | .var x => some x | _ => none)
 
 /-- Bus-sourced domains: proven slot bounds on raw variable slots of interactions with
@@ -149,7 +149,7 @@ def addBusDoms [NeZero p] {cs : ConstraintSystem p} {bs : BusSemantics p}
   | bi :: rest, hmem, T =>
     let hbi := hmem bi (List.mem_cons_self ..)
     let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
-    let rec addVars (xs : List String) (T : DomainTable p cs bs) : DomainTable p cs bs :=
+    let rec addVars (xs : List Variable) (T : DomainTable p cs bs) : DomainTable p cs bs :=
       match xs with
       | [] => T
       | x :: xs =>
@@ -172,22 +172,22 @@ then collect *every* variable on which the survivors agree. -/
 
 /-- Does the assignment satisfy all covered constraints and survive all covered obligations? -/
 def survivesAllM (bs : BusSemantics p) (es : List (Expression p))
-    (bis : List (BusInteraction (Expression p))) (a : List (String × ZMod p)) : Bool :=
+    (bis : List (BusInteraction (Expression p))) (a : List (Variable × ZMod p)) : Bool :=
   es.all (fun e => decide (e.eval (envOf a) = 0)) &&
     bis.all (fun bi => interactionSurvives bs bi a)
 
 /-- The checked certificate: every surviving assignment gives `x = c`. -/
-def checkForcedM (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
+def checkForcedM (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
     (es : List (Expression p)) (bis : List (BusInteraction (Expression p)))
-    (x : String) (c : ZMod p) : Bool :=
+    (x : Variable) (c : ZMod p) : Bool :=
   (assignments doms).all
     (fun a => !survivesAllM bs es bis a || decide (envOf a x = c))
 
 /-- Candidate search (proof-free; `checkForcedM` re-verifies): all variables on which the
     surviving assignments agree, with the agreed value. -/
-def pickForcedM (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
+def pickForcedM (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
     (es : List (Expression p)) (bis : List (BusInteraction (Expression p))) :
-    List (String × ZMod p) :=
+    List (Variable × ZMod p) :=
   match (assignments doms).filter (survivesAllM bs es bis) with
   | [] => (doms.map Prod.fst).map (fun x => (x, 0))
   | a₀ :: survivors =>
@@ -196,20 +196,20 @@ def pickForcedM (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
       else none)
 
 /-- The constraints of the system whose variables all lie in `xs`. -/
-def coveredCs (cs : ConstraintSystem p) (xs : List String) : List (Expression p) :=
+def coveredCs (cs : ConstraintSystem p) (xs : List Variable) : List (Expression p) :=
   cs.algebraicConstraints.filter (fun c => c.vars.all (fun v => xs.contains v))
 
 /-- The interactions of the system whose variables all lie in `xs`. -/
-def coveredBis (cs : ConstraintSystem p) (xs : List String) :
+def coveredBis (cs : ConstraintSystem p) (xs : List Variable) :
     List (BusInteraction (Expression p)) :=
   cs.busInteractions.filter (fun bi => bi.vars.all (fun v => xs.contains v))
 
 theorem checkForcedM_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
-    (T : DomainTable p cs bs) (xs : List String) (doms : List (String × List (ZMod p)))
-    (hdoms : T.doms xs = some doms) (x : String) (c : ZMod p)
+    (T : DomainTable p cs bs) (xs : List Variable) (doms : List (Variable × List (ZMod p)))
+    (hdoms : T.doms xs = some doms) (x : Variable) (c : ZMod p)
     (hx : x ∈ doms.map Prod.fst)
     (hchk : checkForcedM bs doms (coveredCs cs xs) (coveredBis cs xs) x c = true)
-    (env : String → ZMod p) (hsat : cs.satisfies bs env) : env x = c := by
+    (env : Variable → ZMod p) (hsat : cs.satisfies bs env) : env x = c := by
   have hkeys : doms.map Prod.fst = xs := T.doms_fst xs doms hdoms
   -- the restriction of `env` to the domains is an enumerated assignment
   have hmem : doms.map (fun yd => (yd.1, env yd.1)) ∈ assignments doms :=
@@ -266,7 +266,7 @@ def maxEnumWork : Nat := 524288
     constraint and no covered interaction with a compound payload slot (a box constrained
     only by the raw range checks that produced the domains can never force anything). -/
 def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable p cs bs)
-    (xs : List String) : List ((x : String) × { c : ZMod p //
+    (xs : List Variable) : List ((x : Variable) × { c : ZMod p //
       ∀ env, cs.satisfies bs env → env x = c }) :=
   match hdoms : T.doms xs with
   | none => []
@@ -291,14 +291,14 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable 
 /-! ## Collecting all forced values -/
 
 /-- Canonical key of a variable set, for target deduplication. -/
-def varSetKey (xs : List String) : String :=
-  String.intercalate "\x00" (xs.mergeSort (· ≤ ·))
+def varSetKey (xs : List Variable) : String :=
+  String.intercalate "\x00" ((xs.mergeSort (fun a b => compare a b != .gt)).map toString)
 
 /-- Collect forced constants from joint enumerations of the given targets' variable sets,
     skipping variable sets already enumerated. -/
 def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p}
     (T : DomainTable p cs bs) :
-    List (List String) → Std.HashSet String → Solved p cs bs → Solved p cs bs
+    List (List Variable) → Std.HashSet Variable → Solved p cs bs → Solved p cs bs
   | [], _, σ => σ
   | xs :: rest, seen, σ =>
     let key := varSetKey xs

--- a/Leanr/Implementation/OptimizerPasses/DomainProp.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainProp.lean
@@ -39,7 +39,7 @@ variable {p : ℕ}
 
 /-! ## Evaluation depends only on an expression's variables -/
 
-theorem Expression.eval_congr (e : Expression p) (env1 env2 : String → ZMod p)
+theorem Expression.eval_congr (e : Expression p) (env1 env2 : Variable → ZMod p)
     (h : ∀ x ∈ e.vars, env1 x = env2 x) : e.eval env1 = e.eval env2 := by
   induction e with
   | const n => rfl
@@ -54,7 +54,7 @@ theorem Expression.eval_congr (e : Expression p) (env1 env2 : String → ZMod p)
           ihb (fun x hx => h x (by simp [Expression.vars, hx]))]
 
 theorem BusInteraction.eval_congr (bi : BusInteraction (Expression p))
-    (env1 env2 : String → ZMod p) (h : ∀ x ∈ bi.vars, env1 x = env2 x) :
+    (env1 env2 : Variable → ZMod p) (h : ∀ x ∈ bi.vars, env1 x = env2 x) :
     bi.eval env1 = bi.eval env2 := by
   have hmult : bi.multiplicity.eval env1 = bi.multiplicity.eval env2 :=
     bi.multiplicity.eval_congr env1 env2
@@ -74,16 +74,16 @@ theorem BusInteraction.eval_congr (bi : BusInteraction (Expression p))
     the unique root for a single term `a·x` with `a ≠ 0`, `none` otherwise ("cannot bound `x`").
     The root is computed with the ring's `Inv` and then *re-checked* (`a * r + c = 0`), so
     soundness never depends on inversion behaving well. -/
-def rootsOfTerms (x : String) (c : ZMod p) : List (String × ZMod p) → Option (List (ZMod p))
+def rootsOfTerms (x : Variable) (c : ZMod p) : List (Variable × ZMod p) → Option (List (ZMod p))
   | [] => if c = 0 then none else some []
   | [(y, a)] =>
       let r := -(a⁻¹ * c)
       if y = x ∧ a ≠ 0 ∧ a * r + c = 0 then some [r] else none
   | _ :: _ :: _ => none
 
-theorem rootsOfTerms_sound [Fact p.Prime] (x : String) (c : ZMod p)
-    (ts : List (String × ZMod p)) (roots : List (ZMod p))
-    (h : rootsOfTerms x c ts = some roots) (env : String → ZMod p)
+theorem rootsOfTerms_sound [Fact p.Prime] (x : Variable) (c : ZMod p)
+    (ts : List (Variable × ZMod p)) (roots : List (ZMod p))
+    (h : rootsOfTerms x c ts = some roots) (env : Variable → ZMod p)
     (hsum : c + (ts.map (fun t => t.2 * env t.1)).sum = 0) : env x ∈ roots := by
   rcases ts with _ | ⟨⟨y, a⟩, _ | ⟨t2, rest⟩⟩
   · -- no terms: a constant; `hsum` contradicts the nonzero guard
@@ -105,12 +105,12 @@ theorem rootsOfTerms_sound [Fact p.Prime] (x : String) (c : ZMod p)
   · exact absurd h (by simp [rootsOfTerms])
 
 /-- Roots of an expression that is affine in (at most) the single variable `x`. -/
-def affineRootsIn (x : String) (e : Expression p) : Option (List (ZMod p)) :=
+def affineRootsIn (x : Variable) (e : Expression p) : Option (List (ZMod p)) :=
   (linearize e).bind (fun l => rootsOfTerms x l.norm.const l.norm.terms)
 
-theorem affineRootsIn_sound [Fact p.Prime] (x : String) (e : Expression p)
+theorem affineRootsIn_sound [Fact p.Prime] (x : Variable) (e : Expression p)
     (roots : List (ZMod p)) (h : affineRootsIn x e = some roots)
-    (env : String → ZMod p) (he : e.eval env = 0) : env x ∈ roots := by
+    (env : Variable → ZMod p) (he : e.eval env = 0) : env x ∈ roots := by
   simp only [affineRootsIn, Option.bind_eq_some_iff] at h
   obtain ⟨l, hlin, hroot⟩ := h
   have heval : l.norm.const + (l.norm.terms.map (fun t => t.2 * env t.1)).sum = 0 := by
@@ -122,7 +122,7 @@ theorem affineRootsIn_sound [Fact p.Prime] (x : String) (e : Expression p)
 /-- Roots of a constraint viewed as a product of affine factors in the single variable `x`:
     if the constraint is zero, one factor is zero (integral domain), so `x` is one of the
     collected roots. `none` when a factor cannot be bounded. -/
-def rootsIn (x : String) : Expression p → Option (List (ZMod p))
+def rootsIn (x : Variable) : Expression p → Option (List (ZMod p))
   | .const n => affineRootsIn x (.const n)
   | .var y => affineRootsIn x (.var y)
   | .add a b => affineRootsIn x (.add a b)
@@ -134,8 +134,8 @@ def rootsIn (x : String) : Expression p → Option (List (ZMod p))
       | some ra, some rb => some (ra ++ rb)
       | _, _ => none
 
-theorem rootsIn_sound [Fact p.Prime] (x : String) (e : Expression p) (roots : List (ZMod p))
-    (h : rootsIn x e = some roots) (env : String → ZMod p) (he : e.eval env = 0) :
+theorem rootsIn_sound [Fact p.Prime] (x : Variable) (e : Expression p) (roots : List (ZMod p))
+    (h : rootsIn x e = some roots) (env : Variable → ZMod p) (he : e.eval env = 0) :
     env x ∈ roots := by
   induction e generalizing roots with
   | const n => exact affineRootsIn_sound x _ roots h env he
@@ -160,7 +160,7 @@ theorem rootsIn_sound [Fact p.Prime] (x : String) (e : Expression p) (roots : Li
       all_goals exact absurd h (by simp)
 
 /-- The finite domain of `x` derived from the first constraint that bounds it. -/
-def findDomainAlg (all : List (Expression p)) (x : String) : Option (List (ZMod p)) :=
+def findDomainAlg (all : List (Expression p)) (x : Variable) : Option (List (ZMod p)) :=
   match all with
   | [] => none
   | c :: rest =>
@@ -168,8 +168,8 @@ def findDomainAlg (all : List (Expression p)) (x : String) : Option (List (ZMod 
     | some d => some d
     | none => findDomainAlg rest x
 
-theorem findDomainAlg_sound [Fact p.Prime] (all : List (Expression p)) (x : String)
-    (d : List (ZMod p)) (h : findDomainAlg all x = some d) (env : String → ZMod p)
+theorem findDomainAlg_sound [Fact p.Prime] (all : List (Expression p)) (x : Variable)
+    (d : List (ZMod p)) (h : findDomainAlg all x = some d) (env : Variable → ZMod p)
     (hall : ∀ c ∈ all, c.eval env = 0) : env x ∈ d := by
   induction all with
   | nil => exact absurd h (by simp [findDomainAlg])
@@ -192,11 +192,11 @@ theorem findDomainAlg_sound [Fact p.Prime] (all : List (Expression p)) (x : Stri
 def maxDomainBound : Nat := 65536
 
 /-- Is this expression literally the variable `x`? -/
-def isVarOf (x : String) : Expression p → Bool
+def isVarOf (x : Variable) : Expression p → Bool
   | .var y => y = x
   | _ => false
 
-theorem isVarOf_sound (x : String) (e : Expression p) (h : isVarOf x e = true) :
+theorem isVarOf_sound (x : Variable) (e : Expression p) (h : isVarOf x e = true) :
     e = .var x := by
   cases e with
   | var y =>
@@ -207,11 +207,11 @@ theorem isVarOf_sound (x : String) (e : Expression p) (h : isVarOf x e = true) :
   | mul a b => exact absurd h (by simp [isVarOf])
 
 /-- The first payload slot that is literally the variable `x`. -/
-def varSlot (x : String) : List (Expression p) → Option Nat
+def varSlot (x : Variable) : List (Expression p) → Option Nat
   | [] => none
   | e :: rest => if isVarOf x e then some 0 else (varSlot x rest).map (· + 1)
 
-theorem varSlot_sound (x : String) (payload : List (Expression p)) (slot : Nat)
+theorem varSlot_sound (x : Variable) (payload : List (Expression p)) (slot : Nat)
     (h : varSlot x payload = some slot) : payload[slot]? = some (.var x) := by
   induction payload generalizing slot with
   | nil => exact absurd h (by simp [varSlot])
@@ -226,7 +226,7 @@ theorem varSlot_sound (x : String) (payload : List (Expression p)) (slot : Nat)
       simpa using ih s hs
 
 /-- The evaluated payload matches the pattern of its own constant entries. -/
-theorem matches_evalPattern (payload : List (Expression p)) (env : String → ZMod p) :
+theorem matches_evalPattern (payload : List (Expression p)) (env : Variable → ZMod p) :
     Matches (payload.map (fun e => e.eval env)) (payload.map Expression.constValue?) := by
   refine ⟨by simp, ?_⟩
   intro slot c hc
@@ -247,7 +247,7 @@ theorem mem_range_cast [NeZero p] (v : ZMod p) (bound : Nat) (h : v.val < bound)
     multiplicity (so its obligation is active under every assignment) and carries `x` as a raw
     payload entry in a slot bounded by a proven fact. -/
 def interactionBound (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : String) : Option Nat :=
+    (bi : BusInteraction (Expression p)) (x : Variable) : Option Nat :=
   match bi.multiplicity.constValue? with
   | none => none
   | some mval =>
@@ -258,8 +258,8 @@ def interactionBound (bs : BusSemantics p) (facts : BusFacts p bs)
       | some slot => facts.slotBound bi.busId (bi.payload.map Expression.constValue?) slot
 
 theorem interactionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : String) (bound : Nat)
-    (h : interactionBound bs facts bi x = some bound) (env : String → ZMod p)
+    (bi : BusInteraction (Expression p)) (x : Variable) (bound : Nat)
+    (h : interactionBound bs facts bi x = some bound) (env : Variable → ZMod p)
     (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
     (env x).val < bound := by
   unfold interactionBound at h
@@ -288,7 +288,7 @@ theorem interactionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
 
 /-- The value bound of `x` derived from the first bus obligation that bounds it. -/
 def findVarBound (bs : BusSemantics p) (facts : BusFacts p bs) :
-    List (BusInteraction (Expression p)) → String → Option Nat
+    List (BusInteraction (Expression p)) → Variable → Option Nat
   | [], _ => none
   | bi :: rest, x =>
     match interactionBound bs facts bi x with
@@ -296,8 +296,8 @@ def findVarBound (bs : BusSemantics p) (facts : BusFacts p bs) :
     | none => findVarBound bs facts rest x
 
 theorem findVarBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (Expression p))) (x : String) (bound : Nat)
-    (h : findVarBound bs facts bis x = some bound) (env : String → ZMod p)
+    (bis : List (BusInteraction (Expression p))) (x : Variable) (bound : Nat)
+    (h : findVarBound bs facts bis x = some bound) (env : Variable → ZMod p)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : (env x).val < bound := by
   induction bis with
@@ -316,7 +316,7 @@ theorem findVarBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
 
 /-- A finite domain for `x` from one bus obligation (capped bound, materialized as a list). -/
 def interactionDomain (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : String) : Option (List (ZMod p)) :=
+    (bi : BusInteraction (Expression p)) (x : Variable) : Option (List (ZMod p)) :=
   match interactionBound bs facts bi x with
   | none => none
   | some bound =>
@@ -325,8 +325,8 @@ def interactionDomain (bs : BusSemantics p) (facts : BusFacts p bs)
     else none
 
 theorem interactionDomain_sound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : String) (d : List (ZMod p))
-    (h : interactionDomain bs facts bi x = some d) (env : String → ZMod p)
+    (bi : BusInteraction (Expression p)) (x : Variable) (d : List (ZMod p))
+    (h : interactionDomain bs facts bi x = some d) (env : Variable → ZMod p)
     (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
     env x ∈ d := by
   unfold interactionDomain at h
@@ -341,7 +341,7 @@ theorem interactionDomain_sound [NeZero p] (bs : BusSemantics p) (facts : BusFac
 
 /-- The finite domain of `x` derived from the first bus obligation that bounds it. -/
 def findDomainBus (bs : BusSemantics p) (facts : BusFacts p bs) :
-    List (BusInteraction (Expression p)) → String → Option (List (ZMod p))
+    List (BusInteraction (Expression p)) → Variable → Option (List (ZMod p))
   | [], _ => none
   | bi :: rest, x =>
     match interactionDomain bs facts bi x with
@@ -349,8 +349,8 @@ def findDomainBus (bs : BusSemantics p) (facts : BusFacts p bs) :
     | none => findDomainBus bs facts rest x
 
 theorem findDomainBus_sound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (Expression p))) (x : String) (d : List (ZMod p))
-    (h : findDomainBus bs facts bis x = some d) (env : String → ZMod p)
+    (bis : List (BusInteraction (Expression p))) (x : Variable) (d : List (ZMod p))
+    (h : findDomainBus bs facts bis x = some d) (env : Variable → ZMod p)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x ∈ d := by
   induction bis with
@@ -369,15 +369,15 @@ theorem findDomainBus_sound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p
 
 /-- The finite domain of `x`: from a constraint if possible, else from a bus obligation. -/
 def findDomain (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (Expression p))) (x : String) : Option (List (ZMod p)) :=
+    (bis : List (BusInteraction (Expression p))) (x : Variable) : Option (List (ZMod p)) :=
   match findDomainAlg all x with
   | some d => some d
   | none => findDomainBus bs facts bis x
 
 theorem findDomain_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (x : String) (d : List (ZMod p)) (h : findDomain all bs facts bis x = some d)
-    (env : String → ZMod p) (hall : ∀ c ∈ all, c.eval env = 0)
+    (x : Variable) (d : List (ZMod p)) (h : findDomain all bs facts bis x = some d)
+    (env : Variable → ZMod p) (hall : ∀ c ∈ all, c.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x ∈ d := by
   unfold findDomain at h
@@ -393,7 +393,7 @@ theorem findDomain_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
 /-- Domains for a list of variables, all-or-nothing. -/
 def buildDoms (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (Expression p))) :
-    List String → Option (List (String × List (ZMod p)))
+    List Variable → Option (List (Variable × List (ZMod p)))
   | [] => some []
   | x :: xs =>
     match findDomain all bs facts bis x, buildDoms all bs facts bis xs with
@@ -401,8 +401,8 @@ def buildDoms (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFact
     | _, _ => none
 
 theorem buildDoms_fst (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (Expression p))) (xs : List String)
-    (doms : List (String × List (ZMod p))) (h : buildDoms all bs facts bis xs = some doms) :
+    (bis : List (BusInteraction (Expression p))) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p))) (h : buildDoms all bs facts bis xs = some doms) :
     doms.map Prod.fst = xs := by
   induction xs generalizing doms with
   | nil => simp only [buildDoms, Option.some.injEq] at h; subst h; rfl
@@ -421,8 +421,8 @@ theorem buildDoms_fst (all : List (Expression p)) (bs : BusSemantics p) (facts :
 
 theorem buildDoms_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (xs : List String) (doms : List (String × List (ZMod p)))
-    (h : buildDoms all bs facts bis xs = some doms) (env : String → ZMod p)
+    (xs : List Variable) (doms : List (Variable × List (ZMod p)))
+    (h : buildDoms all bs facts bis xs = some doms) (env : Variable → ZMod p)
     (hall : ∀ c ∈ all, c.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
@@ -448,17 +448,17 @@ theorem buildDoms_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
 /-! ## Exhaustive enumeration over domain products -/
 
 /-- All assignments in the cartesian product of the domains. -/
-def assignments : List (String × List (ZMod p)) → List (List (String × ZMod p))
+def assignments : List (Variable × List (ZMod p)) → List (List (Variable × ZMod p))
   | [] => [[]]
   | (x, d) :: rest => (assignments rest).flatMap (fun a => d.map (fun v => (x, v) :: a))
 
 /-- Read an assignment as an environment (`0` for unassigned variables). -/
-def envOf : List (String × ZMod p) → String → ZMod p
+def envOf : List (Variable × ZMod p) → Variable → ZMod p
   | [], _ => 0
   | (x, v) :: rest, y => if y = x then v else envOf rest y
 
 /-- The pointwise-in-domain restriction of `f` is one of the enumerated assignments. -/
-theorem mem_assignments (doms : List (String × List (ZMod p))) (f : String → ZMod p)
+theorem mem_assignments (doms : List (Variable × List (ZMod p))) (f : Variable → ZMod p)
     (h : ∀ yd ∈ doms, f yd.1 ∈ yd.2) :
     doms.map (fun yd => (yd.1, f yd.1)) ∈ assignments doms := by
   induction doms with
@@ -471,7 +471,7 @@ theorem mem_assignments (doms : List (String × List (ZMod p))) (f : String → 
     exact List.mem_map.2 ⟨f x, h (x, d) (List.mem_cons_self ..), rfl⟩
 
 /-- On its own variables, the restriction environment agrees with `f`. -/
-theorem envOf_map (doms : List (String × List (ZMod p))) (f : String → ZMod p) (y : String)
+theorem envOf_map (doms : List (Variable × List (ZMod p))) (f : Variable → ZMod p) (y : Variable)
     (hy : y ∈ doms.map Prod.fst) :
     envOf (doms.map (fun yd => (yd.1, f yd.1))) y = f y := by
   induction doms with
@@ -494,15 +494,15 @@ def maxEnumSize : Nat := 65536
 
 /-- The checked certificate: every enumerated assignment either falsifies the constraint or
     assigns `c` to `x`. -/
-def checkForced (doms : List (String × List (ZMod p))) (e : Expression p) (x : String)
+def checkForced (doms : List (Variable × List (ZMod p))) (e : Expression p) (x : Variable)
     (c : ZMod p) : Bool :=
   (assignments doms).all
     (fun a => !(decide (e.eval (envOf a) = 0)) || decide (envOf a x = c))
 
 /-- Candidate search (proof-free; `checkForced` re-verifies): the value of each variable in the
     first surviving assignment, if all survivors agree on it. -/
-def pickForced (doms : List (String × List (ZMod p))) (e : Expression p) :
-    Option (String × ZMod p) :=
+def pickForced (doms : List (Variable × List (ZMod p))) (e : Expression p) :
+    Option (Variable × ZMod p) :=
   match (assignments doms).filter (fun a => decide (e.eval (envOf a) = 0)) with
   | [] => (doms.map Prod.fst).head?.map (fun x => (x, 0))
   | a₀ :: survivors =>
@@ -514,7 +514,7 @@ def pickForced (doms : List (String × List (ZMod p))) (e : Expression p) :
     (found anywhere in the system), enumerate, and return a *checked* forced `(x, c)`. -/
 def tryConstraint (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (Expression p))) (e : Expression p) :
-    Option (String × ZMod p) :=
+    Option (Variable × ZMod p) :=
   match buildDoms all bs facts bis e.vars.dedup with
   | none => none
   | some doms =>
@@ -528,9 +528,9 @@ def tryConstraint (all : List (Expression p)) (bs : BusSemantics p) (facts : Bus
 
 theorem tryConstraint_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (e : Expression p) (x : String) (c : ZMod p)
+    (e : Expression p) (x : Variable) (c : ZMod p)
     (h : tryConstraint all bs facts bis e = some (x, c)) (he : e ∈ all)
-    (env : String → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
+    (env : Variable → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x = c := by
   unfold tryConstraint at h
@@ -572,18 +572,18 @@ theorem tryConstraint_sound [Fact p.Prime] [NeZero p] (all : List (Expression p)
 
 /-- Does the assignment survive the interaction's obligation (inactive, or accepted)? -/
 def interactionSurvives (bs : BusSemantics p) (bi : BusInteraction (Expression p))
-    (a : List (String × ZMod p)) : Bool :=
+    (a : List (Variable × ZMod p)) : Bool :=
   decide ((bi.eval (envOf a)).multiplicity = 0) || !bs.violatesConstraint (bi.eval (envOf a))
 
 /-- The checked certificate for an interaction target. -/
-def checkForcedBi (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
-    (bi : BusInteraction (Expression p)) (x : String) (c : ZMod p) : Bool :=
+def checkForcedBi (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
+    (bi : BusInteraction (Expression p)) (x : Variable) (c : ZMod p) : Bool :=
   (assignments doms).all
     (fun a => !interactionSurvives bs bi a || decide (envOf a x = c))
 
 /-- Candidate search for an interaction target (proof-free). -/
-def pickForcedBi (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
-    (bi : BusInteraction (Expression p)) : Option (String × ZMod p) :=
+def pickForcedBi (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
+    (bi : BusInteraction (Expression p)) : Option (Variable × ZMod p) :=
   match (assignments doms).filter (interactionSurvives bs bi) with
   | [] => (doms.map Prod.fst).head?.map (fun x => (x, 0))
   | a₀ :: survivors =>
@@ -595,7 +595,7 @@ def pickForcedBi (bs : BusSemantics p) (doms : List (String × List (ZMod p)))
     `violatesConstraint` pointwise on the domain product. -/
 def tryInteraction (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) :
-    Option (String × ZMod p) :=
+    Option (Variable × ZMod p) :=
   match buildDoms all bs facts bis bi.vars.dedup with
   | none => none
   | some doms =>
@@ -609,9 +609,9 @@ def tryInteraction (all : List (Expression p)) (bs : BusSemantics p) (facts : Bu
 
 theorem tryInteraction_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (bi : BusInteraction (Expression p)) (x : String) (c : ZMod p)
+    (bi : BusInteraction (Expression p)) (x : Variable) (c : ZMod p)
     (h : tryInteraction all bs facts bis bi = some (x, c)) (hbi : bi ∈ bis)
-    (env : String → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
+    (env : Variable → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi' ∈ bis, (bi'.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi'.eval env) = false) : env x = c := by
   unfold tryInteraction at h
@@ -657,7 +657,7 @@ theorem tryInteraction_sound [Fact p.Prime] [NeZero p] (all : List (Expression p
 /-- Scan the constraints for the first checked forced value. -/
 def findForcedC (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (Expression p))) :
-    List (Expression p) → Option (String × ZMod p)
+    List (Expression p) → Option (Variable × ZMod p)
   | [] => none
   | e :: rest =>
     match tryConstraint all bs facts bis e with
@@ -666,8 +666,8 @@ def findForcedC (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFa
 
 theorem findForcedC_sound [Fact p.Prime] [NeZero p] (all sub : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (x : String) (c : ZMod p) (h : findForcedC all bs facts bis sub = some (x, c))
-    (hsub : ∀ e ∈ sub, e ∈ all) (env : String → ZMod p)
+    (x : Variable) (c : ZMod p) (h : findForcedC all bs facts bis sub = some (x, c))
+    (hsub : ∀ e ∈ sub, e ∈ all) (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x = c := by
@@ -689,7 +689,7 @@ theorem findForcedC_sound [Fact p.Prime] [NeZero p] (all sub : List (Expression 
 /-- Scan the interactions for the first checked forced value. -/
 def findForcedI (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (Expression p))) :
-    List (BusInteraction (Expression p)) → Option (String × ZMod p)
+    List (BusInteraction (Expression p)) → Option (Variable × ZMod p)
   | [] => none
   | bi :: rest =>
     match tryInteraction all bs facts bis bi with
@@ -698,9 +698,9 @@ def findForcedI (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFa
 
 theorem findForcedI_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis sub : List (BusInteraction (Expression p))) (x : String) (c : ZMod p)
+    (bis sub : List (BusInteraction (Expression p))) (x : Variable) (c : ZMod p)
     (h : findForcedI all bs facts bis sub = some (x, c)) (hsub : ∀ bi ∈ sub, bi ∈ bis)
-    (env : String → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
+    (env : Variable → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x = c := by
   induction sub with
@@ -720,15 +720,15 @@ theorem findForcedI_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
 
 /-- Scan constraints, then interaction obligations, for a checked forced value. -/
 def findForced (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (Expression p))) : Option (String × ZMod p) :=
+    (bis : List (BusInteraction (Expression p))) : Option (Variable × ZMod p) :=
   match findForcedC all bs facts bis all with
   | some r => some r
   | none => findForcedI all bs facts bis bis
 
 theorem findForced_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs) (bis : List (BusInteraction (Expression p)))
-    (x : String) (c : ZMod p) (h : findForced all bs facts bis = some (x, c))
-    (env : String → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
+    (x : Variable) (c : ZMod p) (h : findForced all bs facts bis = some (x, c))
+    (env : Variable → ZMod p) (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) : env x = c := by
   unfold findForced at h

--- a/Leanr/Implementation/OptimizerPasses/Gauss.lean
+++ b/Leanr/Implementation/OptimizerPasses/Gauss.lean
@@ -35,7 +35,7 @@ variable {p : ℕ}
 /-! ## Cheap syntactic helpers (no allocation) -/
 
 /-- Does the expression mention variable `x`? -/
-def Expression.mentions (x : String) : Expression p → Bool
+def Expression.mentions (x : Variable) : Expression p → Bool
   | .const _ => false
   | .var y => y == x
   | .add a b => a.mentions x || b.mentions x
@@ -60,7 +60,7 @@ def Expression.isVar : Expression p → Bool
     cheap; the bundled proof is exactly the hypothesis `ConstraintSystem.substF_correct`
     consumes. -/
 structure Solved (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
-  map : Std.HashMap String (Expression p)
+  map : Std.HashMap Variable (Expression p)
   sound : ∀ env, cs.satisfies bs env → ∀ y t, map[y]? = some t → env y = t.eval env
 
 namespace Solved
@@ -75,23 +75,23 @@ def empty : Solved p cs bs where
     exact absurd h (by simp)
 
 /-- The map as a lookup function (what `substF` consumes). -/
-def fn (σ : Solved p cs bs) : String → Option (Expression p) := fun y => σ.map[y]?
+def fn (σ : Solved p cs bs) : Variable → Option (Expression p) := fun y => σ.map[y]?
 
 /-- Under a satisfying assignment, rebinding by the solution map changes nothing. -/
-theorem envF_self (σ : Solved p cs bs) (env : String → ZMod p)
+theorem envF_self (σ : Solved p cs bs) (env : Variable → ZMod p)
     (hsat : cs.satisfies bs env) : envF σ.fn env = env :=
   envF_eq_self σ.fn env (fun y t hyt => σ.sound env hsat y t hyt)
 
 /-- Reducing an expression by the solution map preserves its value under satisfying
     assignments. -/
-theorem eval_reduce (σ : Solved p cs bs) (e : Expression p) (env : String → ZMod p)
+theorem eval_reduce (σ : Solved p cs bs) (e : Expression p) (env : Variable → ZMod p)
     (hsat : cs.satisfies bs env) :
     ((e.substF σ.fn).normalize).eval env = e.eval env := by
   rw [Expression.normalize_eval, Expression.eval_substF, σ.envF_self env hsat]
 
 /-- Insert a list of entailed pairs (later inserts win, which is harmless: every pair is
     entailed individually). -/
-def insertAll (σ : Solved p cs bs) (pairs : List (String × Expression p))
+def insertAll (σ : Solved p cs bs) (pairs : List (Variable × Expression p))
     (H : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env) :
     Solved p cs bs :=
   match pairs with
@@ -117,8 +117,8 @@ end Solved
 /-! ## Pivot choice -/
 
 /-- Occurrence counts of every variable across the system (one traversal). -/
-def occurrenceMap (cs : ConstraintSystem p) : Std.HashMap String Nat :=
-  let addE := fun (m : Std.HashMap String Nat) (e : Expression p) =>
+def occurrenceMap (cs : ConstraintSystem p) : Std.HashMap Variable Nat :=
+  let addE := fun (m : Std.HashMap Variable Nat) (e : Expression p) =>
     e.vars.foldl (fun m x => m.insert x (m.getD x 0 + 1)) m
   let m := cs.algebraicConstraints.foldl addE ∅
   cs.busInteractions.foldl (fun m bi => bi.payload.foldl addE (addE m bi.multiplicity)) m
@@ -127,14 +127,14 @@ def occurrenceMap (cs : ConstraintSystem p) : Std.HashMap String Nat :=
     compound expression into such a slot destroys fact-derivable range knowledge
     (`interactionBound` in `DomainProp.lean` needs the slot to be literally a variable), so
     pivots on these variables are penalized unless their solution is itself a variable. -/
-def protectedVars (cs : ConstraintSystem p) (bs : BusSemantics p) : Std.HashSet String :=
+def protectedVars (cs : ConstraintSystem p) (bs : BusSemantics p) : Std.HashSet Variable :=
   cs.busInteractions.foldl (init := ∅) fun s bi =>
     if bs.isStateful bi.busId then s
     else bi.payload.foldl (fun s e => match e with | .var x => s.insert x | _ => s) s
 
 /-- The duplication cost of a pivot `x := t`, with the protection penalty. -/
-def pivotScore (occ : Std.HashMap String Nat) (prot : Std.HashSet String)
-    (xt : String × Expression p) : Nat :=
+def pivotScore (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (xt : Variable × Expression p) : Nat :=
   let base := (occ.getD xt.1 1 - 1) * (1 + xt.2.varCount)
   if prot.contains xt.1 && !xt.2.isVar then base + 1000000 else base
 
@@ -147,7 +147,7 @@ def pivotScore (occ : Std.HashMap String Nat) (prot : Std.HashSet String)
     applies; stored solutions stay entailed under resolution because `env x = t.eval env`
     makes `Function.update` a no-op. -/
 def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (occ : Std.HashMap String Nat) (prot : Std.HashSet String) :
+    (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
     (pending : List (Expression p)) → (∀ c ∈ pending, c ∈ cs.algebraicConstraints) →
     Solved p cs bs → Solved p cs bs
   | [], _, σ => σ

--- a/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
@@ -63,7 +63,7 @@ theorem ConstraintSystem.addConstraints_correct (cs : ConstraintSystem p) (bs : 
 /-- `e₂ - e₁` as an expression. -/
 def eqExpr (e2 e1 : Expression p) : Expression p := .add e2 (.mul (.const (-1)) e1)
 
-theorem eqExpr_eval (e2 e1 : Expression p) (env : String → ZMod p) :
+theorem eqExpr_eval (e2 e1 : Expression p) (env : Variable → ZMod p) :
     (eqExpr e2 e1).eval env = e2.eval env - e1.eval env := by
   show e2.eval env + (-1) * e1.eval env = _
   ring
@@ -75,7 +75,7 @@ def constDiff (e1 e2 : Expression p) : Option (ZMod p) :=
   | some l => if l.norm.terms = [] then some l.norm.const else none
 
 theorem constDiff_sound (e1 e2 : Expression p) (k : ZMod p) (h : constDiff e1 e2 = some k)
-    (env : String → ZMod p) : e2.eval env = e1.eval env + k := by
+    (env : Variable → ZMod p) : e2.eval env = e1.eval env + k := by
   unfold constDiff at h
   split at h
   · exact absurd h (by simp)
@@ -92,7 +92,7 @@ theorem constDiff_sound (e1 e2 : Expression p) (k : ZMod p) (h : constDiff e1 e2
 
 /-- Both entries of equal evaluated payloads evaluate equally (with a default for
     out-of-range slots). -/
-theorem payloadSlot_eval_eq (P Q : List (Expression p)) (env : String → ZMod p)
+theorem payloadSlot_eval_eq (P Q : List (Expression p)) (env : Variable → ZMod p)
     (h : P.map (fun e => e.eval env) = Q.map (fun e => e.eval env)) (i : Nat) :
     ((P[i]?).getD (.const 0)).eval env = ((Q[i]?).getD (.const 0)).eval env := by
   have hi := congrArg (fun l => l[i]?) h
@@ -108,7 +108,7 @@ bundled with its soundness. -/
 
 /-- Fact-derived value bounds for variables, each sound under the bus obligations. -/
 structure BoundsMap (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
-  map : Std.HashMap String Nat
+  map : Std.HashMap Variable Nat
   sound : ∀ env, (∀ bi ∈ cs.busInteractions, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) →
     ∀ x b, map[x]? = some b → (env x).val < b
@@ -125,7 +125,7 @@ def empty : BoundsMap p cs bs where
     exact absurd h (by simp)
 
 /-- Insert a sound bound, keeping the smaller of two bounds for a variable. -/
-def insertEntry (T : BoundsMap p cs bs) (x : String) (b : Nat)
+def insertEntry (T : BoundsMap p cs bs) (x : Variable) (b : Nat)
     (h : ∀ env, (∀ bi ∈ cs.busInteractions, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) → (env x).val < b) : BoundsMap p cs bs :=
   let keep : Bool := match T.map[x]? with
@@ -147,7 +147,7 @@ def insertEntry (T : BoundsMap p cs bs) (x : String) (b : Nat)
   else T
 
 /-- The raw-variable payload entries of an interaction. -/
-private def rawVarsOf (bi : BusInteraction (Expression p)) : List String :=
+private def rawVarsOf (bi : BusInteraction (Expression p)) : List Variable :=
   bi.payload.filterMap (fun e => match e with | .var x => some x | _ => none)
 
 /-- Collect bounds from all interactions' fact-bounded raw payload slots. -/
@@ -158,7 +158,7 @@ def addAll (facts : BusFacts p bs) :
   | bi :: rest, hmem, T =>
     let hbi := hmem bi (List.mem_cons_self ..)
     let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
-    let rec addVars (xs : List String) (T : BoundsMap p cs bs) : BoundsMap p cs bs :=
+    let rec addVars (xs : List Variable) (T : BoundsMap p cs bs) : BoundsMap p cs bs :=
       match xs with
       | [] => T
       | x :: xs =>
@@ -182,8 +182,8 @@ Certifies that an affine form `c + Σ aᵢ·vᵢ` is never zero: each coefficien
 `Σ posᵢ·vᵢ` stays strictly below `c.val` — so the sum can never equal `c`. -/
 
 /-- Maximal value of `Σ (-aᵢ)·vᵢ` over the bounds, all-or-nothing. -/
-def boundedSumMax (B : Std.HashMap String Nat) :
-    List (String × ZMod p) → Option Nat
+def boundedSumMax (B : Std.HashMap Variable Nat) :
+    List (Variable × ZMod p) → Option Nat
   | [] => some 0
   | (v, a) :: rest =>
     match B[v]?, boundedSumMax B rest with
@@ -191,9 +191,9 @@ def boundedSumMax (B : Std.HashMap String Nat) :
         if 1 ≤ bound then some ((-a).val * (bound - 1) + m) else none
     | _, _ => none
 
-theorem boundedSum_val (B : Std.HashMap String Nat)
-    (terms : List (String × ZMod p)) (M : Nat)
-    (hM : boundedSumMax B terms = some M) (hMp : M < p) (env : String → ZMod p)
+theorem boundedSum_val (B : Std.HashMap Variable Nat)
+    (terms : List (Variable × ZMod p)) (M : Nat)
+    (hM : boundedSumMax B terms = some M) (hMp : M < p) (env : Variable → ZMod p)
     (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
     ∃ s : ZMod p, (terms.map (fun t => t.2 * env t.1)).sum = -s ∧ s.val ≤ M := by
   induction terms generalizing M with
@@ -231,9 +231,9 @@ theorem boundedSum_val (B : Std.HashMap String Nat)
 
 /-- The refutation core: a normalized affine form whose bounded-negative sum stays below the
     constant can never evaluate to zero. -/
-theorem linNeverZero (B : Std.HashMap String Nat) (l : LinExpr p) (M : Nat)
+theorem linNeverZero (B : Std.HashMap Variable Nat) (l : LinExpr p) (M : Nat)
     (hp : 0 < p) (hM : boundedSumMax B l.terms = some M)
-    (hlt : M < l.const.val) (env : String → ZMod p)
+    (hlt : M < l.const.val) (env : Variable → ZMod p)
     (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
     l.eval env ≠ 0 := by
   intro h0
@@ -264,7 +264,7 @@ def addrConstsEq (shape : MemoryBusShape) (S S' : BusInteraction (Expression p))
     | _, _ => false)
 
 theorem addrConstsEq_sound (shape : MemoryBusShape) (S S' : BusInteraction (Expression p))
-    (h : addrConstsEq shape S S' = true) (env : String → ZMod p) :
+    (h : addrConstsEq shape S S' = true) (env : Variable → ZMod p) :
     shape.address (S.eval env) = shape.address (S'.eval env) := by
   unfold MemoryBusShape.address
   apply List.map_congr_left

--- a/Leanr/Implementation/OptimizerPasses/MonicScale.lean
+++ b/Leanr/Implementation/OptimizerPasses/MonicScale.lean
@@ -36,7 +36,7 @@ def monicScaleAffine (e : Expression p) : Expression p × ZMod p × ZMod p :=
         else (e, 1, 1)
     | [] => (e, 1, 1)
 
-theorem monicScaleAffine_eval (e : Expression p) (env : String → ZMod p) :
+theorem monicScaleAffine_eval (e : Expression p) (env : Variable → ZMod p) :
     (monicScaleAffine e).1.eval env = (monicScaleAffine e).2.1 * e.eval env := by
   unfold monicScaleAffine
   split
@@ -75,7 +75,7 @@ def monicScale : Expression p → Expression p × ZMod p × ZMod p
            (monicScale a).2.2 * (monicScale b).2.2)
   | e => monicScaleAffine e
 
-theorem monicScale_eval (e : Expression p) (env : String → ZMod p) :
+theorem monicScale_eval (e : Expression p) (env : Variable → ZMod p) :
     (monicScale e).1.eval env = (monicScale e).2.1 * e.eval env := by
   induction e with
   | const n => exact monicScaleAffine_eval _ env
@@ -110,7 +110,7 @@ theorem monicScale_unit (e : Expression p) :
           _ = 1 := by rw [iha, ihb, one_mul]
 
 /-- Unit scaling preserves the zero set (over any commutative ring). -/
-theorem monicScale_zero_iff (e : Expression p) (env : String → ZMod p) :
+theorem monicScale_zero_iff (e : Expression p) (env : Variable → ZMod p) :
     ((monicScale e).1.eval env = 0 ↔ e.eval env = 0) := by
   rw [monicScale_eval]
   constructor
@@ -132,7 +132,7 @@ def ConstraintSystem.mapConstraints (cs : ConstraintSystem p)
     satisfying assignments are unchanged, and the (bus-only) side effects are untouched. -/
 theorem ConstraintSystem.mapConstraintsIff_correct (cs : ConstraintSystem p)
     (bs : BusSemantics p) (g : Expression p → Expression p)
-    (hg : ∀ (c : Expression p) (env : String → ZMod p), ((g c).eval env = 0 ↔ c.eval env = 0)) :
+    (hg : ∀ (c : Expression p) (env : Variable → ZMod p), ((g c).eval env = 0 ↔ c.eval env = 0)) :
     PassCorrect cs (cs.mapConstraints g) bs := by
   have hiff : ∀ env, (cs.mapConstraints g).satisfies bs env ↔ cs.satisfies bs env := by
     intro env

--- a/Leanr/Implementation/OptimizerPasses/Normalize.lean
+++ b/Leanr/Implementation/OptimizerPasses/Normalize.lean
@@ -21,12 +21,12 @@ variable {p : ℕ}
 /-! ## Merging a linear form's terms -/
 
 /-- Add coefficient `c` to variable `v` in a term list, merging into an existing entry. -/
-def addCoeff (v : String) (c : ZMod p) : List (String × ZMod p) → List (String × ZMod p)
+def addCoeff (v : Variable) (c : ZMod p) : List (Variable × ZMod p) → List (Variable × ZMod p)
   | [] => [(v, c)]
   | (v', c') :: rest => if v' = v then (v', c' + c) :: rest else (v', c') :: addCoeff v c rest
 
-theorem addCoeff_eval (v : String) (c : ZMod p) (ts : List (String × ZMod p))
-    (env : String → ZMod p) :
+theorem addCoeff_eval (v : Variable) (c : ZMod p) (ts : List (Variable × ZMod p))
+    (env : Variable → ZMod p) :
     ((addCoeff v c ts).map (fun t => t.2 * env t.1)).sum
     = c * env v + (ts.map (fun t => t.2 * env t.1)).sum := by
   induction ts with
@@ -41,10 +41,10 @@ theorem addCoeff_eval (v : String) (c : ZMod p) (ts : List (String × ZMod p))
     appending unseen variables at the tail) preserves first-occurrence order, making the merge
     *idempotent* — a `foldr` here would reverse the term order on every application, so
     normalization would oscillate with period 2 instead of reaching a fixpoint. -/
-def mergeTerms (ts : List (String × ZMod p)) : List (String × ZMod p) :=
+def mergeTerms (ts : List (Variable × ZMod p)) : List (Variable × ZMod p) :=
   ts.foldl (fun acc t => addCoeff t.1 t.2 acc) []
 
-theorem foldl_addCoeff_eval (env : String → ZMod p) (ts acc : List (String × ZMod p)) :
+theorem foldl_addCoeff_eval (env : Variable → ZMod p) (ts acc : List (Variable × ZMod p)) :
     ((ts.foldl (fun acc t => addCoeff t.1 t.2 acc) acc).map (fun t => t.2 * env t.1)).sum
     = (acc.map (fun t => t.2 * env t.1)).sum + (ts.map (fun t => t.2 * env t.1)).sum := by
   induction ts generalizing acc with
@@ -53,12 +53,12 @@ theorem foldl_addCoeff_eval (env : String → ZMod p) (ts acc : List (String × 
       simp only [List.foldl_cons, List.map_cons, List.sum_cons, ih, addCoeff_eval]
       ring
 
-theorem mergeTerms_eval (ts : List (String × ZMod p)) (env : String → ZMod p) :
+theorem mergeTerms_eval (ts : List (Variable × ZMod p)) (env : Variable → ZMod p) :
     ((mergeTerms ts).map (fun t => t.2 * env t.1)).sum
     = (ts.map (fun t => t.2 * env t.1)).sum := by
   simp [mergeTerms, foldl_addCoeff_eval]
 
-theorem dropZero_eval (ts : List (String × ZMod p)) (env : String → ZMod p) :
+theorem dropZero_eval (ts : List (Variable × ZMod p)) (env : Variable → ZMod p) :
     ((ts.filter (fun t => t.2 ≠ 0)).map (fun t => t.2 * env t.1)).sum
     = (ts.map (fun t => t.2 * env t.1)).sum := by
   induction ts with
@@ -75,7 +75,7 @@ theorem dropZero_eval (ts : List (String × ZMod p)) (env : String → ZMod p) :
 def LinExpr.norm (l : LinExpr p) : LinExpr p :=
   ⟨l.const, (mergeTerms l.terms).filter (fun t => t.2 ≠ 0)⟩
 
-theorem LinExpr.norm_eval (l : LinExpr p) (env : String → ZMod p) :
+theorem LinExpr.norm_eval (l : LinExpr p) (env : Variable → ZMod p) :
     l.norm.eval env = l.eval env := by
   simp only [LinExpr.norm, LinExpr.eval, dropZero_eval, mergeTerms_eval]
 
@@ -95,7 +95,7 @@ def Expression.normalize : Expression p → Expression p
       | some l => l.norm.toExpr
       | none => .mul a.normalize b.normalize
 
-theorem Expression.normalize_eval (e : Expression p) (env : String → ZMod p) :
+theorem Expression.normalize_eval (e : Expression p) (env : Variable → ZMod p) :
     e.normalize.eval env = e.eval env := by
   induction e with
   | const n => rfl

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -32,13 +32,13 @@ variable {p : ℕ}
 /-! ## Environment extension by an association list -/
 
 /-- Override `env` on the keys of `pairs` (first match wins, mirroring `envOf`). -/
-def envExt : List (String × ZMod p) → (String → ZMod p) → String → ZMod p
+def envExt : List (Variable × ZMod p) → (Variable → ZMod p) → Variable → ZMod p
   | [], env, y => env y
   | (x, v) :: rest, env, y => if y = x then v else envExt rest env y
 
 /-- On the keys, `envExt` agrees with `envOf`. -/
-theorem envExt_eq_envOf_of_mem (pairs : List (String × ZMod p)) (env : String → ZMod p)
-    (y : String) (h : y ∈ pairs.map Prod.fst) : envExt pairs env y = envOf pairs y := by
+theorem envExt_eq_envOf_of_mem (pairs : List (Variable × ZMod p)) (env : Variable → ZMod p)
+    (y : Variable) (h : y ∈ pairs.map Prod.fst) : envExt pairs env y = envOf pairs y := by
   induction pairs with
   | nil => simp at h
   | cons t rest ih =>
@@ -54,8 +54,8 @@ theorem envExt_eq_envOf_of_mem (pairs : List (String × ZMod p)) (env : String �
       · exact h
 
 /-- Off the keys, `envExt` is `env`. -/
-theorem envExt_eq_env_of_notmem (pairs : List (String × ZMod p)) (env : String → ZMod p)
-    (y : String) (h : y ∉ pairs.map Prod.fst) : envExt pairs env y = env y := by
+theorem envExt_eq_env_of_notmem (pairs : List (Variable × ZMod p)) (env : Variable → ZMod p)
+    (y : Variable) (h : y ∉ pairs.map Prod.fst) : envExt pairs env y = env y := by
   induction pairs with
   | nil => rfl
   | cons t rest ih =>
@@ -66,7 +66,7 @@ theorem envExt_eq_env_of_notmem (pairs : List (String × ZMod p)) (env : String 
 
 /-! ## `mentions` and variable membership -/
 
-theorem mentions_false_not_mem_vars (x : String) (e : Expression p)
+theorem mentions_false_not_mem_vars (x : Variable) (e : Expression p)
     (h : e.mentions x = false) : x ∉ e.vars := by
   induction e with
   | const n => simp [Expression.vars]
@@ -121,7 +121,7 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
         ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
       busInteractions := cs.busInteractions.map (·.mapExpr rw) } with hout
   -- message-list equality under expression-wise agreement
-  have hmsgs : ∀ (env env' : String → ZMod p),
+  have hmsgs : ∀ (env env' : Variable → ZMod p),
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
       ∀ busId, (out.busInteractions.filter (fun bi => bi.busId = busId)).map
           (fun bi => bi.eval env')
@@ -138,7 +138,7 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     exact List.map_congr_left (fun bi hbi =>
       hB bi (List.mem_of_mem_filter hbi))
   -- side-effect equality under expression-wise agreement
-  have hside : ∀ (env env' : String → ZMod p),
+  have hside : ∀ (env env' : Variable → ZMod p),
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
       out.sideEffects bsem env' = cs.sideEffects bsem env := by
     intro env env' hB
@@ -152,7 +152,7 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     exact List.map_congr_left (fun bi hbi => by
       simp only [Function.comp_apply, hB bi (List.mem_of_mem_filter hbi)])
   -- admissible transfer under expression-wise agreement (the evaluated messages coincide)
-  have hdisc : ∀ (env env' : String → ZMod p),
+  have hdisc : ∀ (env env' : Variable → ZMod p),
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
       (out.admissible bsem env' ↔ cs.admissible bsem env) := by
     intro env env' hB
@@ -224,8 +224,8 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
 /-! ## Structure of enumerated assignments -/
 
 /-- Every enumerated assignment has the domains' keys, in order. -/
-theorem assignments_keys (doms : List (String × List (ZMod p)))
-    (a : List (String × ZMod p)) (h : a ∈ assignments doms) :
+theorem assignments_keys (doms : List (Variable × List (ZMod p)))
+    (a : List (Variable × ZMod p)) (h : a ∈ assignments doms) :
     a.map Prod.fst = doms.map Prod.fst := by
   induction doms generalizing a with
   | nil =>
@@ -240,8 +240,8 @@ theorem assignments_keys (doms : List (String × List (ZMod p)))
 
 /-- Every enumerated assignment's value at a (distinct-keyed) domain entry lies in that
     domain. -/
-theorem envOf_mem_of_assignments (doms : List (String × List (ZMod p)))
-    (hnd : (doms.map Prod.fst).Nodup) (a : List (String × ZMod p))
+theorem envOf_mem_of_assignments (doms : List (Variable × List (ZMod p)))
+    (hnd : (doms.map Prod.fst).Nodup) (a : List (Variable × ZMod p))
     (h : a ∈ assignments doms) : ∀ xd ∈ doms, envOf a xd.1 ∈ xd.2 := by
   induction doms generalizing a with
   | nil => simp
@@ -260,7 +260,7 @@ theorem envOf_mem_of_assignments (doms : List (String × List (ZMod p)))
       exact ih hnd.2 a' ha' yd hyd
 
 /-- `envOf` of a zipped image list reads off the image function. -/
-theorem envOf_zipimg (xs : List String) (g : String → ZMod p) (y : String) (hy : y ∈ xs) :
+theorem envOf_zipimg (xs : List Variable) (g : Variable → ZMod p) (y : Variable) (hy : y ∈ xs) :
     envOf (xs.map (fun x => (x, g x))) y = g y := by
   induction xs with
   | nil => simp at hy
@@ -277,21 +277,21 @@ theorem envOf_zipimg (xs : List String) (g : String → ZMod p) (y : String) (hy
 /-! ## Pointwise environment facts for the substitution map -/
 
 /-- `envF` at any variable is the evaluation of the substituted variable expression. -/
-theorem envF_eq_varSubst (σ : String → Option (Expression p)) (env : String → ZMod p)
-    (y : String) : envF σ env y = ((Expression.var y).substF σ).eval env := by
+theorem envF_eq_varSubst (σ : Variable → Option (Expression p)) (env : Variable → ZMod p)
+    (y : Variable) : envF σ env y = ((Expression.var y).substF σ).eval env := by
   show (match σ y with | some t => t.eval env | none => env y)
     = ((match σ y with | some t => t | none => .var y) : Expression p).eval env
   cases σ y <;> rfl
 
 /-- Expression-level agreement from pointwise environment agreement. -/
-theorem substF_eval_agree (σ : String → Option (Expression p)) (env₀ env₁ : String → ZMod p)
+theorem substF_eval_agree (σ : Variable → Option (Expression p)) (env₀ env₁ : Variable → ZMod p)
     (e : Expression p) (h : ∀ y ∈ e.vars, envF σ env₀ y = env₁ y) :
     (e.substF σ).eval env₀ = e.eval env₁ := by
   rw [Expression.eval_substF]
   exact Expression.eval_congr e _ _ h
 
 /-- Bus-interaction-level agreement from pointwise environment agreement over its vars. -/
-theorem substF_bi_agree (σ : String → Option (Expression p)) (env₀ env₁ : String → ZMod p)
+theorem substF_bi_agree (σ : Variable → Option (Expression p)) (env₀ env₁ : Variable → ZMod p)
     (bi : BusInteraction (Expression p)) (h : ∀ y ∈ bi.vars, envF σ env₀ y = env₁ y) :
     (bi.substF σ).eval env₀ = bi.eval env₁ := by
   rw [BusInteraction.eval_substF]
@@ -300,15 +300,15 @@ theorem substF_bi_agree (σ : String → Option (Expression p)) (env₀ env₁ :
 /-! ## Booleanity constraints for the fresh bits -/
 
 /-- `b · (b − 1)`. -/
-def boolConstraint (b : String) : Expression p :=
+def boolConstraint (b : Variable) : Expression p :=
   .mul (.var b) (.add (.var b) (.const (-1)))
 
-theorem boolConstraint_eval_of_bool (b : String) (env : String → ZMod p)
+theorem boolConstraint_eval_of_bool (b : Variable) (env : Variable → ZMod p)
     (h : env b = 0 ∨ env b = 1) : (boolConstraint b).eval env = 0 := by
   show env b * (env b + (-1)) = 0
   rcases h with h | h <;> rw [h] <;> ring
 
-theorem bool_of_boolConstraint_eval [Fact p.Prime] (b : String) (env : String → ZMod p)
+theorem bool_of_boolConstraint_eval [Fact p.Prime] (b : Variable) (env : Variable → ZMod p)
     (h : (boolConstraint b).eval env = 0) : env b = 0 ∨ env b = 1 := by
   have h' : env b * (env b + (-1)) = 0 := h
   rcases mul_eq_zero.mp h' with h0 | h1
@@ -326,13 +326,13 @@ def Expression.hasVar : Expression p → Bool
   | .mul a b => a.hasVar || b.hasVar
 
 /-- Do all the expression's variables lie in `xs`? (No allocation.) -/
-def Expression.varsIn (xs : List String) : Expression p → Bool
+def Expression.varsIn (xs : List Variable) : Expression p → Bool
   | .const _ => true
   | .var y => xs.contains y
   | .add a b => a.varsIn xs && b.varsIn xs
   | .mul a b => a.varsIn xs && b.varsIn xs
 
-theorem Expression.varsIn_sound (xs : List String) (e : Expression p)
+theorem Expression.varsIn_sound (xs : List Variable) (e : Expression p)
     (h : e.varsIn xs = true) : ∀ v ∈ e.vars, v ∈ xs := by
   induction e with
   | const n => simp [Expression.vars]
@@ -355,19 +355,19 @@ theorem Expression.varsIn_sound (xs : List String) (e : Expression p)
       · exact ihb h.2 v hv
 
 /-- Constraints whose (nonempty) variable set lies inside the group. -/
-def coveredBy (xs : List String) (c : Expression p) : Bool :=
+def coveredBy (xs : List Variable) (c : Expression p) : Bool :=
   c.hasVar && c.varsIn xs
 
 /-- Domains for the group's variables, from the covered constraints only. -/
-def groupDoms (es : List (Expression p)) : List String → Option (List (String × List (ZMod p)))
+def groupDoms (es : List (Expression p)) : List Variable → Option (List (Variable × List (ZMod p)))
   | [] => some []
   | x :: rest =>
     match findDomainAlg es x, groupDoms es rest with
     | some d, some ds => some ((x, d) :: ds)
     | _, _ => none
 
-theorem groupDoms_fst (es : List (Expression p)) (xs : List String)
-    (doms : List (String × List (ZMod p))) (h : groupDoms es xs = some doms) :
+theorem groupDoms_fst (es : List (Expression p)) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p))) (h : groupDoms es xs = some doms) :
     doms.map Prod.fst = xs := by
   induction xs generalizing doms with
   | nil => simp only [groupDoms, Option.some.injEq] at h; subst h; rfl
@@ -384,9 +384,9 @@ theorem groupDoms_fst (es : List (Expression p)) (xs : List String)
         subst h
         simp [ih ds hr]
 
-theorem groupDoms_sound [Fact p.Prime] (es : List (Expression p)) (xs : List String)
-    (doms : List (String × List (ZMod p))) (h : groupDoms es xs = some doms)
-    (env : String → ZMod p) (hall : ∀ c ∈ es, c.eval env = 0) :
+theorem groupDoms_sound [Fact p.Prime] (es : List (Expression p)) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p))) (h : groupDoms es xs = some doms)
+    (env : Variable → ZMod p) (hall : ∀ c ∈ es, c.eval env = 0) :
     ∀ yd ∈ doms, env yd.1 ∈ yd.2 := by
   induction xs generalizing doms with
   | nil => simp only [groupDoms, Option.some.injEq] at h; subst h; simp
@@ -407,12 +407,12 @@ theorem groupDoms_sound [Fact p.Prime] (es : List (Expression p)) (xs : List Str
         · exact ih ds hr yd hyd
 
 /-- The group substitution: defined on the group only, backed by a hash map. -/
-def groupSubst (xs : List String) (hm : Std.HashMap String (Expression p)) :
-    String → Option (Expression p) :=
+def groupSubst (xs : List Variable) (hm : Std.HashMap Variable (Expression p)) :
+    Variable → Option (Expression p) :=
   fun y => if xs.contains y then hm[y]? else none
 
 /-- The `{0,1}` domain box of the fresh bits. -/
-def bitBox (bits : List String) : List (String × List (ZMod p)) :=
+def bitBox (bits : List Variable) : List (Variable × List (ZMod p)) :=
   bits.map (fun b => (b, ([0, 1] : List (ZMod p))))
 
 /-! ## Degree-aware group rewriting
@@ -427,7 +427,7 @@ check), otherwise the rewrite falls back to the plain substitution (and the step
 degree guard decides). -/
 
 /-- `Π_j (bit_j or its complement)`: `1` exactly at the given pattern. -/
-def indicatorExpr (aβ : List (String × ZMod p)) : Expression p :=
+def indicatorExpr (aβ : List (Variable × ZMod p)) : Expression p :=
   aβ.foldl (fun acc bv =>
     .mul acc (if bv.2 = 1 then .var bv.1
               else .add (.const 1) (.mul (.const (-1)) (.var bv.1)))) (.const 1)
@@ -440,8 +440,8 @@ def indicatorExpr (aβ : List (String × ZMod p)) : Expression p :=
     chaining — and lowers the degree. Only the `varsIn`/agreement check in `groupRewriteCand`
     consumes `interpOf`, and a constant passes both (no vars; equals the shared value on every
     pattern), so this is transparent to the correctness proof. -/
-def interpOf (σfn : String → Option (Expression p))
-    (patts : List (List (String × ZMod p))) (e : Expression p) : Expression p :=
+def interpOf (σfn : Variable → Option (Expression p))
+    (patts : List (List (Variable × ZMod p))) (e : Expression p) : Expression p :=
   match patts with
   | [] => .const 0
   | aβ₀ :: _ =>
@@ -451,8 +451,8 @@ def interpOf (σfn : String → Option (Expression p))
       .add acc (.mul (indicatorExpr aβ) (.const ((e.substF σfn).eval (envOf aβ))))) (.const 0)
 
 /-- Interpolation candidate with the checked fallback to plain substitution. -/
-def groupRewriteCand (bits : List String) (σfn : String → Option (Expression p))
-    (patts : List (List (String × ZMod p))) (e : Expression p) : Expression p :=
+def groupRewriteCand (bits : List Variable) (σfn : Variable → Option (Expression p))
+    (patts : List (List (Variable × ZMod p))) (e : Expression p) : Expression p :=
   if ((interpOf σfn patts e).fold).varsIn bits &&
       patts.all (fun aβ => decide (((interpOf σfn patts e).fold).eval (envOf aβ)
         = (e.substF σfn).eval (envOf aβ)))
@@ -461,8 +461,8 @@ def groupRewriteCand (bits : List String) (σfn : String → Option (Expression 
 
 /-- Replace maximal wholly-in-group subexpressions by their interpolations; substitute
     variable-wise everywhere else. -/
-def groupRewrite (xs bits : List String) (σfn : String → Option (Expression p))
-    (patts : List (List (String × ZMod p))) : Expression p → Expression p
+def groupRewrite (xs bits : List Variable) (σfn : Variable → Option (Expression p))
+    (patts : List (List (Variable × ZMod p))) : Expression p → Expression p
   | .const n => .const n
   | .var y =>
       if xs.contains y then groupRewriteCand bits σfn patts (.var y) else .var y
@@ -473,9 +473,9 @@ def groupRewrite (xs bits : List String) (σfn : String → Option (Expression p
       if (Expression.mul a b).varsIn xs then groupRewriteCand bits σfn patts (.mul a b)
       else .mul (groupRewrite xs bits σfn patts a) (groupRewrite xs bits σfn patts b)
 
-theorem groupRewriteCand_agree (xs bits : List String)
-    (σfn : String → Option (Expression p)) (patts : List (List (String × ZMod p)))
-    (env₀ env₁ : String → ZMod p) (aβ : List (String × ZMod p)) (haβ : aβ ∈ patts)
+theorem groupRewriteCand_agree (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p)) (patts : List (List (Variable × ZMod p)))
+    (env₀ env₁ : Variable → ZMod p) (aβ : List (Variable × ZMod p)) (haβ : aβ ∈ patts)
     (hbitsagree : ∀ b ∈ bits, env₀ b = envOf aβ b)
     (hpolyvars : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
     (hpoint : ∀ y, y ∉ bits → envF σfn env₀ y = env₁ y)
@@ -516,10 +516,10 @@ theorem groupRewriteCand_agree (xs bits : List String)
     exact hpoint y (hnotbits y hy)
   · exact hsubstF
 
-theorem groupRewrite_agree (xs bits : List String)
-    (σfn : String → Option (Expression p)) (patts : List (List (String × ZMod p)))
+theorem groupRewrite_agree (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p)) (patts : List (List (Variable × ZMod p)))
     (hσnone : ∀ y, y ∉ xs → σfn y = none)
-    (env₀ env₁ : String → ZMod p) (aβ : List (String × ZMod p)) (haβ : aβ ∈ patts)
+    (env₀ env₁ : Variable → ZMod p) (aβ : List (Variable × ZMod p)) (haβ : aβ ∈ patts)
     (hbitsagree : ∀ b ∈ bits, env₀ b = envOf aβ b)
     (hpolyvars : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
     (hpoint : ∀ y, y ∉ bits → envF σfn env₀ y = env₁ y)
@@ -585,10 +585,10 @@ theorem groupRewrite_agree (xs bits : List String)
         rw [iha hfa, ihb hfb]
 
 /-- Bus-interaction-level agreement for the group rewrite. -/
-theorem groupRewrite_bi_agree (xs bits : List String)
-    (σfn : String → Option (Expression p)) (patts : List (List (String × ZMod p)))
+theorem groupRewrite_bi_agree (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p)) (patts : List (List (Variable × ZMod p)))
     (hσnone : ∀ y, y ∉ xs → σfn y = none)
-    (env₀ env₁ : String → ZMod p) (aβ : List (String × ZMod p)) (haβ : aβ ∈ patts)
+    (env₀ env₁ : Variable → ZMod p) (aβ : List (Variable × ZMod p)) (haβ : aβ ∈ patts)
     (hbitsagree : ∀ b ∈ bits, env₀ b = envOf aβ b)
     (hpolyvars : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
     (hpoint : ∀ y, y ∉ bits → envF σfn env₀ y = env₁ y)
@@ -608,27 +608,27 @@ theorem groupRewrite_bi_agree (xs bits : List String)
 
 /-- The re-encoded system: substitute the group everywhere, keep only uncovered constraints,
     add booleanity for the bits. -/
-def reencodeOut (cs : ConstraintSystem p) (xs bits : List String)
-    (hm : Std.HashMap String (Expression p)) : ConstraintSystem p :=
+def reencodeOut (cs : ConstraintSystem p) (xs bits : List Variable)
+    (hm : Std.HashMap Variable (Expression p)) : ConstraintSystem p :=
   { algebraicConstraints :=
       ((cs.algebraicConstraints.filter (fun c => !coveredBy xs c)).map
         (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))) ++ bits.map boolConstraint,
     busInteractions := cs.busInteractions.map (·.mapExpr (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))) }
 
 /-- The group's covered constraints. -/
-def coveredCsOf (cs : ConstraintSystem p) (xs : List String) : List (Expression p) :=
+def coveredCsOf (cs : ConstraintSystem p) (xs : List Variable) : List (Expression p) :=
   cs.algebraicConstraints.filter (coveredBy xs)
 
 /-- The surviving group values: enumerated over the group's domains, filtered by the covered
     constraints. -/
-def groupSurvivors (cs : ConstraintSystem p) (xs : List String)
-    (doms : List (String × List (ZMod p))) : List (List (String × ZMod p)) :=
+def groupSurvivors (cs : ConstraintSystem p) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p))) : List (List (Variable × ZMod p)) :=
   (assignments doms).filter
     (fun a => (coveredCsOf cs xs).all (fun c => decide (c.eval (envOf a) = 0)))
 
 /-- All checked side conditions for one re-encoding step. -/
-def checkReencode (cs : ConstraintSystem p) (xs bits : List String)
-    (hm : Std.HashMap String (Expression p)) : Bool :=
+def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
+    (hm : Std.HashMap Variable (Expression p)) : Bool :=
   match groupDoms (coveredCsOf cs xs) xs with
   | none => false
   | some doms =>
@@ -653,7 +653,7 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List String)
       decide ((c.substF (groupSubst xs hm)).eval (envOf aβ) = 0)))
 
 theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : BusSemantics p)
-    (xs bits : List String) (hm : Std.HashMap String (Expression p))
+    (xs bits : List Variable) (hm : Std.HashMap Variable (Expression p))
     (hchk : checkReencode cs xs bits hm = true) :
     PassCorrect cs (reencodeOut cs xs bits hm) bsem := by
   unfold checkReencode at hchk
@@ -883,15 +883,15 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
 /-! ## Building the interpolation (proof-free) and the pass -/
 
 /-- Interpolation polynomial for group variable `x` over pattern/survivor pairs. -/
-def interpPoly (pz : List (List (String × ZMod p) × List (String × ZMod p))) (x : String) :
+def interpPoly (pz : List (List (Variable × ZMod p) × List (Variable × ZMod p))) (x : Variable) :
     Expression p :=
   pz.foldl (fun acc az => .add acc (.mul (indicatorExpr az.1) (.const (envOf az.2 x))))
     (.const 0)
 
 /-- Construct the bits and the substitution map for a candidate group (proof-free — the
     checked certificate re-verifies everything). -/
-def buildReencode (cs : ConstraintSystem p) (xs : List String) (freshBase : String) :
-    Option (List String × Std.HashMap String (Expression p)) :=
+def buildReencode (cs : ConstraintSystem p) (xs : List Variable) (freshBase : String) :
+    Option (List Variable × Std.HashMap Variable (Expression p)) :=
   match groupDoms (coveredCsOf cs xs) xs with
   | none => none
   | some doms =>
@@ -900,7 +900,7 @@ def buildReencode (cs : ConstraintSystem p) (xs : List String) (freshBase : Stri
       if 2 ≤ survs.length then
         let k := Nat.clog 2 survs.length
         if k < xs.length then
-          let bits := (List.range k).map (fun j => freshBase ++ "_" ++ toString j)
+          let bits := (List.range k).map (fun j => ({ name := freshBase ++ "_" ++ toString j } : Variable))
           let patts := assignments (bitBox (p := p) bits)
           let survsP := survs ++ List.replicate (patts.length - survs.length) (survs.headD [])
           let pz := patts.zip survsP
@@ -911,7 +911,7 @@ def buildReencode (cs : ConstraintSystem p) (xs : List String) (freshBase : Stri
 
 /-- One checked re-encoding step (identity if construction or certificate fails). -/
 def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p)
-    (xs : List String) (freshBase : String) :
+    (xs : List Variable) (freshBase : String) :
     { out : ConstraintSystem p // PassCorrect cs out bsem } :=
   match buildReencode cs xs freshBase with
   | none => ⟨cs, cs.refines_refl bsem, _root_.id⟩
@@ -926,7 +926,7 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p
 
 /-- Process the candidate groups sequentially (correctness composes by transitivity). -/
 def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
-    List (List String) → Nat → (cs : ConstraintSystem p) →
+    List (List Variable) → Nat → (cs : ConstraintSystem p) →
     { out : ConstraintSystem p // PassCorrect cs out bsem }
   | [], _, cs => ⟨cs, cs.refines_refl bsem, _root_.id⟩
   | xs :: rest, idx, cs =>
@@ -945,6 +945,6 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
     haveI : Fact p.Prime := ⟨hpr⟩
     let targets := (cs.algebraicConstraints.filterMap (fun c =>
       let vs := c.vars.dedup
-      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (· ≤ ·)) else none)).dedup
+      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none)).dedup
     reencodeLoop bsem targets 0 cs
   else ⟨cs, cs.refines_refl bsem, _root_.id⟩

--- a/Leanr/Implementation/OptimizerPasses/Rewrite.lean
+++ b/Leanr/Implementation/OptimizerPasses/Rewrite.lean
@@ -36,11 +36,11 @@ def ConstraintSystem.mapExpr (cs : ConstraintSystem p) (g : Expression p → Exp
     busInteractions := cs.busInteractions.map (·.mapExpr g) }
 
 section EvalPreserving
-variable {g : Expression p → Expression p} (hg : ∀ e (env : String → ZMod p), (g e).eval env = e.eval env)
+variable {g : Expression p → Expression p} (hg : ∀ e (env : Variable → ZMod p), (g e).eval env = e.eval env)
 
 include hg
 
-theorem BusInteraction.eval_mapExpr (bi : BusInteraction (Expression p)) (env : String → ZMod p) :
+theorem BusInteraction.eval_mapExpr (bi : BusInteraction (Expression p)) (env : Variable → ZMod p) :
     (bi.mapExpr g).eval env = bi.eval env := by
   simp only [BusInteraction.mapExpr, BusInteraction.eval, hg, List.map_map]
   congr 1
@@ -51,7 +51,7 @@ theorem BusInteraction.eval_mapExpr (bi : BusInteraction (Expression p)) (env : 
 /-- The evaluated interactions of a rewritten system, restricted to one bus, are unchanged
     (an eval-preserving map never changes a bus id or a value). -/
 theorem ConstraintSystem.msgs_mapExpr (cs : ConstraintSystem p) (busId : Nat)
-    (env : String → ZMod p) :
+    (env : Variable → ZMod p) :
     ((cs.mapExpr g).busInteractions.filter (fun bi => bi.busId = busId)).map
       (fun bi => bi.eval env)
     = (cs.busInteractions.filter (fun bi => bi.busId = busId)).map (fun bi => bi.eval env) := by
@@ -66,7 +66,7 @@ theorem ConstraintSystem.msgs_mapExpr (cs : ConstraintSystem p) (busId : Nat)
 
 /-- `admissible` is untouched by eval-preserving rewrites — generically in the VM predicate. -/
 theorem ConstraintSystem.admissible_mapExpr (cs : ConstraintSystem p)
-    (bs : BusSemantics p) (env : String → ZMod p) :
+    (bs : BusSemantics p) (env : Variable → ZMod p) :
     (cs.mapExpr g).admissible bs env ↔ cs.admissible bs env := by
   unfold ConstraintSystem.admissible
   have hmap : (cs.mapExpr g).busInteractions.map (fun bi => bi.eval env)
@@ -76,7 +76,7 @@ theorem ConstraintSystem.admissible_mapExpr (cs : ConstraintSystem p)
   rw [hmap]
 
 theorem ConstraintSystem.satisfies_mapExpr (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (env : String → ZMod p) : (cs.mapExpr g).satisfies bs env ↔ cs.satisfies bs env := by
+    (env : Variable → ZMod p) : (cs.mapExpr g).satisfies bs env ↔ cs.satisfies bs env := by
   simp only [ConstraintSystem.satisfies, ConstraintSystem.mapExpr] at *
   constructor
   · rintro ⟨hc, hb⟩
@@ -89,7 +89,7 @@ theorem ConstraintSystem.satisfies_mapExpr (cs : ConstraintSystem p) (bs : BusSe
     · obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi'; rw [bi0.eval_mapExpr hg]; exact hb bi0 hbi0
 
 theorem ConstraintSystem.sideEffects_mapExpr (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (env : String → ZMod p) : (cs.mapExpr g).sideEffects bs env = cs.sideEffects bs env := by
+    (env : Variable → ZMod p) : (cs.mapExpr g).sideEffects bs env = cs.sideEffects bs env := by
   simp only [ConstraintSystem.sideEffects, ConstraintSystem.mapExpr]
   induction cs.busInteractions with
   | nil => rfl
@@ -169,7 +169,7 @@ def ConstraintSystem.filterBus (cs : ConstraintSystem p) (keep : BusInteraction 
     only looks at the active *stateful* evaluated messages, which such a drop leaves unchanged.
     Covers both zero-multiplicity removal (`ZeroMultBus`) and stateless-lookup removal (`TautoBus`). -/
 theorem ConstraintSystem.admissible_filterBus (cs : ConstraintSystem p)
-    (bs : BusSemantics p) (keep : BusInteraction (Expression p) → Bool) (a : String → ZMod p)
+    (bs : BusSemantics p) (keep : BusInteraction (Expression p) → Bool) (a : Variable → ZMod p)
     (h : ∀ bi ∈ cs.busInteractions, keep bi = false →
         (bi.eval a).multiplicity = 0 ∨ bs.isStateful bi.busId = false) :
     (cs.filterBus keep).admissible bs a ↔ cs.admissible bs a := by
@@ -206,7 +206,7 @@ theorem ConstraintSystem.admissible_filterBus (cs : ConstraintSystem p)
 /-- Net multiplicity is unchanged by dropping (via `keep = false`) bus interactions whose evaluated
     multiplicity is `0`: such an interaction contributes `0` to every message's net multiplicity, so
     the two bus states are `≈`-equal. -/
-theorem multiplicitySum_filterBus (bs : BusSemantics p) (env : String → ZMod p)
+theorem multiplicitySum_filterBus (bs : BusSemantics p) (env : Variable → ZMod p)
     (keep : BusInteraction (Expression p) → Bool) (message : BusMessage p)
     (bis : List (BusInteraction (Expression p)))
     (h0 : ∀ bi ∈ bis, keep bi = false → (bi.eval env).multiplicity = 0) :

--- a/Leanr/Implementation/OptimizerPasses/Subst.lean
+++ b/Leanr/Implementation/OptimizerPasses/Subst.lean
@@ -26,7 +26,7 @@ variable {p : ℕ}
 /-! ## Substitution on expressions -/
 
 /-- Substitute variable `x` by expression `t` throughout an expression. -/
-def Expression.subst (e : Expression p) (x : String) (t : Expression p) : Expression p :=
+def Expression.subst (e : Expression p) (x : Variable) (t : Expression p) : Expression p :=
   match e with
   | .const n => .const n
   | .var y => if y = x then t else .var y
@@ -35,8 +35,8 @@ def Expression.subst (e : Expression p) (x : String) (t : Expression p) : Expres
 
 /-- Substitution semantics: substituting `x := t` and evaluating is the same as evaluating in the
     environment with `x` rebound to `t.eval env`. -/
-theorem Expression.eval_subst (e : Expression p) (x : String) (t : Expression p)
-    (env : String → ZMod p) :
+theorem Expression.eval_subst (e : Expression p) (x : Variable) (t : Expression p)
+    (env : Variable → ZMod p) :
     (e.subst x t).eval env = e.eval (Function.update env x (t.eval env)) := by
   induction e with
   | const n => simp [Expression.subst, Expression.eval]
@@ -51,14 +51,14 @@ theorem Expression.eval_subst (e : Expression p) (x : String) (t : Expression p)
 /-! ## Substitution on bus interactions -/
 
 /-- Substitute `x := t` in every expression of a bus interaction. -/
-def BusInteraction.subst (bi : BusInteraction (Expression p)) (x : String) (t : Expression p) :
+def BusInteraction.subst (bi : BusInteraction (Expression p)) (x : Variable) (t : Expression p) :
     BusInteraction (Expression p) :=
   { busId := bi.busId,
     multiplicity := bi.multiplicity.subst x t,
     payload := bi.payload.map (·.subst x t) }
 
-theorem BusInteraction.eval_subst (bi : BusInteraction (Expression p)) (x : String)
-    (t : Expression p) (env : String → ZMod p) :
+theorem BusInteraction.eval_subst (bi : BusInteraction (Expression p)) (x : Variable)
+    (t : Expression p) (env : Variable → ZMod p) :
     (bi.subst x t).eval env = bi.eval (Function.update env x (t.eval env)) := by
   simp only [BusInteraction.subst, BusInteraction.eval, Expression.eval_subst, List.map_map]
   congr 1
@@ -69,15 +69,15 @@ theorem BusInteraction.eval_subst (bi : BusInteraction (Expression p)) (x : Stri
 /-! ## Substitution on constraint systems -/
 
 /-- Substitute `x := t` everywhere in a constraint system. -/
-def ConstraintSystem.subst (cs : ConstraintSystem p) (x : String) (t : Expression p) :
+def ConstraintSystem.subst (cs : ConstraintSystem p) (x : Variable) (t : Expression p) :
     ConstraintSystem p :=
   { algebraicConstraints := cs.algebraicConstraints.map (·.subst x t),
     busInteractions := cs.busInteractions.map (·.subst x t) }
 
 /-- The evaluated interactions of a substituted system, restricted to one bus, are those of the
     original under the rebound environment (substitution never changes a bus id). -/
-theorem ConstraintSystem.msgs_subst (cs : ConstraintSystem p) (x : String) (t : Expression p)
-    (busId : Nat) (a : String → ZMod p) :
+theorem ConstraintSystem.msgs_subst (cs : ConstraintSystem p) (x : Variable) (t : Expression p)
+    (busId : Nat) (a : Variable → ZMod p) :
     ((cs.subst x t).busInteractions.filter (fun bi => bi.busId = busId)).map
       (fun bi => bi.eval a)
     = (cs.busInteractions.filter (fun bi => bi.busId = busId)).map
@@ -93,8 +93,8 @@ theorem ConstraintSystem.msgs_subst (cs : ConstraintSystem p) (x : String) (t : 
 
 /-- `admissible` transfers across substitution — generically in the VM predicate, since
     substitution preserves the evaluated messages under the rebound environment. -/
-theorem ConstraintSystem.admissible_subst (cs : ConstraintSystem p) (x : String)
-    (t : Expression p) (bs : BusSemantics p) (a : String → ZMod p) :
+theorem ConstraintSystem.admissible_subst (cs : ConstraintSystem p) (x : Variable)
+    (t : Expression p) (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.subst x t).admissible bs a
       ↔ cs.admissible bs (Function.update a x (t.eval a)) := by
   unfold ConstraintSystem.admissible
@@ -106,8 +106,8 @@ theorem ConstraintSystem.admissible_subst (cs : ConstraintSystem p) (x : String)
 
 /-- `satisfies` transfers across substitution: the substituted system is satisfied at `a` exactly
     when the original is satisfied at `a` with `x` rebound to `t.eval a`. -/
-theorem ConstraintSystem.satisfies_subst (cs : ConstraintSystem p) (x : String) (t : Expression p)
-    (bs : BusSemantics p) (a : String → ZMod p) :
+theorem ConstraintSystem.satisfies_subst (cs : ConstraintSystem p) (x : Variable) (t : Expression p)
+    (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.subst x t).satisfies bs a ↔ cs.satisfies bs (Function.update a x (t.eval a)) := by
   simp only [ConstraintSystem.satisfies, ConstraintSystem.subst] at *
   constructor
@@ -125,8 +125,8 @@ theorem ConstraintSystem.satisfies_subst (cs : ConstraintSystem p) (x : String) 
       rw [BusInteraction.eval_subst]; exact hb bi0 hbi0
 
 /-- `sideEffects` transfers across substitution. -/
-theorem ConstraintSystem.sideEffects_subst (cs : ConstraintSystem p) (x : String)
-    (t : Expression p) (bs : BusSemantics p) (a : String → ZMod p) :
+theorem ConstraintSystem.sideEffects_subst (cs : ConstraintSystem p) (x : Variable)
+    (t : Expression p) (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.subst x t).sideEffects bs a = cs.sideEffects bs (Function.update a x (t.eval a)) := by
   simp only [ConstraintSystem.sideEffects, ConstraintSystem.subst]
   induction cs.busInteractions with
@@ -142,7 +142,7 @@ theorem ConstraintSystem.sideEffects_subst (cs : ConstraintSystem p) (x : String
 /-- **Substitution correctness.** If every satisfying assignment of `cs` forces `x = t`, then
     substituting `x := t` everywhere produces a `PassCorrect` system: equivalent to `cs` and
     invariant-preserving. This is the workhorse behind all variable-elimination passes. -/
-theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : String) (t : Expression p)
+theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : Variable) (t : Expression p)
     (bs : BusSemantics p) (H : ∀ env, cs.satisfies bs env → env x = t.eval env) :
     PassCorrect cs (cs.subst x t) bs := by
   refine ⟨⟨?_, ?_⟩, ?_⟩
@@ -182,8 +182,8 @@ and its soundness lemma. -/
     the algebraic constraints for the first one `solve` handles and substitutes `x := t`; identity
     otherwise. Correct by `subst_correct`, since a solved constraint (being satisfied, hence `0`)
     entails `x = t`. -/
-def substFromConstraint (solve : Expression p → Option (String × Expression p))
-    (hsolve : ∀ (c : Expression p) (x : String) (t : Expression p), solve c = some (x, t) →
+def substFromConstraint (solve : Expression p → Option (Variable × Expression p))
+    (hsolve : ∀ (c : Expression p) (x : Variable) (t : Expression p), solve c = some (x, t) →
       ∀ env, c.eval env = 0 → env x = t.eval env) :
     VerifiedPass p := fun cs bs =>
   match hfound : cs.algebraicConstraints.find? (fun c => (solve c).isSome) with

--- a/Leanr/Implementation/OptimizerPasses/SubstMap.lean
+++ b/Leanr/Implementation/OptimizerPasses/SubstMap.lean
@@ -8,7 +8,7 @@ set_option autoImplicit false
 solvable variables that costs one full-system traversal *per variable*. This file provides the
 batch core: substitute a whole *map* of solved variables in a single traversal.
 
-The map is any function `f : String → Option (Expression p)` (passes use a `Std.HashMap`
+The map is any function `f : Variable → Option (Expression p)` (passes use a `Std.HashMap`
 lookup); `x` with `f x = some t` is replaced by `t`. Semantics are stated against the rebound
 environment `envF f env` (each mapped variable rebound to its solution's value), exactly like
 `Function.update` in the single-variable case. The correctness theorem
@@ -26,18 +26,18 @@ variable {p : ℕ}
 
 /-- Substitute every variable `x` with `f x = some t` by `t` (one traversal; inserted
     solutions are not re-visited). -/
-def Expression.substF (f : String → Option (Expression p)) : Expression p → Expression p
+def Expression.substF (f : Variable → Option (Expression p)) : Expression p → Expression p
   | .const n => .const n
   | .var y => match f y with | some t => t | none => .var y
   | .add a b => .add (a.substF f) (b.substF f)
   | .mul a b => .mul (a.substF f) (b.substF f)
 
 /-- The environment with every mapped variable rebound to its solution's value. -/
-def envF (f : String → Option (Expression p)) (env : String → ZMod p) : String → ZMod p :=
+def envF (f : Variable → Option (Expression p)) (env : Variable → ZMod p) : Variable → ZMod p :=
   fun y => match f y with | some t => t.eval env | none => env y
 
-theorem Expression.eval_substF (e : Expression p) (f : String → Option (Expression p))
-    (env : String → ZMod p) : (e.substF f).eval env = e.eval (envF f env) := by
+theorem Expression.eval_substF (e : Expression p) (f : Variable → Option (Expression p))
+    (env : Variable → ZMod p) : (e.substF f).eval env = e.eval (envF f env) := by
   induction e with
   | const n => rfl
   | var y =>
@@ -48,7 +48,7 @@ theorem Expression.eval_substF (e : Expression p) (f : String → Option (Expres
   | mul a b iha ihb => simp only [Expression.substF, Expression.eval, iha, ihb]
 
 /-- If every mapped pair is respected by `env`, rebinding changes nothing. -/
-theorem envF_eq_self (f : String → Option (Expression p)) (env : String → ZMod p)
+theorem envF_eq_self (f : Variable → Option (Expression p)) (env : Variable → ZMod p)
     (H : ∀ y t, f y = some t → env y = t.eval env) : envF f env = env := by
   funext y
   unfold envF
@@ -60,13 +60,13 @@ theorem envF_eq_self (f : String → Option (Expression p)) (env : String → ZM
 
 /-- Substitute the map in every expression of a bus interaction. -/
 def BusInteraction.substF (bi : BusInteraction (Expression p))
-    (f : String → Option (Expression p)) : BusInteraction (Expression p) :=
+    (f : Variable → Option (Expression p)) : BusInteraction (Expression p) :=
   { busId := bi.busId,
     multiplicity := bi.multiplicity.substF f,
     payload := bi.payload.map (·.substF f) }
 
 theorem BusInteraction.eval_substF (bi : BusInteraction (Expression p))
-    (f : String → Option (Expression p)) (env : String → ZMod p) :
+    (f : Variable → Option (Expression p)) (env : Variable → ZMod p) :
     (bi.substF f).eval env = bi.eval (envF f env) := by
   simp only [BusInteraction.substF, BusInteraction.eval, Expression.eval_substF, List.map_map]
   congr 1
@@ -75,7 +75,7 @@ theorem BusInteraction.eval_substF (bi : BusInteraction (Expression p))
   simp only [Function.comp_apply, Expression.eval_substF]
 
 /-- Substitute the map everywhere in a constraint system. -/
-def ConstraintSystem.substF (cs : ConstraintSystem p) (f : String → Option (Expression p)) :
+def ConstraintSystem.substF (cs : ConstraintSystem p) (f : Variable → Option (Expression p)) :
     ConstraintSystem p :=
   { algebraicConstraints := cs.algebraicConstraints.map (·.substF f),
     busInteractions := cs.busInteractions.map (·.substF f) }
@@ -83,7 +83,7 @@ def ConstraintSystem.substF (cs : ConstraintSystem p) (f : String → Option (Ex
 /-- The evaluated interactions of a substituted system, restricted to one bus, are those of
     the original under the rebound environment (substitution never changes a bus id). -/
 theorem ConstraintSystem.msgs_substF (cs : ConstraintSystem p)
-    (f : String → Option (Expression p)) (busId : Nat) (a : String → ZMod p) :
+    (f : Variable → Option (Expression p)) (busId : Nat) (a : Variable → ZMod p) :
     ((cs.substF f).busInteractions.filter (fun bi => bi.busId = busId)).map
       (fun bi => bi.eval a)
     = (cs.busInteractions.filter (fun bi => bi.busId = busId)).map
@@ -99,7 +99,7 @@ theorem ConstraintSystem.msgs_substF (cs : ConstraintSystem p)
 
 /-- `admissible` transfers across simultaneous substitution — generically in the VM predicate. -/
 theorem ConstraintSystem.admissible_substF (cs : ConstraintSystem p)
-    (f : String → Option (Expression p)) (bs : BusSemantics p) (a : String → ZMod p) :
+    (f : Variable → Option (Expression p)) (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.substF f).admissible bs a ↔ cs.admissible bs (envF f a) := by
   unfold ConstraintSystem.admissible
   have hmap : (cs.substF f).busInteractions.map (fun bi => bi.eval a)
@@ -110,7 +110,7 @@ theorem ConstraintSystem.admissible_substF (cs : ConstraintSystem p)
 
 /-- `satisfies` transfers across simultaneous substitution. -/
 theorem ConstraintSystem.satisfies_substF (cs : ConstraintSystem p)
-    (f : String → Option (Expression p)) (bs : BusSemantics p) (a : String → ZMod p) :
+    (f : Variable → Option (Expression p)) (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.substF f).satisfies bs a ↔ cs.satisfies bs (envF f a) := by
   simp only [ConstraintSystem.satisfies, ConstraintSystem.substF] at *
   constructor
@@ -129,7 +129,7 @@ theorem ConstraintSystem.satisfies_substF (cs : ConstraintSystem p)
 
 /-- `sideEffects` transfers across simultaneous substitution. -/
 theorem ConstraintSystem.sideEffects_substF (cs : ConstraintSystem p)
-    (f : String → Option (Expression p)) (bs : BusSemantics p) (a : String → ZMod p) :
+    (f : Variable → Option (Expression p)) (bs : BusSemantics p) (a : Variable → ZMod p) :
     (cs.substF f).sideEffects bs a = cs.sideEffects bs (envF f a) := by
   simp only [ConstraintSystem.sideEffects, ConstraintSystem.substF]
   induction cs.busInteractions with
@@ -147,7 +147,7 @@ theorem ConstraintSystem.sideEffects_substF (cs : ConstraintSystem p)
     `PassCorrect`: equivalent to `cs` and invariant-preserving. The batch counterpart of
     `ConstraintSystem.subst_correct`. -/
 theorem ConstraintSystem.substF_correct (cs : ConstraintSystem p)
-    (f : String → Option (Expression p)) (bs : BusSemantics p)
+    (f : Variable → Option (Expression p)) (bs : BusSemantics p)
     (H : ∀ env, cs.satisfies bs env → ∀ y t, f y = some t → env y = t.eval env) :
     PassCorrect cs (cs.substF f) bs := by
   refine ⟨⟨?_, ?_⟩, ?_⟩

--- a/Leanr/Implementation/OptimizerPasses/TautoBus.lean
+++ b/Leanr/Implementation/OptimizerPasses/TautoBus.lean
@@ -33,7 +33,7 @@ def Expression.constValue? (e : Expression p) : Option (ZMod p) :=
   | _ => none
 
 theorem Expression.constValue?_sound (e : Expression p) (c : ZMod p)
-    (h : e.constValue? = some c) (env : String → ZMod p) : e.eval env = c := by
+    (h : e.constValue? = some c) (env : Variable → ZMod p) : e.eval env = c := by
   unfold Expression.constValue? at h
   split at h
   · rename_i c' hfold
@@ -52,7 +52,7 @@ def constValues? : List (Expression p) → Option (List (ZMod p))
     | _, _ => none
 
 theorem constValues?_sound (es : List (Expression p)) (vs : List (ZMod p))
-    (h : constValues? es = some vs) (env : String → ZMod p) :
+    (h : constValues? es = some vs) (env : Variable → ZMod p) :
     es.map (fun e => e.eval env) = vs := by
   induction es generalizing vs with
   | nil => simp only [constValues?, Option.some.injEq] at h; subst h; rfl
@@ -78,7 +78,7 @@ def BusInteraction.constMessage? (bi : BusInteraction (Expression p)) :
 
 theorem BusInteraction.constMessage?_sound (bi : BusInteraction (Expression p))
     (msg : BusInteraction (ZMod p)) (h : bi.constMessage? = some msg)
-    (env : String → ZMod p) : bi.eval env = msg := by
+    (env : Variable → ZMod p) : bi.eval env = msg := by
   unfold BusInteraction.constMessage? at h
   cases hm : bi.multiplicity.constValue? with
   | none => rw [hm] at h; exact absurd h (by simp)

--- a/Leanr/Implementation/OptimizerPasses/TrivialConstraint.lean
+++ b/Leanr/Implementation/OptimizerPasses/TrivialConstraint.lean
@@ -24,7 +24,7 @@ def Expression.isConstZero : Expression p → Bool
   | _ => false
 
 theorem Expression.isConstZero_sound (e : Expression p) (h : e.isConstZero = true)
-    (env : String → ZMod p) : e.eval env = 0 := by
+    (env : Variable → ZMod p) : e.eval env = 0 := by
   cases e <;> simp_all [Expression.isConstZero, Expression.eval]
 
 /-- The trivial-constraint removal pass: drop every algebraic constraint whose fold is the literal

--- a/Leanr/Implementation/Variable.lean
+++ b/Leanr/Implementation/Variable.lean
@@ -1,0 +1,54 @@
+import Leanr.Spec
+
+set_option autoImplicit false
+
+/-!
+# Implementation support for structured variables
+
+Helpers and typeclass laws for using spec-level `Variable` values in parsers, hash maps,
+and other implementation data structures. Kept out of `Leanr/Spec.lean` to minimize the
+audited surface.
+-/
+
+/-- Parse powdr's legacy `<name>@<id>` variable notation into a structured variable. -/
+instance : Ord Variable := ⟨fun a b =>
+  match compare a.name b.name with
+  | .eq => compare a.powdrId? b.powdrId?
+  | o => o⟩
+
+instance : Hashable Variable := ⟨fun a => mixHash (hash a.name) (hash a.powdrId?)⟩
+
+def Variable.ofPowdrName (raw : String) : Variable :=
+  match raw.splitOn "@" with
+  | [base, id] =>
+      match id.toNat? with
+      | some n => { name := base, powdrId? := some n }
+      | none => { name := raw }
+  | _ => { name := raw }
+
+instance : ReflBEq Variable where
+  rfl := by intro a; simp [BEq.beq]
+
+instance : LawfulBEq Variable where
+  eq_of_beq := by
+    intro a b h
+    simpa [BEq.beq] using h
+
+instance : PartialEquivBEq Variable where
+  symm := by
+    intro a b h
+    cases (LawfulBEq.eq_of_beq h)
+    simp [BEq.beq]
+  trans := by
+    intro a b c hab hbc
+    cases (LawfulBEq.eq_of_beq hab)
+    cases (LawfulBEq.eq_of_beq hbc)
+    simp [BEq.beq]
+
+instance : EquivBEq Variable where
+
+instance : LawfulHashable Variable where
+  hash_eq := by
+    intro a b h
+    cases (LawfulBEq.eq_of_beq h)
+    rfl

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -7,15 +7,65 @@ variable {p : ℕ} [Fact p.Prime]
 
 --------- Expressions ---------
 
-/-- An arithmetic expression over variables (identified by `String`) and field constants. -/
+/-- A circuit variable: a display `name` plus an optional powdr witness-column ID. -/
+structure Variable where
+  name : String
+  powdrId? : Option Nat := none
+  deriving DecidableEq, Repr, Ord
+
+instance : BEq Variable := ⟨fun a b => decide (a = b)⟩
+instance : LE Variable := ⟨fun a b => a.name ≤ b.name ∧ a.powdrId? ≤ b.powdrId?⟩
+instance : Hashable Variable := ⟨fun a => mixHash (hash a.name) (hash a.powdrId?)⟩
+
+instance : Coe String Variable := ⟨fun name => { name }⟩
+
+/-- Parse powdr's legacy `<name>@<id>` variable notation into a structured variable. -/
+def Variable.ofPowdrName (raw : String) : Variable :=
+  match raw.splitOn "@" with
+  | [base, id] =>
+      match id.toNat? with
+      | some n => { name := base, powdrId? := some n }
+      | none => { name := raw }
+  | _ => { name := raw }
+
+instance : ToString Variable := ⟨fun x => x.name⟩
+
+instance : ReflBEq Variable where
+  rfl := by intro a; simp [BEq.beq]
+
+instance : LawfulBEq Variable where
+  eq_of_beq := by
+    intro a b h
+    simpa [BEq.beq] using h
+
+instance : PartialEquivBEq Variable where
+  symm := by
+    intro a b h
+    cases (LawfulBEq.eq_of_beq h)
+    simp [BEq.beq]
+  trans := by
+    intro a b c hab hbc
+    cases (LawfulBEq.eq_of_beq hab)
+    cases (LawfulBEq.eq_of_beq hbc)
+    simp [BEq.beq]
+
+instance : EquivBEq Variable where
+
+instance : LawfulHashable Variable where
+  hash_eq := by
+    intro a b h
+    cases (LawfulBEq.eq_of_beq h)
+    rfl
+
+/-- An arithmetic expression over structured variables and field constants. -/
 inductive Expression (p : ℕ) where
   | const (n : ZMod p)
-  | var (x : String)
+  | var (x : Variable)
   | add (e1 e2 : Expression p)
   | mul (e1 e2 : Expression p)
 
 /-- Evaluate an expression under an assignment `env` of variables to field elements. -/
-def Expression.eval (e : Expression p) (env : String → ZMod p) : ZMod p :=
+def Expression.eval (e : Expression p) (env : Variable → ZMod p) : ZMod p :=
   match e with
   | .const n => n
   | .var x => env x
@@ -41,7 +91,7 @@ structure BusInteraction (α : Type) where
 
 /-- Evaluate a bus interaction under an assignment `env`, turning a symbolic bus
     interaction into a bus interaction message. -/
-def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : String → ZMod p) :
+def BusInteraction.eval (bi : BusInteraction (Expression p)) (env : Variable → ZMod p) :
     BusInteraction (ZMod p) :=
   { busId := bi.busId,
     multiplicity := bi.multiplicity.eval env,
@@ -100,7 +150,7 @@ structure ConstraintSystem (p : ℕ) where
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
 def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
-    (busSemantics : BusSemantics p) (env : String → ZMod p) : BusState p :=
+    (busSemantics : BusSemantics p) (env : Variable → ZMod p) : BusState p :=
   cs.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
     |>.map (fun bi =>
       let m := bi.eval env
@@ -108,14 +158,14 @@ def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
 
 /-- Whether a given assignment is admissible under the bus semantics. -/
 def ConstraintSystem.admissible (s : ConstraintSystem p) (busSemantics : BusSemantics p)
-    (env : String → ZMod p) : Prop :=
+    (env : Variable → ZMod p) : Prop :=
   busSemantics.admissible ((s.busInteractions.map (fun bi => bi.eval env)).filter
     (fun m => decide (m.multiplicity ≠ 0) && busSemantics.isStateful m.busId))
 
 /-- Whether a constraint system is satisfied under a given environment and bus semantics,
     i.e., whether it satisfies all algebraic constraints and does not violate any bus constraints. -/
 def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSemantics p)
-    (env : String → ZMod p) : Prop :=
+    (env : Variable → ZMod p) : Prop :=
   (∀ c ∈ s.algebraicConstraints, c.eval env = 0) ∧
   (∀ bi ∈ s.busInteractions,
     let message := bi.eval env

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -11,52 +11,9 @@ variable {p : ℕ} [Fact p.Prime]
 structure Variable where
   name : String
   powdrId? : Option Nat := none
-  deriving DecidableEq, Repr, Ord
+  deriving DecidableEq, Repr
 
 instance : BEq Variable := ⟨fun a b => decide (a = b)⟩
-instance : LE Variable := ⟨fun a b => a.name ≤ b.name ∧ a.powdrId? ≤ b.powdrId?⟩
-instance : Hashable Variable := ⟨fun a => mixHash (hash a.name) (hash a.powdrId?)⟩
-
-instance : Coe String Variable := ⟨fun name => { name }⟩
-
-/-- Parse powdr's legacy `<name>@<id>` variable notation into a structured variable. -/
-def Variable.ofPowdrName (raw : String) : Variable :=
-  match raw.splitOn "@" with
-  | [base, id] =>
-      match id.toNat? with
-      | some n => { name := base, powdrId? := some n }
-      | none => { name := raw }
-  | _ => { name := raw }
-
-instance : ToString Variable := ⟨fun x => x.name⟩
-
-instance : ReflBEq Variable where
-  rfl := by intro a; simp [BEq.beq]
-
-instance : LawfulBEq Variable where
-  eq_of_beq := by
-    intro a b h
-    simpa [BEq.beq] using h
-
-instance : PartialEquivBEq Variable where
-  symm := by
-    intro a b h
-    cases (LawfulBEq.eq_of_beq h)
-    simp [BEq.beq]
-  trans := by
-    intro a b c hab hbc
-    cases (LawfulBEq.eq_of_beq hab)
-    cases (LawfulBEq.eq_of_beq hbc)
-    simp [BEq.beq]
-
-instance : EquivBEq Variable where
-
-instance : LawfulHashable Variable where
-  hash_eq := by
-    intro a b h
-    cases (LawfulBEq.eq_of_beq h)
-    rfl
-
 /-- An arithmetic expression over structured variables and field constants. -/
 inductive Expression (p : ℕ) where
   | const (n : ZMod p)

--- a/Leanr/Utils/Dsl.lean
+++ b/Leanr/Utils/Dsl.lean
@@ -28,7 +28,7 @@ instance : Sub (Expression p) := ⟨fun a b => a + (-b)⟩
 instance {n : ℕ} : OfNat (Expression p) n := ⟨Expression.const (OfNat.ofNat n)⟩
 
 /-- A variable, referenced by name. -/
-def V (x : String) : Expression p := .var x
+def V (x : String) : Expression p := .var (Variable.ofPowdrName x)
 
 /-! ## Rendering
 
@@ -37,18 +37,8 @@ constant folding of numeric factors, dropping `+ 0` / `* 1` / `* 0`, and showing
 upper half of `[0, p)` as negatives — so `x + (p-1) * y` prints as `x - y` and `(p-1) * 2` as `-2`.
 Parentheses are emitted only around sum factors of a product, where precedence requires them.
 
-Variable names carry a trailing `@<id>` witness-column disambiguator (e.g. `opcode_add_flag_0@31`)
-that is stripped for display by `displayVar`; within a single circuit the names are already unique
-without it. -/
-
-/-- Strip a trailing `@<id>` suffix from a variable name for display, e.g. `opcode_add_flag_0@31`
-    renders as `opcode_add_flag_0`. The suffix is a witness-column disambiguator and the names are
-    already unique without it within a single circuit, so this loses no information. A name without
-    such a suffix (no `@`, or a non-numeric one) is returned unchanged. -/
-def displayVar (name : String) : String :=
-  match name.splitOn "@" with
-  | [base, id] => if id ≠ "" && id.all Char.isDigit then base else name
-  | _ => name
+Variables render using only their display name; any parsed powdr witness-column ID is kept
+in the structured `Variable` value but hidden in rendered output. -/
 
 /-- Split a field constant into a sign and magnitude: constants in the upper half of `[0, p)`
     are shown as negatives (e.g. `p - 1` renders as `-1`, `p - 2` as `-2`). -/
@@ -62,7 +52,7 @@ mutual
   private partial def prodFold : Expression p → ZMod p × List String
     | .mul a b => let (ca, fa) := prodFold a; let (cb, fb) := prodFold b; (ca * cb, fa ++ fb)
     | .const n => (n, [])
-    | .var x => (1, [displayVar x])
+    | .var x => (1, [toString x])
     | e =>                                                 -- an additive factor
       match collectSummands e with
       | [(neg, body)] => (if neg then -1 else 1, [body])   -- single term: splice in, no parens

--- a/Leanr/Utils/Dsl.lean
+++ b/Leanr/Utils/Dsl.lean
@@ -113,10 +113,10 @@ def matchesSnapshot (cs : ConstraintSystem p) (expected : String) : Bool :=
 private def busGroupingSnapshot : ConstraintSystem 7 :=
   { algebraicConstraints := [],
     busInteractions := [
-      { busId := 2, multiplicity := (1 : Expression 7), payload := [V "two_a@1"] },
-      { busId := 1, multiplicity := (1 : Expression 7), payload := [V "one_a@2"] },
-      { busId := 2, multiplicity := (1 : Expression 7), payload := [V "two_b@3"] },
-      { busId := 1, multiplicity := (1 : Expression 7), payload := [V "one_b@4"] }
+      { busId := 2, multiplicity := (1 : Expression 7), payload := [V "two_a"] },
+      { busId := 1, multiplicity := (1 : Expression 7), payload := [V "one_a"] },
+      { busId := 2, multiplicity := (1 : Expression 7), payload := [V "two_b"] },
+      { busId := 1, multiplicity := (1 : Expression 7), payload := [V "one_b"] }
     ] }
 
 #guard renderBusInteractions busGroupingSnapshot.busInteractions ==

--- a/Leanr/Utils/Dsl.lean
+++ b/Leanr/Utils/Dsl.lean
@@ -28,7 +28,7 @@ instance : Sub (Expression p) := ⟨fun a b => a + (-b)⟩
 instance {n : ℕ} : OfNat (Expression p) n := ⟨Expression.const (OfNat.ofNat n)⟩
 
 /-- A variable, referenced by name. -/
-def V (x : String) : Expression p := .var (Variable.ofPowdrName x)
+def V (x : String) : Expression p := .var { name := x }
 
 /-! ## Rendering
 
@@ -52,7 +52,7 @@ mutual
   private partial def prodFold : Expression p → ZMod p × List String
     | .mul a b => let (ca, fa) := prodFold a; let (cb, fb) := prodFold b; (ca * cb, fa ++ fb)
     | .const n => (n, [])
-    | .var x => (1, [toString x])
+    | .var x => (1, [x.name])
     | e =>                                                 -- an additive factor
       match collectSummands e with
       | [(neg, body)] => (if neg then -1 else 1, [body])   -- single term: splice in, no parens

--- a/Leanr/Utils/Size.lean
+++ b/Leanr/Utils/Size.lean
@@ -33,18 +33,18 @@ variable {p : ℕ}
 /-! ## Collecting variables -/
 
 /-- All variable names occurring in an expression (with multiplicity / duplicates). -/
-def Expression.vars : Expression p → List String
+def Expression.vars : Expression p → List Variable
   | .const _ => []
   | .var x => [x]
   | .add a b => a.vars ++ b.vars
   | .mul a b => a.vars ++ b.vars
 
 /-- All variable names occurring in a bus interaction (multiplicity and payload). -/
-def BusInteraction.vars (bi : BusInteraction (Expression p)) : List String :=
+def BusInteraction.vars (bi : BusInteraction (Expression p)) : List Variable :=
   bi.multiplicity.vars ++ bi.payload.flatMap Expression.vars
 
 /-- The distinct variables of a constraint system, across constraints and bus interactions. -/
-def ConstraintSystem.variables (cs : ConstraintSystem p) : List String :=
+def ConstraintSystem.variables (cs : ConstraintSystem p) : List Variable :=
   (cs.algebraicConstraints.flatMap Expression.vars ++
     cs.busInteractions.flatMap BusInteraction.vars).dedup
 
@@ -63,7 +63,7 @@ def ConstraintSystem.busInteractionCount (cs : ConstraintSystem p) : Nat :=
 
 /-- Number of occurrences of `x` (with multiplicity) across the whole system. Used e.g. to pick
     substitution pivots that minimize expression duplication. -/
-def ConstraintSystem.occurrences (cs : ConstraintSystem p) (x : String) : Nat :=
+def ConstraintSystem.occurrences (cs : ConstraintSystem p) (x : Variable) : Nat :=
   (cs.algebraicConstraints.flatMap Expression.vars
     ++ cs.busInteractions.flatMap BusInteraction.vars).count x
 

--- a/Main.lean
+++ b/Main.lean
@@ -63,17 +63,15 @@ structure Stats where
 def distinctVarCount (cs : ConstraintSystem babyBear) : Nat :=
   let occurrences := cs.algebraicConstraints.flatMap Expression.vars ++
     cs.busInteractions.flatMap BusInteraction.vars
-  (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).size
+  (occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).size
 
-/-- The distinct variable names of a constraint system, sorted and rendered for display (the
-    `@<id>` witness-column suffix stripped via `Leanr.Spec.Dsl.displayVar`). The report uses these
-    to map variables between the original and optimized circuits (removed / added). Since names are
-    unique without the suffix within a circuit, this stays one-to-one with `distinctVarCount`. -/
+/-- The distinct variable names of a constraint system, sorted and rendered for display.
+    Variables may carry structured powdr IDs internally, but reports show only `Variable.name`. -/
 def distinctVars (cs : ConstraintSystem babyBear) : List String :=
   let occurrences := cs.algebraicConstraints.flatMap Expression.vars ++
     cs.busInteractions.flatMap BusInteraction.vars
-  ((occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList.map
-    Leanr.Spec.Dsl.displayVar).mergeSort (· ≤ ·)
+  ((occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList.map
+    toString).mergeSort (fun a b => decide (a ≤ b))
 
 def statsOf (cs : ConstraintSystem babyBear) : Stats :=
   { vars := distinctVarCount cs,
@@ -132,8 +130,8 @@ def cmdVars (fileName : String) (iters : Nat) : IO Unit := do
   let optimized ← IO.lazyPure (fun _ => openVmOptimizer busMap.toBusMap iters cs)
   let occurrences := optimized.algebraicConstraints.flatMap Expression.vars ++
     optimized.busInteractions.flatMap BusInteraction.vars
-  let distinct := (occurrences.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList
-  for v in (distinct.map Leanr.Spec.Dsl.displayVar).mergeSort (· ≤ ·) do
+  let distinct := (occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList
+  for v in (distinct.map toString).mergeSort (fun a b => decide (a ≤ b)) do
     IO.println v
 
 /-- Render the optimized system (for diagnosing residual constraints/interactions). -/

--- a/Main.lean
+++ b/Main.lean
@@ -71,7 +71,7 @@ def distinctVars (cs : ConstraintSystem babyBear) : List String :=
   let occurrences := cs.algebraicConstraints.flatMap Expression.vars ++
     cs.busInteractions.flatMap BusInteraction.vars
   ((occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList.map
-    toString).mergeSort (fun a b => decide (a ≤ b))
+    (fun x => x.name)).mergeSort (fun a b => decide (a ≤ b))
 
 def statsOf (cs : ConstraintSystem babyBear) : Stats :=
   { vars := distinctVarCount cs,
@@ -131,7 +131,7 @@ def cmdVars (fileName : String) (iters : Nat) : IO Unit := do
   let occurrences := optimized.algebraicConstraints.flatMap Expression.vars ++
     optimized.busInteractions.flatMap BusInteraction.vars
   let distinct := (occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList
-  for v in (distinct.map toString).mergeSort (fun a b => decide (a ≤ b)) do
+  for v in (distinct.map (fun x => x.name)).mergeSort (fun a b => decide (a ≤ b)) do
     IO.println v
 
 /-- Render the optimized system (for diagnosing residual constraints/interactions). -/


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `<name>@<id>` string convention with a first-class variable representation to avoid string parsing/formatting spread throughout the code.
- Preserve backwards compatibility with powdr exports by parsing legacy `<name>@<id>` names into a `Variable` carrying the original name and optional powdr ID while rendering only the display name.
- Simplify rendering and many ad-hoc `@<id>`-stripping helpers by keeping the witness-column id in data but hiding it for display.
- Enable robust, type-safe propagation of the variable key change across the spec and optimizer codepaths (expressions, environments, passes, and CLI). 

### Description
- Introduce `structure Variable` with fields `name : String` and `powdrId? : Option Nat`, plus `ToString`, `BEq`/ordered/hash instances and helpers like `Variable.ofPowdrName` (parses legacy `"name@id"`).
- Change `Expression.var` and all evaluation environments from `String → ZMod p` to `Variable → ZMod p`, and update `Expression`, `BusInteraction`, `ConstraintSystem` APIs and related lemmas accordingly.
- Parse powdr JSON variable names into `Variable` in `parseJsonExpr` via `Variable.ofPowdrName`.
- Remove the renderer-side `displayVar` suffix stripping and update the DSL renderer to call `toString` on `Variable` so only `Variable.name` is shown.
- Propagate the `Variable` key type throughout the optimizer and tooling: replace `List String`, `Std.HashMap String …`, `Std.HashSet String`, `Option (String × …)` etc. with `Variable` variants in many passes (`Affine`, `Gauss`, `Subst`, `SubstMap`, `DomainProp`, `DomainBatch`, `Reencode`, `Normalize`, `Rewrite`, `Reencode`, `DisconnectedComponent`, `MemoryUnify`, etc.).
- Update CLI reporting to count and render distinct variables using `Std.HashSet Variable` and `toString` for display.
- Add/adjust required typeclass instances and small helpers so proofs and hash/map usage work with `Variable` keys.

### Testing
- Built the whole project with `lake build`, which completed successfully (all targets built).
- Confirmed the CLI/main target also builds successfully as part of the `lake build` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4d5698f71c8324b5c55ed3e7775951)