### PR TITLE
Merge stateless lookups: byte-pair and byte+range→tuple packing

### DIFF
--- a/Leanr/Implementation/BusFacts.lean
+++ b/Leanr/Implementation/BusFacts.lean
@@ -19,6 +19,10 @@ interaction, so facts can be conditional on e.g. an op-selector slot (see `Leanr
 
 variable {p : ℕ}
 
+-- Structural equality of expressions, needed by fact instances (e.g. recognizing a self-xor
+-- lookup `[x, x, …]`) and by fact-consuming passes.
+deriving instance DecidableEq for Expression
+
 /-- Does a payload match a pattern? Same length, and every constant pattern entry agrees. -/
 def Matches (payload : List (ZMod p)) (pattern : List (Option (ZMod p))) : Prop :=
   payload.length = pattern.length ∧
@@ -57,6 +61,46 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
   neverViolates_sound :
     ∀ (m : BusInteraction (ZMod p)),
       neverViolates m.busId = true → bs.violatesConstraint m = false
+  /-- Optionally merge two lookup interactions into one that imposes *exactly* the two obligations
+      together — the "pack several range/table checks into one bus interaction" knowledge (e.g. two
+      single-byte range checks becoming one two-byte range check). Expression-level: the merged
+      interaction is built from the inputs' sub-expressions so a pass can splice it into the system
+      in place of the two originals. All three must be stateless (so removing/adding them cannot
+      affect stateful side effects or the `admissible` filter), active, invariant-safe, and the
+      merged message's obligation must be equivalent to the conjunction of the two. -/
+  mergeLookups : BusInteraction (Expression p) → BusInteraction (Expression p) →
+    Option (BusInteraction (Expression p))
+  mergeLookups_sound :
+    ∀ (bi1 bi2 bi3 : BusInteraction (Expression p)),
+      mergeLookups bi1 bi2 = some bi3 →
+      bs.isStateful bi1.busId = false ∧
+      bs.isStateful bi2.busId = false ∧
+      bs.isStateful bi3.busId = false ∧
+      (∀ env, (bi1.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi2.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi3.eval env).multiplicity ≠ 0) ∧
+      (∀ env, bs.breaksInvariant (bi3.eval env) = false) ∧
+      (∀ env, bs.violatesConstraint (bi3.eval env) = false ↔
+        (bs.violatesConstraint (bi1.eval env) = false ∧
+          bs.violatesConstraint (bi2.eval env) = false))
+  /-- A second lookup-merge channel with the identical contract as `mergeLookups`, kept separate so
+      a pass can apply it *before* `mergeLookups` (e.g. packing a byte check and a range check into
+      a tuple range check, which must win over pairing the byte check with another byte check). -/
+  mergeTupleLookups : BusInteraction (Expression p) → BusInteraction (Expression p) →
+    Option (BusInteraction (Expression p))
+  mergeTupleLookups_sound :
+    ∀ (bi1 bi2 bi3 : BusInteraction (Expression p)),
+      mergeTupleLookups bi1 bi2 = some bi3 →
+      bs.isStateful bi1.busId = false ∧
+      bs.isStateful bi2.busId = false ∧
+      bs.isStateful bi3.busId = false ∧
+      (∀ env, (bi1.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi2.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi3.eval env).multiplicity ≠ 0) ∧
+      (∀ env, bs.breaksInvariant (bi3.eval env) = false) ∧
+      (∀ env, bs.violatesConstraint (bi3.eval env) = false ↔
+        (bs.violatesConstraint (bi1.eval env) = false ∧
+          bs.violatesConstraint (bi2.eval env) = false))
   /-- The last-write-wins shape declared for a bus, or `none`. Passes read `addressFields` to
       group same-address accesses; this is the VM-side memory knowledge (`Leanr/MemoryBus.lean`)
       the spec's abstract `admissible` predicate deliberately omits. -/
@@ -86,6 +130,10 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   slotFun_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
   neverViolates _ := false
   neverViolates_sound := by intro _ h; exact absurd h (by simp)
+  mergeLookups _ _ := none
+  mergeLookups_sound := by intro _ _ _ h; exact absurd h (by simp)
+  mergeTupleLookups _ _ := none
+  mergeTupleLookups_sound := by intro _ _ _ h; exact absurd h (by simp)
   memShape _ := none
   memShape_stateful := by intro _ _ h; exact absurd h (by simp)
   admissible_sound := by intro _ _ _ _ h; exact absurd h (by simp)

--- a/Leanr/Implementation/OpenVmFacts.lean
+++ b/Leanr/Implementation/OpenVmFacts.lean
@@ -53,6 +53,230 @@ private def neverViolatesImpl (busMap : Nat → Option OpenVmBusType) (busId : N
   -- length is not 9, so it can violate and is not unconditionally sound.
   | _ => false
 
+/-- The literal constant value of an expression, if it is a `const` node. Payload/multiplicity
+    entries are literal constants after constant folding, so this suffices for pattern recognition. -/
+private def constVal? (e : Expression p) : Option (ZMod p) :=
+  match e with | .const c => some c | _ => none
+
+private theorem constVal?_eval {e : Expression p} {c : ZMod p} (h : constVal? e = some c)
+    (env : Variable → ZMod p) : e.eval env = c := by
+  cases e with
+  | const c' => simp only [constVal?, Option.some.injEq] at h; subst h; rfl
+  | _ => simp [constVal?] at h
+
+/-- If `bi` is a bitwise self-xor byte check — op 1 (xor) with both operands the same expression,
+    active multiplicity, and `1 < p` — return the checked operand expression. Such a check asserts
+    exactly that the operand is a byte (`xor x x = 0` holds automatically). -/
+private def byteCheckOperand? (busMap : Nat → Option OpenVmBusType)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match bi.payload with
+  | [x, x', z, op] =>
+      if busMap bi.busId = some .bitwiseLookup ∧ 1 < p ∧ x = x' ∧
+         constVal? bi.multiplicity ≠ some 0 ∧ constVal? bi.multiplicity ≠ none ∧
+         constVal? z = some 0 ∧ constVal? op = some 1 then
+        some x
+      else none
+  | _ => none
+
+private theorem byteCheckOperand?_spec (busMap : Nat → Option OpenVmBusType)
+    (bi : BusInteraction (Expression p)) (x : Expression p)
+    (h : byteCheckOperand? busMap bi = some x) :
+    1 < p ∧ busMap bi.busId = some .bitwiseLookup ∧
+      (∀ env, (bi.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi.eval env).payload = [x.eval env, x.eval env, 0, 1]) := by
+  unfold byteCheckOperand? at h
+  split at h
+  · rename_i x0 x' z op hpay
+    split_ifs at h with hc
+    · obtain ⟨hbus, h1p, hxx, hm0, hmn, hz, hop⟩ := hc
+      simp only [Option.some.injEq] at h
+      subst h
+      obtain ⟨m, hm⟩ := Option.ne_none_iff_exists'.1 hmn
+      refine ⟨h1p, hbus, fun env => ?_, fun env => ?_⟩
+      · show bi.multiplicity.eval env ≠ 0
+        rw [constVal?_eval hm env]
+        intro h0; exact hm0 (h0 ▸ hm)
+      · show bi.payload.map (fun e => e.eval env) = [x0.eval env, x0.eval env, 0, 1]
+        simp only [hpay, List.map_cons, List.map_nil, ← hxx, constVal?_eval hz env,
+          constVal?_eval hop env]
+  all_goals exact absurd h (by simp)
+
+/-- On the bitwise bus, a self-xor lookup `[a, a, 0, 1]` (op 1) is accepted iff `a` is a byte:
+    `xor a a = 0` holds automatically, so the only real content is the byte range check on `a`.
+    (Stated with `decide (a.val < 256)` — the definition of the audited-but-private `isByte`.) -/
+private theorem violates_selfxor (busMap : Nat → Option OpenVmBusType) (h1p : 1 < p)
+    (m : BusInteraction (ZMod p)) (a : ZMod p)
+    (hbus : busMap m.busId = some .bitwiseLookup) (hpay : m.payload = [a, a, 0, 1]) :
+    (violates busMap m = false) ↔ a.val < 256 := by
+  haveI : Fact (1 < p) := ⟨h1p⟩
+  unfold violates
+  simp only [hbus, hpay, ZMod.val_one]
+  change ((!(decide (a.val < 256) && decide (a.val < 256)
+      && decide ((0 : ZMod p).val = Nat.xor a.val a.val))) = false) ↔ a.val < 256
+  simp [ZMod.val_zero, Nat.xor_self]
+
+/-- On the bitwise bus, an op-0 lookup `[a, b, 0, 0]` is accepted iff both `a` and `b` are bytes. -/
+private theorem violates_bytepair (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) (a b : ZMod p)
+    (hbus : busMap m.busId = some .bitwiseLookup) (hpay : m.payload = [a, b, 0, 0]) :
+    (violates busMap m = false) ↔ (a.val < 256 ∧ b.val < 256) := by
+  unfold violates
+  simp only [hbus, hpay, ZMod.val_zero]
+  change ((!(decide (a.val < 256) && decide (b.val < 256) && decide True)) = false)
+      ↔ (a.val < 256 ∧ b.val < 256)
+  simp
+
+/-- The variable range checker accepts `[y, bits]` iff `bits ≤ 25` and `y < 2 ^ bits`. -/
+private theorem violates_varrc (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) (y bits : ZMod p)
+    (hbus : busMap m.busId = some .variableRangeChecker) (hpay : m.payload = [y, bits]) :
+    (violates busMap m = false) ↔ (bits.val ≤ 25 ∧ y.val < 2 ^ bits.val) := by
+  unfold violates
+  simp only [hbus, hpay]
+  simp [decide_eq_true_eq]
+
+/-- The tuple range checker accepts `[x, y]` iff `x < s1` and `y < s2`. -/
+private theorem violates_tuple (busMap : Nat → Option OpenVmBusType) (s1 s2 : Nat)
+    (m : BusInteraction (ZMod p)) (x y : ZMod p)
+    (hbus : busMap m.busId = some (.tupleRangeChecker s1 s2)) (hpay : m.payload = [x, y]) :
+    (violates busMap m = false) ↔ (x.val < s1 ∧ y.val < s2) := by
+  unfold violates
+  simp only [hbus, hpay]
+  simp [decide_eq_true_eq]
+
+/-- The op-0 bitwise range check on operands `x` and `y`, asserting both are bytes. -/
+private def mergedBytePair (busId : Nat) (x y : Expression p) : BusInteraction (Expression p) :=
+  { busId := busId, multiplicity := .const 1, payload := [x, y, .const 0, .const 0] }
+
+/-- Merge two single-byte range checks into one two-byte range check. Each bitwise self-xor lookup
+    `[x, x, 0, 1]` asserts exactly its operand is a byte, so two such checks on `x` and `y` combine
+    into the single op-0 range check `[x, y, 0, 0]` — the same conjoined obligation `x, y` bytes, but
+    one fewer bus interaction. -/
+private def mergeLookupsImpl (busMap : Nat → Option OpenVmBusType)
+    (bi1 bi2 : BusInteraction (Expression p)) : Option (BusInteraction (Expression p)) :=
+  match byteCheckOperand? busMap bi1, byteCheckOperand? busMap bi2 with
+  | some x, some y =>
+      if bi1.busId = bi2.busId then some (mergedBytePair bi1.busId x y)
+      else none
+  | _, _ => none
+
+/-- If `bi` is an active variable-range check `[y, bits]` with a constant `bits ≤ 25`, return the
+    checked value and the (constant) bit-width value. -/
+private def varRcOperand? (busMap : Nat → Option OpenVmBusType)
+    (bi : BusInteraction (Expression p)) : Option (Expression p × ZMod p) :=
+  match bi.payload with
+  | [y, bexpr] =>
+      match constVal? bexpr with
+      | some bval =>
+          if busMap bi.busId = some .variableRangeChecker ∧
+             constVal? bi.multiplicity ≠ some 0 ∧ constVal? bi.multiplicity ≠ none ∧
+             bval.val ≤ 25 then some (y, bval)
+          else none
+      | none => none
+  | _ => none
+
+private theorem varRcOperand?_spec (busMap : Nat → Option OpenVmBusType)
+    (bi : BusInteraction (Expression p)) (y : Expression p) (bval : ZMod p)
+    (h : varRcOperand? busMap bi = some (y, bval)) :
+    busMap bi.busId = some .variableRangeChecker ∧ bval.val ≤ 25 ∧
+      (∀ env, (bi.eval env).multiplicity ≠ 0) ∧
+      (∀ env, (bi.eval env).payload = [y.eval env, bval]) := by
+  unfold varRcOperand? at h
+  split at h
+  · rename_i y0 bexpr hpay
+    split at h
+    · rename_i bval0 hbval
+      split_ifs at h with hc
+      · obtain ⟨hbus, hm0, hmn, hble⟩ := hc
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨hy, hb⟩ := h
+        subst hy; subst hb
+        obtain ⟨mm, hm⟩ := Option.ne_none_iff_exists'.1 hmn
+        refine ⟨hbus, hble, fun env => ?_, fun env => ?_⟩
+        · show bi.multiplicity.eval env ≠ 0
+          rw [constVal?_eval hm env]; intro h0; exact hm0 (h0 ▸ hm)
+        · show bi.payload.map (fun e => e.eval env) = [y0.eval env, bval0]
+          simp only [hpay, List.map_cons, List.map_nil, constVal?_eval hbval env]
+    all_goals exact absurd h (by simp)
+  all_goals exact absurd h (by simp)
+
+/-- Find a tuple-range-check bus whose sizes are `(s1, s2)` (bounded search over small bus ids). -/
+private def findTupleBus (busMap : Nat → Option OpenVmBusType) (s1 s2 : Nat) : Option Nat :=
+  (List.range 256).find? (fun k => decide (busMap k = some (.tupleRangeChecker s1 s2)))
+
+private theorem findTupleBus_spec (busMap : Nat → Option OpenVmBusType) (s1 s2 k : Nat)
+    (h : findTupleBus busMap s1 s2 = some k) :
+    busMap k = some (.tupleRangeChecker s1 s2) := by
+  unfold findTupleBus at h
+  have hp := List.find?_some h
+  simp only [decide_eq_true_eq] at hp
+  exact hp
+
+/-- Try to merge `a` (a byte check) and `b` (a range check) into a tuple range check `[x, y]` on a
+    `(256, 2^bits)` tuple bus. -/
+private def tryTuple (busMap : Nat → Option OpenVmBusType)
+    (a b : BusInteraction (Expression p)) : Option (BusInteraction (Expression p)) :=
+  match byteCheckOperand? busMap a, varRcOperand? busMap b with
+  | some x, some yb =>
+      (findTupleBus busMap 256 (2 ^ yb.2.val)).map
+        (fun k => { busId := k, multiplicity := .const 1, payload := [x, yb.1] })
+  | _, _ => none
+
+/-- Soundness of one-directional tuple packing: `a` a byte check, `b` a range check on a matching
+    tuple bus. The merged tuple's obligation is `a`'s ∧ `b`'s (byte + range = the tuple's two bounds). -/
+private theorem tryTuple_sound (busMap : Nat → Option OpenVmBusType)
+    (a b bi3 : BusInteraction (Expression p)) (h : tryTuple busMap a b = some bi3) :
+    (openVmBusSemantics p busMap).isStateful a.busId = false ∧
+    (openVmBusSemantics p busMap).isStateful b.busId = false ∧
+    (openVmBusSemantics p busMap).isStateful bi3.busId = false ∧
+    (∀ env, (a.eval env).multiplicity ≠ 0) ∧ (∀ env, (b.eval env).multiplicity ≠ 0) ∧
+    (∀ env, (bi3.eval env).multiplicity ≠ 0) ∧
+    (∀ env, breaksInvariant busMap (bi3.eval env) = false) ∧
+    (∀ env, violates busMap (bi3.eval env) = false ↔
+      (violates busMap (a.eval env) = false ∧ violates busMap (b.eval env) = false)) := by
+  unfold tryTuple at h
+  split at h
+  · rename_i x yb hbc hvr
+    obtain ⟨y, bval⟩ := yb
+    rw [Option.map_eq_some_iff] at h
+    obtain ⟨k, htuple, hk⟩ := h
+    subst hk
+    obtain ⟨h1p, hbusB, hmB, hpayB⟩ := byteCheckOperand?_spec busMap a x hbc
+    obtain ⟨hbusR, hble, hmR, hpayR⟩ := varRcOperand?_spec busMap b y bval hvr
+    have hbusK : busMap k = some (.tupleRangeChecker 256 (2 ^ bval.val)) :=
+      findTupleBus_spec busMap 256 (2 ^ bval.val) k htuple
+    haveI : Fact (1 < p) := ⟨h1p⟩
+    refine ⟨?_, ?_, ?_, hmB, hmR, ?_, ?_, ?_⟩
+    · show (match busMap a.busId with | some t => t.isStateful | none => false) = false
+      simp only [hbusB, OpenVmBusType.isStateful]
+    · show (match busMap b.busId with | some t => t.isStateful | none => false) = false
+      simp only [hbusR, OpenVmBusType.isStateful]
+    · show (match busMap k with | some t => t.isStateful | none => false) = false
+      simp only [hbusK, OpenVmBusType.isStateful]
+    · intro env; show (Expression.const 1).eval env ≠ 0; simpa using one_ne_zero
+    · intro env
+      show breaksInvariant busMap
+        (({ busId := k, multiplicity := .const 1, payload := [x, y] }
+          : BusInteraction (Expression p)).eval env) = false
+      simp [breaksInvariant, BusInteraction.eval, Expression.eval, hbusK]
+    · intro env
+      rw [violates_tuple busMap 256 (2 ^ bval.val) _ (x.eval env) (y.eval env) hbusK rfl,
+          violates_selfxor busMap h1p (a.eval env) (x.eval env) hbusB (hpayB env),
+          violates_varrc busMap (b.eval env) (y.eval env) bval hbusR (hpayR env)]
+      constructor
+      · rintro ⟨hx, hy⟩; exact ⟨hx, hble, hy⟩
+      · rintro ⟨hx, _, hy⟩; exact ⟨hx, hy⟩
+  · exact absurd h (by simp)
+
+/-- Merge a bitwise byte check `[x,x,0,1]` (x < 256) and a variable-range check `[y, b]` (y < 2^b)
+    into a single tuple range check `[x, y]` on a `(256, 2^b)` tuple bus — the same conjoined
+    obligation, one fewer interaction. Tries both operand orders. -/
+private def mergeTupleLookupsImpl (busMap : Nat → Option OpenVmBusType)
+    (bi1 bi2 : BusInteraction (Expression p)) : Option (BusInteraction (Expression p)) :=
+  match tryTuple busMap bi1 bi2 with
+  | some bi3 => some bi3
+  | none => tryTuple busMap bi2 bi1
+
 /-- A payload matching a 4-entry pattern is a 4-entry list. -/
 private theorem payload_four {payload : List (ZMod p)} {p0 p1 p2 p3 : Option (ZMod p)}
     (h : Matches payload [p0, p1, p2, p3]) :
@@ -200,6 +424,53 @@ def openVmFacts (p : ℕ) [NeZero p]
     · rename_i hbus; rw [hbus]
     · rename_i hbus; rw [hbus]
     · exact absurd h (by simp)
+  mergeLookups := mergeLookupsImpl busMap
+  mergeLookups_sound := by
+    intro bi1 bi2 bi3 hmerge
+    unfold mergeLookupsImpl at hmerge
+    split at hmerge
+    · rename_i x y hx hy
+      split_ifs at hmerge with hbuseq
+      · simp only [Option.some.injEq] at hmerge
+        subst hmerge
+        obtain ⟨h1p, hbus1, hm1, hpay1⟩ := byteCheckOperand?_spec busMap bi1 x hx
+        obtain ⟨_, hbus2, hm2, hpay2⟩ := byteCheckOperand?_spec busMap bi2 y hy
+        haveI : Fact (1 < p) := ⟨h1p⟩
+        have hst1 : (openVmBusSemantics p busMap).isStateful bi1.busId = false := by
+          show (match busMap bi1.busId with | some t => t.isStateful | none => false) = false
+          simp only [hbus1, OpenVmBusType.isStateful]
+        have hst2 : (openVmBusSemantics p busMap).isStateful bi2.busId = false := by
+          show (match busMap bi2.busId with | some t => t.isStateful | none => false) = false
+          simp only [hbus2, OpenVmBusType.isStateful]
+        refine ⟨hst1, hst2, hst1, hm1, hm2, ?_, ?_, ?_⟩
+        · intro env
+          show (Expression.const 1).eval env ≠ 0
+          simpa using one_ne_zero
+        · intro env
+          show breaksInvariant busMap ((mergedBytePair bi1.busId x y).eval env) = false
+          simp [breaksInvariant, mergedBytePair, BusInteraction.eval, Expression.eval, hbus1]
+        · intro env
+          show (violates busMap ((mergedBytePair bi1.busId x y).eval env) = false) ↔
+            ((violates busMap (bi1.eval env) = false) ∧ (violates busMap (bi2.eval env) = false))
+          rw [violates_bytepair busMap ((mergedBytePair bi1.busId x y).eval env)
+                (x.eval env) (y.eval env) hbus1 rfl,
+              violates_selfxor busMap h1p (bi1.eval env) (x.eval env) hbus1 (hpay1 env),
+              violates_selfxor busMap h1p (bi2.eval env) (y.eval env) hbus2 (hpay2 env)]
+    all_goals exact absurd hmerge (by simp)
+  mergeTupleLookups := mergeTupleLookupsImpl busMap
+  mergeTupleLookups_sound := by
+    intro bi1 bi2 bi3 hmerge
+    unfold mergeTupleLookupsImpl at hmerge
+    split at hmerge
+    · -- tuple pack in the given order (`bi1` byte, `bi2` range)
+      rename_i b3 h1
+      simp only [Option.some.injEq] at hmerge
+      subst hmerge
+      exact tryTuple_sound busMap bi1 bi2 b3 h1
+    · -- the reversed order (`bi2` byte, `bi1` range); swap the symmetric components
+      rename_i h1
+      obtain ⟨s1, s2, s3, a1, a2, a3, inv, obl⟩ := tryTuple_sound busMap bi2 bi1 bi3 hmerge
+      exact ⟨s2, s1, s3, a2, a1, a3, inv, fun env => (obl env).trans and_comm⟩
   memShape := memShapeOf busMap
   memShape_stateful := fun busId shape hshape =>
     openVm_isStateful_of_memShape busMap busId shape hshape

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -13,6 +13,7 @@ import Leanr.Implementation.OptimizerPasses.TautoBus
 import Leanr.Implementation.OptimizerPasses.MonicScale
 import Leanr.Implementation.OptimizerPasses.MemoryUnify
 import Leanr.Implementation.OptimizerPasses.BusUnify
+import Leanr.Implementation.OptimizerPasses.BusMerge
 import Leanr.Implementation.OptimizerPasses.DisconnectedComponent
 import Leanr.Implementation.OptimizerPasses.Reencode
 
@@ -45,8 +46,10 @@ pass's own `PassCorrect`. -/
     substitute one variable forced by finite-domain enumeration (boolean/one-hot case
     analysis, bus-fact domains, probed bus obligations; prime `p` only), re-normalize and
     re-fold, drop trivially-true constraints, drop zero-multiplicity bus interactions, drop
-    stateless interactions whose constant message satisfies the bus table, and add the
-    receive-equals-send equations entailed by the memory discipline. Finally, canonicalize:
+    stateless interactions whose constant message satisfies the bus table, merge pairs of
+    stateless lookups into one carrying their combined obligation (proven bus facts, e.g. two
+    single-byte range checks into one two-byte check), and add the receive-equals-send equations
+    entailed by the memory discipline. Finally, canonicalize:
     scale every constraint's affine factors to monic form (zero-set preserving) and re-fold.
     Extend it by composing passes with `.andThen`. -/
 def cleanupCycle : VerifiedPassW p :=
@@ -59,6 +62,8 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen trivialConstraintDropPass.withFacts.guardDegree
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree
     |>.andThen tautoBusDropPass.withFacts.guardDegree
+    |>.andThen mergeTuplePass.guardDegree
+    |>.andThen mergeLookupPass.guardDegree
     |>.andThen busUnifyPass.guardDegree
     |>.andThen disconnectedComponentPass.withFacts.guardDegree
     |>.andThen reencodePass.withFacts.guardDegree

--- a/Leanr/Implementation/OptimizerPasses/BusMerge.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusMerge.lean
@@ -1,0 +1,184 @@
+import Leanr.Implementation.OptimizerPasses.Rewrite
+import Leanr.Implementation.OptimizerPasses.FactPass
+
+set_option autoImplicit false
+
+/-! # Stateless lookup merging
+
+Replaces two *stateless* lookup interactions by a single one carrying exactly their combined
+obligation, using the proven `BusFacts.mergeLookups` (e.g. two single-byte range checks packed into
+one two-byte range check on the OpenVM bitwise bus). Because all three interactions are stateless,
+this cannot touch `sideEffects` or the `admissible` filter (both range over active *stateful*
+messages only), so soundness/completeness reduce to the obligation equivalence the fact provides:
+
+* the merged interaction's `violatesConstraint` obligation holds iff both originals' do
+  (`mergeLookups_sound`), so `satisfies` is preserved in both directions (the originals are active
+  by the fact, unlocking their guards);
+* the merged interaction is invariant-safe (`breaksInvariant = false`).
+
+The pass drops *every* copy of the two originals and prepends the merged interaction — a net
+reduction in bus interactions with no change to the variable set. Generic in the bus semantics: with
+`BusFacts.trivial` (`mergeLookups = fun _ _ => none`) it is the identity. -/
+
+variable {p : ℕ}
+
+/-- Filtering out interactions that are all stateless leaves the *stateful* sublist unchanged. -/
+theorem filterKeep_stateful (bs : BusSemantics p) (keep : BusInteraction (Expression p) → Bool)
+    (L : List (BusInteraction (Expression p)))
+    (h : ∀ b ∈ L, keep b = false → bs.isStateful b.busId = false) :
+    (L.filter keep).filter (fun bi => bs.isStateful bi.busId)
+      = L.filter (fun bi => bs.isStateful bi.busId) := by
+  induction L with
+  | nil => rfl
+  | cons b rest ih =>
+    have hrest := ih (fun b' hb' => h b' (List.mem_cons_of_mem _ hb'))
+    by_cases hk : keep b = true
+    · rw [List.filter_cons_of_pos hk]
+      by_cases hst : bs.isStateful b.busId = true
+      · rw [List.filter_cons_of_pos (by simpa using hst),
+            List.filter_cons_of_pos (by simpa using hst), hrest]
+      · rw [List.filter_cons_of_neg (by simpa using hst),
+            List.filter_cons_of_neg (by simpa using hst), hrest]
+    · have hst : bs.isStateful b.busId = false := h b (List.mem_cons_self ..) (by simpa using hk)
+      rw [List.filter_cons_of_neg (by simpa using hk),
+          List.filter_cons_of_neg (by simp [hst]), hrest]
+
+/-- **Correctness of stateless lookup merging.** Given two stateless, active, invariant-safe
+    interactions whose merged interaction `bi3` (also stateless, active, invariant-safe) has the
+    conjoined obligation, replacing every copy of `bi1`/`bi2` by `bi3` is equivalence- and
+    invariant-preserving. -/
+theorem ConstraintSystem.mergeLookups_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (bi1 bi2 bi3 : BusInteraction (Expression p))
+    (hmem1 : bi1 ∈ cs.busInteractions) (hmem2 : bi2 ∈ cs.busInteractions)
+    (hs1 : bs.isStateful bi1.busId = false) (hs2 : bs.isStateful bi2.busId = false)
+    (hs3 : bs.isStateful bi3.busId = false)
+    (ha1 : ∀ env, (bi1.eval env).multiplicity ≠ 0) (ha2 : ∀ env, (bi2.eval env).multiplicity ≠ 0)
+    (ha3 : ∀ env, (bi3.eval env).multiplicity ≠ 0)
+    (hinv3 : ∀ env, bs.breaksInvariant (bi3.eval env) = false)
+    (hobl : ∀ env, bs.violatesConstraint (bi3.eval env) = false ↔
+      (bs.violatesConstraint (bi1.eval env) = false ∧ bs.violatesConstraint (bi2.eval env) = false)) :
+    PassCorrect cs
+      { cs with busInteractions :=
+        bi3 :: cs.busInteractions.filter (fun b => decide (b ≠ bi1) && decide (b ≠ bi2)) } bs := by
+  set keep : BusInteraction (Expression p) → Bool :=
+    fun b => decide (b ≠ bi1) && decide (b ≠ bi2) with hkeep
+  -- a dropped interaction is `bi1` or `bi2`
+  have hdrop : ∀ b, keep b = false → b = bi1 ∨ b = bi2 := by
+    intro b hb
+    rw [hkeep] at hb
+    simp only [Bool.and_eq_false_iff, decide_eq_false_iff_not, not_not] at hb
+    exact hb
+  have hdropStateless : ∀ b ∈ cs.busInteractions, keep b = false → bs.isStateful b.busId = false := by
+    intro b _ hb; rcases hdrop b hb with rfl | rfl
+    · exact hs1
+    · exact hs2
+  -- satisfies is preserved in both directions
+  have hiff : ∀ env,
+      ({ cs with busInteractions :=
+        bi3 :: cs.busInteractions.filter keep } : ConstraintSystem p).satisfies bs env
+        ↔ cs.satisfies bs env := by
+    intro env
+    simp only [ConstraintSystem.satisfies]
+    constructor
+    · rintro ⟨hc, hb⟩
+      refine ⟨hc, fun bi hbimem => ?_⟩
+      by_cases hk : keep bi = true
+      · exact hb bi (List.mem_cons_of_mem _ (List.mem_filter.2 ⟨hbimem, hk⟩))
+      · -- bi = bi1 or bi2: obligation follows from bi3's (in the output) via hobl
+        have hb3 : bs.violatesConstraint (bi3.eval env) = false := by
+          have := hb bi3 (List.mem_cons_self ..)
+          exact this (ha3 env)
+        obtain ⟨hv1, hv2⟩ := (hobl env).1 hb3
+        rcases hdrop bi (by simpa using hk) with rfl | rfl
+        · intro _; exact hv1
+        · intro _; exact hv2
+    · rintro ⟨hc, hb⟩
+      refine ⟨hc, fun bi hbimem => ?_⟩
+      rcases List.mem_cons.1 hbimem with rfl | hbi
+      · -- bi3: obligation from bi1, bi2 (active in the input)
+        intro _
+        exact (hobl env).2 ⟨hb bi1 hmem1 (ha1 env), hb bi2 hmem2 (ha2 env)⟩
+      · exact hb bi (List.mem_filter.1 hbi).1
+  -- side effects are unchanged (all three are stateless)
+  have hside : ∀ env,
+      ({ cs with busInteractions :=
+        bi3 :: cs.busInteractions.filter keep } : ConstraintSystem p).sideEffects bs env
+        = cs.sideEffects bs env := by
+    intro env
+    simp only [ConstraintSystem.sideEffects]
+    rw [List.filter_cons_of_neg (by simp [hs3]),
+        filterKeep_stateful bs keep cs.busInteractions hdropStateless]
+  -- admissibility is unchanged (all three are stateless)
+  have hadm : ∀ env,
+      ({ cs with busInteractions :=
+        bi3 :: cs.busInteractions.filter keep } : ConstraintSystem p).admissible bs env
+        ↔ cs.admissible bs env := by
+    intro env
+    have hbi3ns : bs.isStateful (bi3.eval env).busId = false := hs3
+    have hfilt : ((bi3 :: cs.busInteractions.filter keep).map (fun bi => bi.eval env)).filter
+          (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
+        = ((cs.busInteractions.filter keep).map (fun bi => bi.eval env)).filter
+          (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId) := by
+      rw [List.map_cons, List.filter_cons_of_neg (by simp [hbi3ns])]
+    have h1 : ({ cs with busInteractions :=
+          bi3 :: cs.busInteractions.filter keep } : ConstraintSystem p).admissible bs env
+        ↔ (cs.filterBus keep).admissible bs env :=
+      Iff.of_eq (congrArg bs.admissible hfilt)
+    rw [h1]
+    exact cs.admissible_filterBus bs keep env
+      (fun bi hbi hkf => Or.inr (hdropStateless bi hbi hkf))
+  -- assemble
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · intro env hsat
+    exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro env hint hsat
+    exact ⟨env, (hiff env).2 hsat, (hadm env).2 hint, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro hinv env hsat bi hbi
+    rcases List.mem_cons.1 hbi with rfl | hbimem
+    · exact fun _ => hinv3 env
+    · exact hinv env ((hiff env).1 hsat) bi (List.mem_filter.1 hbimem).1
+
+/-! ## The pass -/
+
+/-- Scan for the first pair of interactions `merge` can combine: the earliest `bi1` with a later
+    `bi2` such that `merge bi1 bi2` succeeds. Linear per starting position. -/
+def findMergeable (merge : BusInteraction (Expression p) → BusInteraction (Expression p) →
+      Option (BusInteraction (Expression p))) :
+    List (BusInteraction (Expression p)) →
+    Option (BusInteraction (Expression p) × BusInteraction (Expression p) ×
+      BusInteraction (Expression p))
+  | [] => none
+  | bi1 :: rest =>
+    match rest.findSome? (fun bi2 => (merge bi1 bi2).map (fun bi3 => (bi2, bi3))) with
+    | some (bi2, bi3) => some (bi1, bi2, bi3)
+    | none => findMergeable merge rest
+
+/-- The stateless lookup-merge pass: find a `mergeLookups`-mergeable pair and replace both with the
+    merged interaction (dropping every copy of the two originals). Identity when no pair merges. -/
+def mergeLookupPass : VerifiedPassW p := fun cs bs facts =>
+  match findMergeable facts.mergeLookups cs.busInteractions with
+  | some (bi1, bi2, bi3) =>
+    if h : (bi1 ∈ cs.busInteractions ∧ bi2 ∈ cs.busInteractions)
+        ∧ facts.mergeLookups bi1 bi2 = some bi3 then
+      let ⟨hs1, hs2, hs3, ha1, ha2, ha3, hinv3, hobl⟩ := facts.mergeLookups_sound bi1 bi2 bi3 h.2
+      ⟨{ cs with busInteractions :=
+          bi3 :: cs.busInteractions.filter (fun b => decide (b ≠ bi1) && decide (b ≠ bi2)) },
+       cs.mergeLookups_correct bs bi1 bi2 bi3 h.1.1 h.1.2 hs1 hs2 hs3 ha1 ha2 ha3 hinv3 hobl⟩
+    else ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | none => ⟨cs, cs.refines_refl bs, _root_.id⟩
+
+/-- The tuple-packing pass: pack a `mergeTupleLookups`-mergeable pair (e.g. a byte check and a range
+    check) into one tuple range check. Runs before `mergeLookupPass` so tuple packing wins over
+    byte-pairing the same byte check. Identity when no pair merges. -/
+def mergeTuplePass : VerifiedPassW p := fun cs bs facts =>
+  match findMergeable facts.mergeTupleLookups cs.busInteractions with
+  | some (bi1, bi2, bi3) =>
+    if h : (bi1 ∈ cs.busInteractions ∧ bi2 ∈ cs.busInteractions)
+        ∧ facts.mergeTupleLookups bi1 bi2 = some bi3 then
+      let ⟨hs1, hs2, hs3, ha1, ha2, ha3, hinv3, hobl⟩ :=
+        facts.mergeTupleLookups_sound bi1 bi2 bi3 h.2
+      ⟨{ cs with busInteractions :=
+          bi3 :: cs.busInteractions.filter (fun b => decide (b ≠ bi1) && decide (b ≠ bi2)) },
+       cs.mergeLookups_correct bs bi1 bi2 bi3 h.1.1 h.1.2 hs1 hs2 hs3 ha1 ha2 ha3 hinv3 hobl⟩
+    else ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | none => ⟨cs, cs.refines_refl bs, _root_.id⟩

--- a/Leanr/Implementation/OptimizerPasses/FactPass.lean
+++ b/Leanr/Implementation/OptimizerPasses/FactPass.lean
@@ -35,7 +35,8 @@ def VerifiedPassW.iterate (f : VerifiedPassW p) : Nat → VerifiedPassW p
   | 0 => fun cs bs _ => ⟨cs, cs.refines_refl bs, _root_.id⟩
   | n + 1 => (f.iterate n).andThen f
 
-deriving instance DecidableEq for Expression
+-- `DecidableEq (Expression p)` is derived in `Leanr.Implementation.BusFacts` (imported above), so
+-- that fact-consuming passes and the fact instances share one instance.
 deriving instance DecidableEq for BusInteraction
 deriving instance DecidableEq for ConstraintSystem
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,22 +1,28 @@
 # Ideas for future optimization passes
 
-## Drop never-violating stateless lookups (bus-interaction effectiveness)
+## Batch all merges per pass (bus-interaction effectiveness)
 
-The new bus-interaction metric (log entry 42) shows leanr well behind powdr on bus interactions
-(~1.4× vs ~2.5× on a small sample), while at variable parity. powdr removes PC lookups and other
-stateless lookups that are proven never to violate; leanr keeps them (never-violating model), so
-they inflate the bus count without affecting variables.
+`mergeTuplePass` and `mergeLookupPass` (entries 43–44) each perform *one* merge per cleanup cycle,
+so they race for the shared byte checks: on `apc_003` only 4 of 8 possible `tupleRangeChecker[a, m]`
+packings form before the remaining `a__k` get byte-paired instead. Making each pass remove *all*
+disjoint mergeable pairs in a single application would capture the rest (and converge faster). This
+needs a batch version of `ConstraintSystem.mergeLookups_correct` — a positional/simultaneous-removal
+proof over a list of pairs rather than the current single-pair `bi3 :: filter (≠bi1) (≠bi2)`. Modest
+gain (the un-packed leftovers are few), moderate proof effort.
 
-A `VerifiedPass` that drops a stateless bus interaction whose multiplicity is provably `0`, or that
-is proven never-violating via `BusFacts.neverViolates`, would be sound (removing a
-never-violating, non-stateful interaction changes no stateful side effect) and would raise bus
-effectiveness without regressing variables — a clean win under the priority order
-(variables > bus interactions > constraints). Check the existing zero-multiplicity drop in
-`cleanupCycle` first; this may be an extension of it rather than a new pass.
+## Broaden `mergeLookups` instances
+
+The generic `mergeLookups` / `mergeTupleLookups` passes accept any obligation-preserving 2→1 merge a
+`BusFacts` instance certifies. Beyond the two OpenVM instances landed (bitwise byte-pair; byte +
+`varRC[·,b]` → `(256, 2^b)` tuple), other same-obligation packings could be added as new
+`OpenVmFacts` cases with no pass change — e.g. two `varRC[·,b]` on the same width into a `(2^b, 2^b)`
+tuple bus (when such a bus is declared), or a byte check + `varRC[·,8]` into a bitwise op-0 check
+(stays on the bitwise bus, no tuple bus needed). Check the benchmark for which widths actually occur
+before adding (apc_003 varRC widths are 12/13/14/17; only 13 matches the declared `(256,8192)` bus).
 
 ## Smarter witnesses for `disconnectedComponentPass`
 
-`disconnectedComponentPass` (entry 43) removes a disconnected component only if the **all-zero**
+`disconnectedComponentPass` removes a disconnected component only if the **all-zero**
 witness certifies it satisfiable (every dropped constraint evaluates to `0`, every dropped
 stateless interaction is non-violating). This captures dead range-checked auxiliaries (e.g. the
 `bit_shift_carry` limbs) but **not** the most common disconnected pattern in the benchmark: an
@@ -30,3 +36,18 @@ correctness machinery already supports any witness (it only re-checks `violatesC
 at run time), so **only the finder needs to change**, not the proof. Caveat: a decomposition solver
 leans toward the OpenVM limb structure — phrase it as a general "solve the component's lookups"
 search (probe `violatesConstraint`) rather than hard-coding base-256, to avoid overfitting.
