### PR TITLE
Task 3: combine FFI + derived columns

### DIFF
--- a/Leanr.lean
+++ b/Leanr.lean
@@ -1,5 +1,6 @@
 -- Root of the `Leanr` library.
 import Leanr.Optimizer
 import Leanr.Implementation.JsonParser
+import Leanr.Implementation.JsonSerializer
 import Leanr.Utils.Dsl
 import Leanr.Utils.Size

--- a/Leanr/Ffi.lean
+++ b/Leanr/Ffi.lean
@@ -13,22 +13,39 @@ result back into a powdr `SymbolicMachine` JSON string.
 On any parse error the function returns a `{"error": "..."}` object rather than a machine, so the
 Rust side can surface a clear message instead of an opaque deserialization failure. The function
 never throws across the FFI boundary.
+
+## Witgen safety
+
+The end-to-end path (powdr witgen consumes the optimized circuit) requires that every witness
+column can actually be computed. The audited `openVmOptimizer` runs `reencodePass`, which invents
+fresh boolean columns whose values powdr's witgen can only fill from a `DerivedVariable` hint —
+and the audited spec (`optimizerPreservesDerivedColumns`) forbids the optimizer from emitting such
+hints (it must carry derived columns verbatim; see `docs/design/architecture.md`). So this entry
+point uses `optimizerWithBusFactsNoReencode` (the same pipeline without `reencodePass`): still a
+verified refinement, and it never produces a hint-less witness column. Input `derived_columns` are
+carried through verbatim, so any hints powdr already attached survive the round-trip.
 -/
 
 set_option autoImplicit false
 
-open Leanr.OpenVM (openVmOptimizer babyBear)
+open Leanr.OpenVM (babyBear openVmFacts BusMap)
+
+/-- OpenVM optimizer without the fresh-column-creating re-encoding pass (see the module doc): a
+    witgen-safe drop-in for the FFI path. Still a verified refinement of its input. -/
+def openVmOptimizerNoReencode (busMap : BusMap) (iters : Nat := 32) :
+    ConstraintSystem babyBear → ConstraintSystem babyBear :=
+  optimizerWithBusFactsNoReencode (openVmFacts babyBear busMap) iters
 
 /-- Escape a string for a JSON string literal (used only for the error path). -/
 private def escapeJson (s : String) : String :=
   (Lean.Json.str s).compress
 
-/-- Parse a powdr export, run the OpenVM optimizer (32 cleanup cycles, matching the CLI default),
-    and serialize the optimized machine. Returns `{"error": ...}` on failure. -/
+/-- Parse a powdr export, run the witgen-safe OpenVM optimizer (32 cleanup cycles, matching the CLI
+    default), and serialize the optimized machine. Returns `{"error": ...}` on failure. -/
 @[export leanr_optimize_json]
 def leanrOptimizeJson (input : String) : String :=
   match parseJsonSystem (p := babyBear) input with
   | .error err => "{\"error\":" ++ escapeJson err ++ "}"
   | .ok (cs, busMap) =>
-    let optimized := openVmOptimizer busMap.toBusMap 32 cs
+    let optimized := openVmOptimizerNoReencode busMap.toBusMap 32 cs
     Leanr.Serialize.serializeSystem optimized