+
+## (Investigated, blocked) Stateful send/receive chain collapse — exec bridge & memory
+
+The dominant bus-interaction gap vs powdr is stateful (entry 43: exec 328 vs 2, memory 952 vs 362):
+powdr collapses a receive→send→receive→…→send chain to just the first receive and last send, since
+the identical middle send/receive pairs cancel. This is **not currently provable** in this spec:
+cancelling active stateful interactions changes the active∧stateful message list, and completeness
+(`impliesAdmissible`) then needs `bs.admissible` *reconstructed* for the output. `bs.admissible` is
+an opaque `BusSemantics` field that `BusFacts` can only *consume* (`admissible_sound`, one
+direction); a reverse fact cannot be a `BusFacts` field because `BusFacts.trivial` (arbitrary `bs`)
+could not supply it. Worse, naive identical-pair cancellation is genuinely *unsound* for memory when
+a write is shadowed (a `[addr,v1]` write, then `[addr,v2]` write/read pair removed, exposes an
+unintended `[addr,v1]`→later-read match). Any attempt needs either a spec/`BusSemantics` change
+(out of scope: don't touch the audited surface) or a very carefully restricted, separately-justified
+transformation. Left here as a known-hard item, not a quick win.

--- a/docs/log.md
+++ b/docs/log.md
@@ -956,3 +956,77 @@ shift-limbs): 1027 → 1003 vars. The dominant *unremoved* pattern is the orphan
 (data limbs in a bitwise byte-check `[K − Σ256ⁱ·limbᵢ, …]`): all-zero is not a satisfying witness
 there (the affine slot is a large constant, not a byte) — left for a smarter witness finder (see
 `docs/ideas.md`).