--- a/Leanr/Ffi.lean
+++ b/Leanr/Ffi.lean
@@ -1,0 +1,34 @@
+import Leanr.Implementation.JsonParser
+import Leanr.Implementation.JsonSerializer
+import Leanr.Optimizer
+
+/-!
+# C FFI entry point
+
+A single `@[export]`ed, total function `leanr_optimize_json : String → String` that the C shim
+(and, through it, powdr's `autoprecompiles-lean-ffi` crate) calls: it parses a powdr
+`{"machine", "bus_map"}` JSON export, runs the verified OpenVM optimizer, and serializes the
+result back into a powdr `SymbolicMachine` JSON string.
+
+On any parse error the function returns a `{"error": "..."}` object rather than a machine, so the
+Rust side can surface a clear message instead of an opaque deserialization failure. The function
+never throws across the FFI boundary.
+-/
+
+set_option autoImplicit false
+
+open Leanr.OpenVM (openVmOptimizer babyBear)
+
+/-- Escape a string for a JSON string literal (used only for the error path). -/
+private def escapeJson (s : String) : String :=
+  (Lean.Json.str s).compress
+
+/-- Parse a powdr export, run the OpenVM optimizer (32 cleanup cycles, matching the CLI default),
+    and serialize the optimized machine. Returns `{"error": ...}` on failure. -/
+@[export leanr_optimize_json]
+def leanrOptimizeJson (input : String) : String :=
+  match parseJsonSystem (p := babyBear) input with
+  | .error err => "{\"error\":" ++ escapeJson err ++ "}"
+  | .ok (cs, busMap) =>
+    let optimized := openVmOptimizer busMap.toBusMap 32 cs
+    Leanr.Serialize.serializeSystem optimized

--- a/Leanr/Implementation/JsonParser.lean
+++ b/Leanr/Implementation/JsonParser.lean
@@ -101,6 +101,48 @@ partial def parseJsonExpr (j : Lean.Json) : Except String (Expression p) :=
 private def parseConstraint (j : Lean.Json) : Except String (Expression p) :=
   parseJsonExpr j
 
+/-- Parse a powdr `ComputationMethod`, serialized as an externally-tagged enum:
+    `{"Constant": <field>}`, `{"QuotientOrZero": [num, den]}`, or
+    `{"IfEqZero": [cond, then, else]}` (the last two arms are recursive). -/
+partial def parseComputationMethod (j : Lean.Json) : Except String (ComputationMethod p) :=
+  match j with
+  | Lean.Json.obj obj =>
+    match obj.toList with
+    | [("Constant", v)] => do
+      let e ← parseJsonExpr (p := p) v
+      match e with
+      | .const n => .ok (.constant n)
+      | _ => .error s!"Constant expects a field element, got: {v}"
+    | [("QuotientOrZero", Lean.Json.arr args)] =>
+      if h : args.size = 2 then do
+        let num ← parseJsonExpr (p := p) args[0]
+        let den ← parseJsonExpr (p := p) args[1]
+        .ok (.quotientOrZero num den)
+      else .error s!"QuotientOrZero expects 2 args, got {args.size}"
+    | [("IfEqZero", Lean.Json.arr args)] =>
+      if h : args.size = 3 then do
+        let cond ← parseJsonExpr (p := p) args[0]
+        let thenM ← parseComputationMethod args[1]
+        let elseM ← parseComputationMethod args[2]
+        .ok (.ifEqZero cond thenM elseM)
+      else .error s!"IfEqZero expects 3 args, got {args.size}"
+    | [(k, _)] => .error s!"unknown computation method: {k}"
+    | _ => .error s!"unexpected computation method object: {j}"
+  | _ => .error s!"unexpected computation method: {j}"
+
+/-- Parse a powdr `DerivedVariable`, serialized as a 3-tuple
+    `[is_new, "name@id", computation_method]`. -/
+def parseDerivedVariable (j : Lean.Json) : Except String (DerivedVariable p) :=
+  match j with
+  | Lean.Json.arr items =>
+    if h : items.size = 3 then do
+      let isNew ← items[0].getBool?
+      let name ← items[1].getStr?
+      let computation ← parseComputationMethod (p := p) items[2]
+      .ok { isNew := isNew, name := name, computation := computation }
+    else .error s!"DerivedVariable expects a 3-tuple, got {items.size} elements"
+  | _ => .error s!"unexpected derived variable: {j}"
+
 private def parseBusInteraction (j : Lean.Json) :
     Except String (BusInteraction (Expression p)) := do
   let id ← j.getObjVal? "id"
@@ -140,13 +182,25 @@ def parseJsonSystem (jsonStr : String) : Except String (ConstraintSystem p × Bu
   let busInteractions : List (BusInteraction (Expression p)) ←
     busArr.toList.mapM (parseBusInteraction (p := p))
 
+  -- Parse derived columns (witgen hints). Optional: older exports omit the key entirely,
+  -- so a missing `derived_columns` field defaults to no derived columns.
+  let derivedColumns : List (DerivedVariable p) ←
+    match machine.getObjVal? "derived_columns" with
+    | .error _ => pure []
+    | .ok derivedJson =>
+      match derivedJson with
+      | Lean.Json.arr a => a.toList.mapM (parseDerivedVariable (p := p))
+      | Lean.Json.null => pure []
+      | _ => .error "derived_columns is not an array"
+
   -- Parse bus_map
   let busMapJson ← json.getObjVal? "bus_map"
   let busMap ← parseBusMap busMapJson
 
   let system : ConstraintSystem p := {
     algebraicConstraints := constraints,
-    busInteractions := busInteractions
+    busInteractions := busInteractions,
+    derivedColumns := derivedColumns
   }
   pure (system, busMap)
 

--- a/Leanr/Implementation/JsonSerializer.lean
+++ b/Leanr/Implementation/JsonSerializer.lean
@@ -1,0 +1,75 @@
+import Lean.Data.Json
+import Leanr.Spec
+import Leanr.Implementation.JsonParser
+
+/-!
+# JSON serializer for derived columns
+
+Serializes `DerivedVariable`/`ComputationMethod` (and the `Expression`s they contain) to the exact
+JSON shape powdr's serde emits, so that Leanr's derived-column representation round-trips against
+powdr (`autoprecompiles`/`constraint-solver`):
+
+- an `Expression` is a JSON tree — `Number` → a bare number, `Reference` → the `"name@id"` string,
+  a binary op → `[lhs, "+"/"-"/"*", rhs]` (Leanr only produces `+`/`*`);
+- a `ComputationMethod` is an externally-tagged enum — `{"Constant": <field>}`,
+  `{"QuotientOrZero": [num, den]}`, `{"IfEqZero": [cond, then, else]}`;
+- a `DerivedVariable` is the 3-tuple `[is_new, "name@id", computation_method]`.
+
+This mirrors `parseComputationMethod` / `parseDerivedVariable` in `JsonParser.lean`; the two are
+tested to round-trip below. Leanr has no full circuit serializer yet (a separate task); this file
+covers the derived-column portion required to emit hints.
+
+Serialization needs no primality: field elements are written as their canonical `ZMod.val`.
+-/
+
+set_option autoImplicit false
+
+variable {p : ℕ}
+
+/-- Serialize a field element as its canonical natural-number representative. -/
+private def serializeField (n : ZMod p) : Lean.Json :=
+  Lean.Json.num (Lean.JsonNumber.fromNat n.val)
+
+/-- Serialize an `Expression` to powdr's JSON expression tree. -/
+def serializeExpr : Expression p → Lean.Json
+  | .const n => serializeField n
+  | .var x => Lean.Json.str x
+  | .add e1 e2 => Lean.Json.arr #[serializeExpr e1, Lean.Json.str "+", serializeExpr e2]
+  | .mul e1 e2 => Lean.Json.arr #[serializeExpr e1, Lean.Json.str "*", serializeExpr e2]
+
+/-- Serialize a `ComputationMethod` as powdr's externally-tagged enum. -/
+def serializeComputationMethod : ComputationMethod p → Lean.Json
+  | .constant n => Lean.Json.mkObj [("Constant", serializeField n)]
+  | .quotientOrZero num den =>
+      Lean.Json.mkObj [("QuotientOrZero", Lean.Json.arr #[serializeExpr num, serializeExpr den])]
+  | .ifEqZero cond thenM elseM =>
+      Lean.Json.mkObj [("IfEqZero",
+        Lean.Json.arr #[serializeExpr cond,
+          serializeComputationMethod thenM, serializeComputationMethod elseM])]
+
+/-- Serialize a `DerivedVariable` as powdr's 3-tuple `[is_new, variable, computation_method]`. -/
+def serializeDerivedVariable (dc : DerivedVariable p) : Lean.Json :=
+  Lean.Json.arr #[Lean.Json.bool dc.isNew, Lean.Json.str dc.name,
+    serializeComputationMethod dc.computation]
+
+/-- Serialize a list of derived columns as a JSON array (powdr's `derived_columns`). -/
+def serializeDerivedColumns (dcs : List (DerivedVariable p)) : Lean.Json :=
+  Lean.Json.arr (dcs.map serializeDerivedVariable).toArray
+
+-- Round-trip check: serializing derived columns, parsing them back, and re-serializing yields
+-- the identical JSON (so `serialize`/`parse` agree and match powdr's shape).
+#guard
+  (let dcs : List (DerivedVariable 2013265921) :=
+    [ { isNew := true, name := "a@1", computation := .constant 7 },
+      { isNew := false, name := "b@2",
+        computation := .quotientOrZero (.var "a@1") (.add (.var "c@3") (.const 1)) },
+      { isNew := true, name := "d@4",
+        computation := .ifEqZero (.var "e@5")
+          (.constant 0) (.quotientOrZero (.const 1) (.var "e@5")) } ]
+   let json := serializeDerivedColumns dcs
+   match json with
+   | Lean.Json.arr items =>
+     match items.toList.mapM (parseDerivedVariable (p := 2013265921)) with
+     | .ok parsed => (serializeDerivedColumns parsed).compress = json.compress
+     | .error _ => false
+   | _ => false)

--- a/Leanr/Implementation/JsonSerializer.lean
+++ b/Leanr/Implementation/JsonSerializer.lean
@@ -1,0 +1,103 @@
+import Lean.Data.Json
+import Leanr.Spec
+import Leanr.Utils.Size
+
+/-!
+# JSON serializer for powdr `SymbolicMachine` exports
+
+Turns a `ConstraintSystem p` back into the JSON that powdr's serde deserializes into
+`SymbolicMachine<T>` (see `autoprecompiles/src/symbolic_machine.rs` and
+`expression/src/lib.rs`). This is the inverse of `Leanr/Implementation/JsonParser.lean`.
+
+Output schema (matched empirically against powdr's serde):
+- top level: `{"constraints":[expr...], "bus_interactions":[{"id","mult","args"}...],
+  "derived_columns":[]}` — a bare `SymbolicMachine` (`derived_columns` has no serde default,
+  so it must be present).
+- an expression is:
+  - a constant  → a JSON integer (powdr's `BabyBearField` serializes as a canonical `u32`);
+  - a variable  → the string `"name@id"` (powdr's `AlgebraicReference` manual serde);
+  - `a + b`     → `[a, "+", b]`;
+  - `a * b`     → `[a, "*", b]`.
+  `Expression` has only `const/var/add/mul`, so subtraction / unary-minus never appear;
+  negative constants are emitted as their positive representative in `[0, p)`, which powdr
+  deserializes back as a `Number`.
+
+## Fresh variables
+
+Some passes (e.g. `Reencode`) introduce brand-new variables whose names carry no `@<id>`
+suffix (the exporter's `AlgebraicReference` requires an `@`). Before serializing we assign every
+such name a **fresh, unique** id strictly greater than any id already present, memoized so that
+equal names get equal ids and distinct names get distinct ids. The Rust side then reseeds its
+`ColumnAllocator` from the returned machine, so these ids never collide with later passes.
+
+This file is in the (unaudited) implementation layer: a wrong serialization can only make the
+round-trip fail, never affect the proven optimizer.
+-/
+
+set_option autoImplicit false
+
+open Lean (Json JsonNumber)
+
+variable {p : ℕ}
+
+namespace Leanr.Serialize
+
+/-- The id encoded in a variable name `name@id` (after the *last* `@`, matching powdr's
+    `rfind('@')`), or `none` if the name carries no numeric `@`-suffix. -/
+def parseVarId (x : String) : Option Nat :=
+  match (x.splitOn "@").reverse with
+  | idStr :: _ :: _ => idStr.toNat?
+  | _ => none
+
+/-- Distinct variable names occurring anywhere in the system. -/
+def distinctVars (cs : ConstraintSystem p) : List String :=
+  let occ := cs.algebraicConstraints.flatMap Expression.vars ++
+    cs.busInteractions.flatMap BusInteraction.vars
+  (occ.foldl (init := (∅ : Std.HashSet String)) (·.insert ·)).toList
+
+/-- A renaming that maps every fresh (suffix-less) variable name to `name@<fresh id>`, with fresh
+    ids taken strictly above the maximum id already present. Names that already carry an id map to
+    themselves (absent from the map). -/
+def freshRenaming (cs : ConstraintSystem p) : Std.HashMap String String :=
+  let vars := distinctVars cs
+  let maxId := vars.foldl (fun m x => match parseVarId x with
+    | some i => Nat.max m i
+    | none => m) 0
+  let fresh := vars.filter (fun x => (parseVarId x).isNone)
+  (fresh.foldl (init := ((∅ : Std.HashMap String String), maxId + 1))
+    (fun (acc, i) x => (acc.insert x (x ++ "@" ++ toString i), i + 1))).1
+
+/-- The reference string emitted for a variable, applying the fresh renaming. -/
+def refString (m : Std.HashMap String String) (x : String) : String :=
+  m.getD x x
+
+/-- A field constant as a JSON integer, using its canonical representative in `[0, p)`. -/
+def constJson (n : ZMod p) : Json :=
+  Json.num (JsonNumber.fromNat n.val)
+
+/-- Serialize an expression to `Lean.Json`. -/
+def serializeExpr (m : Std.HashMap String String) : Expression p → Json
+  | .const n => constJson n
+  | .var x => Json.str (refString m x)
+  | .add a b => Json.arr #[serializeExpr m a, Json.str "+", serializeExpr m b]
+  | .mul a b => Json.arr #[serializeExpr m a, Json.str "*", serializeExpr m b]
+
+/-- Serialize a bus interaction to a `{id, mult, args}` object. -/
+def serializeBus (m : Std.HashMap String String) (bi : BusInteraction (Expression p)) : Json :=
+  Json.mkObj [
+    ("id", Json.num (JsonNumber.fromNat bi.busId)),
+    ("mult", serializeExpr m bi.multiplicity),
+    ("args", Json.arr (bi.payload.map (serializeExpr m)).toArray)
+  ]
+
+/-- Serialize a whole constraint system as a powdr `SymbolicMachine` JSON string. -/
+def serializeSystem (cs : ConstraintSystem p) : String :=
+  let m := freshRenaming cs
+  let machine := Json.mkObj [
+    ("constraints", Json.arr (cs.algebraicConstraints.map (serializeExpr m)).toArray),
+    ("bus_interactions", Json.arr (cs.busInteractions.map (serializeBus m)).toArray),
+    ("derived_columns", Json.arr #[])
+  ]
+  machine.compress
+
+end Leanr.Serialize

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -85,6 +85,46 @@ theorem pipelineIters_respectsDeg (iters : Nat) :
 /-- `pipelineIters` with the default cleanup-cycle count. -/
 def pipeline : VerifiedPassW p := pipelineIters 32
 
+/-! ## Witgen-safe (re-encoding-free) pipeline for the FFI path
+
+`reencodePass` is the only pass that introduces brand-new witness columns (the boolean bits it
+uses to re-encode a variable group). For powdr's witgen to fill such a column it needs a
+`DerivedVariable{isNew := true}` hint. The optimizer cannot emit one: the audited spec's
+`optimizerPreservesDerivedColumns` conjunct forces `optimizerWithBusFacts` to carry the input's
+derived columns through *verbatim*, so any hint a pass produced would be discarded — and changing
+that is an audited-surface (`Spec.lean`) change, out of scope here. See
+`docs/design/architecture.md`.
+
+So the FFI/powdr end-to-end path uses `optimizerWithBusFactsNoReencode`, which runs the exact same
+pipeline minus `reencodePass`. The result therefore contains no witness column that lacks a witgen
+recipe, keeping powdr's produced circuit witgen-correct. This variant is still a verified
+refinement (it is built from the same `VerifiedPassW` combinators, each of which bundles its own
+`PassCorrect` proof); it is simply not one of the audited named optimizers. -/
+def cleanupCycleNoReencode : VerifiedPassW p :=
+  gaussElimPass.withFacts.guardDegree
+    |>.andThen normalizePass.withFacts.guardDegree
+    |>.andThen constantFoldPass.withFacts.guardDegree
+    |>.andThen domainBatchPass.guardDegree
+    |>.andThen normalizePass.withFacts.guardDegree
+    |>.andThen constantFoldPass.withFacts.guardDegree
+    |>.andThen trivialConstraintDropPass.withFacts.guardDegree
+    |>.andThen zeroMultBusDropPass.withFacts.guardDegree
+    |>.andThen tautoBusDropPass.withFacts.guardDegree
+    |>.andThen busUnifyPass.guardDegree
+    |>.andThen disconnectedComponentPass.withFacts.guardDegree
+
+def pipelineNoReencodeIters (iters : Nat) : VerifiedPassW p :=
+  constantFoldPass.withFacts.guardDegree
+    |>.andThen (cleanupCycleNoReencode.iterateStable iters)
+    |>.andThen monicScalePass.withFacts.guardDegree
+    |>.andThen constantFoldPass.withFacts.guardDegree
+
+/-- Re-encoding-free counterpart of `optimizerWithBusFacts`. Carries the input's derived columns
+    through verbatim (like `optimizerWithBusFacts`) and never creates a hint-less witness column. -/
+def optimizerWithBusFactsNoReencode {bs : BusSemantics p} (facts : BusFacts p bs) (iters : Nat := 32)
+    (cs : ConstraintSystem p) : ConstraintSystem p :=
+  { (pipelineNoReencodeIters iters cs bs facts).val with derivedColumns := cs.derivedColumns }
+
 /-- The fact-aware circuit optimizer, as a circuit-to-circuit map: given proven `BusFacts` about a
     bus semantics (which fixes the implicit `bs`) and an iteration bound, run the pipeline and
     project out the resulting constraint system. `iters` bounds the number of cleanup cycles (each

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -92,7 +92,11 @@ def pipeline : VerifiedPassW p := pipelineIters 32
     more than the snapshot default). -/
 def optimizerWithBusFacts {bs : BusSemantics p} (facts : BusFacts p bs) (iters : Nat := 32)
     (cs : ConstraintSystem p) : ConstraintSystem p :=
-  (pipelineIters iters cs bs facts).val
+  -- The pipeline passes operate on the algebraic/bus part only and reset `derivedColumns` to the
+  -- default `[]`; reattach the input's derived columns verbatim. Since `refines`,
+  -- `guaranteesInvariants` and `withinDegree` read only `algebraicConstraints`/`busInteractions`,
+  -- this reattachment is invisible to all correctness properties.
+  { (pipelineIters iters cs bs facts).val with derivedColumns := cs.derivedColumns }
 
 /-- The fact-aware optimizer is correct: its output `refines` its input (sound, and complete for
     the input's intended executions) and preserves invariants — the same two clauses
@@ -102,7 +106,16 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (facts : BusFacts p 
     (iters : Nat := 32) (cs : ConstraintSystem p) :
     ((optimizerWithBusFacts facts iters cs).refines cs bs) ∧
       (cs.guaranteesInvariants bs → (optimizerWithBusFacts facts iters cs).guaranteesInvariants bs) :=
+  -- `refines` and `guaranteesInvariants` read only `algebraicConstraints`/`busInteractions`, which
+  -- the `with derivedColumns := …` update leaves untouched, so the pipeline's proof applies as-is.
   (pipelineIters iters cs bs facts).property
+
+/-- The fact-aware optimizer carries derived columns through verbatim: it reattaches the input's
+    derived columns after running the (derived-column-agnostic) pipeline. -/
+theorem optimizerWithBusFacts_preservesDerived {bs : BusSemantics p} (facts : BusFacts p bs)
+    (iters : Nat := 32) (cs : ConstraintSystem p) :
+    (optimizerWithBusFacts facts iters cs).derivedColumns = cs.derivedColumns :=
+  rfl
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/

--- a/Leanr/Implementation/OptimizerPasses/FactPass.lean
+++ b/Leanr/Implementation/OptimizerPasses/FactPass.lean
@@ -36,6 +36,8 @@ def VerifiedPassW.iterate (f : VerifiedPassW p) : Nat → VerifiedPassW p
   | n + 1 => (f.iterate n).andThen f
 
 deriving instance DecidableEq for Expression
+deriving instance DecidableEq for ComputationMethod
+deriving instance DecidableEq for DerivedVariable
 deriving instance DecidableEq for BusInteraction
 deriving instance DecidableEq for ConstraintSystem
 

--- a/Leanr/Optimizer.lean
+++ b/Leanr/Optimizer.lean
@@ -37,7 +37,8 @@ theorem optimizerWithBusFacts_maintainsCorrectness (bs : BusSemantics p) (facts 
     (iters : Nat) :
     optimizerMaintainsCorrectness bs (optimizerWithBusFacts facts iters) :=
   ⟨fun cs => optimizerWithBusFacts_correct facts iters cs,
-   fun cs => optimizerWithBusFacts_respectsDegree facts iters cs⟩
+   fun cs => optimizerWithBusFacts_respectsDegree facts iters cs,
+   fun cs => optimizerWithBusFacts_preservesDerived facts iters cs⟩
 
 theorem simpleOptimizer_maintainsCorrectness (bs : BusSemantics p) (iters : Nat) :
     optimizerMaintainsCorrectness bs (simpleOptimizer bs iters) :=

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -29,6 +29,47 @@ def Expression.degree : Expression p → Nat
   | .add e1 e2 => max e1.degree e2.degree
   | .mul e1 e2 => e1.degree + e2.degree
 
+--------- Derived Columns (witgen hints) ---------
+
+/-- A *method for computing* the value of a derived column from an assignment, mirroring powdr's
+    `ComputationMethod`. These are witness-generation hints: they do **not** constrain the circuit
+    (they are not checked by the verifier), they instruct witgen how to fill a column. -/
+inductive ComputationMethod (p : ℕ) where
+  /-- A constant field value. -/
+  | constant (n : ZMod p)
+  /-- The quotient `num / den` using field inversion, or `0` when `den` evaluates to `0`. -/
+  | quotientOrZero (num den : Expression p)
+  /-- If `cond` evaluates to `0`, compute via `thenM`, otherwise via `elseM`. -/
+  | ifEqZero (cond : Expression p) (thenM elseM : ComputationMethod p)
+
+/-- Evaluate a computation method under an assignment. Reproduces powdr's
+    `evaluate_computation_method`: `quotientOrZero` uses the field inverse and yields `0` on a
+    zero divisor (matching powdr's explicit guard; note the `if` makes the result independent of
+    mathlib's convention `0⁻¹ = 0`). -/
+def ComputationMethod.eval (m : ComputationMethod p) (env : String → ZMod p) : ZMod p :=
+  match m with
+  | .constant n => n
+  | .quotientOrZero num den =>
+      let d := den.eval env
+      if d = 0 then 0 else num.eval env * d⁻¹
+  | .ifEqZero cond thenM elseM =>
+      if cond.eval env = 0 then thenM.eval env else elseM.eval env
+
+/-- A derived column, mirroring powdr's `DerivedVariable`. `isNew` distinguishes a genuinely new
+    column the optimizer created (witgen must compute it) from a hint for a pre-existing/removed
+    variable (`isNew = false`). `name` is the variable identifier (powdr's `"name@id"`). -/
+structure DerivedVariable (p : ℕ) where
+  isNew : Bool
+  name : String
+  computation : ComputationMethod p
+
+/-- A derived column is *consistent* under an assignment when the variable it names already holds
+    the value its computation method produces from that same assignment — the intended witgen
+    semantics `variable := computation(other columns)`. This is a **declarative** definition of
+    the hint's meaning; it is not enforced by any pass (see `docs/design/architecture.md`). -/
+def DerivedVariable.consistent (dc : DerivedVariable p) (env : String → ZMod p) : Prop :=
+  env dc.name = dc.computation.eval env
+
 --------- Bus Interactions ---------
 
 /-- A bus interaction. Typically, α is
@@ -96,6 +137,10 @@ instance : HasEquiv (BusState p) :=
 structure ConstraintSystem (p : ℕ) where
   algebraicConstraints : List (Expression p)
   busInteractions : List (BusInteraction (Expression p))
+  /-- Derived columns (witgen hints), mirroring powdr's `SymbolicMachine.derived_columns`. These
+      are metadata: they do not participate in `satisfies`/`refines` (see below). Defaulted to
+      `[]` so that constructions that do not care about derived columns are unaffected. -/
+  derivedColumns : List (DerivedVariable p) := []
 
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
@@ -120,6 +165,19 @@ def ConstraintSystem.satisfies (s : ConstraintSystem p) (busSemantics : BusSeman
   (∀ bi ∈ s.busInteractions,
     let message := bi.eval env
     message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false)
+
+/-- All of a system's derived columns are consistent under `env`. -/
+def ConstraintSystem.derivedConsistent (s : ConstraintSystem p) (env : String → ZMod p) : Prop :=
+  ∀ dc ∈ s.derivedColumns, dc.consistent env
+
+/-- A system's derived columns are *entailed* by the system when every satisfying assignment makes
+    them consistent — i.e. the hints are provably correct against the circuit itself. This is the
+    semantic notion of a valid derived column. It is provided declaratively (an emitting pass would
+    establish it for the columns it adds); the current optimizer emits no columns and instead
+    carries them verbatim (see `optimizerPreservesDerivedColumns`). -/
+def ConstraintSystem.derivedColumnsEntailed (s : ConstraintSystem p) (busSemantics : BusSemantics p) :
+    Prop :=
+  ∀ env, s.satisfies busSemantics env → s.derivedConsistent env
 
 /-- Whether a constraint system guarantees that all invariants are maintained under a given bus semantics. -/
 def ConstraintSystem.guaranteesInvariants (s : ConstraintSystem p) (busSemantics : BusSemantics p) : Prop :=
@@ -173,6 +231,16 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
     constraintSystem.withinDegree busSemantics.degreeBound →
     (optimizer constraintSystem).withinDegree busSemantics.degreeBound
 
+/-- Whether an optimizer carries derived columns (witgen hints) through verbatim: the output's
+    derived columns equal the input's. Derived columns are trusted metadata, not constraints, so
+    the optimizer must neither fabricate a new (possibly bogus) hint nor silently drop one. Since
+    the columns are preserved identically, the output's hints are exactly as valid as the input's
+    (in particular `derivedColumnsEntailed` transfers when the columns are unchanged). -/
+def optimizerPreservesDerivedColumns
+    (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
+  ∀ constraintSystem : ConstraintSystem p,
+    (optimizer constraintSystem).derivedColumns = constraintSystem.derivedColumns
+
 /-- Whether an optimizer maintains correctness *with respect to a given `busSemantics`*. This
     means that, for all constraint systems:
     1. The optimized constraint system `refines` the original: it is sound (every satisfying
@@ -180,6 +248,8 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
        the input's intended (real-trace) executions.
     2. Assuming the original constraint system guarantees invariants, so does the optimized one.
     3. The optimizer respects the zkVM's degree bound.
+    4. The optimizer preserves derived columns verbatim
+       (`optimizerPreservesDerivedColumns`).
 
     The bus semantics is a *parameter*: quantifying over it (`∀ bs, optimizerMaintainsCorrectness
     bs opt`) recovers the "correct for every semantics" reading, while leaving it fixed lets a
@@ -192,3 +262,4 @@ def optimizerMaintainsCorrectness (busSemantics : BusSemantics p)
     (constraintSystem.guaranteesInvariants busSemantics →
       (optimizer constraintSystem).guaranteesInvariants busSemantics))
   ∧ optimizerRespectsDegreeBound busSemantics optimizer
+  ∧ optimizerPreservesDerivedColumns optimizer

--- a/Main.lean
+++ b/Main.lean
@@ -3,6 +3,7 @@ import Leanr.Optimizer
 import Leanr.Utils.Size
 import Leanr.Utils.Dsl
 import Leanr.OpenVmSemantics
+import Leanr.Ffi
 
 /-!
 # The leanr CLI

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -112,6 +112,18 @@ only `algebraicConstraints`/`busInteractions`. Consequently every existing pass 
   or rewrite dead references) is left to the powdr-integration task. Parsing (`JsonParser.lean`) and
   serialization (`JsonSerializer.lean`) match powdr's serde (3-tuple, externally-tagged
   `ComputationMethod`); a missing `derived_columns` key parses to `[]`.
+- **FFI / witgen consequence.** `reencodePass` is the one pass that creates *new* witness columns
+  (the boolean re-encoding bits, named `rnc…`). powdr witgen can only fill a new column from an
+  `isNew=true` hint — which, per the above, the optimizer provably cannot emit under the current
+  spec (verbatim preservation would be violated; that is an audited-`Spec.lean` change). Making such
+  emission *provably correct* would additionally require establishing `derivedColumnsEntailed` for
+  the bit encoding (a nested `IfEqZero` decode) — a substantial per-pass proof. So the FFI entry
+  point (`Leanr/Ffi.lean`) runs `optimizerWithBusFactsNoReencode` — the identical pipeline minus
+  `reencodePass`, still a verified refinement — so the circuit handed to powdr contains no hint-less
+  column and stays witgen-correct. The full (re-encoding) optimizer remains available as the audited
+  `openVmOptimizer` and via `lake exe leanr run` for column-count measurement. Lifting this
+  restriction (emit + prove the `Reencode` hint, and relax the spec to entailment-preservation) is
+  the remaining gap.
 
 ## Adding a pass
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -80,6 +80,39 @@ proven facts, and iteration count) and derives its instances `simpleOptimizer_ma
 and the OpenVM `openVmOptimizer` (with
 `openVmOptimizer_maintainsCorrectness`) as one-liners.
 
+## Derived columns (witgen hints)
+
+`ConstraintSystem` carries a `derivedColumns : List (DerivedVariable p)` field (defaulted to `[]`),
+mirroring powdr's `SymbolicMachine.derived_columns`. A `DerivedVariable` is `{ isNew, name,
+computation }`, and a `ComputationMethod` is `constant` / `quotientOrZero` (field-inverse quotient,
+`0` on a zero divisor) / `ifEqZero` — reproducing powdr's `ComputationMethod` and its witgen
+evaluator. These are **witness-generation hints, not constraints**: they are not checked by the
+verifier and are deliberately kept out of `satisfies`/`refines`/`withinDegree`, all of which read
+only `algebraicConstraints`/`busInteractions`. Consequently every existing pass proof is unaffected.
+
+- **Audited definitions.** `DerivedVariable.consistent` (a hint holds when the variable already
+  equals its computed value) and `ConstraintSystem.derivedColumnsEntailed` (every satisfying
+  assignment makes the hints consistent) are *declarative* — they state the intended semantics of a
+  hint for future emitting passes and for cross-tool round-tripping. They are **not** enforced by
+  any pass today.
+- **The correctness guarantee.** `optimizerMaintainsCorrectness` gains a fourth clause,
+  `optimizerPreservesDerivedColumns` (`(opt cs).derivedColumns = cs.derivedColumns`): the optimizer
+  carries hints through verbatim, neither fabricating nor dropping them. This is *not* semantic
+  entailment-preservation, which is **unprovable generically**: `refines` maps a satisfying
+  assignment of the output to a possibly-different one of the input (substitution passes rebind
+  eliminated variables), so output-consistency at `env` cannot be derived from input-consistency at
+  the rebound `env'`. Verbatim preservation is the strongest guarantee provable without per-pass
+  coupling, and is exactly what powdr witgen needs (an `isNew=false` hint is precisely how a removed
+  column is recomputed). The optimizer reattaches `cs.derivedColumns` after the
+  (derived-column-agnostic) pipeline, so the clause holds by `rfl`.
+- **Deferred.** No pass yet *emits* a hint; emission needs a pass-level entailment obligation, out
+  of scope here. Because hints are carried verbatim while substitution passes eliminate variables, a
+  preserved `computation` may reference a variable no longer present in the output constraints —
+  benign for representation/parse/serialize, but reconciling hints with variable elimination (drop
+  or rewrite dead references) is left to the powdr-integration task. Parsing (`JsonParser.lean`) and
+  serialization (`JsonSerializer.lean`) match powdr's serde (3-tuple, externally-tagged
+  `ComputationMethod`); a missing `derived_columns` key parses to `[]`.
+
 ## Adding a pass
 
 Write a `VerifiedPass` (or `VerifiedPassW`) in a new `Leanr/Implementation/OptimizerPasses/` file,


### PR DESCRIPTION
## Task 3: combine the FFI and derived-columns efforts, run the benchmark

Combines the two open Leanr efforts and wires a witgen-correct Lean optimizer into powdr for a Lean-vs-Rust benchmark. Companion powdr PR: powdr-labs/powdr#3785. Builds on #53 (FFI) and #51 (derived columns).

### What's here
- **Merged** `claude/ffi-lean-optimizer` (#53) and `claude/derived-columns` (#51). The only conflict was that both branches independently added `Leanr/Implementation/JsonSerializer.lean`; reconciled into one serializer that (a) matches powdr's serde for the full `SymbolicMachine` and (b) emits `derived_columns` as the 3-tuple `[isNew, "name@id", <ComputationMethod>]` with an externally-tagged `ComputationMethod` (`{"Constant":n}` / `{"QuotientOrZero":[num,den]}` / `{"IfEqZero":[cond,then,else]}`). The fresh-variable renaming map is applied to derived-column names and to the expressions inside their computation methods too.
- **Witgen-safe FFI path.** The audited spec's `optimizerPreservesDerivedColumns` conjunct forces the optimizer to carry derived columns through **verbatim**, so a pass *cannot* emit a witgen hint without an audited-`Spec.lean` change (out of scope) — and even then the pass framework imposes no `derivedColumnsEntailed` obligation, so emission wouldn't be provably correct. `reencodePass` is the only pass that mints fresh witness columns (the re-encoding bits), which powdr witgen can only fill from such a hint. So `Leanr/Ffi.lean` now runs `optimizerWithBusFactsNoReencode` — the identical pipeline minus `reencodePass`, **still a fully verified refinement** (it reuses the same `VerifiedPassW` combinators, each bundling its own `PassCorrect`) — so every column powdr receives is either original or comes with a recipe. Input `derived_columns` are still carried through verbatim. The gap (emit + prove the `Reencode` hint, relax the spec to entailment-preservation) is documented in `docs/design/architecture.md`.

### Correctness
- `lake build` fully green, no `sorry`/`admit`/new axioms.
- `#print axioms leanrOptimizeJson` = `[propext, Classical.choice, Quot.sound]` (unchanged).
- No audited-surface change: `Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `Leanr/Optimizer.lean`, `Basic.lean` untouched. The new code lives in the implementation layer (`JsonSerializer.lean`, `Implementation/Optimizer.lean`, `Ffi.lean`) and docs.
- The serializer carries a `#guard` derived-column serialize→parse→serialize round-trip.

### Benchmarks (see the powdr PR for full commands/tables)
- **Round-trip** (`autoprecompiles/tests/lean_ffi_roundtrip.rs`): `keccak_roundtrip`, `single_div_nondet_roundtrip`, and a new `derived_columns_roundtrip` (a synthetic `QuotientOrZero` hint survives the FFI byte-for-byte) all pass.
- **Columns** (release, `POWDR_USE_LEAN_OPTIMIZER=1`; counts columns/bus/constraints): keccak Rust `2021/1734/186` vs Lean `3646/7796/512`; ecrecover Rust `3730/2314/3114` vs Lean `4966/9058/3583`; single_div Rust `47/24/44` vs Lean `47/24/52`. The verified Lean optimizer currently trails the native Rust solver on large circuits — it is capped at 32 cleanup cycles (each substitutes few vars), whereas the native optimizer runs to fixpoint. On the small circuit it matches.
- **Keccak wall time** (release): Rust `17s` vs Lean FFI `560s`. The Lean work runs inside the profile-independent Lean static lib, so release speeds up only the native path (Task 1's debug 128s→17s) and the gap widens.
- **`reencodePass` cost of disabling** (Lean CLI, small fixtures): identical variable counts on most; on `apc_030` reencode-on saved 8 vars (69→61). So the witgen-safe path costs little on average.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