+
+### 44. Merge stateless byte-pair range checks (bus-interaction effectiveness)
+Follow-up to entry 42's bus-interaction gap. Investigated where leanr keeps more bus interactions
+than powdr (rendered per-bus counts over 5 top cases): the dominant gap is **stateful** (exec bus
+328 vs 2, memory 952 vs 362 — powdr collapses the send/receive chains), but that is **not provable**
+in this spec: cancelling active stateful interactions changes the active∧stateful message list, and
+the spec's `admissible` is an *opaque* `BusSemantics` predicate that a pass can only *consume*
+(`BusFacts.admissible_sound`), never *reconstruct* — `BusFacts.trivial` could not supply a reverse
+direction, so completeness (`impliesAdmissible`) cannot be discharged. (PC lookups, entry 42's
+suggestion, turned out to be **already** removed by `tautoBusDropPass`: their payloads fold to
+constants and the arity-9 lookup then probes as satisfied.)
+
+The tractable, provable gap is **stateless**: leanr byte-range-checks each limb with a *self-xor*
+bitwise lookup `[x, x, 0, 1]` (op 1, `xor x x = 0` so the only content is "x is a byte"), while
+powdr packs two bytes into one op-0 lookup `[x, y, 0, 0]`. Both are stateless with the identical
+combined obligation `x, y < 256`, so replacing the two with the one is sound *and* stateless →
+`sideEffects` and `admissible` are untouched (both range over active **stateful** messages only).
+
+Implementation (all under `Leanr/Implementation/`, zero audit-surface change):
+- `BusFacts.mergeLookups`: a new proof-carrying fact — given two expression interactions, optionally
+  a merged one that is stateless, active, invariant-safe, and whose `violatesConstraint` obligation
+  is *equivalent to the conjunction* of the two. `BusFacts.trivial` returns `none` (identity).
+- `OpenVmFacts`: proves it for the bitwise bus (`[x,x,0,1] + [y,y,0,1] → [x,y,0,0]`), via
+  `violates_selfxor`/`violates_bytepair` helper lemmas (the audited `isByte` is `private`, so the
+  helpers state the byte bound as its definitional `decide (·.val < 256)` and `change` into it).
+  Guarded on `1 < p` for `ZMod.val_one`.
+- `OptimizerPasses/BusMerge.lean`: `mergeLookupPass : VerifiedPassW`, generic in the semantics —
+  finds the first fact-mergeable pair and replaces every copy of the two with the merged one.
+  `ConstraintSystem.mergeLookups_correct` discharges `PassCorrect` (satisfies both directions via the
+  obligation equivalence; `sideEffects`/`admissible` unchanged since all three are stateless).
+  `.andThen`ed into `cleanupCycle` after `tautoBusDropPass`.
+
+Worked. `lake build` green; `optimizerWithBusFacts/simpleOptimizer/openVmOptimizer_maintainsCorrectness`
+all still `{propext, Classical.choice, Quot.sound}`-only (proof-integrity script passes). On
+`apc_001`: bus interactions **44 → 38** (the 12 self-xor byte checks become 6 op-0 pairs), per-case
+bus effectiveness **1.61× → 1.87×**. Top-20 benchmark (`benchmark.py --n 20`), leanr before → after:
+- **variables 3.980× / 3.508× → 3.980× / 3.508×** (identical — the merge keeps both operands, so no
+  variable is added or removed)
+- **bus interactions 1.550× / 1.477× → 1.566× / 1.526×** (agg +0.016×, geomean +0.049×)
+- **constraints 8.853× / 8.369× → unchanged**
+
+A clean win on the requested axis (bus interactions) with no regression on the higher-priority
+variable axis (nor on constraints). powdr's bus lead (agg 3.525×) remains, but the rest of it is the
+stateful chain collapse (out of reach here) plus varRC→tupleRC packing (a future `mergeLookups`
+instance — see `docs/ideas.md`).
+
+### 45. Byte + range → tuple lookup packing (bus-interaction effectiveness)
+Follow-up to entry 44, implementing the `docs/ideas.md` tuple-packing idea. powdr packs a byte check
+and a variable-range check into one tuple range check: `bitwise[a,a,0,1]` (a < 256) + `varRC[m,13]`
+(m < 2^13 = 8192) → `tupleRangeChecker(256,8192)[a, m]`. On the load/store cases the `mem_ptr_limbs`
+are exactly `varRC[·,13]`, and the circuits declare a `(256, 8192)` tuple bus, so the pattern applies.
+
+Same machinery as entry 44, reusing `ConstraintSystem.mergeLookups_correct`:
+- Second fact `BusFacts.mergeTupleLookups` (identical contract to `mergeLookups`), so a pass can run
+  it *before* `mergeLookupPass` (tuple packing must win over byte-pairing the same byte check).
+- `OpenVmFacts`: `varRcOperand?` (recognize an active `varRC[y, const b]`, `b ≤ 25`), `findTupleBus`
+  (bounded search for a `(256, 2^b)` tuple bus), `tryTuple` + `tryTuple_sound` (obligation:
+  tuple's `x<256 ∧ y<2^b` = byte's ∧ range's), tried in both operand orders. `violates_varrc` /
+  `violates_tuple` helper lemmas.
+- `mergeTuplePass` (parameterized `findMergeable` over the merge fn), `.andThen`ed before
+  `mergeLookupPass`.
+
+Worked. `lake build` green, proof-integrity `{propext, Classical.choice, Quot.sound}`-only. On
+`apc_003` the pass emits `tupleRangeChecker[a__k, mem_ptr_limbs__1_j]` (matching powdr); leanr bus
+interactions 209 → 142 (was 150 pre-merges). Top-20 benchmark bus effectiveness with both merges:
+**1.570× / 1.534× (agg / geo)** — up from byte-pair-only **1.566× / 1.526×** and baseline
+**1.550× / 1.477×**; variables (**3.980× / 3.508×**) and constraints (**8.853× / 8.369×**) unchanged.
+
+Note: `mergeTuplePass` and `mergeLookupPass` each do one merge per cleanup cycle, so they race for
+the byte checks — on `apc_003` only 4 of 8 possible tuples form before the remaining `a__k` get
+byte-paired. Batching all merges per pass (a harder positional proof) would capture the rest; the
+current gain is already a strict, provable improvement (each tuple/byte merge only removes
+interactions, never touches variables). Diminishing returns: the large remaining bus gap vs powdr
+is the stateful exec/memory chain collapse, which stays out of reach (entry 44 / `docs/ideas.md`).


### PR DESCRIPTION
## Summary

Implements two stateless lookup-merging optimizations to improve bus-interaction effectiveness:

1. **Byte-pair merging**: Combines two single-byte range checks (bitwise self-xor lookups `[x,x,0,1]`) into one two-byte range check (`[x,y,0,0]`).
2. **Byte+range→tuple packing**: Merges a byte check and a variable-range check into a single tuple range check on a `(256, 2^bits)` bus.

Both optimizations are stateless (all three interactions involved are stateless), so they preserve `sideEffects` and `admissible` filters unchanged. Soundness reduces to obligation equivalence: the merged interaction's constraint obligation is equivalent to the conjunction of the two originals'.

## Key Changes

### Core Framework (`Leanr/Implementation/BusFacts.lean`)
- Added `DecidableEq` instance for `Expression` (needed for structural equality checks in fact instances and passes)
- Added two new fact fields to `BusFacts`:
  - `mergeLookups`: optionally merge two lookups into one with conjoined obligation
  - `mergeTupleLookups`: a second merge channel (runs before `mergeLookups` to prioritize tuple packing over byte-pairing)
  - Both include soundness proofs guaranteeing statefulness, activity, invariant-safety, and obligation equivalence

### OpenVM Instance (`Leanr/Implementation/OpenVmFacts.lean`)
- `constVal?`: extract literal constant values from expressions
- `byteCheckOperand?`: recognize active bitwise self-xor byte checks `[x,x,0,1]`
- `mergedBytePair`: construct a merged op-0 two-byte check `[x,y,0,0]`
- `mergeLookupsImpl`: merge two byte checks if on the same bus
- `varRcOperand?`: recognize active variable-range checks `[y, const bits]` with `bits ≤ 25`
- `findTupleBus`: bounded search for a `(256, 2^bits)` tuple bus
- `tryTuple`: merge a byte check and range check into a tuple check (tried in both orders)
- `mergeTupleLookupsImpl`: wrapper trying both operand orders
- Helper lemmas: `violates_selfxor`, `violates_bytepair`, `violates_varrc`, `violates_tuple` characterizing when each lookup type violates constraints

### Pass Implementation (`Leanr/Implementation/OptimizerPasses/BusMerge.lean`)
- `ConstraintSystem.mergeLookups_correct`: generic soundness proof for merging two stateless interactions
  - Obligation equivalence via the fact's `hobl` field
  - `sideEffects` and `admissible` unchanged (all three interactions are stateless)
  - Satisfies preserved in both directions
- `findMergeable`: scan for the first fact-mergeable pair in a list
- `mergeLookupPass`: find and merge a `mergeLookups`-mergeable pair
- `mergeTuplePass`: find and merge a `mergeTupleLookups`-mergeable pair (runs before `mergeLookupPass`)

### Integration (`Leanr/Implementation/Optimizer.lean`)
- Imported `BusMerge` module
- Added `mergeTuplePass` and `mergeLookupPass` to `cleanupCycle` (tuple pass runs first)

### Documentation (`docs/log.md`, `docs/ideas.md`)
- Documented entries 43–44 with benchmark results and design rationale
- Updated ideas with future directions (batch merges, broader instances, blocked stateful collapse)

## Benchmark Results

On top-20 benchmarks with both merges enabled:
- **Bus interactions**: 1.550× / 1.477× (baseline) → 1.570× / 1.534× (agg / geomean)
- **Variables**: 3.980× / 3.508× (unchanged)
- **Constraints**: 8

https://claude.ai/code/session_01WvUaYZU2ARDs6Pa8RnKpY7