### PR TITLE
Derived columns: emit ComputationMethods for optimizer-introduced columns

### DIFF
--- a/Leanr/Ffi.lean
+++ b/Leanr/Ffi.lean
@@ -30,5 +30,7 @@ def leanrOptimizeJson (input : String) : String :=
   match parseJsonSystem (p := babyBear) input with
   | .error err => "{\"error\":" ++ escapeJson err ++ "}"
   | .ok (cs, busMap) =>
-    let optimized := openVmOptimizer busMap.toBusMap cs
+    -- `.1` is the optimized circuit; `.2` are the `Derivations` for witness generation, not yet
+    -- threaded through the JSON serialization (would need a matching powdr-side format).
+    let optimized := (openVmOptimizer busMap.toBusMap cs).1
     Leanr.Serialize.serializeSystem optimized

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -81,30 +81,31 @@ theorem pipeline_respectsDeg : RespectsDeg (pipeline (p := p)) := by
   · exact VerifiedPassW.guardDegree_respectsDeg _
   · exact VerifiedPassW.guardDegree_respectsDeg _
 
-/-- The fact-aware circuit optimizer, as a circuit-to-circuit map: given proven `BusFacts` about a
-    bus semantics (which fixes the implicit `bs`), run the pipeline and project out the resulting
-    constraint system. The cleanup loop (`iterateToFixpoint`) takes no iteration count: it runs the
-    cleanup cycle until it stops strictly shrinking the lexicographic size key `(vars, bus,
-    constraints)`, provably terminating on that well-founded measure — no budget to set, and no cap a
-    large basic block could exceed. -/
+/-- The fact-aware circuit optimizer: given proven `BusFacts` about a bus semantics (which fixes the
+    implicit `bs`), run the pipeline and return the resulting constraint system together with the
+    `Derivations` for its newly-introduced variables. The cleanup loop (`iterateToFixpoint`) takes no
+    iteration count: it runs the cleanup cycle until it stops strictly shrinking the lexicographic
+    size key `(vars, bus, constraints)`, provably terminating on that well-founded measure — no
+    budget to set, and no cap a large basic block could exceed. -/
 def optimizerWithBusFacts {bs : BusSemantics p} (facts : BusFacts p bs)
-    (cs : ConstraintSystem p) : ConstraintSystem p :=
-  (pipeline cs bs facts).val
+    (cs : ConstraintSystem p) : ConstraintSystem p × Derivations p :=
+  let r := pipeline cs bs facts
+  (r.out, r.derivs)
 
 /-- The fact-aware optimizer is correct: its output `refines` its input (sound, and complete for
-    the input's intended executions) and preserves invariants — the same two clauses
-    `optimizerMaintainsCorrectness` demands, stated per instance because nontrivial facts are tied
-    to one semantics. -/
+    the input's intended executions with the returned witness-reconstruction data) and preserves
+    invariants — the same clauses `optimizerMaintainsCorrectness` demands, stated per instance
+    because nontrivial facts are tied to one semantics. -/
 theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (facts : BusFacts p bs)
     (cs : ConstraintSystem p) :
-    ((optimizerWithBusFacts facts cs).refines cs bs) ∧
-      (cs.guaranteesInvariants bs → (optimizerWithBusFacts facts cs).guaranteesInvariants bs) :=
-  (pipeline cs bs facts).property
+    ((optimizerWithBusFacts facts cs).1.refines cs bs (optimizerWithBusFacts facts cs).2) ∧
+      (cs.guaranteesInvariants bs → (optimizerWithBusFacts facts cs).1.guaranteesInvariants bs) :=
+  ⟨(pipeline cs bs facts).correct.toRefines, (pipeline cs bs facts).correct.2.1⟩
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/
 theorem optimizerWithBusFacts_respectsDegree {bs : BusSemantics p} (facts : BusFacts p bs)
     (cs : ConstraintSystem p)
     (h : cs.withinDegree bs.degreeBound) :
-    (optimizerWithBusFacts facts cs).withinDegree bs.degreeBound :=
+    (optimizerWithBusFacts facts cs).1.withinDegree bs.degreeBound :=
   pipeline_respectsDeg cs bs facts h

--- a/Leanr/Implementation/OptimizerPasses/Affine.lean
+++ b/Leanr/Implementation/OptimizerPasses/Affine.lean
@@ -161,6 +161,83 @@ theorem LinExpr.toExpr_eval (l : LinExpr p) (env : Variable → ZMod p) :
     l.toExpr.eval env = l.eval env := by
   simp only [LinExpr.toExpr, LinExpr.eval, toExpr_foldl_eval, Expression.eval]
 
+/-! ## Variable bounds (for `out.vars ⊆ cs.vars`) -/
+
+theorem toExpr_foldl_vars (terms : List (Variable × ZMod p)) :
+    ∀ (init : Expression p) (x : Variable),
+      x ∈ (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).vars →
+      x ∈ init.vars ∨ x ∈ terms.map Prod.fst := by
+  induction terms with
+  | nil => intro init x hx; exact Or.inl hx
+  | cons t rest ih =>
+      intro init x hx
+      simp only [List.foldl_cons] at hx
+      rcases ih _ x hx with h | h
+      · simp only [Expression.vars, List.mem_append, List.nil_append, List.mem_singleton] at h
+        rcases h with h | h
+        · exact Or.inl h
+        · exact Or.inr (by subst h; exact List.mem_cons_self ..)
+      · exact Or.inr (List.mem_cons_of_mem _ h)
+
+/-- `toExpr` only mentions the term variables. -/
+theorem LinExpr.toExpr_vars (l : LinExpr p) : ∀ x ∈ l.toExpr.vars, x ∈ l.terms.map Prod.fst := by
+  intro x hx
+  rcases toExpr_foldl_vars l.terms _ x hx with h | h
+  · simp [Expression.vars] at h
+  · exact h
+
+theorem LinExpr.scale_terms_fst (k : ZMod p) (l : LinExpr p) :
+    (l.scale k).terms.map Prod.fst = l.terms.map Prod.fst := by
+  simp [LinExpr.scale, List.map_map, Function.comp]
+
+theorem LinExpr.others_terms_fst_subset (l : LinExpr p) (v x : Variable)
+    (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
+  simp only [LinExpr.others, List.mem_map] at h ⊢
+  obtain ⟨t, ht, rfl⟩ := h
+  exact ⟨t, List.mem_of_mem_filter ht, rfl⟩
+
+/-- Linearization introduces no variable outside the expression. -/
+theorem linearize_vars (e : Expression p) (l : LinExpr p) (h : linearize e = some l) :
+    ∀ x ∈ l.terms.map Prod.fst, x ∈ e.vars := by
+  induction e generalizing l with
+  | const n => simp only [linearize, Option.some.injEq] at h; subst h; simp
+  | var y =>
+      simp only [linearize, Option.some.injEq] at h; subst h
+      intro x hx; simpa [Expression.vars] using hx
+  | add a b iha ihb =>
+      cases hla : linearize a with
+      | none => simp [linearize, hla] at h
+      | some la => cases hlb : linearize b with
+        | none => simp [linearize, hla, hlb] at h
+        | some lb =>
+          simp only [linearize, hla, hlb, Option.some.injEq] at h
+          subst h
+          intro x hx
+          simp only [LinExpr.add, List.map_append, List.mem_append] at hx
+          simp only [Expression.vars, List.mem_append]
+          exact hx.imp (iha la hla x) (ihb lb hlb x)
+  | mul a b iha ihb =>
+      cases hla : linearize a with
+      | none => simp [linearize, hla] at h
+      | some la => cases hlb : linearize b with
+        | none => simp [linearize, hla, hlb] at h
+        | some lb =>
+          by_cases h1 : la.terms.isEmpty = true
+          · simp only [linearize, hla, hlb, if_pos h1, Option.some.injEq] at h
+            subst h
+            intro x hx
+            rw [LinExpr.scale_terms_fst] at hx
+            exact List.mem_append.2 (Or.inr (ihb lb hlb x hx))
+          · by_cases h2 : lb.terms.isEmpty = true
+            · simp only [linearize, hla, hlb, if_neg h1, if_pos h2, Option.some.injEq] at h
+              subst h
+              intro x hx
+              rw [LinExpr.scale_terms_fst] at hx
+              exact List.mem_append.2 (Or.inl (iha la hla x hx))
+            · simp only [linearize, hla, hlb] at h
+              rw [if_neg h1, if_neg h2] at h
+              exact absurd h (by simp)
+
 /-- Try to solve the linear form `= 0` for variable `v`, when `v` has coefficient `±1`. -/
 def LinExpr.trySolve (l : LinExpr p) (v : Variable) : Option (Variable × Expression p) :=
   if l.coeff v = 1 then some (v, ((l.others v).scale (-1)).toExpr)
@@ -206,6 +283,31 @@ theorem LinExpr.trySolveUnit_sound (l : LinExpr p) (v x : Variable) (t : Express
   have hs := l.eval_split v env
   have h0 : l.coeff v * env v + (l.others v).eval env = 0 := by rw [← hs]; exact hl
   linear_combination (l.coeff v)⁻¹ * h0 - env v * h1
+
+theorem LinExpr.trySolve_vars (l : LinExpr p) (v x : Variable) (t : Expression p)
+    (h : l.trySolve v = some (x, t)) : ∀ y ∈ t.vars, y ∈ l.terms.map Prod.fst := by
+  intro y hy
+  unfold LinExpr.trySolve at h
+  split_ifs at h with h1 h2
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    have := LinExpr.toExpr_vars _ y hy
+    rw [LinExpr.scale_terms_fst] at this
+    exact l.others_terms_fst_subset v y this
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    exact l.others_terms_fst_subset v y (LinExpr.toExpr_vars _ y hy)
+
+theorem LinExpr.trySolveUnit_vars (l : LinExpr p) (v x : Variable) (t : Expression p)
+    (h : l.trySolveUnit v = some (x, t)) : ∀ y ∈ t.vars, y ∈ l.terms.map Prod.fst := by
+  intro y hy
+  unfold LinExpr.trySolveUnit at h
+  split_ifs at h with h1
+  simp only [Option.some.injEq, Prod.mk.injEq] at h
+  obtain ⟨rfl, rfl⟩ := h
+  have := LinExpr.toExpr_vars _ y hy
+  rw [LinExpr.scale_terms_fst] at this
+  exact l.others_terms_fst_subset v y this
 
 /-- Solve the linear form for the first `±1`-coefficient variable; failing that, for the first
     variable whose coefficient is a unit. -/
@@ -304,6 +406,37 @@ theorem solvableFrom_sound (all : List (Expression p)) (x : Variable) (t : Expre
   · exact pm1PivotsOf_sound c x t hp env (hall c hc)
   · exact unitPivotsOf_sound c x t hp env (hall c hc)
 
+theorem pm1PivotsOf_vars (c : Expression p) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ pm1PivotsOf c) : ∀ y ∈ t.vars, y ∈ c.vars := by
+  intro y hy
+  unfold pm1PivotsOf at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i l hlin
+    obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
+    exact linearize_vars c l hlin y (l.trySolve_vars v x t hv y hy)
+
+theorem unitPivotsOf_vars (c : Expression p) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ unitPivotsOf c) : ∀ y ∈ t.vars, y ∈ c.vars := by
+  intro y hy
+  unfold unitPivotsOf at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i l hlin
+    obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
+    cases htr : l.trySolve v with
+    | some r => rw [htr] at hv; exact absurd hv (by simp)
+    | none =>
+        rw [htr] at hv
+        exact linearize_vars c l hlin y (l.trySolveUnit_vars v x t hv y hy)
+
+theorem solvableFrom_vars (all : List (Expression p)) (x : Variable) (t : Expression p)
+    (h : (x, t) ∈ solvableFrom all) : ∀ y ∈ t.vars, ∃ c ∈ all, y ∈ c.vars := by
+  intro y hy
+  rcases List.mem_append.1 h with h' | h' <;> obtain ⟨c, hc, hp⟩ := List.mem_flatMap.1 h'
+  · exact ⟨c, hc, pm1PivotsOf_vars c x t hp y hy⟩
+  · exact ⟨c, hc, unitPivotsOf_vars c x t hp y hy⟩
+
 /-- The duplication cost of substituting `x := t`: every *other* occurrence of `x` is replaced
     by a copy of `t`. A variable occurring only in its defining constraint costs `0`. -/
 def pivotCost (cs : ConstraintSystem p) (x : Variable) (t : Expression p) : Nat :=
@@ -319,7 +452,12 @@ def bestAffinePivot (cs : ConstraintSystem p) : Option (Variable × Expression p
 def affineSubstPass : VerifiedPass p := fun cs bs =>
   match hf : bestAffinePivot cs with
   | some (x, t) =>
-      ⟨cs.subst x t, cs.subst_correct x t bs (fun env hsat =>
-        solvableFrom_sound cs.algebraicConstraints x t
-          (List.argmin_mem hf) env (fun c hc => hsat.1 c hc))⟩
-  | none => ⟨cs, cs.refines_refl bs, _root_.id⟩
+      ⟨cs.subst x t, [], cs.subst_correct x t bs
+        (fun env hsat =>
+          solvableFrom_sound cs.algebraicConstraints x t
+            (List.argmin_mem hf) env (fun c hc => hsat.1 c hc))
+        (fun y hy => by
+          obtain ⟨c, hc, hyc⟩ :=
+            solvableFrom_vars cs.algebraicConstraints x t (List.argmin_mem hf) y hy
+          exact ConstraintSystem.mem_vars_of_constraint hc hyc)⟩
+  | none => ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/Leanr/Implementation/OptimizerPasses/Basic.lean
+++ b/Leanr/Implementation/OptimizerPasses/Basic.lean
@@ -54,34 +54,6 @@ theorem ConstraintSystem.implies_trans {a b c : ConstraintSystem p} {busSemantic
     let ⟨env'', hc, hbc⟩ := h2 env' hb
     ⟨env'', hc, BusState.equiv_trans hab hbc⟩
 
-/-- Any constraint system admissibly-implies itself: the same admissible assignment works. -/
-theorem ConstraintSystem.impliesAdmissible_refl (cs : ConstraintSystem p)
-    (busSemantics : BusSemantics p) : cs.impliesAdmissible cs busSemantics :=
-  fun env hadm hsat => ⟨env, hsat, hadm, BusState.equiv_refl _⟩
-
-/-- `impliesAdmissible` is transitive: chain the admissible witnesses and the side-effect
-    equalities. The middle witness is admissible (delivered by the first step), so the second
-    step applies. -/
-theorem ConstraintSystem.impliesAdmissible_trans {a b c : ConstraintSystem p}
-    {busSemantics : BusSemantics p} (h1 : a.impliesAdmissible b busSemantics)
-    (h2 : b.impliesAdmissible c busSemantics) : a.impliesAdmissible c busSemantics :=
-  fun env hadm hsat =>
-    let ⟨env', hb, hbadm, hab⟩ := h1 env hadm hsat
-    let ⟨env'', hc, hcadm, hbc⟩ := h2 env' hbadm hb
-    ⟨env'', hc, hcadm, BusState.equiv_trans hab hbc⟩
-
-/-- Any constraint system refines itself. -/
-theorem ConstraintSystem.refines_refl (cs : ConstraintSystem p) (busSemantics : BusSemantics p) :
-    cs.refines cs busSemantics :=
-  ⟨cs.implies_refl busSemantics, cs.impliesAdmissible_refl busSemantics⟩
-
-/-- `refines` is transitive: soundness chains through `implies_trans`, completeness through
-    `impliesAdmissible_trans`. (It is *not* symmetric — see `ConstraintSystem.refines`.) -/
-theorem ConstraintSystem.refines_trans {a b c : ConstraintSystem p} {busSemantics : BusSemantics p}
-    (h1 : a.refines b busSemantics) (h2 : b.refines c busSemantics) :
-    a.refines c busSemantics :=
-  ⟨ConstraintSystem.implies_trans h1.1 h2.1, ConstraintSystem.impliesAdmissible_trans h2.2 h1.2⟩
-
 /-! ## Verified passes
 
 A single optimization step, packaged with its correctness proof. `VerifiedPass` is a function
@@ -91,40 +63,107 @@ proof is part of the return value, there is no separate theorem to weaken: a pas
 be written down without discharging its obligations.
 
 Passes compose with `VerifiedPass.andThen` (run one, then the next), which threads the two proofs
-through `refines_trans` and the composition of invariant-preservation.
+through `PassCorrect.andThen` (soundness via `implies_trans`, reconstruction by concatenating
+derivations) and the composition of invariant-preservation.
 
 **To add an optimization:** create a `VerifiedPass` for it in a new file under
 `Leanr/Implementation/OptimizerPasses/`, then `.andThen` it into `pipeline` in
 `Leanr/Implementation/Optimizer.lean`. Prove `PassCorrect` for your transformation; do not change
 `Spec.lean` or the glue above. -/
 
-/-- The per-pass correctness obligation: `out` `refines` the input `cs` (sound, and complete for
-    `cs`'s intended executions), and if `cs` guarantees the system's invariants then so does
-    `out`. This is exactly the two-part contract of `optimizerMaintainsCorrectness`, stated for a
-    single step. -/
-def PassCorrect (cs out : ConstraintSystem p) (busSemantics : BusSemantics p) : Prop :=
-  out.refines cs busSemantics ∧
-    (cs.guaranteesInvariants busSemantics → out.guaranteesInvariants busSemantics)
+/-- The per-pass correctness obligation. `out` is sound (`implies cs`), preserves invariants, adds
+    no new powdr-ID column, and satisfies the completeness direction: every admissible satisfying
+    assignment of `cs` extends to one of `out` with equal side effects that keeps every input-column
+    value and reconstructs `out`'s derived variables from the input columns. `dsLocal` are the
+    derivations this step introduces; reconstruction is threaded through any incoming `dsIn`, so
+    passes compose simply by concatenating derivations. -/
+def PassCorrect (cs out : ConstraintSystem p) (dsLocal : Derivations p) (bs : BusSemantics p) :
+    Prop :=
+  out.implies cs bs ∧
+  (cs.guaranteesInvariants bs → out.guaranteesInvariants bs) ∧
+  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ cs.vars) ∧
+  (∀ env, cs.admissible bs env → cs.satisfies bs env →
+    ∃ env', out.satisfies bs env' ∧ out.admissible bs env' ∧
+      cs.sideEffects bs env ≈ out.sideEffects bs env' ∧
+      (∀ v, v.powdrId?.isSome → env' v = env v) ∧
+      (∀ dsIn, cs.reconstructs dsIn env → out.reconstructs (dsIn ++ dsLocal) env'))
 
-/-- A proof-carrying optimization pass: maps a constraint system to a new one, bundled with a
-    proof that the step is correct (`PassCorrect`). -/
+/-- Reflexivity: the unchanged system with no new derivations is correct. -/
+theorem PassCorrect.refl (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    PassCorrect cs cs [] bs :=
+  ⟨cs.implies_refl bs, _root_.id, fun _ hv _ => hv,
+   fun env hadm hsat =>
+     ⟨env, hsat, hadm, BusState.equiv_refl _, fun _ _ => rfl,
+      fun dsIn hrec => by rwa [List.append_nil]⟩⟩
+
+/-- Sequential composition: derivations concatenate, soundness/invariants compose, and the threaded
+    reconstruction chains (`dsIn ↦ dsIn ++ df ↦ (dsIn ++ df) ++ dg = dsIn ++ (df ++ dg)`). -/
+theorem PassCorrect.andThen {cs mid out : ConstraintSystem p} {bs : BusSemantics p}
+    {df dg : Derivations p} (hf : PassCorrect cs mid df bs) (hg : PassCorrect mid out dg bs) :
+    PassCorrect cs out (df ++ dg) bs := by
+  obtain ⟨hf1, hf2, hf3, hf4⟩ := hf
+  obtain ⟨hg1, hg2, hg3, hg4⟩ := hg
+  refine ⟨ConstraintSystem.implies_trans hg1 hf1, fun h => hg2 (hf2 h),
+    fun v hv hpw => hf3 v (hg3 v hv hpw) hpw, fun env hadm hsat => ?_⟩
+  obtain ⟨env1, hs1, ha1, he1, hpw1, hr1⟩ := hf4 env hadm hsat
+  obtain ⟨env2, hs2, ha2, he2, hpw2, hr2⟩ := hg4 env1 ha1 hs1
+  refine ⟨env2, hs2, ha2, BusState.equiv_trans he1 he2,
+    fun v hpw => by rw [hpw2 v hpw, hpw1 v hpw], fun dsIn hrec => ?_⟩
+  have := hr2 (dsIn ++ df) (hr1 dsIn hrec)
+  rwa [List.append_assoc] at this
+
+/-- Build `PassCorrect` for a pass whose completeness witness is the input assignment itself and
+    which introduces no new variables (`out.vars ⊆ cs.vars`) — the shape of every pass except the
+    column-introducing re-encoder. It emits no derivations. -/
+theorem PassCorrect.ofEnvEq {cs out : ConstraintSystem p} {bs : BusSemantics p}
+    (hsound : out.implies cs bs)
+    (hinv : cs.guaranteesInvariants bs → out.guaranteesInvariants bs)
+    (hsub : ∀ v ∈ out.vars, v ∈ cs.vars)
+    (hcomp : ∀ env, cs.admissible bs env → cs.satisfies bs env →
+      out.satisfies bs env ∧ out.admissible bs env ∧
+        cs.sideEffects bs env ≈ out.sideEffects bs env) :
+    PassCorrect cs out [] bs := by
+  refine ⟨hsound, hinv, fun v hv _ => hsub v hv, fun env hadm hsat => ?_⟩
+  obtain ⟨ho1, ho2, ho3⟩ := hcomp env hadm hsat
+  refine ⟨env, ho1, ho2, ho3, fun _ _ => rfl, fun dsIn hrec => ?_⟩
+  rw [List.append_nil]
+  exact fun v hvout hvnone => hrec v (hsub v hvout) hvnone
+
+/-- Bridge to the audited spec: a threaded `PassCorrect` (with incoming derivations `[]`) gives the
+    spec's `refines` — soundness, plus completeness whose witness `derivesWitness` (when the input's
+    columns all carry powdr IDs, so it has no unaccounted derived variables). -/
+theorem PassCorrect.toRefines {cs out : ConstraintSystem p} {ds : Derivations p}
+    {bs : BusSemantics p} (h : PassCorrect cs out ds bs) : out.refines cs bs ds := by
+  obtain ⟨himpl, _hinv, hS, hcomp⟩ := h
+  refine ⟨himpl, fun env hadm hsat => ?_⟩
+  obtain ⟨env', hsat', hadm', hse, hA, hR⟩ := hcomp env hadm hsat
+  refine ⟨env', hsat', hadm', hse, fun hpow => ⟨fun v hvout hvpow => ⟨hS v hvout hvpow, hA v hvpow⟩, ?_⟩⟩
+  have hrec0 : cs.reconstructs [] env :=
+    fun v hv hvnone => absurd (hpow v hv) (by simp [hvnone])
+  simpa using hR [] hrec0
+
+/-- The result of a verified pass: the transformed system, the derivations it introduces, and the
+    correctness proof. -/
+structure PassResult {p : ℕ} (cs : ConstraintSystem p) (bs : BusSemantics p) where
+  out : ConstraintSystem p
+  derivs : Derivations p
+  correct : PassCorrect cs out derivs bs
+
+/-- A proof-carrying optimization pass: maps a constraint system to a new one and the derivations it
+    introduces, bundled with a `PassCorrect` proof. -/
 abbrev VerifiedPass (p : ℕ) :=
-  (cs : ConstraintSystem p) → (busSemantics : BusSemantics p) →
-    { out : ConstraintSystem p // PassCorrect cs out busSemantics }
+  (cs : ConstraintSystem p) → (bs : BusSemantics p) → PassResult cs bs
 
 /-- The identity pass: returns the system unchanged, correct by reflexivity. -/
 def VerifiedPass.id : VerifiedPass p :=
-  fun cs busSemantics => ⟨cs, cs.refines_refl busSemantics, _root_.id⟩
+  fun cs bs => ⟨cs, [], PassCorrect.refl cs bs⟩
 
-/-- Sequential composition: run `f`, then run `g` on its output. The result is correct by
-    transitivity of `refines` and composition of the invariant-preservation implications. -/
+/-- Sequential composition: run `f`, then run `g` on its output; concatenate derivations. -/
 def VerifiedPass.andThen (f g : VerifiedPass p) : VerifiedPass p :=
-  fun cs busSemantics =>
-    let r1 := f cs busSemantics
-    let r2 := g r1.val busSemantics
-    ⟨r2.val,
-     ConstraintSystem.refines_trans r2.property.1 r1.property.1,
-     fun h => r2.property.2 (r1.property.2 h)⟩
+  fun cs bs =>
+    let r1 := f cs bs
+    let r2 := g r1.out bs
+    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
 /-- Iterate a pass `n` times. Used to run local, one-step passes (e.g. "substitute one variable")
     to a fixpoint: each application is a `VerifiedPass`, so the composite is correct by construction.
@@ -132,6 +171,33 @@ def VerifiedPass.andThen (f g : VerifiedPass p) : VerifiedPass p :=
 def VerifiedPass.iterate (f : VerifiedPass p) : Nat → VerifiedPass p
   | 0 => VerifiedPass.id
   | n + 1 => (f.iterate n).andThen f
+
+/-! ## Variable-set membership
+
+Helpers for discharging the `out.vars ⊆ cs.vars` obligation of `PassCorrect.ofEnvEq`: a variable of
+a sub-expression is a variable of the whole system, and vice versa. -/
+
+/-- Membership in `cs.vars`: a variable occurs in some constraint, some multiplicity, or some
+    payload expression. -/
+theorem ConstraintSystem.mem_vars {cs : ConstraintSystem p} {x : Variable} :
+    x ∈ cs.vars ↔
+      (∃ c ∈ cs.algebraicConstraints, x ∈ c.vars) ∨
+      (∃ bi ∈ cs.busInteractions, x ∈ bi.multiplicity.vars ∨ ∃ e ∈ bi.payload, x ∈ e.vars) := by
+  simp only [ConstraintSystem.vars, List.mem_append, List.mem_flatMap]
+
+theorem ConstraintSystem.mem_vars_of_constraint {cs : ConstraintSystem p} {c : Expression p}
+    {x : Variable} (hc : c ∈ cs.algebraicConstraints) (hx : x ∈ c.vars) : x ∈ cs.vars :=
+  ConstraintSystem.mem_vars.2 (Or.inl ⟨c, hc, hx⟩)
+
+theorem ConstraintSystem.mem_vars_of_mult {cs : ConstraintSystem p}
+    {bi : BusInteraction (Expression p)} {x : Variable} (hbi : bi ∈ cs.busInteractions)
+    (hx : x ∈ bi.multiplicity.vars) : x ∈ cs.vars :=
+  ConstraintSystem.mem_vars.2 (Or.inr ⟨bi, hbi, Or.inl hx⟩)
+
+theorem ConstraintSystem.mem_vars_of_payload {cs : ConstraintSystem p}
+    {bi : BusInteraction (Expression p)} {e : Expression p} {x : Variable}
+    (hbi : bi ∈ cs.busInteractions) (he : e ∈ bi.payload) (hx : x ∈ e.vars) : x ∈ cs.vars :=
+  ConstraintSystem.mem_vars.2 (Or.inr ⟨bi, hbi, Or.inr ⟨e, he, hx⟩⟩)
 
 /-! ## Decidable degree-bound check
 

--- a/Leanr/Implementation/OptimizerPasses/Basic.lean
+++ b/Leanr/Implementation/OptimizerPasses/Basic.lean
@@ -130,14 +130,14 @@ theorem PassCorrect.ofEnvEq {cs out : ConstraintSystem p} {bs : BusSemantics p}
   exact fun v hvout hvnone => hrec v (hsub v hvout) hvnone
 
 /-- Bridge to the audited spec: a threaded `PassCorrect` (with incoming derivations `[]`) gives the
-    spec's `refines` — soundness, plus completeness whose witness `derivesWitness` (when the input's
+    spec's `refines` — soundness, plus completeness whose witness `derivesWitnessFrom` (when the input's
     columns all carry powdr IDs, so it has no unaccounted derived variables). -/
 theorem PassCorrect.toRefines {cs out : ConstraintSystem p} {ds : Derivations p}
     {bs : BusSemantics p} (h : PassCorrect cs out ds bs) : out.refines cs bs ds := by
   obtain ⟨himpl, _hinv, hS, hcomp⟩ := h
   refine ⟨himpl, fun env hadm hsat => ?_⟩
   obtain ⟨env', hsat', hadm', hse, hA, hR⟩ := hcomp env hadm hsat
-  refine ⟨env', hsat', hadm', hse, fun hpow => ⟨fun v hvout hvpow => ⟨hS v hvout hvpow, hA v hvpow⟩, ?_⟩⟩
+  refine ⟨env', hsat', hadm', hse, fun hpow => ⟨?_, fun v hvout hvpow => ⟨hS v hvout hvpow, hA v hvpow⟩⟩⟩
   have hrec0 : cs.reconstructs [] env :=
     fun v hv hvnone => absurd (hpow v hv) (by simp [hvnone])
   simpa using hR [] hrec0

--- a/Leanr/Implementation/OptimizerPasses/BusUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusUnify.lean
@@ -254,11 +254,18 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
     let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
+    -- keep only equalities over existing columns, so the pass introduces no new variable
+    -- (the real slot equalities are built from `cs`'s payloads, so none are dropped)
     let new := eqs.filter
-      (fun c => !c.normalize.fold.isConstZero && !cs.algebraicConstraints.contains c)
-    if new.isEmpty then ⟨cs, cs.refines_refl bs, _root_.id⟩
+      (fun c => !c.normalize.fold.isConstZero && !cs.algebraicConstraints.contains c
+        && c.vars.all (fun z => decide (z ∈ cs.vars)))
+    if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else
-      ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new },
-       cs.addConstraints_correct bs new (fun env hadm hsat c hc =>
-         heqs env hadm hsat c (List.mem_of_mem_filter hc))⟩
-  else ⟨cs, cs.refines_refl bs, _root_.id⟩
+      ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+       cs.addConstraints_correct bs new
+         (fun env hadm hsat c hc => heqs env hadm hsat c (List.mem_of_mem_filter hc))
+         (fun c hc z hz => by
+           have hp := (List.mem_filter.1 hc).2
+           simp only [Bool.and_eq_true, List.all_eq_true] at hp
+           exact of_decide_eq_true (hp.2 z hz))⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/Leanr/Implementation/OptimizerPasses/ConstantFold.lean
+++ b/Leanr/Implementation/OptimizerPasses/ConstantFold.lean
@@ -65,8 +65,37 @@ theorem Expression.fold_eval (e : Expression p) (env : Variable → ZMod p) :
   | add a b iha ihb => rw [Expression.fold, Expression.foldAdd_eval, iha, ihb]; rfl
   | mul a b iha ihb => rw [Expression.fold, Expression.foldMul_eval, iha, ihb]; rfl
 
+theorem Expression.foldAdd_vars (a b : Expression p) :
+    ∀ x ∈ (a.foldAdd b).vars, x ∈ a.vars ++ b.vars := by
+  intro x hx
+  unfold Expression.foldAdd at hx
+  split at hx <;> (try split_ifs at hx) <;> simp_all [Expression.vars]
+
+theorem Expression.foldMul_vars (a b : Expression p) :
+    ∀ x ∈ (a.foldMul b).vars, x ∈ a.vars ++ b.vars := by
+  intro x hx
+  unfold Expression.foldMul at hx
+  split at hx <;> (try split_ifs at hx) <;> simp_all [Expression.vars]
+
+theorem Expression.fold_vars (e : Expression p) : ∀ x ∈ e.fold.vars, x ∈ e.vars := by
+  induction e with
+  | const n => intro x hx; simp [Expression.fold, Expression.vars] at hx
+  | var y => intro x hx; simpa [Expression.fold] using hx
+  | add a b iha ihb =>
+      intro x hx
+      rw [Expression.fold] at hx
+      rcases List.mem_append.1 (Expression.foldAdd_vars _ _ x hx) with h | h
+      · exact List.mem_append.2 (Or.inl (iha x h))
+      · exact List.mem_append.2 (Or.inr (ihb x h))
+  | mul a b iha ihb =>
+      intro x hx
+      rw [Expression.fold] at hx
+      rcases List.mem_append.1 (Expression.foldMul_vars _ _ x hx) with h | h
+      · exact List.mem_append.2 (Or.inl (iha x h))
+      · exact List.mem_append.2 (Or.inr (ihb x h))
+
 /-- The constant-folding pass: normalize every expression. Correct via `mapExpr_correct`. -/
 def constantFoldPass : VerifiedPass p := fun cs bs =>
-  ⟨cs.mapExpr Expression.fold,
+  ⟨cs.mapExpr Expression.fold, [],
    ConstraintSystem.mapExpr_correct (g := Expression.fold)
-     (fun e env => Expression.fold_eval e env) cs bs⟩
+     (fun e env => Expression.fold_eval e env) cs bs Expression.fold_vars⟩

--- a/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/Leanr/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -86,7 +86,7 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (hBstateless : ∀ bi ∈ cs.busInteractions, keepBi bi = false → bs.isStateful bi.busId = false)
     (hBkeep : ∀ bi ∈ cs.busInteractions, keepBi bi = true → ∀ x ∈ bi.vars, remV x = false) :
     PassCorrect cs { algebraicConstraints := cs.algebraicConstraints.filter keepCon,
-                     busInteractions := cs.busInteractions.filter keepBi } bs := by
+                     busInteractions := cs.busInteractions.filter keepBi } [] bs := by
   -- the merge: keep `env` on kept variables, use the witness on removed ones
   set m : (Variable → ZMod p) → (Variable → ZMod p) :=
     fun env x => if remV x = true then w x else env x with hm
@@ -131,7 +131,7 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
         exact hsb bi (List.mem_filter.2 ⟨hbi, hk⟩) hne
       · rw [hmwB env bi (hBrem bi hbi (by simpa using hk))]
         exact hBsat bi hbi (by simpa using hk)
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
   · -- soundness: out.implies cs
     intro env hsat
     refine ⟨m env, keySat env hsat.1 hsat.2, ?_⟩
@@ -143,10 +143,27 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
         (fun bi hbi hkf => hBstateless bi hbi hkf)
         (fun bi hbi hstate => hmeB env bi (hBkeep bi hbi (hstKeep bi hbi hstate)))
     rw [hse]; exact BusState.equiv_refl _
-  · -- completeness: cs.impliesAdmissible out
+  · -- invariant preservation
+    intro hinv env hsat bi hbi
+    have hbimem : bi ∈ cs.busInteractions := (List.mem_filter.1 hbi).1
+    have hbikeep : keepBi bi = true := (List.mem_filter.1 hbi).2
+    have hsatm : cs.satisfies bs (m env) := keySat env hsat.1 hsat.2
+    have heval : bi.eval (m env) = bi.eval env := hmeB env bi (hBkeep bi hbimem hbikeep)
+    have key := hinv (m env) hsatm bi hbimem
+    simp only [heval] at key
+    exact key
+  · -- introduces no new variable (both lists are filtered)
+    intro z hz
+    rw [ConstraintSystem.mem_vars] at hz
+    rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hzbi⟩
+    · exact ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc) hzc
+    · rcases hzbi with hmm | ⟨e, he, hze⟩
+      · exact ConstraintSystem.mem_vars_of_mult (List.mem_of_mem_filter hbi) hmm
+      · exact ConstraintSystem.mem_vars_of_payload (List.mem_of_mem_filter hbi) he hze
+  · -- completeness: witness `env`
     intro env hadm hsat
-    refine ⟨env, ⟨fun c hc => hsat.1 c (List.mem_filter.1 hc).1,
-                  fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_⟩
+    refine ⟨⟨fun c hc => hsat.1 c (List.mem_filter.1 hc).1,
+             fun bi hbi => hsat.2 bi (List.mem_filter.1 hbi).1⟩, ?_, ?_⟩
     · -- admissibility carries over (dropped interactions are stateless)
       exact (cs.admissible_filterBus bs keepBi env
         (fun bi hbi hkf => Or.inr (hBstateless bi hbi hkf))).2 hadm
@@ -157,15 +174,6 @@ theorem dropComponent_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
         sideEffects_drop_eq bs keepBi env env cs.busInteractions
           (fun bi hbi hkf => hBstateless bi hbi hkf) (fun _ _ _ => rfl)
       rw [hse]; exact BusState.equiv_refl _
-  · -- invariant preservation
-    intro hinv env hsat bi hbi
-    have hbimem : bi ∈ cs.busInteractions := (List.mem_filter.1 hbi).1
-    have hbikeep : keepBi bi = true := (List.mem_filter.1 hbi).2
-    have hsatm : cs.satisfies bs (m env) := keySat env hsat.1 hsat.2
-    have heval : bi.eval (m env) = bi.eval env := hmeB env bi (hBkeep bi hbimem hbikeep)
-    have key := hinv (m env) hsatm bi hbimem
-    simp only [heval] at key
-    exact key
 
 /-! ## Finding a component: connectivity from the stateful buses -/
 
@@ -249,7 +257,7 @@ def disconnectedComponentPass : VerifiedPass p := fun cs bs =>
         !keepBiWith bs remV bi || bi.vars.all (fun x => !remV x))
     ) = true then
     ⟨{ algebraicConstraints := cs.algebraicConstraints.filter (keepConWith remV),
-       busInteractions := cs.busInteractions.filter (keepBiWith bs remV) },
+       busInteractions := cs.busInteractions.filter (keepBiWith bs remV) }, [],
      by
        simp only [Bool.and_eq_true, and_assoc] at hchk
        obtain ⟨_hne, hcz, hbz, hck, hbk⟩ := hchk
@@ -290,4 +298,4 @@ def disconnectedComponentPass : VerifiedPass p := fun cs bs =>
          simp only [Bool.not_true, Bool.false_or] at h1
          simpa using (List.all_eq_true.1 h1) x hx⟩
   else
-    ⟨cs, cs.refines_refl bs, id⟩
+    ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
@@ -310,7 +310,11 @@ def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p}
           (by
             intro env hsat yt hyt
             obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
-            exact f.2.property env hsat))
+            exact f.2.property env hsat)
+          (by
+            intro yt hyt z hz
+            obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+            simp [Expression.vars] at hz))
 
 /-! ## The pass -/
 
@@ -327,7 +331,8 @@ def domainBatchPass : VerifiedPassW p := fun cs bs facts =>
     let targets := cs.algebraicConstraints.map (fun e => e.vars.dedup) ++
       cs.busInteractions.map (fun bi => bi.vars.dedup)
     let σ := collectForced T targets ∅ Solved.empty
-    if σ.map.isEmpty then ⟨cs, cs.refines_refl bs, _root_.id⟩
-    else ⟨cs.substF σ.fn,
-      cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)⟩
-  else ⟨cs, cs.refines_refl bs, _root_.id⟩
+    if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+    else ⟨cs.substF σ.fn, [],
+      cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
+        (fun y t hyt => σ.varsIn y t hyt)⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/Leanr/Implementation/OptimizerPasses/DomainProp.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainProp.lean
@@ -751,9 +751,11 @@ def domainPropPass : VerifiedPassW p := fun cs bs facts =>
     haveI : NeZero p := ⟨hp.ne_zero⟩
     match hf : findForced cs.algebraicConstraints bs facts cs.busInteractions with
     | some (x, c) =>
-        ⟨cs.subst x (.const c),
-         cs.subst_correct x (.const c) bs (fun env hsat =>
-           findForced_sound cs.algebraicConstraints bs facts cs.busInteractions x c hf
-             env (fun c' hc' => hsat.1 c' hc') (fun bi hbi => hsat.2 bi hbi))⟩
-    | none => ⟨cs, cs.refines_refl bs, _root_.id⟩
-  else ⟨cs, cs.refines_refl bs, _root_.id⟩
+        ⟨cs.subst x (.const c), [],
+         cs.subst_correct x (.const c) bs
+           (fun env hsat =>
+             findForced_sound cs.algebraicConstraints bs facts cs.busInteractions x c hf
+               env (fun c' hc' => hsat.1 c' hc') (fun bi hbi => hsat.2 bi hbi))
+           (fun y hy => by simp [Expression.vars] at hy)⟩
+    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/Leanr/Implementation/OptimizerPasses/FactPass.lean
+++ b/Leanr/Implementation/OptimizerPasses/FactPass.lean
@@ -16,25 +16,22 @@ variable {p : ℕ}
 
 /-- A proof-carrying pass that may consult proven facts about the bus semantics. -/
 abbrev VerifiedPassW (p : ℕ) :=
-  (cs : ConstraintSystem p) → (bs : BusSemantics p) → (facts : BusFacts p bs) →
-    { out : ConstraintSystem p // PassCorrect cs out bs }
+  (cs : ConstraintSystem p) → (bs : BusSemantics p) → (facts : BusFacts p bs) → PassResult cs bs
 
 /-- Any fact-free pass is a fact-aware pass that ignores the facts. -/
 def VerifiedPass.withFacts (f : VerifiedPass p) : VerifiedPassW p :=
   fun cs bs _ => f cs bs
 
-/-- Sequential composition (same proof shape as `VerifiedPass.andThen`). -/
+/-- Sequential composition (same proof shape as `VerifiedPass.andThen`): derivations concatenate. -/
 def VerifiedPassW.andThen (f g : VerifiedPassW p) : VerifiedPassW p :=
   fun cs bs facts =>
     let r1 := f cs bs facts
-    let r2 := g r1.val bs facts
-    ⟨r2.val,
-     ConstraintSystem.refines_trans r2.property.1 r1.property.1,
-     fun h => r2.property.2 (r1.property.2 h)⟩
+    let r2 := g r1.out bs facts
+    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
 /-- Iterate a fact-aware pass `n` times. -/
 def VerifiedPassW.iterate (f : VerifiedPassW p) : Nat → VerifiedPassW p
-  | 0 => fun cs bs _ => ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | 0 => fun cs bs _ => ⟨cs, [], PassCorrect.refl cs bs⟩
   | n + 1 => (f.iterate n).andThen f
 
 deriving instance DecidableEq for Expression
@@ -50,7 +47,8 @@ significant — exactly the optimizer's effectiveness priority. Each cleanup cyc
 lowers this key (so we recurse) or does not (so we stop, keeping the pre-cycle system). The
 recursion is guarded by precisely the strict-decrease it needs, so `decreasing_by` is immediate and
 no `iters` parameter is required. As a bonus the loop is size-monotone by construction: its output
-never has a larger key than its input (`iterateToFixpoint_monotone`).
+never has a larger key than its input (`iterateToFixpoint_monotone`). Derivations accumulate across
+the kept steps exactly as in `andThen`.
 
 The distinct-variable count uses a `HashSet` (not `ConstraintSystem.size`'s `dedup`, which is
 quadratic) so the per-cycle measure stays cheap on large circuits. -/
@@ -71,18 +69,16 @@ def ConstraintSystem.sizeKey (cs : ConstraintSystem p) : Nat ×ₗ Nat ×ₗ Nat
 /-- Iterate a fact-aware pass to a fixpoint, with **no** iteration budget: apply `f`; if the result
     is strictly smaller (lexicographically in `sizeKey`), recurse from it; otherwise stop and return
     the input unchanged. Terminates because every recursive step strictly decreases the well-founded
-    `sizeKey`. Correct by construction (each kept step is `PassCorrect`; stopping returns the input,
-    correct by reflexivity). -/
+    `sizeKey`. Correct by construction (each kept step is `PassCorrect`, derivations concatenating;
+    stopping returns the input, correct by reflexivity). -/
 def iterateToFixpoint (f : VerifiedPassW p) (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (facts : BusFacts p bs) : { out : ConstraintSystem p // PassCorrect cs out bs } :=
+    (facts : BusFacts p bs) : PassResult cs bs :=
   let r := f cs bs facts
-  if _h : r.val.sizeKey < cs.sizeKey then
-    let r2 := iterateToFixpoint f r.val bs facts
-    ⟨r2.val,
-     ConstraintSystem.refines_trans r2.property.1 r.property.1,
-     fun hg => r2.property.2 (r.property.2 hg)⟩
+  if _h : r.out.sizeKey < cs.sizeKey then
+    let r2 := iterateToFixpoint f r.out bs facts
+    ⟨r2.out, r.derivs ++ r2.derivs, r.correct.andThen r2.correct⟩
   else
-    ⟨cs, cs.refines_refl bs, _root_.id⟩
+    ⟨cs, [], PassCorrect.refl cs bs⟩
   termination_by cs.sizeKey
   decreasing_by exact _h
 
@@ -96,19 +92,19 @@ composition and iteration. -/
 /-- A pass never pushes a within-bound system past the semantics' degree bound. -/
 def RespectsDeg (f : VerifiedPassW p) : Prop :=
   ∀ (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs),
-    cs.withinDegree bs.degreeBound → (f cs bs facts).val.withinDegree bs.degreeBound
+    cs.withinDegree bs.degreeBound → (f cs bs facts).out.withinDegree bs.degreeBound
 
 /-- Wrap a pass with a degree guard: if the output would exceed the bound, keep the input. -/
 def VerifiedPassW.guardDegree (f : VerifiedPassW p) : VerifiedPassW p :=
   fun cs bs facts =>
     let r := f cs bs facts
-    if r.val.withinDegreeB bs.degreeBound then r
-    else ⟨cs, cs.refines_refl bs, _root_.id⟩
+    if r.out.withinDegreeB bs.degreeBound then r
+    else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 theorem VerifiedPassW.guardDegree_respectsDeg (f : VerifiedPassW p) :
     RespectsDeg f.guardDegree := by
   intro cs bs facts h
-  by_cases hok : (f cs bs facts).val.withinDegreeB bs.degreeBound = true
+  by_cases hok : (f cs bs facts).out.withinDegreeB bs.degreeBound = true
   · simp only [VerifiedPassW.guardDegree, hok, if_true]
     exact (ConstraintSystem.withinDegreeB_iff _ _).1 hok
   · simp only [VerifiedPassW.guardDegree, hok]
@@ -150,7 +146,7 @@ theorem iterateToFixpoint_respectsDeg {f : VerifiedPassW p} (hf : RespectsDeg f)
     input: every recursive step strictly lowers the key, and the stopping case returns the input. -/
 theorem iterateToFixpoint_monotone {f : VerifiedPassW p}
     (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs) :
-    (iterateToFixpoint f cs bs facts).val.sizeKey ≤ cs.sizeKey := by
+    (iterateToFixpoint f cs bs facts).out.sizeKey ≤ cs.sizeKey := by
   induction cs using sizeKey_wf.induction with
   | _ cs ih =>
     rw [iterateToFixpoint]

--- a/Leanr/Implementation/OptimizerPasses/Gauss.lean
+++ b/Leanr/Implementation/OptimizerPasses/Gauss.lean
@@ -62,6 +62,7 @@ def Expression.isVar : Expression p → Bool
 structure Solved (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
   map : Std.HashMap Variable (Expression p)
   sound : ∀ env, cs.satisfies bs env → ∀ y t, map[y]? = some t → env y = t.eval env
+  varsIn : ∀ (y : Variable) (t : Expression p), map[y]? = some t → ∀ z ∈ t.vars, z ∈ cs.vars
 
 namespace Solved
 
@@ -71,6 +72,10 @@ def empty : Solved p cs bs where
   map := ∅
   sound := by
     intro _ _ y t h
+    rw [Std.HashMap.getElem?_empty] at h
+    exact absurd h (by simp)
+  varsIn := by
+    intro y t h
     rw [Std.HashMap.getElem?_empty] at h
     exact absurd h (by simp)
 
@@ -92,7 +97,8 @@ theorem eval_reduce (σ : Solved p cs bs) (e : Expression p) (env : Variable →
 /-- Insert a list of entailed pairs (later inserts win, which is harmless: every pair is
     entailed individually). -/
 def insertAll (σ : Solved p cs bs) (pairs : List (Variable × Expression p))
-    (H : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env) :
+    (H : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env)
+    (Hv : ∀ yt ∈ pairs, ∀ z ∈ yt.2.vars, z ∈ cs.vars) :
     Solved p cs bs :=
   match pairs with
   | [] => σ
@@ -109,8 +115,19 @@ def insertAll (σ : Solved p cs bs) (pairs : List (Variable × Expression p))
               subst hxy'; subst hts
               exact H env hsat (x, t) (List.mem_cons_self ..)
             · rw [if_neg hxy] at hys
-              exact σ.sound env hsat y s hys }
+              exact σ.sound env hsat y s hys
+          varsIn := by
+            intro y s hys
+            rw [Std.HashMap.getElem?_insert] at hys
+            by_cases hxy : (x == y) = true
+            · rw [if_pos hxy] at hys
+              have hts : t = s := by simpa using hys
+              subst hts
+              exact Hv (x, t) (List.mem_cons_self ..)
+            · rw [if_neg hxy] at hys
+              exact σ.varsIn y s hys }
       σ'.insertAll rest (fun env hsat yt hyt => H env hsat yt (List.mem_cons_of_mem _ hyt))
+        (fun yt hyt => Hv yt (List.mem_cons_of_mem _ hyt))
 
 end Solved
 
@@ -166,6 +183,19 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
           rcases List.mem_append.1 (List.argmin_mem hbest) with h | h
           · exact pm1PivotsOf_sound c' x t h env hc'
           · exact unitPivotsOf_sound c' x t h env hc'
+        -- every variable of the reduced constraint (hence of any pivot solved from it) is a
+        -- variable of `cs`: reduction only substitutes stored solutions (all in `cs`) and folds
+        have hc'vars : ∀ z ∈ c'.vars, z ∈ cs.vars := by
+          intro z hz
+          rcases Expression.substF_vars σ.fn c z (Expression.normalize_vars _ z hz) with
+            h2 | ⟨y', t', hft', hzt'⟩
+          · exact ConstraintSystem.mem_vars_of_constraint (hmem c (List.mem_cons_self ..)) h2
+          · exact σ.varsIn y' t' hft' z hzt'
+        have htvars : ∀ z ∈ t.vars, z ∈ cs.vars := by
+          intro z hz
+          rcases List.mem_append.1 (List.argmin_mem hbest) with h | h
+          · exact hc'vars z (pm1PivotsOf_vars c' x t h z hz)
+          · exact hc'vars z (unitPivotsOf_vars c' x t h z hz)
         -- resolve `x` out of the stored solutions, then store `x := t`
         let touched := σ.map.toList.filter (fun ys => ys.2.mentions x)
         let pairs := touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
@@ -182,7 +212,18 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
               Function.update_eq_self, hy]
           · obtain rfl : yt = (x, t) := by simpa using h
             exact hx env hsat
-        gaussLoop cs bs occ prot rest hrest (σ.insertAll pairs hpairs)
+        have hpairsV : ∀ yt ∈ pairs, ∀ z ∈ yt.2.vars, z ∈ cs.vars := by
+          intro yt hyt z hz
+          rcases List.mem_append.1 hyt with h | h
+          · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 h
+            have hmemys : σ.map[y]? = some s :=
+              Std.HashMap.mem_toList_iff_getElem?_eq_some.1 (List.mem_of_mem_filter hys)
+            rcases Expression.subst_vars s x t z (Expression.normalize_vars _ z hz) with h2 | h2
+            · exact σ.varsIn y s hmemys z h2
+            · exact htvars z h2
+          · obtain rfl : yt = (x, t) := by simpa using h
+            exact htvars z hz
+        gaussLoop cs bs occ prot rest hrest (σ.insertAll pairs hpairs hpairsV)
 
 /-- The batch linear-elimination pass. Two sweeps over the constraints (so substitutions can
     unlock later pivots within one invocation), then a single full-system substitution. -/
@@ -192,6 +233,7 @@ def gaussElimPass : VerifiedPass p := fun cs bs =>
   let pending := cs.algebraicConstraints ++ cs.algebraicConstraints
   let σ := gaussLoop cs bs occ prot pending
     (fun _c hc => (List.mem_append.1 hc).elim id id) Solved.empty
-  if σ.map.isEmpty then ⟨cs, cs.refines_refl bs, _root_.id⟩
-  else ⟨cs.substF σ.fn,
-    cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)⟩
+  if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs.substF σ.fn, [],
+    cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
+      (fun y t hyt => σ.varsIn y t hyt)⟩

--- a/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/MemoryUnify.lean
@@ -32,10 +32,24 @@ variable {p : ℕ}
     `PassCorrect`. The entailment `H` may consume the memory discipline (`admissible`), since it
     is only needed for the completeness direction; soundness drops the added constraints, and the
     added constraints touch no bus interaction, so `admissible` and the side effects are unchanged. -/
+theorem ConstraintSystem.addConstraints_vars_subset (cs : ConstraintSystem p)
+    (new : List (Expression p)) (hnv : ∀ c ∈ new, ∀ z ∈ c.vars, z ∈ cs.vars) :
+    ∀ z ∈ ({ cs with algebraicConstraints := cs.algebraicConstraints ++ new }).vars, z ∈ cs.vars := by
+  intro z hz
+  rw [ConstraintSystem.mem_vars] at hz
+  rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hzbi⟩
+  · rcases List.mem_append.1 hc with h | h
+    · exact ConstraintSystem.mem_vars_of_constraint h hzc
+    · exact hnv c h z hzc
+  · rcases hzbi with hm | ⟨e, he, hze⟩
+    · exact ConstraintSystem.mem_vars_of_mult hbi hm
+    · exact ConstraintSystem.mem_vars_of_payload hbi he hze
+
 theorem ConstraintSystem.addConstraints_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (new : List (Expression p))
-    (H : ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ new, c.eval env = 0) :
-    PassCorrect cs { cs with algebraicConstraints := cs.algebraicConstraints ++ new } bs := by
+    (H : ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ new, c.eval env = 0)
+    (hnv : ∀ c ∈ new, ∀ z ∈ c.vars, z ∈ cs.vars) :
+    PassCorrect cs { cs with algebraicConstraints := cs.algebraicConstraints ++ new } [] bs := by
   -- soundness helper: the augmented system's satisfaction always implies the original's
   have hfwd : ∀ env,
       (ConstraintSystem.satisfies
@@ -43,20 +57,20 @@ theorem ConstraintSystem.addConstraints_correct (cs : ConstraintSystem p) (bs : 
       → cs.satisfies bs env := by
     rintro env ⟨hc, hb⟩
     exact ⟨fun c hcm => hc c (List.mem_append_left _ hcm), hb⟩
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.addConstraints_vars_subset new hnv) ?_
   · -- soundness
     intro env hsat
     exact ⟨env, hfwd env hsat, BusState.equiv_refl _⟩
-  · -- completeness (uses the discipline to discharge the added constraints)
-    intro env hint hsat
-    obtain ⟨hc, hb⟩ := hsat
-    refine ⟨env, ⟨fun c hcm => ?_, hb⟩, hint, BusState.equiv_refl _⟩
-    rcases List.mem_append.1 hcm with h | h
-    · exact hc c h
-    · exact H env hint ⟨hc, hb⟩ c h
   · -- invariant preservation
     intro hinv env hsat bi hbi
     exact hinv env (hfwd env hsat) bi hbi
+  · -- completeness (uses the discipline to discharge the added constraints), witness `env`
+    intro env hadm hsat
+    obtain ⟨hc, hb⟩ := hsat
+    refine ⟨⟨fun c hcm => ?_, hb⟩, hadm, BusState.equiv_refl _⟩
+    rcases List.mem_append.1 hcm with h | h
+    · exact hc c h
+    · exact H env hadm ⟨hc, hb⟩ c h
 
 /-! ## Small verified building blocks -/
 

--- a/Leanr/Implementation/OptimizerPasses/MonicScale.lean
+++ b/Leanr/Implementation/OptimizerPasses/MonicScale.lean
@@ -63,6 +63,22 @@ theorem monicScaleAffine_unit (e : Expression p) :
       · simp
     · simp
 
+theorem monicScaleAffine_vars (e : Expression p) :
+    ∀ z ∈ (monicScaleAffine e).1.vars, z ∈ e.vars := by
+  intro z hz
+  unfold monicScaleAffine at hz
+  split at hz
+  · exact hz
+  · rename_i l hlin
+    split at hz
+    · rename_i y k rest ht
+      split_ifs at hz with hk
+      · have h1 := LinExpr.toExpr_vars _ z hz
+        rw [LinExpr.scale_terms_fst] at h1
+        exact linearize_vars e l hlin z (l.norm_terms_fst z h1)
+      · exact hz
+    · exact hz
+
 /-- Scale the affine factors of a product tree to monic form, with the accumulated unit
     certificate. -/
 def monicScale : Expression p → Expression p × ZMod p × ZMod p
@@ -121,6 +137,19 @@ theorem monicScale_zero_iff (e : Expression p) (env : Variable → ZMod p) :
   · intro h
     rw [h, mul_zero]
 
+theorem monicScale_vars (e : Expression p) : ∀ z ∈ (monicScale e).1.vars, z ∈ e.vars := by
+  induction e with
+  | const n => exact monicScaleAffine_vars _
+  | var y => exact monicScaleAffine_vars _
+  | add a b _ _ => exact monicScaleAffine_vars _
+  | mul a b iha ihb =>
+      intro z hz
+      rw [monicScale] at hz
+      split at hz
+      · exact monicScaleAffine_vars _ z hz
+      · simp only [Expression.vars, List.mem_append] at hz ⊢
+        exact hz.imp (iha z) (ihb z)
+
 /-! ## The correctness core: zero-set-preserving constraint rewrites -/
 
 /-- Rewrite only the algebraic constraints. -/
@@ -128,12 +157,25 @@ def ConstraintSystem.mapConstraints (cs : ConstraintSystem p)
     (g : Expression p → Expression p) : ConstraintSystem p :=
   { cs with algebraicConstraints := cs.algebraicConstraints.map g }
 
+theorem ConstraintSystem.mapConstraints_vars_subset (cs : ConstraintSystem p)
+    {g : Expression p → Expression p}
+    (hgv : ∀ (c : Expression p) (z : Variable), z ∈ (g c).vars → z ∈ c.vars) :
+    ∀ z ∈ (cs.mapConstraints g).vars, z ∈ cs.vars := by
+  intro z hz
+  rw [ConstraintSystem.mem_vars] at hz ⊢
+  rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hzbi⟩
+  · simp only [ConstraintSystem.mapConstraints, List.mem_map] at hc
+    obtain ⟨c0, hc0, rfl⟩ := hc
+    exact Or.inl ⟨c0, hc0, hgv c0 z hzc⟩
+  · exact Or.inr ⟨bi, hbi, hzbi⟩
+
 /-- Rewriting constraints with any pointwise zero-set-preserving map is `PassCorrect`: the
     satisfying assignments are unchanged, and the (bus-only) side effects are untouched. -/
 theorem ConstraintSystem.mapConstraintsIff_correct (cs : ConstraintSystem p)
     (bs : BusSemantics p) (g : Expression p → Expression p)
-    (hg : ∀ (c : Expression p) (env : Variable → ZMod p), ((g c).eval env = 0 ↔ c.eval env = 0)) :
-    PassCorrect cs (cs.mapConstraints g) bs := by
+    (hg : ∀ (c : Expression p) (env : Variable → ZMod p), ((g c).eval env = 0 ↔ c.eval env = 0))
+    (hgv : ∀ (c : Expression p) (z : Variable), z ∈ (g c).vars → z ∈ c.vars) :
+    PassCorrect cs (cs.mapConstraints g) [] bs := by
   have hiff : ∀ env, (cs.mapConstraints g).satisfies bs env ↔ cs.satisfies bs env := by
     intro env
     simp only [ConstraintSystem.satisfies, ConstraintSystem.mapConstraints]
@@ -147,18 +189,18 @@ theorem ConstraintSystem.mapConstraintsIff_correct (cs : ConstraintSystem p)
       exact (hg c0 env).2 (hc c0 hc0)
   have hside : ∀ env, (cs.mapConstraints g).sideEffects bs env = cs.sideEffects bs env :=
     fun _ => rfl
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.mapConstraints_vars_subset hgv) ?_
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
-    -- `mapConstraints` leaves bus interactions untouched, so `isIntended` is definitionally `cs`'s
-    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _⟩
   · intro hinv env hsat bi hbi
     exact hinv env ((hiff env).1 hsat) bi hbi
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat, hadm, by rw [hside]; exact BusState.equiv_refl _⟩
 
 /-! ## The pass -/
 
 /-- The monic-scaling pass: canonicalize every constraint's affine factors to monic form. -/
 def monicScalePass : VerifiedPass p := fun cs bs =>
-  ⟨cs.mapConstraints (fun c => (monicScale c).1),
-   cs.mapConstraintsIff_correct bs _ (fun c env => monicScale_zero_iff c env)⟩
+  ⟨cs.mapConstraints (fun c => (monicScale c).1), [],
+   cs.mapConstraintsIff_correct bs _ (fun c env => monicScale_zero_iff c env)
+     (fun c z hz => monicScale_vars c z hz)⟩

--- a/Leanr/Implementation/OptimizerPasses/Normalize.lean
+++ b/Leanr/Implementation/OptimizerPasses/Normalize.lean
@@ -111,8 +111,74 @@ theorem Expression.normalize_eval (e : Expression p) (env : Variable → ZMod p)
       · next l hl => rw [LinExpr.toExpr_eval, LinExpr.norm_eval, ← linearize_eval _ l hl]
       · rw [Expression.eval, iha, ihb, Expression.eval]
 
+/-! ## Variable bounds -/
+
+theorem addCoeff_fst (v : Variable) (c : ZMod p) (ts : List (Variable × ZMod p)) (x : Variable)
+    (h : x ∈ (addCoeff v c ts).map Prod.fst) : x = v ∨ x ∈ ts.map Prod.fst := by
+  induction ts with
+  | nil => simp only [addCoeff, List.map_cons, List.map_nil, List.mem_singleton] at h; exact Or.inl h
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [addCoeff] at h
+      split at h
+      · rename_i hv
+        simp only [List.map_cons, List.mem_cons] at h ⊢
+        tauto
+      · simp only [List.map_cons, List.mem_cons] at h ⊢
+        rcases h with h | h
+        · exact Or.inr (Or.inl h)
+        · exact (ih h).imp id (Or.inr ·)
+
+theorem foldl_addCoeff_fst (ts : List (Variable × ZMod p)) :
+    ∀ (init : List (Variable × ZMod p)) (x : Variable),
+      x ∈ (ts.foldl (fun acc t => addCoeff t.1 t.2 acc) init).map Prod.fst →
+      x ∈ init.map Prod.fst ∨ x ∈ ts.map Prod.fst := by
+  induction ts with
+  | nil => intro init x hx; exact Or.inl hx
+  | cons t rest ih =>
+      intro init x hx
+      simp only [List.foldl_cons] at hx
+      rcases ih _ x hx with h | h
+      · rcases addCoeff_fst t.1 t.2 init x h with h | h
+        · exact Or.inr (by simp [h])
+        · exact Or.inl h
+      · exact Or.inr (List.mem_cons_of_mem _ h)
+
+theorem mergeTerms_fst (ts : List (Variable × ZMod p)) (x : Variable)
+    (h : x ∈ (mergeTerms ts).map Prod.fst) : x ∈ ts.map Prod.fst := by
+  rcases foldl_addCoeff_fst ts [] x h with h | h
+  · simp at h
+  · exact h
+
+theorem LinExpr.norm_terms_fst (l : LinExpr p) (x : Variable)
+    (h : x ∈ l.norm.terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
+  simp only [LinExpr.norm, List.mem_map] at h
+  obtain ⟨t, ht, rfl⟩ := h
+  exact mergeTerms_fst l.terms t.1 (List.mem_map.2 ⟨t, List.mem_of_mem_filter ht, rfl⟩)
+
+theorem Expression.normalize_vars (e : Expression p) : ∀ x ∈ e.normalize.vars, x ∈ e.vars := by
+  induction e with
+  | const n => intro x hx; simpa [Expression.normalize] using hx
+  | var y => intro x hx; simpa [Expression.normalize] using hx
+  | add a b iha ihb =>
+      intro x hx
+      simp only [Expression.normalize] at hx
+      split at hx
+      · rename_i l hl
+        exact linearize_vars _ l hl x (l.norm_terms_fst x (LinExpr.toExpr_vars _ x hx))
+      · simp only [Expression.vars, List.mem_append] at hx ⊢
+        exact hx.imp (iha x) (ihb x)
+  | mul a b iha ihb =>
+      intro x hx
+      simp only [Expression.normalize] at hx
+      split at hx
+      · rename_i l hl
+        exact linearize_vars _ l hl x (l.norm_terms_fst x (LinExpr.toExpr_vars _ x hx))
+      · simp only [Expression.vars, List.mem_append] at hx ⊢
+        exact hx.imp (iha x) (ihb x)
+
 /-- The affine-normalization pass. Correct via `mapExpr_correct` (only `normalize_eval`). -/
 def normalizePass : VerifiedPass p := fun cs bs =>
-  ⟨cs.mapExpr Expression.normalize,
+  ⟨cs.mapExpr Expression.normalize, [],
    ConstraintSystem.mapExpr_correct (g := Expression.normalize)
-     (fun e env => Expression.normalize_eval e env) cs bs⟩
+     (fun e env => Expression.normalize_eval e env) cs bs Expression.normalize_vars⟩

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -91,11 +91,25 @@ theorem mentions_false_not_mem_vars (x : Variable) (e : Expression p)
 
 /-! ## The transport core -/
 
+/-- The soundness + completeness + invariant obligations of the re-encoder, *without* the
+    derived-variable reconstruction (and input-column frame) that the threaded `PassCorrect`
+    additionally requires. This is the pre-derivations refinement, spelled out (`implies` + a plain
+    admissible-completeness witness + invariant preservation) rather than via the audited
+    `refines`, which now also carries the derivations. The transport proofs below establish this;
+    wiring the fresh bits' `ComputationMethod`s into a full `PassCorrect` (so the re-encoder can
+    rejoin the pipeline) is the remaining work — see the note on `reencodePass`. -/
+def ConstraintSystem.reencCorrect (cs out : ConstraintSystem p) (bs : BusSemantics p) : Prop :=
+  (out.implies cs bs ∧
+    (∀ env, cs.admissible bs env → cs.satisfies bs env →
+      ∃ env', out.satisfies bs env' ∧ out.admissible bs env' ∧
+        cs.sideEffects bs env ≈ out.sideEffects bs env')) ∧
+  (cs.guaranteesInvariants bs → out.guaranteesInvariants bs)
+
 /-- **Re-encoding correctness.** `out` replaces every expression `e` by `e.substF σ`, keeps
     only the constraints selected by `keep`, and appends `newCs`. If satisfying assignments
     transport in both directions such that every original expression *evaluates identically*
     (forward additionally establishing `newCs`, backward additionally the dropped
-    constraints), the step is `PassCorrect`. Nothing here mentions bits or groups — it is a
+    constraints), the step is `reencCorrect`. Nothing here mentions bits or groups — it is a
     generic witness-transport principle. -/
 theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusSemantics p)
     (rw : Expression p → Expression p) (keep : Expression p → Bool)
@@ -112,10 +126,11 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
       (∀ c ∈ cs.algebraicConstraints, (rw c).eval env' = c.eval env) ∧
       (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) ∧
       (∀ c ∈ cs.algebraicConstraints, keep c = false → c.eval env = 0)) :
-    PassCorrect cs
+    ConstraintSystem.reencCorrect cs
       { algebraicConstraints :=
           ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
         busInteractions := cs.busInteractions.map (·.mapExpr rw) } bsem := by
+  unfold ConstraintSystem.reencCorrect
   set out : ConstraintSystem p :=
     { algebraicConstraints :=
         ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
@@ -220,6 +235,85 @@ theorem ConstraintSystem.reencode_correct (cs : ConstraintSystem p) (bsem : BusS
     obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi'
     rw [hB bi0 hbi0]
     exact hinv env hsatcs bi0 hbi0
+
+/-- The threaded (derived-variable) version of `reencode_correct`: the same transport, but the forward
+    additionally keeps every input column's value (`hpow`) and reconstructs the output's derived
+    columns from the input columns via `deriv` (`hrecon`), and no new powdr-ID column is introduced
+    (`hS`). Produces the full `PassCorrect` the pipeline consumes. -/
+theorem ConstraintSystem.reencode_correct_D (cs : ConstraintSystem p) (bsem : BusSemantics p)
+    (rw : Expression p → Expression p) (keep : Expression p → Bool)
+    (newCs : List (Expression p)) (deriv : Derivations p)
+    (hfwd : ∀ env, cs.satisfies bsem env → ∃ env',
+      (∀ c ∈ cs.algebraicConstraints, (rw c).eval env' = c.eval env) ∧
+      (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) ∧
+      (∀ c ∈ newCs, c.eval env' = 0) ∧
+      (∀ v : Variable, v.powdrId?.isSome → env' v = env v) ∧
+      (∀ dsIn : Derivations p, cs.reconstructs dsIn env →
+        ({ algebraicConstraints := ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
+           busInteractions := cs.busInteractions.map (·.mapExpr rw) } :
+             ConstraintSystem p).reconstructs (dsIn ++ deriv) env'))
+    (hbwd : ∀ env',
+      (ConstraintSystem.satisfies
+        { algebraicConstraints :=
+            ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
+          busInteractions := cs.busInteractions.map (·.mapExpr rw) } bsem env') → ∃ env,
+      (∀ c ∈ cs.algebraicConstraints, (rw c).eval env' = c.eval env) ∧
+      (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) ∧
+      (∀ c ∈ cs.algebraicConstraints, keep c = false → c.eval env = 0))
+    (hS : ∀ v ∈ ({ algebraicConstraints := ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
+                    busInteractions := cs.busInteractions.map (·.mapExpr rw) } :
+                    ConstraintSystem p).vars, v.powdrId?.isSome → v ∈ cs.vars) :
+    PassCorrect cs
+      { algebraicConstraints :=
+          ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
+        busInteractions := cs.busInteractions.map (·.mapExpr rw) } deriv bsem := by
+  set out : ConstraintSystem p :=
+    { algebraicConstraints :=
+        ((cs.algebraicConstraints.filter keep).map rw) ++ newCs,
+      busInteractions := cs.busInteractions.map (·.mapExpr rw) } with hout
+  have hside : ∀ (env env' : Variable → ZMod p),
+      (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
+      out.sideEffects bsem env' = cs.sideEffects bsem env := by
+    intro env env' hB
+    show ((cs.busInteractions.map (·.mapExpr rw)).filter
+        (fun bi => bsem.isStateful bi.busId)).map _ = _
+    rw [List.filter_map]
+    rw [List.filter_congr (fun bi _ => (rfl :
+      ((fun b : BusInteraction (Expression p) => bsem.isStateful b.busId) ∘
+        (fun b => b.mapExpr rw)) bi = bsem.isStateful bi.busId))]
+    rw [List.map_map]
+    exact List.map_congr_left (fun bi hbi => by
+      simp only [Function.comp_apply, hB bi (List.mem_of_mem_filter hbi)])
+  have hdisc : ∀ (env env' : Variable → ZMod p),
+      (∀ bi ∈ cs.busInteractions, (bi.mapExpr rw).eval env' = bi.eval env) →
+      (out.admissible bsem env' ↔ cs.admissible bsem env) := by
+    intro env env' hB
+    unfold ConstraintSystem.admissible
+    have hmap : (out.busInteractions.map (fun bi => bi.eval env'))
+        = cs.busInteractions.map (fun bi => bi.eval env) := by
+      show ((cs.busInteractions.map (·.mapExpr rw)).map (fun bi => bi.eval env')) = _
+      rw [List.map_map]
+      exact List.map_congr_left (fun bi hbi => hB bi hbi)
+    rw [hmap]
+  -- soundness and invariant come from the plain transport
+  have hplain := cs.reencode_correct bsem rw keep newCs
+    (fun env hsat => let ⟨env', hA, hB, hnew, _, _⟩ := hfwd env hsat; ⟨env', hA, hB, hnew⟩) hbwd
+  rw [ConstraintSystem.reencCorrect] at hplain
+  refine ⟨hplain.1.1, hplain.2, hS, ?_⟩
+  intro env hadm hsat
+  obtain ⟨env', hA, hB, hnew, hpow, hrecon⟩ := hfwd env hsat
+  refine ⟨env', ⟨?_, ?_⟩, (hdisc env env' hB).2 hadm, ?_, hpow, hrecon⟩
+  · intro c hc
+    rcases List.mem_append.1 hc with h | h
+    · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 h
+      rw [hA c0 (List.mem_of_mem_filter hc0)]
+      exact hsat.1 c0 (List.mem_of_mem_filter hc0)
+    · exact hnew c h
+  · intro bi hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+    rw [hB bi0 hbi0]
+    exact hsat.2 bi0 hbi0
+  · rw [hside env env' hB]; exact BusState.equiv_refl _
 
 /-! ## Structure of enumerated assignments -/
 
@@ -652,10 +746,277 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
     (assignments (bitBox bits)).all (fun aβ => (coveredCsOf cs xs).all (fun c =>
       decide ((c.substF (groupSubst xs hm)).eval (envOf aβ) = 0)))
 
-theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : BusSemantics p)
+/-! ## Derived-variable methods for the fresh bits
+
+Each bit is recovered from the group by a decision tree over the bit patterns: at the first pattern
+whose interpolation image equals the group's values, output that pattern's bit. This inverts
+`group = poly(bits)` for witness generation, and — crucially — the pattern the forward direction
+selects (`find?` below) is exactly this first match, so the method computes the witness's bit. -/
+
+/-- A computation method reads only its variables. -/
+theorem ComputationMethod.eval_congr (cm : ComputationMethod p) (e1 e2 : Variable → ZMod p) :
+    (∀ v ∈ cm.vars, e1 v = e2 v) → cm.eval e1 = cm.eval e2 := by
+  induction cm with
+  | const c => intro _; rfl
+  | quotientOrZero num den =>
+      intro h
+      have hn : num.eval e1 = num.eval e2 :=
+        Expression.eval_congr num _ _ (fun v hv => h v (List.mem_append_left _ hv))
+      have hd : den.eval e1 = den.eval e2 :=
+        Expression.eval_congr den _ _ (fun v hv => h v (List.mem_append_right _ hv))
+      show (if den.eval e1 = 0 then 0 else (den.eval e1)⁻¹ * num.eval e1)
+         = (if den.eval e2 = 0 then 0 else (den.eval e2)⁻¹ * num.eval e2)
+      rw [hn, hd]
+  | ifEqZero cond thenM elseM iht ihe =>
+      intro h
+      have hc : cond.eval e1 = cond.eval e2 :=
+        Expression.eval_congr cond _ _ (fun v hv =>
+          h v (List.mem_append_left _ (List.mem_append_left _ hv)))
+      have ht := iht (fun v hv => h v (List.mem_append_left _ (List.mem_append_right _ hv)))
+      have he := ihe (fun v hv => h v (List.mem_append_right _ hv))
+      show (if cond.eval e1 = 0 then thenM.eval e1 else elseM.eval e1)
+         = (if cond.eval e2 = 0 then thenM.eval e2 else elseM.eval e2)
+      rw [hc, ht, he]
+
+/-- The interpolation image of group variable `x` at pattern `aβ` (a field constant). -/
+def imgVal (xs : List Variable) (hm : Std.HashMap Variable (Expression p))
+    (aβ : List (Variable × ZMod p)) (x : Variable) : ZMod p :=
+  ((Expression.var x).substF (groupSubst xs hm)).eval (envOf aβ)
+
+/-- `thenM` if every `x ∈ xs` has `imgFn x = env x`, else `elseM`, as nested `ifEqZero`. -/
+def matchCM (xs : List Variable) (imgFn : Variable → ZMod p)
+    (thenM elseM : ComputationMethod p) : ComputationMethod p :=
+  match xs with
+  | [] => thenM
+  | x :: rest =>
+      .ifEqZero (.add (.var x) (.const (-(imgFn x)))) (matchCM rest imgFn thenM elseM) elseM
+
+theorem matchCM_eval (xs : List Variable) (imgFn : Variable → ZMod p)
+    (thenM elseM : ComputationMethod p) (env : Variable → ZMod p) :
+    (matchCM xs imgFn thenM elseM).eval env
+    = if xs.all (fun x => decide (imgFn x = env x)) then thenM.eval env else elseM.eval env := by
+  induction xs with
+  | nil => rfl
+  | cons x rest ih =>
+      show (ComputationMethod.ifEqZero _ (matchCM rest imgFn thenM elseM) elseM).eval env = _
+      rw [ComputationMethod.eval]
+      by_cases hx : imgFn x = env x
+      · rw [if_pos (show (Expression.add (.var x) (.const (-(imgFn x)))).eval env = 0 by
+              show env x + -(imgFn x) = 0; rw [hx]; ring), ih, List.all_cons]
+        simp [hx]
+      · rw [if_neg (show (Expression.add (.var x) (.const (-(imgFn x)))).eval env ≠ 0 by
+              show env x + -(imgFn x) ≠ 0; intro h; exact hx (by linear_combination -h)),
+            List.all_cons]
+        simp [hx]
+
+/-- Variables of `matchCM` lie in `xs` together with those of the branches. -/
+theorem matchCM_vars (xs : List Variable) (imgFn : Variable → ZMod p)
+    (thenM elseM : ComputationMethod p) :
+    ∀ v ∈ (matchCM xs imgFn thenM elseM).vars, v ∈ xs ∨ v ∈ thenM.vars ∨ v ∈ elseM.vars := by
+  induction xs with
+  | nil => intro v hv; exact Or.inr (Or.inl hv)
+  | cons x rest ih =>
+      intro v hv
+      simp only [matchCM, ComputationMethod.vars, Expression.vars, List.nil_append,
+        List.append_assoc, List.mem_append, List.mem_singleton] at hv
+      rcases hv with rfl | hv | hv
+      · exact Or.inl (List.mem_cons_self ..)
+      · rcases ih v hv with h | h | h
+        · exact Or.inl (List.mem_cons_of_mem _ h)
+        · exact Or.inr (Or.inl h)
+        · exact Or.inr (Or.inr h)
+      · exact Or.inr (Or.inr hv)
+
+/-- The derivation of bit `b`: scan the patterns, output the first matching pattern's `b`-bit. -/
+def bitCM (patts : List (List (Variable × ZMod p))) (xs : List Variable)
+    (hm : Std.HashMap Variable (Expression p)) (b : Variable) : ComputationMethod p :=
+  match patts with
+  | [] => .const 0
+  | aβ :: rest => matchCM xs (imgVal xs hm aβ) (.const (envOf aβ b)) (bitCM rest xs hm b)
+
+theorem bitCM_eval (patts : List (List (Variable × ZMod p))) (xs : List Variable)
+    (hm : Std.HashMap Variable (Expression p)) (b : Variable) (env : Variable → ZMod p) :
+    (bitCM patts xs hm b).eval env
+    = match patts.find? (fun aβ => xs.all (fun x => decide (imgVal xs hm aβ x = env x))) with
+      | some aβ => envOf aβ b
+      | none => 0 := by
+  induction patts with
+  | nil => rfl
+  | cons aβ rest ih =>
+      show (matchCM xs (imgVal xs hm aβ) (.const (envOf aβ b)) (bitCM rest xs hm b)).eval env = _
+      rw [matchCM_eval, List.find?_cons]
+      by_cases hmatch : xs.all (fun x => decide (imgVal xs hm aβ x = env x)) = true
+      · rw [if_pos hmatch, hmatch]; rfl
+      · rw [if_neg hmatch]
+        simp only [hmatch, ih]
+
+/-- The derivation of bit `b` reads only group variables. -/
+theorem bitCM_vars (patts : List (List (Variable × ZMod p))) (xs : List Variable)
+    (hm : Std.HashMap Variable (Expression p)) (b : Variable) :
+    ∀ v ∈ (bitCM patts xs hm b).vars, v ∈ xs := by
+  induction patts with
+  | nil => intro v hv; simp [bitCM, ComputationMethod.vars] at hv
+  | cons aβ rest ih =>
+      intro v hv
+      rcases matchCM_vars xs (imgVal xs hm aβ) (.const (envOf aβ b)) (bitCM rest xs hm b) v hv
+        with h | h | h
+      · exact h
+      · simp [ComputationMethod.vars] at h
+      · exact ih v h
+
+/-- Substituting a wholly-in-group expression (whose group variables `σfn` maps into the bits)
+    yields an expression over the bits only. -/
+theorem Expression.substF_varsIn_bits (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p))
+    (hσ : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
+    (e : Expression p) (hin : e.varsIn xs = true) :
+    ∀ v ∈ (e.substF σfn).vars, v ∈ bits := by
+  induction e with
+  | const n => intro v hv; simp [Expression.substF, Expression.vars] at hv
+  | var y =>
+      intro v hv
+      exact hσ y (List.contains_iff_mem.mp (by simpa [Expression.varsIn] using hin)) v hv
+  | add a b iha ihb =>
+      rw [Expression.varsIn, Bool.and_eq_true] at hin
+      intro v hv
+      simp only [Expression.substF, Expression.vars, List.mem_append] at hv
+      rcases hv with hv | hv
+      · exact iha hin.1 v hv
+      · exact ihb hin.2 v hv
+  | mul a b iha ihb =>
+      rw [Expression.varsIn, Bool.and_eq_true] at hin
+      intro v hv
+      simp only [Expression.substF, Expression.vars, List.mem_append] at hv
+      rcases hv with hv | hv
+      · exact iha hin.1 v hv
+      · exact ihb hin.2 v hv
+
+/-- A rewritten wholly-in-group expression is over the bits only. -/
+theorem groupRewriteCand_vars (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p)) (patts : List (List (Variable × ZMod p)))
+    (hσ : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
+    (e : Expression p) (hin : e.varsIn xs = true) :
+    ∀ v ∈ (groupRewriteCand bits σfn patts e).vars, v ∈ bits := by
+  intro v hv
+  unfold groupRewriteCand at hv
+  split at hv
+  · next hchk =>
+      rw [Bool.and_eq_true] at hchk
+      exact Expression.varsIn_sound bits _ hchk.1 v hv
+  · exact Expression.substF_varsIn_bits xs bits σfn hσ e hin v hv
+
+/-- Every variable of a group-rewritten expression is either an original variable of `e` or a
+    fresh bit. -/
+theorem groupRewrite_vars (xs bits : List Variable)
+    (σfn : Variable → Option (Expression p)) (patts : List (List (Variable × ZMod p)))
+    (hσ : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF σfn).vars, v ∈ bits)
+    (e : Expression p) :
+    ∀ v ∈ (groupRewrite xs bits σfn patts e).vars, v ∈ e.vars ∨ v ∈ bits := by
+  induction e with
+  | const n => simp [groupRewrite, Expression.vars]
+  | var y =>
+      simp only [groupRewrite]
+      by_cases hyx : xs.contains y
+      · rw [if_pos hyx]; intro v hv
+        exact Or.inr (groupRewriteCand_vars xs bits σfn patts hσ (.var y)
+          (by simpa [Expression.varsIn] using hyx) v hv)
+      · rw [if_neg hyx]; intro v hv; exact Or.inl hv
+  | add a b iha ihb =>
+      simp only [groupRewrite]
+      by_cases hin : (Expression.add a b).varsIn xs = true
+      · rw [if_pos hin]; intro v hv
+        exact Or.inr (groupRewriteCand_vars xs bits σfn patts hσ (.add a b) hin v hv)
+      · rw [if_neg hin]; intro v hv
+        simp only [Expression.vars, List.mem_append] at hv ⊢
+        rcases hv with hv | hv
+        · rcases iha v hv with h | h
+          · exact Or.inl (Or.inl h)
+          · exact Or.inr h
+        · rcases ihb v hv with h | h
+          · exact Or.inl (Or.inr h)
+          · exact Or.inr h
+  | mul a b iha ihb =>
+      simp only [groupRewrite]
+      by_cases hin : (Expression.mul a b).varsIn xs = true
+      · rw [if_pos hin]; intro v hv
+        exact Or.inr (groupRewriteCand_vars xs bits σfn patts hσ (.mul a b) hin v hv)
+      · rw [if_neg hin]; intro v hv
+        simp only [Expression.vars, List.mem_append] at hv ⊢
+        rcases hv with hv | hv
+        · rcases iha v hv with h | h
+          · exact Or.inl (Or.inl h)
+          · exact Or.inr h
+        · rcases ihb v hv with h | h
+          · exact Or.inl (Or.inr h)
+          · exact Or.inr h
+
+/-- Every variable of the re-encoded system is either an original variable of `cs` or a fresh
+    bit — proven by construction from the certified substitution, so the pass needs no scan. -/
+theorem reencodeOut_vars_subset (cs : ConstraintSystem p) (xs bits : List Variable)
+    (hm : Std.HashMap Variable (Expression p))
+    (hσ : ∀ y ∈ xs, ∀ v ∈ ((Expression.var y).substF (groupSubst xs hm)).vars, v ∈ bits) :
+    ∀ v ∈ (reencodeOut cs xs bits hm).vars, v ∈ cs.vars ∨ v ∈ bits := by
+  intro v hv
+  have gr := groupRewrite_vars xs bits (groupSubst xs hm) (assignments (bitBox bits)) hσ
+  rcases ConstraintSystem.mem_vars.1 hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
+  · simp only [reencodeOut, List.mem_append] at hc
+    rcases hc with hc | hc
+    · rcases List.mem_map.1 hc with ⟨c0, hc0, rfl⟩
+      rcases gr c0 v hcv with h | h
+      · exact Or.inl (ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc0) h)
+      · exact Or.inr h
+    · rcases List.mem_map.1 hc with ⟨b, hb, rfl⟩
+      right
+      have hvb : v = b := by simpa [boolConstraint, Expression.vars] using hcv
+      exact hvb ▸ hb
+  · simp only [reencodeOut, List.mem_map] at hbi
+    rcases hbi with ⟨bi0, hbi0, rfl⟩
+    rcases hbiv with hmv | ⟨e, he, hev⟩
+    · simp only [BusInteraction.mapExpr] at hmv
+      rcases gr bi0.multiplicity v hmv with h | h
+      · exact Or.inl (ConstraintSystem.mem_vars_of_mult hbi0 h)
+      · exact Or.inr h
+    · simp only [BusInteraction.mapExpr] at he
+      rcases List.mem_map.1 he with ⟨e0, he0, rfl⟩
+      rcases gr e0 v hev with h | h
+      · exact Or.inl (ConstraintSystem.mem_vars_of_payload hbi0 he0 h)
+      · exact Or.inr h
+
+/-- Appending derivations: the later list `B` takes precedence, so a fresh variable's method there
+    overrides any earlier entry for it (this is what makes the reconstruction robust to duplicates). -/
+theorem Derivations.methodFor_append (A B : Derivations p) (v : Variable) :
+    Derivations.methodFor (A ++ B) v
+      = (Derivations.methodFor B v).orElse (fun _ => Derivations.methodFor A v) := by
+  induction A with
+  | nil => simp [Derivations.methodFor]
+  | cons pcm rest ih =>
+      obtain ⟨u, cm⟩ := pcm
+      simp only [List.cons_append, Derivations.methodFor, ih]
+      cases Derivations.methodFor B v <;> simp [Option.orElse]
+
+/-- The method list built for the fresh bits supplies `g w` for a bit `w`, nothing otherwise. -/
+theorem Derivations.methodFor_map (bits : List Variable) (g : Variable → ComputationMethod p)
+    (w : Variable) :
+    Derivations.methodFor (bits.map (fun b => (b, g b))) w
+      = if w ∈ bits then some (g w) else none := by
+  induction bits with
+  | nil => simp [Derivations.methodFor]
+  | cons b rest ih =>
+      simp only [List.map_cons, Derivations.methodFor, ih, List.mem_cons]
+      by_cases hw : w ∈ rest
+      · simp [hw]
+      · by_cases hbw : b = w
+        · subst hbw; simp [hw]
+        · have hwb : w ≠ b := fun h => hbw h.symm
+          simp [hw, hbw, hwb, Option.orElse]
+
+theorem checkReencode_sound_D [Fact p.Prime] (cs : ConstraintSystem p) (bsem : BusSemantics p)
     (xs bits : List Variable) (hm : Std.HashMap Variable (Expression p))
+    (hxs : ∀ x ∈ xs, x.powdrId?.isSome) (hxsB : ∀ x ∈ xs, x ∉ bits)
+    (hbn : ∀ b ∈ bits, b.powdrId? = none)
     (hchk : checkReencode cs xs bits hm = true) :
-    PassCorrect cs (reencodeOut cs xs bits hm) bsem := by
+    PassCorrect cs (reencodeOut cs xs bits hm)
+      (bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b))) bsem := by
   unfold checkReencode at hchk
   split at hchk
   · exact absurd hchk (by simp)
@@ -694,6 +1055,9 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
     intro y hy v hv
     exact List.contains_iff_mem.mp
       (List.all_eq_true.mp (List.all_eq_true.mp hvarsB y hy) v hv)
+  -- output variables are original `cs` variables or fresh bits (by construction, no scan)
+  have hvars : ∀ v ∈ (reencodeOut cs xs bits hm).vars, v ∈ cs.vars ∨ v ∈ bits :=
+    reencodeOut_vars_subset cs xs bits hm hpolyVars
   have hσnone : ∀ y, y ∉ xs → groupSubst xs hm y = none := by
     intro y hy
     simp [groupSubst, hy]
@@ -718,13 +1082,28 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
     have h2 := List.all_eq_true.mp h1.2 bi hbi
     rw [Bool.and_eq_true] at h2
     simpa using List.all_eq_true.mp h2.2 e he
-  -- FORWARD
-  have hfwd : ∀ env, cs.satisfies bsem env → ∃ env',
+  -- bits are fresh: none of them occurs in `cs`
+  have hbitsCs : ∀ b ∈ bits, b ∉ cs.vars := by
+    intro b hb hmem
+    rw [ConstraintSystem.mem_vars] at hmem
+    rcases hmem with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
+    · exact hfreshC b hb c hc hcv
+    · refine hfreshBi b hb bi hbi ?_
+      unfold BusInteraction.vars
+      rcases hbiv with h | ⟨e, he, hev⟩
+      · exact List.mem_append_left _ h
+      · exact List.mem_append_right _ (List.mem_flatMap.2 ⟨e, he, hev⟩)
+  -- FORWARD (with the frame and derived-variable reconstruction)
+  have hfwd_D : ∀ env, cs.satisfies bsem env → ∃ env',
       (∀ c ∈ cs.algebraicConstraints,
         ((groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits))) c).eval env' = c.eval env) ∧
       (∀ bi ∈ cs.busInteractions,
         (bi.mapExpr (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits)))).eval env' = bi.eval env) ∧
-      (∀ c ∈ bits.map boolConstraint, c.eval env' = 0) := by
+      (∀ c ∈ bits.map boolConstraint, c.eval env' = 0) ∧
+      (∀ v : Variable, v.powdrId?.isSome → env' v = env v) ∧
+      (∀ dsIn : Derivations p, cs.reconstructs dsIn env →
+        (reencodeOut cs xs bits hm).reconstructs
+          (dsIn ++ bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b))) env') := by
     intro env hsat
     have hallES : ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 := fun c hc =>
       hsat.1 c (List.mem_of_mem_filter hc)
@@ -745,48 +1124,102 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
         Expression.eval_congr c _ _ (fun v hv => envOf_map doms env v (hcvars v hv))
       rw [heq]
       exact hallES c hc
-    obtain ⟨aβ, haβ, hβval⟩ := List.any_eq_true.1 (List.all_eq_true.mp hC5 _ hasurv)
-    have hkeysβ : aβ.map Prod.fst = bits := by
-      rw [assignments_keys (bitBox bits) aβ haβ, hbitKeys]
-    -- pointwise agreement off the bits
-    have hpoint : ∀ y, y ∉ bits → envF (groupSubst xs hm) (envExt aβ env) y = env y := by
-      intro y hyb
-      by_cases hyx : y ∈ xs
-      · rw [envF_eq_varSubst]
-        have hagree : ((Expression.var y).substF (groupSubst xs hm)).eval (envExt aβ env)
-            = ((Expression.var y).substF (groupSubst xs hm)).eval (envOf aβ) := by
-          apply Expression.eval_congr
-          intro v hv
-          exact envExt_eq_envOf_of_mem aβ env v (hkeysβ ▸ hpolyVars y hyx v hv)
-        rw [hagree]
-        have hval := List.all_eq_true.mp hβval y hyx
-        rw [decide_eq_true_iff] at hval
-        rw [hval]
-        exact envOf_map doms env y (hkeys ▸ hyx)
-      · have hnone : groupSubst xs hm y = none := by
-          simp [groupSubst, hyx]
-        unfold envF
-        rw [hnone]
-        exact envExt_eq_env_of_notmem aβ env y (hkeysβ ▸ hyb)
-    have hbitsagree : ∀ b ∈ bits, envExt aβ env b = envOf aβ b := fun b hb =>
-      envExt_eq_envOf_of_mem aβ env b (hkeysβ ▸ hb)
-    refine ⟨envExt aβ env, ?_, ?_, ?_⟩
-    · intro c hc
-      exact groupRewrite_agree xs bits (groupSubst xs hm) (assignments (bitBox bits))
-        hσnone (envExt aβ env) env aβ haβ hbitsagree hpolyVars hpoint c (hfreshCm c hc)
-    · intro bi hbi
-      exact groupRewrite_bi_agree xs bits (groupSubst xs hm) (assignments (bitBox bits))
-        hσnone (envExt aβ env) env aβ haβ hbitsagree hpolyVars hpoint bi
-        (hfreshMm bi hbi) (hfreshPm bi hbi)
-    · intro c hc
-      obtain ⟨b, hb, rfl⟩ := List.mem_map.1 hc
-      apply boolConstraint_eval_of_bool
-      have hbk : b ∈ aβ.map Prod.fst := hkeysβ ▸ hb
-      rw [envExt_eq_envOf_of_mem aβ env b hbk]
-      have hmem := envOf_mem_of_assignments (bitBox bits)
-        (by rw [hbitKeys]; exact hnodup') aβ haβ
-        (b, ([0, 1] : List (ZMod p))) (List.mem_map.2 ⟨b, hb, rfl⟩)
-      simpa using hmem
+    -- select the first pattern whose interpolation image matches the group (deterministic, so it
+    -- coincides with what `bitCM` computes); it exists by the `hC5` completeness check
+    have hC5' : (assignments (bitBox bits)).any
+        (fun aβ => xs.all (fun x => decide (imgVal xs hm aβ x = env x))) = true := by
+      rw [List.any_eq_true]
+      obtain ⟨aβ, ha, hp⟩ := List.any_eq_true.1 (List.all_eq_true.mp hC5 _ hasurv)
+      refine ⟨aβ, ha, ?_⟩
+      rw [List.all_eq_true] at hp ⊢
+      intro x hx
+      have hsx : envOf (doms.map (fun yd => (yd.1, env yd.1))) x = env x :=
+        envOf_map doms env x (hkeys ▸ hx)
+      have := hp x hx
+      rwa [hsx] at this
+    cases hfindEnv : (assignments (bitBox bits)).find?
+        (fun aβ => xs.all (fun x => decide (imgVal xs hm aβ x = env x))) with
+    | none =>
+        exfalso
+        rw [List.find?_eq_none] at hfindEnv
+        obtain ⟨aβ0, ha0, hp0⟩ := List.any_eq_true.1 hC5'
+        exact absurd hp0 (by simpa using hfindEnv aβ0 ha0)
+    | some aβ =>
+      have haβ : aβ ∈ assignments (bitBox bits) := List.mem_of_find?_eq_some hfindEnv
+      have hβpred : xs.all (fun x => decide (imgVal xs hm aβ x = env x)) = true := by
+        simpa using List.find?_some hfindEnv
+      have hkeysβ : aβ.map Prod.fst = bits := by
+        rw [assignments_keys (bitBox bits) aβ haβ, hbitKeys]
+      have hxbits : ∀ x ∈ xs, x ∉ bits := hxsB
+      have henvxs : ∀ x ∈ xs, envExt aβ env x = env x := fun x hx =>
+        envExt_eq_env_of_notmem aβ env x (by rw [hkeysβ]; exact hxbits x hx)
+      -- pointwise agreement off the bits
+      have hpoint : ∀ y, y ∉ bits → envF (groupSubst xs hm) (envExt aβ env) y = env y := by
+        intro y hyb
+        by_cases hyx : y ∈ xs
+        · rw [envF_eq_varSubst]
+          have hagree : ((Expression.var y).substF (groupSubst xs hm)).eval (envExt aβ env)
+              = ((Expression.var y).substF (groupSubst xs hm)).eval (envOf aβ) := by
+            apply Expression.eval_congr
+            intro v hv
+            exact envExt_eq_envOf_of_mem aβ env v (hkeysβ ▸ hpolyVars y hyx v hv)
+          rw [hagree]
+          exact of_decide_eq_true (List.all_eq_true.mp hβpred y hyx)
+        · have hnone : groupSubst xs hm y = none := by
+            simp [groupSubst, hyx]
+          unfold envF
+          rw [hnone]
+          exact envExt_eq_env_of_notmem aβ env y (hkeysβ ▸ hyb)
+      have hbitsagree : ∀ b ∈ bits, envExt aβ env b = envOf aβ b := fun b hb =>
+        envExt_eq_envOf_of_mem aβ env b (hkeysβ ▸ hb)
+      refine ⟨envExt aβ env, ?_, ?_, ?_, ?_, ?_⟩
+      · intro c hc
+        exact groupRewrite_agree xs bits (groupSubst xs hm) (assignments (bitBox bits))
+          hσnone (envExt aβ env) env aβ haβ hbitsagree hpolyVars hpoint c (hfreshCm c hc)
+      · intro bi hbi
+        exact groupRewrite_bi_agree xs bits (groupSubst xs hm) (assignments (bitBox bits))
+          hσnone (envExt aβ env) env aβ haβ hbitsagree hpolyVars hpoint bi
+          (hfreshMm bi hbi) (hfreshPm bi hbi)
+      · intro c hc
+        obtain ⟨b, hb, rfl⟩ := List.mem_map.1 hc
+        apply boolConstraint_eval_of_bool
+        have hbk : b ∈ aβ.map Prod.fst := hkeysβ ▸ hb
+        rw [envExt_eq_envOf_of_mem aβ env b hbk]
+        have hmem := envOf_mem_of_assignments (bitBox bits)
+          (by rw [hbitKeys]; exact hnodup') aβ haβ
+          (b, ([0, 1] : List (ZMod p))) (List.mem_map.2 ⟨b, hb, rfl⟩)
+        simpa using hmem
+      · -- frame: input columns keep their value (only fresh bits change)
+        intro v hvpow
+        refine envExt_eq_env_of_notmem aβ env v ?_
+        rw [hkeysβ]
+        intro hvb
+        rw [hbn v hvb] at hvpow
+        simp at hvpow
+      · -- reconstruction (later derivations win, so a fresh bit's method overrides any dsIn entry)
+        intro dsIn hdsIn w hwout hwnone
+        rcases hvars w hwout with hwcs | hwb
+        · -- a surviving input column of `cs`: not a fresh bit, so `dsIn`'s method is the one used
+          have hwnb : w ∉ bits := fun h => hbitsCs w h hwcs
+          obtain ⟨cm, hcm, hcmv, hcmeval⟩ := hdsIn w hwcs hwnone
+          refine ⟨cm, ?_, hcmv, ?_⟩
+          · simp [Derivations.methodFor_append, Derivations.methodFor_map, hwnb, hcm]
+          · rw [ComputationMethod.eval_congr cm (envExt aβ env) env (fun v hv => by
+              refine envExt_eq_env_of_notmem aβ env v ?_
+              rw [hkeysβ]
+              intro hvb
+              have hp := hcmv v hv
+              rw [hbn v hvb] at hp
+              simp at hp), hcmeval]
+            exact (envExt_eq_env_of_notmem aβ env w (by
+              rw [hkeysβ]; intro hwb; exact hbitsCs w hwb hwcs)).symm
+        · -- a fresh bit: its `bitCM` method (the last listed for `w`) computes it
+          refine ⟨bitCM (assignments (bitBox bits)) xs hm w, ?_,
+            fun v hv => hxs v (bitCM_vars _ xs hm w v hv), ?_⟩
+          · simp [Derivations.methodFor_append, Derivations.methodFor_map, hwb]
+          · rw [ComputationMethod.eval_congr (bitCM (assignments (bitBox bits)) xs hm w)
+              (envExt aβ env) env (fun v hv => henvxs v (bitCM_vars _ xs hm w v hv)),
+              bitCM_eval, hfindEnv, envExt_eq_envOf_of_mem aβ env w (hkeysβ ▸ hwb)]
   -- BACKWARD
   have hbwd : ∀ env',
       (ConstraintSystem.satisfies
@@ -875,10 +1308,19 @@ theorem checkReencode_sound [Fact p.Prime] (cs : ConstraintSystem p) (bsem : Bus
         exact hβenv v (hpolyVars y (hcvars y hy) v hv)
       rw [← hexpr c, ← hagree]
       exact h6
-  show PassCorrect cs (reencodeOut cs xs bits hm) bsem
+  -- no new powdr-ID column: every output variable is a `cs` variable or a (no-ID) bit
+  have hS : ∀ v ∈ (reencodeOut cs xs bits hm).vars, v.powdrId?.isSome → v ∈ cs.vars := by
+    intro v hv hvpow
+    rcases hvars v hv with h | h
+    · exact h
+    · rw [hbn v h] at hvpow; simp at hvpow
+  show PassCorrect cs (reencodeOut cs xs bits hm)
+    (bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b))) bsem
   unfold reencodeOut
-  exact cs.reencode_correct bsem (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits))) (fun c => !coveredBy xs c)
-    (bits.map boolConstraint) hfwd hbwd
+  exact cs.reencode_correct_D bsem
+    (groupRewrite xs bits (groupSubst xs hm) (assignments (bitBox bits))) (fun c => !coveredBy xs c)
+    (bits.map boolConstraint) (bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)))
+    hfwd_D hbwd hS
 
 /-! ## Building the interpolation (proof-free) and the pass -/
 
@@ -909,37 +1351,47 @@ def buildReencode (cs : ConstraintSystem p) (xs : List Variable) (freshBase : St
       else none
     else none
 
-/-- One checked re-encoding step (identity if construction or certificate fails). -/
+/-- One checked re-encoding step (identity if construction or certificate fails). The expensive
+    filter — `buildReencode` — runs first, so the remaining side conditions (all cheap: the group
+    is all input columns and disjoint from the fresh bits, the bits carry no powdr ID) are only
+    checked for the few groups that are actually re-encodable. The output-variable frame is proven
+    by construction (`reencodeOut_vars_subset`), so no per-variable scan is needed. -/
 def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p)
-    (xs : List Variable) (freshBase : String) :
-    { out : ConstraintSystem p // PassCorrect cs out bsem } :=
-  match buildReencode cs xs freshBase with
-  | none => ⟨cs, cs.refines_refl bsem, _root_.id⟩
+    (xs : List Variable) (freshBase : String) : PassResult cs bsem :=
+  if hxs : xs.all (fun x => x.powdrId?.isSome) = true then
+  match hb : buildReencode cs xs freshBase with
+  | none => ⟨cs, [], PassCorrect.refl cs bsem⟩
   | some (bits, hm) =>
+    if hxsB : xs.all (fun x => decide (x ∉ bits)) = true then
+    if hbn : bits.all (fun b => decide (b.powdrId? = none)) = true then
     if hchk : checkReencode cs xs bits hm = true then
-      -- degree guard: interpolation polynomials have degree `bits.length`; skip the group
-      -- if any substitution site would exceed the zkVM's bound
       if (reencodeOut cs xs bits hm).withinDegreeB bsem.degreeBound then
-        ⟨reencodeOut cs xs bits hm, checkReencode_sound cs bsem xs bits hm hchk⟩
-      else ⟨cs, cs.refines_refl bsem, _root_.id⟩
-    else ⟨cs, cs.refines_refl bsem, _root_.id⟩
+        ⟨reencodeOut cs xs bits hm,
+         bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)),
+         checkReencode_sound_D cs bsem xs bits hm
+           (fun x hx => by simpa using List.all_eq_true.mp hxs x hx)
+           (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
+           (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
+           hchk⟩
+      else ⟨cs, [], PassCorrect.refl cs bsem⟩
+    else ⟨cs, [], PassCorrect.refl cs bsem⟩
+    else ⟨cs, [], PassCorrect.refl cs bsem⟩
+    else ⟨cs, [], PassCorrect.refl cs bsem⟩
+  else ⟨cs, [], PassCorrect.refl cs bsem⟩
 
-/-- Process the candidate groups sequentially (correctness composes by transitivity). -/
+/-- Process the candidate groups sequentially (correctness composes; derivations concatenate). -/
 def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
-    List (List Variable) → Nat → (cs : ConstraintSystem p) →
-    { out : ConstraintSystem p // PassCorrect cs out bsem }
-  | [], _, cs => ⟨cs, cs.refines_refl bsem, _root_.id⟩
+    List (List Variable) → Nat → (cs : ConstraintSystem p) → PassResult cs bsem
+  | [], _, cs => ⟨cs, [], PassCorrect.refl cs bsem⟩
   | xs :: rest, idx, cs =>
     let r1 := reencodeStep bsem cs xs
       (s!"rnc{cs.algebraicConstraints.length}_{cs.busInteractions.length}_{idx}")
-    let r2 := reencodeLoop bsem rest (idx + 1) r1.val
-    ⟨r2.val,
-     ConstraintSystem.refines_trans r2.property.1 r1.property.1,
-     fun h => r2.property.2 (r1.property.2 h)⟩
+    let r2 := reencodeLoop bsem rest (idx + 1) r1.out
+    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
-/-- The witness re-encoding pass: for every constraint's (small) variable group whose covered
-    constraints allow only a few joint values, re-encode the group with `⌈log₂ m⌉` fresh booleans.
-    Prime `p` only (booleanity needs an integral domain); identity otherwise. -/
+/-- The witness re-encoding pass: for every constraint's (small) all-input-column variable group
+    whose covered constraints allow only a few joint values, re-encode the group with `⌈log₂ m⌉`
+    fresh booleans and ship each bit's derived-variable method. Prime `p` only; identity otherwise. -/
 def reencodePass : VerifiedPass p := fun cs bsem =>
   if hpr : p.Prime then
     haveI : Fact p.Prime := ⟨hpr⟩
@@ -947,4 +1399,4 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
       let vs := c.vars.dedup
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none)).dedup
     reencodeLoop bsem targets 0 cs
-  else ⟨cs, cs.refines_refl bsem, _root_.id⟩
+  else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/Leanr/Implementation/OptimizerPasses/Rewrite.lean
+++ b/Leanr/Implementation/OptimizerPasses/Rewrite.lean
@@ -35,6 +35,26 @@ def ConstraintSystem.mapExpr (cs : ConstraintSystem p) (g : Expression p → Exp
   { algebraicConstraints := cs.algebraicConstraints.map g,
     busInteractions := cs.busInteractions.map (·.mapExpr g) }
 
+/-- If `g` introduces no new variables per expression, the rewritten system introduces none. -/
+theorem ConstraintSystem.mapExpr_vars_subset (cs : ConstraintSystem p)
+    {g : Expression p → Expression p}
+    (hgv : ∀ (e : Expression p) (x : Variable), x ∈ (g e).vars → x ∈ e.vars) :
+    ∀ x ∈ (cs.mapExpr g).vars, x ∈ cs.vars := by
+  intro x hx
+  rw [ConstraintSystem.mem_vars] at hx
+  rcases hx with ⟨c, hc, hxc⟩ | ⟨bi, hbi, hxbi⟩
+  · simp only [ConstraintSystem.mapExpr, List.mem_map] at hc
+    obtain ⟨c0, hc0, rfl⟩ := hc
+    exact ConstraintSystem.mem_vars_of_constraint hc0 (hgv c0 x hxc)
+  · simp only [ConstraintSystem.mapExpr, List.mem_map] at hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := hbi
+    rcases hxbi with hm | ⟨e, he, hxe⟩
+    · simp only [BusInteraction.mapExpr] at hm
+      exact ConstraintSystem.mem_vars_of_mult hbi0 (hgv bi0.multiplicity x hm)
+    · simp only [BusInteraction.mapExpr, List.mem_map] at he
+      obtain ⟨e0, he0, rfl⟩ := he
+      exact ConstraintSystem.mem_vars_of_payload hbi0 he0 (hgv e0 x hxe)
+
 section EvalPreserving
 variable {g : Expression p → Expression p} (hg : ∀ e (env : Variable → ZMod p), (g e).eval env = e.eval env)
 
@@ -101,17 +121,15 @@ theorem ConstraintSystem.sideEffects_mapExpr (cs : ConstraintSystem p) (bs : Bus
       · simp only [if_pos hstate, List.map_cons, ih, bi.eval_mapExpr hg]
       · simp only [if_neg hstate, ih]
 
-/-- **Correctness of eval-preserving maps.** If `g` never changes what an expression evaluates to,
-    then rewriting every expression with `g` yields an equivalent, invariant-preserving system. -/
-theorem ConstraintSystem.mapExpr_correct (cs : ConstraintSystem p) (bs : BusSemantics p) :
-    PassCorrect cs (cs.mapExpr g) bs := by
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+/-- **Correctness of eval-preserving maps.** If `g` never changes what an expression evaluates to
+    (`hg`) and introduces no new variables (`hgv`), then rewriting every expression with `g` yields
+    an equivalent, invariant-preserving system. -/
+theorem ConstraintSystem.mapExpr_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (hgv : ∀ (e : Expression p) (x : Variable), x ∈ (g e).vars → x ∈ e.vars) :
+    PassCorrect cs (cs.mapExpr g) [] bs := by
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.mapExpr_vars_subset hgv) ?_
   · intro env hsat
     refine ⟨env, (cs.satisfies_mapExpr hg bs env).1 hsat, ?_⟩
-    rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
-  · intro env hint hsat
-    refine ⟨env, (cs.satisfies_mapExpr hg bs env).2 hsat,
-      (cs.admissible_mapExpr hg bs env).2 hint, ?_⟩
     rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
   · intro hinv env hsat bi hbi
     have hsatcs : cs.satisfies bs env := (cs.satisfies_mapExpr hg bs env).1 hsat
@@ -119,6 +137,9 @@ theorem ConstraintSystem.mapExpr_correct (cs : ConstraintSystem p) (bs : BusSema
     obtain ⟨bi0, hbi0, rfl⟩ := hbi
     simp only [bi0.eval_mapExpr hg]
     exact hinv env hsatcs bi0 hbi0
+  · intro env hadm hsat
+    refine ⟨(cs.satisfies_mapExpr hg bs env).2 hsat, (cs.admissible_mapExpr hg bs env).2 hadm, ?_⟩
+    rw [cs.sideEffects_mapExpr hg]; exact BusState.equiv_refl _
 
 end EvalPreserving
 
@@ -129,12 +150,20 @@ def ConstraintSystem.filterConstraints (cs : ConstraintSystem p) (keep : Express
     ConstraintSystem p :=
   { cs with algebraicConstraints := cs.algebraicConstraints.filter keep }
 
+theorem ConstraintSystem.filterConstraints_vars_subset (cs : ConstraintSystem p)
+    (keep : Expression p → Bool) : ∀ x ∈ (cs.filterConstraints keep).vars, x ∈ cs.vars := by
+  intro x hx
+  rw [ConstraintSystem.mem_vars] at hx ⊢
+  rcases hx with ⟨c, hc, hxc⟩ | ⟨bi, hbi, hxbi⟩
+  · exact Or.inl ⟨c, List.mem_of_mem_filter hc, hxc⟩
+  · exact Or.inr ⟨bi, hbi, hxbi⟩
+
 /-- **Correctness of trivial-constraint removal.** Dropping algebraic constraints is equivalence-
     preserving as long as every dropped constraint is identically zero (hence vacuously true). -/
 theorem ConstraintSystem.filterConstraints_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (keep : Expression p → Bool)
     (h : ∀ c ∈ cs.algebraicConstraints, keep c = false → ∀ env, c.eval env = 0) :
-    PassCorrect cs (cs.filterConstraints keep) bs := by
+    PassCorrect cs (cs.filterConstraints keep) [] bs := by
   have hiff : ∀ env, (cs.filterConstraints keep).satisfies bs env ↔ cs.satisfies bs env := by
     intro env
     simp only [ConstraintSystem.satisfies, ConstraintSystem.filterConstraints]
@@ -148,14 +177,13 @@ theorem ConstraintSystem.filterConstraints_correct (cs : ConstraintSystem p) (bs
       exact ⟨fun c hcmem => hc c (List.mem_filter.1 hcmem).1, hb⟩
   have hside : ∀ env, (cs.filterConstraints keep).sideEffects bs env = cs.sideEffects bs env :=
     fun _ => rfl
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.filterConstraints_vars_subset keep) ?_
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
-    -- `filterConstraints` leaves bus interactions untouched, so `isIntended` is definitionally `cs`'s
-    exact ⟨env, (hiff env).2 hsat, hint, by rw [hside]; exact BusState.equiv_refl _⟩
   · intro hinv env hsat bi hbi
     exact hinv env ((hiff env).1 hsat) bi hbi
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat, hadm, by rw [hside]; exact BusState.equiv_refl _⟩
 
 /-! ## Removing zero-multiplicity bus interactions -/
 
@@ -163,6 +191,15 @@ theorem ConstraintSystem.filterConstraints_correct (cs : ConstraintSystem p) (bs
 def ConstraintSystem.filterBus (cs : ConstraintSystem p) (keep : BusInteraction (Expression p) → Bool) :
     ConstraintSystem p :=
   { cs with busInteractions := cs.busInteractions.filter keep }
+
+theorem ConstraintSystem.filterBus_vars_subset (cs : ConstraintSystem p)
+    (keep : BusInteraction (Expression p) → Bool) :
+    ∀ x ∈ (cs.filterBus keep).vars, x ∈ cs.vars := by
+  intro x hx
+  rw [ConstraintSystem.mem_vars] at hx ⊢
+  rcases hx with ⟨c, hc, hxc⟩ | ⟨bi, hbi, hxbi⟩
+  · exact Or.inl ⟨c, hc, hxc⟩
+  · exact Or.inr ⟨bi, List.mem_of_mem_filter hbi, hxbi⟩
 
 /-- Dropping interactions that are (under `a`) either inactive (multiplicity `0`) or on a
     stateless bus preserves `admissible` — generically in the VM predicate. `ConstraintSystem.admissible`
@@ -250,7 +287,7 @@ theorem multiplicitySum_filterBus (bs : BusSemantics p) (env : Variable → ZMod
 theorem ConstraintSystem.filterBus_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (keep : BusInteraction (Expression p) → Bool) (_hp1 : (1 : ZMod p) ≠ 0)
     (h : ∀ bi ∈ cs.busInteractions, keep bi = false → ∀ env, (bi.eval env).multiplicity = 0) :
-    PassCorrect cs (cs.filterBus keep) bs := by
+    PassCorrect cs (cs.filterBus keep) [] bs := by
   have hiff : ∀ env, (cs.filterBus keep).satisfies bs env ↔ cs.satisfies bs env := by
     intro env
     simp only [ConstraintSystem.satisfies]
@@ -267,14 +304,14 @@ theorem ConstraintSystem.filterBus_correct (cs : ConstraintSystem p) (bs : BusSe
     simp only [ConstraintSystem.sideEffects, ConstraintSystem.filterBus]
     exact multiplicitySum_filterBus bs env keep message cs.busInteractions
       (fun bi hbi hkf => h bi hbi hkf env)
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.filterBus_vars_subset keep) ?_
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, BusState.equiv_symm (hside env)⟩
-  · intro env hint hsat
-    exact ⟨env, (hiff env).2 hsat,
-      (cs.admissible_filterBus bs keep env
-        (fun bi hbi hkf => Or.inl (h bi hbi hkf env))).2 hint, hside env⟩
   · intro hinv env hsat bi hbi
     have hbimem : bi ∈ cs.busInteractions :=
       (List.mem_filter.1 (by simpa only [ConstraintSystem.filterBus] using hbi)).1
     exact hinv env ((hiff env).1 hsat) bi hbimem
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat,
+      (cs.admissible_filterBus bs keep env (fun bi hbi hkf => Or.inl (h bi hbi hkf env))).2 hadm,
+      hside env⟩

--- a/Leanr/Implementation/OptimizerPasses/Subst.lean
+++ b/Leanr/Implementation/OptimizerPasses/Subst.lean
@@ -139,27 +139,66 @@ theorem ConstraintSystem.sideEffects_subst (cs : ConstraintSystem p) (x : Variab
       · simp only [if_pos hstate, List.map_cons, ih, BusInteraction.eval_subst]
       · simp only [if_neg hstate, ih]
 
-/-- **Substitution correctness.** If every satisfying assignment of `cs` forces `x = t`, then
-    substituting `x := t` everywhere produces a `PassCorrect` system: equivalent to `cs` and
-    invariant-preserving. This is the workhorse behind all variable-elimination passes. -/
+/-- Substitution introduces no variable outside `e` and `t`. -/
+theorem Expression.subst_vars (e : Expression p) (x : Variable) (t : Expression p) :
+    ∀ z ∈ (e.subst x t).vars, z ∈ e.vars ∨ z ∈ t.vars := by
+  induction e with
+  | const n => intro z hz; simp [Expression.subst, Expression.vars] at hz
+  | var y =>
+      intro z hz
+      simp only [Expression.subst] at hz
+      by_cases h : y = x
+      · rw [if_pos h] at hz; exact Or.inr hz
+      · rw [if_neg h] at hz; exact Or.inl hz
+  | add a b iha ihb =>
+      intro z hz
+      simp only [Expression.subst, Expression.vars, List.mem_append] at hz
+      rcases hz with hz | hz
+      · exact (iha z hz).imp (List.mem_append.2 <| Or.inl ·) id
+      · exact (ihb z hz).imp (List.mem_append.2 <| Or.inr ·) id
+  | mul a b iha ihb =>
+      intro z hz
+      simp only [Expression.subst, Expression.vars, List.mem_append] at hz
+      rcases hz with hz | hz
+      · exact (iha z hz).imp (List.mem_append.2 <| Or.inl ·) id
+      · exact (ihb z hz).imp (List.mem_append.2 <| Or.inr ·) id
+
+/-- If `t`'s variables are all in `cs`, substitution introduces no new variable. -/
+theorem ConstraintSystem.subst_vars_subset (cs : ConstraintSystem p) (x : Variable)
+    (t : Expression p) (htv : ∀ y ∈ t.vars, y ∈ cs.vars) :
+    ∀ z ∈ (cs.subst x t).vars, z ∈ cs.vars := by
+  intro z hz
+  rw [ConstraintSystem.mem_vars] at hz
+  rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hzbi⟩
+  · simp only [ConstraintSystem.subst, List.mem_map] at hc
+    obtain ⟨c0, hc0, rfl⟩ := hc
+    exact (Expression.subst_vars c0 x t z hzc).elim
+      (ConstraintSystem.mem_vars_of_constraint hc0) (htv z)
+  · simp only [ConstraintSystem.subst, List.mem_map] at hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := hbi
+    rcases hzbi with hm | ⟨e, he, hze⟩
+    · simp only [BusInteraction.subst] at hm
+      exact (Expression.subst_vars bi0.multiplicity x t z hm).elim
+        (ConstraintSystem.mem_vars_of_mult hbi0) (htv z)
+    · simp only [BusInteraction.subst, List.mem_map] at he
+      obtain ⟨e0, he0, rfl⟩ := he
+      exact (Expression.subst_vars e0 x t z hze).elim
+        (ConstraintSystem.mem_vars_of_payload hbi0 he0) (htv z)
+
+/-- **Substitution correctness.** If every satisfying assignment of `cs` forces `x = t` and `t`
+    mentions only `cs`'s variables, then substituting `x := t` everywhere produces a `PassCorrect`
+    system: equivalent to `cs`, invariant-preserving, and introducing no new column. This is the
+    workhorse behind all variable-elimination passes. -/
 theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : Variable) (t : Expression p)
-    (bs : BusSemantics p) (H : ∀ env, cs.satisfies bs env → env x = t.eval env) :
-    PassCorrect cs (cs.subst x t) bs := by
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+    (bs : BusSemantics p) (H : ∀ env, cs.satisfies bs env → env x = t.eval env)
+    (htv : ∀ y ∈ t.vars, y ∈ cs.vars) :
+    PassCorrect cs (cs.subst x t) [] bs := by
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.subst_vars_subset x t htv) ?_
   · -- soundness: (cs.subst x t) implies cs
     intro env hsat
     refine ⟨Function.update env x (t.eval env), (cs.satisfies_subst x t bs env).1 hsat, ?_⟩
     rw [cs.sideEffects_subst]
     exact BusState.equiv_refl _
-  · -- completeness: cs intended-implies (cs.subst x t)
-    intro env hint hsat
-    have hx : env x = t.eval env := H env hsat
-    have hupd : Function.update env x (t.eval env) = env := by
-      rw [← hx]; exact Function.update_eq_self x env
-    refine ⟨env, ?_, ?_, ?_⟩
-    · rw [cs.satisfies_subst, hupd]; exact hsat
-    · rw [cs.admissible_subst, hupd]; exact hint
-    · rw [cs.sideEffects_subst, hupd]; exact BusState.equiv_refl _
   · -- invariant preservation
     intro hinv env hsat bi hbi
     have hsatcs : cs.satisfies bs (Function.update env x (t.eval env)) :=
@@ -168,6 +207,15 @@ theorem ConstraintSystem.subst_correct (cs : ConstraintSystem p) (x : Variable) 
     obtain ⟨bi0, hbi0, rfl⟩ := hbi
     simp only [bi0.eval_subst x t env]
     exact hinv (Function.update env x (t.eval env)) hsatcs bi0 hbi0
+  · -- completeness: cs intended-implies (cs.subst x t), witness `env`
+    intro env hadm hsat
+    have hx : env x = t.eval env := H env hsat
+    have hupd : Function.update env x (t.eval env) = env := by
+      rw [← hx]; exact Function.update_eq_self x env
+    refine ⟨?_, ?_, ?_⟩
+    · rw [cs.satisfies_subst, hupd]; exact hsat
+    · rw [cs.admissible_subst, hupd]; exact hadm
+    · rw [cs.sideEffects_subst, hupd]; exact BusState.equiv_refl _
 
 /-! ## Building substitution passes from a constraint solver
 
@@ -184,14 +232,17 @@ and its soundness lemma. -/
     entails `x = t`. -/
 def substFromConstraint (solve : Expression p → Option (Variable × Expression p))
     (hsolve : ∀ (c : Expression p) (x : Variable) (t : Expression p), solve c = some (x, t) →
-      ∀ env, c.eval env = 0 → env x = t.eval env) :
+      ∀ env, c.eval env = 0 → env x = t.eval env)
+    (hsolveV : ∀ (c : Expression p) (x : Variable) (t : Expression p), solve c = some (x, t) →
+      ∀ y ∈ t.vars, y ∈ c.vars) :
     VerifiedPass p := fun cs bs =>
   match hfound : cs.algebraicConstraints.find? (fun c => (solve c).isSome) with
-  | none => ⟨cs, cs.refines_refl bs, _root_.id⟩
+  | none => ⟨cs, [], PassCorrect.refl cs bs⟩
   | some c =>
       have hmem : c ∈ cs.algebraicConstraints := List.mem_of_find?_eq_some hfound
       match hc : solve c with
       | some (x, t) =>
-          ⟨cs.subst x t, cs.subst_correct x t bs
-            (fun env hsat => hsolve c x t hc env (hsat.1 c hmem))⟩
+          ⟨cs.subst x t, [], cs.subst_correct x t bs
+            (fun env hsat => hsolve c x t hc env (hsat.1 c hmem))
+            (fun y hy => ConstraintSystem.mem_vars_of_constraint hmem (hsolveV c x t hc y hy))⟩
       | none => by have hsome := List.find?_some hfound; simp [hc] at hsome

--- a/Leanr/Implementation/OptimizerPasses/SubstMap.lean
+++ b/Leanr/Implementation/OptimizerPasses/SubstMap.lean
@@ -142,27 +142,70 @@ theorem ConstraintSystem.sideEffects_substF (cs : ConstraintSystem p)
       · simp only [if_pos hstate, List.map_cons, ih, BusInteraction.eval_substF]
       · simp only [if_neg hstate, ih]
 
+/-- Simultaneous substitution introduces no variable outside `e` and the mapped solutions. -/
+theorem Expression.substF_vars (f : Variable → Option (Expression p)) (e : Expression p) :
+    ∀ z ∈ (e.substF f).vars, z ∈ e.vars ∨ ∃ y t, f y = some t ∧ z ∈ t.vars := by
+  induction e with
+  | const n => intro z hz; simp [Expression.substF, Expression.vars] at hz
+  | var y =>
+      intro z hz
+      cases hfy : f y with
+      | none => simp only [Expression.substF, hfy] at hz; exact Or.inl hz
+      | some t => simp only [Expression.substF, hfy] at hz; exact Or.inr ⟨y, t, hfy, hz⟩
+  | add a b iha ihb =>
+      intro z hz
+      simp only [Expression.substF, Expression.vars, List.mem_append] at hz
+      rcases hz with hz | hz
+      · exact (iha z hz).imp (List.mem_append.2 <| Or.inl ·) id
+      · exact (ihb z hz).imp (List.mem_append.2 <| Or.inr ·) id
+  | mul a b iha ihb =>
+      intro z hz
+      simp only [Expression.substF, Expression.vars, List.mem_append] at hz
+      rcases hz with hz | hz
+      · exact (iha z hz).imp (List.mem_append.2 <| Or.inl ·) id
+      · exact (ihb z hz).imp (List.mem_append.2 <| Or.inr ·) id
+
+/-- If every mapped solution mentions only `cs`'s variables, substitution introduces no new one. -/
+theorem ConstraintSystem.substF_vars_subset (cs : ConstraintSystem p)
+    (f : Variable → Option (Expression p))
+    (hfv : ∀ (y : Variable) (t : Expression p), f y = some t → ∀ z ∈ t.vars, z ∈ cs.vars) :
+    ∀ z ∈ (cs.substF f).vars, z ∈ cs.vars := by
+  intro z hz
+  rw [ConstraintSystem.mem_vars] at hz
+  rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hzbi⟩
+  · simp only [ConstraintSystem.substF, List.mem_map] at hc
+    obtain ⟨c0, hc0, rfl⟩ := hc
+    rcases Expression.substF_vars f c0 z hzc with h | ⟨y, t, hft, hzt⟩
+    · exact ConstraintSystem.mem_vars_of_constraint hc0 h
+    · exact hfv y t hft z hzt
+  · simp only [ConstraintSystem.substF, List.mem_map] at hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := hbi
+    rcases hzbi with hm | ⟨e, he, hze⟩
+    · simp only [BusInteraction.substF] at hm
+      rcases Expression.substF_vars f bi0.multiplicity z hm with h | ⟨y, t, hft, hzt⟩
+      · exact ConstraintSystem.mem_vars_of_mult hbi0 h
+      · exact hfv y t hft z hzt
+    · simp only [BusInteraction.substF, List.mem_map] at he
+      obtain ⟨e0, he0, rfl⟩ := he
+      rcases Expression.substF_vars f e0 z hze with h | ⟨y, t, hft, hzt⟩
+      · exact ConstraintSystem.mem_vars_of_payload hbi0 he0 h
+      · exact hfv y t hft z hzt
+
 /-- **Simultaneous-substitution correctness.** If every satisfying assignment of `cs` forces
-    `x = t` for every mapped pair `f x = some t`, then substituting the whole map at once is
-    `PassCorrect`: equivalent to `cs` and invariant-preserving. The batch counterpart of
+    `x = t` for every mapped pair `f x = some t`, and every solution mentions only `cs`'s
+    variables, then substituting the whole map at once is `PassCorrect`. The batch counterpart of
     `ConstraintSystem.subst_correct`. -/
 theorem ConstraintSystem.substF_correct (cs : ConstraintSystem p)
     (f : Variable → Option (Expression p)) (bs : BusSemantics p)
-    (H : ∀ env, cs.satisfies bs env → ∀ y t, f y = some t → env y = t.eval env) :
-    PassCorrect cs (cs.substF f) bs := by
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+    (H : ∀ env, cs.satisfies bs env → ∀ y t, f y = some t → env y = t.eval env)
+    (hfv : ∀ (y : Variable) (t : Expression p), f y = some t → ∀ z ∈ t.vars, z ∈ cs.vars) :
+    PassCorrect cs (cs.substF f) [] bs := by
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.substF_vars_subset f hfv) ?_
   · -- soundness: (cs.substF f) implies cs
     intro env hsat
     refine ⟨envF f env, (cs.satisfies_substF f bs env).1 hsat, ?_⟩
     rw [cs.sideEffects_substF]
     exact BusState.equiv_refl _
-  · -- completeness: cs intended-implies (cs.substF f)
-    intro env hint hsat
-    have henv : envF f env = env := envF_eq_self f env (H env hsat)
-    refine ⟨env, ?_, ?_, ?_⟩
-    · rw [cs.satisfies_substF, henv]; exact hsat
-    · rw [cs.admissible_substF, henv]; exact hint
-    · rw [cs.sideEffects_substF, henv]; exact BusState.equiv_refl _
   · -- invariant preservation
     intro hinv env hsat bi hbi
     have hsatcs : cs.satisfies bs (envF f env) := (cs.satisfies_substF f bs env).1 hsat
@@ -170,3 +213,10 @@ theorem ConstraintSystem.substF_correct (cs : ConstraintSystem p)
     obtain ⟨bi0, hbi0, rfl⟩ := hbi
     simp only [bi0.eval_substF f env]
     exact hinv (envF f env) hsatcs bi0 hbi0
+  · -- completeness: cs intended-implies (cs.substF f), witness `env`
+    intro env hadm hsat
+    have henv : envF f env = env := envF_eq_self f env (H env hsat)
+    refine ⟨?_, ?_, ?_⟩
+    · rw [cs.satisfies_substF, henv]; exact hsat
+    · rw [cs.admissible_substF, henv]; exact hadm
+    · rw [cs.sideEffects_substF, henv]; exact BusState.equiv_refl _

--- a/Leanr/Implementation/OptimizerPasses/TautoBus.lean
+++ b/Leanr/Implementation/OptimizerPasses/TautoBus.lean
@@ -104,7 +104,7 @@ theorem ConstraintSystem.filterBusStateless_correct (cs : ConstraintSystem p)
       bs.isStateful bi.busId = false)
     (hok : ∀ bi ∈ cs.busInteractions, keep bi = false → ∀ env,
       bs.violatesConstraint (bi.eval env) = false) :
-    PassCorrect cs (cs.filterBus keep) bs := by
+    PassCorrect cs (cs.filterBus keep) [] bs := by
   have hiff : ∀ env, (cs.filterBus keep).satisfies bs env ↔ cs.satisfies bs env := by
     intro env
     simp only [ConstraintSystem.satisfies]
@@ -141,18 +141,18 @@ theorem ConstraintSystem.filterBusStateless_correct (cs : ConstraintSystem p)
     intro env
     simp only [ConstraintSystem.sideEffects, ConstraintSystem.filterBus]
     rw [hfilter cs.busInteractions hstateless]
-  refine ⟨⟨?_, ?_⟩, ?_⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.filterBus_vars_subset keep) ?_
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro env hint hsat
-    exact ⟨env, (hiff env).2 hsat,
-      (cs.admissible_filterBus bs keep env
-        (fun bi hbi hkf => Or.inr (hstateless bi hbi hkf))).2 hint,
-      by rw [hside]; exact BusState.equiv_refl _⟩
   · intro hinv env hsat bi hbi
     have hbimem : bi ∈ cs.busInteractions :=
       (List.mem_filter.1 (by simpa only [ConstraintSystem.filterBus] using hbi)).1
     exact hinv env ((hiff env).1 hsat) bi hbimem
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat,
+      (cs.admissible_filterBus bs keep env
+        (fun bi hbi hkf => Or.inr (hstateless bi hbi hkf))).2 hadm,
+      by rw [hside]; exact BusState.equiv_refl _⟩
 
 /-! ## The pass -/
 
@@ -166,7 +166,7 @@ def isTautoLookup (bs : BusSemantics p) (bi : BusInteraction (Expression p)) : B
 /-- The tautology-lookup removal pass: drop stateless interactions whose constant message is
     accepted by the bus's table. -/
 def tautoBusDropPass : VerifiedPass p := fun cs bs =>
-  ⟨cs.filterBus (fun bi => !isTautoLookup bs bi),
+  ⟨cs.filterBus (fun bi => !isTautoLookup bs bi), [],
    cs.filterBusStateless_correct bs _
      (by
        intro bi _ hkf

--- a/Leanr/Implementation/OptimizerPasses/TrivialConstraint.lean
+++ b/Leanr/Implementation/OptimizerPasses/TrivialConstraint.lean
@@ -31,7 +31,7 @@ theorem Expression.isConstZero_sound (e : Expression p) (h : e.isConstZero = tru
     `0`. Correct via `filterConstraints_correct`, discharging the dropped-constraints-are-zero
     obligation through `fold_eval` and `isConstZero_sound`. -/
 def trivialConstraintDropPass : VerifiedPass p := fun cs bs =>
-  ⟨cs.filterConstraints (fun c => !c.fold.isConstZero),
+  ⟨cs.filterConstraints (fun c => !c.fold.isConstZero), [],
    cs.filterConstraints_correct bs (fun c => !c.fold.isConstZero) (by
      intro c _ hkf env
      have hz : c.fold.isConstZero = true := by simpa using hkf

--- a/Leanr/Implementation/OptimizerPasses/ZeroMultBus.lean
+++ b/Leanr/Implementation/OptimizerPasses/ZeroMultBus.lean
@@ -21,9 +21,9 @@ variable {p : ℕ}
     `0`. Correct via `filterBus_correct`, discharging the multiplicity-is-zero obligation through
     `fold_eval` and `isConstZero_sound`. -/
 def zeroMultBusDropPass : VerifiedPass p := fun cs bs =>
-  if hp1 : (1 : ZMod p) = 0 then ⟨cs, cs.refines_refl bs, _root_.id⟩
+  if hp1 : (1 : ZMod p) = 0 then ⟨cs, [], PassCorrect.refl cs bs⟩
   else
-    ⟨cs.filterBus (fun bi => !bi.multiplicity.fold.isConstZero),
+    ⟨cs.filterBus (fun bi => !bi.multiplicity.fold.isConstZero), [],
      cs.filterBus_correct bs (fun bi => !bi.multiplicity.fold.isConstZero) hp1 (by
        intro bi _ hkf env
        have hz : bi.multiplicity.fold.isConstZero = true := by simpa using hkf

--- a/Leanr/Optimizer.lean
+++ b/Leanr/Optimizer.lean
@@ -16,15 +16,16 @@ variable {p : ℕ}
       a new VM with no proven bus facts. It will likely be less effective than the fact-aware optimizer.
     - `openVmOptimizer busMap`: A specialization for the OpenVM semantics. -/
 
-/-- Optimizer which does not use any bus facts. Works with any VM, but is less effective. -/
-def simpleOptimizer (bs : BusSemantics p) : ConstraintSystem p → ConstraintSystem p :=
+/-- Optimizer which does not use any bus facts. Works with any VM, but is less effective. Returns
+    the optimized system together with the `Derivations` for its newly-introduced columns. -/
+def simpleOptimizer (bs : BusSemantics p) : ConstraintSystem p → ConstraintSystem p × Derivations p :=
   optimizerWithBusFacts (BusFacts.trivial bs)
 
 namespace Leanr.OpenVM
 
 /-- Optimizer specialized for the OpenVM semantics. -/
 def openVmOptimizer (busMap : BusMap := defaultBusMap) :
-    ConstraintSystem babyBear → ConstraintSystem babyBear :=
+    ConstraintSystem babyBear → ConstraintSystem babyBear × Derivations babyBear :=
   optimizerWithBusFacts (openVmFacts babyBear busMap)
 
 end Leanr.OpenVM

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -46,7 +46,9 @@ def Expression.vars : Expression p → List Variable
 --------- Computation Methods ---------
 
 /-- A method for computing a *derived* variable's value from other variables, mirroring powdr's
-    `ComputationMethod`. `quotientOrZero num den` is `num / den` in the field, or `0` when
+    `ComputationMethod`. For newly introduced variables, this is interpreted by powdr's witness
+    generator.
+    `quotientOrZero num den` is `num / den` in the field, or `0` when
     `den = 0`; `ifEqZero cond thenM elseM` picks `thenM` when `cond` evaluates to `0`, else `elseM`. -/
 inductive ComputationMethod (p : ℕ) where
   | const (c : ZMod p)
@@ -154,6 +156,34 @@ def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
       let m := bi.eval env
       ((m.busId, m.payload), m.multiplicity))
 
+--------- Derived variables ---------
+
+/-- The `ComputationMethod` witness generation uses for `v`: the **last** one `ds` lists for it
+    (later derivations override earlier ones), or `none` if `v` is not derived. -/
+def Derivations.methodFor : Derivations p → Variable → Option (ComputationMethod p)
+  | [], _ => none
+  | (u, cm) :: rest, v =>
+      (Derivations.methodFor rest v).orElse (fun _ => if u = v then some cm else none)
+
+/-- Derived-variable reconstruction under `e`: every no-powdr-ID variable of `cs` is computed by
+    the method `ds` uses for it, reading only input (powdr-ID) columns. -/
+def ConstraintSystem.reconstructs (cs : ConstraintSystem p) (ds : Derivations p)
+    (e : Variable → ZMod p) : Prop :=
+  ∀ v ∈ cs.vars, v.powdrId? = none →
+    ∃ cm, Derivations.methodFor ds v = some cm ∧ (∀ x ∈ cm.vars, x.powdrId?.isSome) ∧ cm.eval e = e v
+
+/-- How the completeness witness `env'` of an output `out` is obtained from an assignment `env` of
+    the input `inp`, via derivations `ds`: every variable of `out` that carries a powdr ID is an
+    input column, present in `inp` with an unchanged value; every derived variable (no powdr ID) is
+    computed by a method in `ds` reading only input columns. This is exactly the data witness
+    generation needs to extend an input trace to an output trace. -/
+def ConstraintSystem.derivesWitness (out inp : ConstraintSystem p) (ds : Derivations p)
+    (env env' : Variable → ZMod p) : Prop :=
+  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ inp.vars ∧ env' v = env v) ∧
+  out.reconstructs ds env'
+
+--------- Constraint system implications ---------
+
 /-- Whether a given assignment is admissible under the bus semantics. -/
 def ConstraintSystem.admissible (s : ConstraintSystem p) (busSemantics : BusSemantics p)
     (env : Variable → ZMod p) : Prop :=
@@ -187,34 +217,6 @@ def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : B
     ∃ env', other.satisfies busSemantics env' ∧
       self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
 
---------- Derived variables ---------
-
-/-- The `ComputationMethod` witness generation uses for `v`: the **last** one `ds` lists for it
-    (later derivations override earlier ones), or `none` if `v` is not derived. The tail (later
-    entries) takes precedence over the head. -/
-def Derivations.methodFor : Derivations p → Variable → Option (ComputationMethod p)
-  | [], _ => none
-  | (u, cm) :: rest, v =>
-      (Derivations.methodFor rest v).orElse (fun _ => if u = v then some cm else none)
-
-/-- Derived-variable reconstruction under `e`: every no-powdr-ID variable of `cs` is computed by
-    the method `ds` uses for it (`methodFor`, i.e. its last entry — duplicates are allowed, the
-    later one wins), reading only input (powdr-ID) columns. -/
-def ConstraintSystem.reconstructs (cs : ConstraintSystem p) (ds : Derivations p)
-    (e : Variable → ZMod p) : Prop :=
-  ∀ v ∈ cs.vars, v.powdrId? = none →
-    ∃ cm, Derivations.methodFor ds v = some cm ∧ (∀ x ∈ cm.vars, x.powdrId?.isSome) ∧ cm.eval e = e v
-
-/-- How the completeness witness `env'` of an output `out` is obtained from an assignment `env` of
-    the input `inp`, via derivations `ds`: every variable of `out` that carries a powdr ID is an
-    input column, present in `inp` with an unchanged value; every derived variable (no powdr ID) is
-    computed by a method in `ds` reading only input columns. This is exactly the data witness
-    generation needs to extend an input trace to an output trace. -/
-def ConstraintSystem.derivesWitness (out inp : ConstraintSystem p) (ds : Derivations p)
-    (env env' : Variable → ZMod p) : Prop :=
-  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ inp.vars ∧ env' v = env v) ∧
-  out.reconstructs ds env'
-
 /-- Like `implies`, but the obligation is only required for `self`'s **admissible** (real-trace)
     assignments, the produced witness is itself admissible, and — when `self`'s variables are all
     genuine input columns — that witness additionally `derivesWitness`: it is reconstructible from
@@ -242,6 +244,8 @@ def ConstraintSystem.refines (self other : ConstraintSystem p) (busSemantics : B
     (ds : Derivations p) : Prop :=
   self.implies other busSemantics ∧ other.impliesAdmissible self busSemantics ds
 
+--------- Degree bound ---------
+
 /-- Whether a constraint system stays within a degree bound. -/
 def ConstraintSystem.withinDegree (s : ConstraintSystem p) (b : DegreeBound) : Prop :=
   (∀ c ∈ s.algebraicConstraints, c.degree ≤ b.identities) ∧
@@ -255,6 +259,8 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
   ∀ constraintSystem : ConstraintSystem p,
     constraintSystem.withinDegree busSemantics.degreeBound →
     (optimizer constraintSystem).withinDegree busSemantics.degreeBound
+
+--------- Optimizer correctness ---------
 
 /-- Whether an optimizer maintains correctness *with respect to a given `busSemantics`*. This
     means that, for all constraint systems:

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -36,6 +36,41 @@ def Expression.degree : Expression p → Nat
   | .add e1 e2 => max e1.degree e2.degree
   | .mul e1 e2 => e1.degree + e2.degree
 
+/-- The variables occurring in an expression. -/
+def Expression.vars : Expression p → List Variable
+  | .const _ => []
+  | .var x => [x]
+  | .add e1 e2 => e1.vars ++ e2.vars
+  | .mul e1 e2 => e1.vars ++ e2.vars
+
+--------- Computation Methods ---------
+
+/-- A method for computing a *derived* variable's value from other variables, mirroring powdr's
+    `ComputationMethod`. `quotientOrZero num den` is `num / den` in the field, or `0` when
+    `den = 0`; `ifEqZero cond thenM elseM` picks `thenM` when `cond` evaluates to `0`, else `elseM`. -/
+inductive ComputationMethod (p : ℕ) where
+  | const (c : ZMod p)
+  | quotientOrZero (num den : Expression p)
+  | ifEqZero (cond : Expression p) (thenM elseM : ComputationMethod p)
+
+/-- Evaluate a computation method under an assignment (cf. powdr's `evaluate_computation_method`). -/
+def ComputationMethod.eval : ComputationMethod p → (Variable → ZMod p) → ZMod p
+  | .const c, _ => c
+  | .quotientOrZero num den, env =>
+      if den.eval env = 0 then 0 else (den.eval env)⁻¹ * num.eval env
+  | .ifEqZero cond thenM elseM, env =>
+      if cond.eval env = 0 then thenM.eval env else elseM.eval env
+
+/-- The variables a computation method may read. -/
+def ComputationMethod.vars : ComputationMethod p → List Variable
+  | .const _ => []
+  | .quotientOrZero num den => num.vars ++ den.vars
+  | .ifEqZero cond thenM elseM => cond.vars ++ thenM.vars ++ elseM.vars
+
+/-- A list of derived variables paired with how to compute each, in order — the extra output of
+    the optimizer, consumed by witness generation. -/
+abbrev Derivations (p : ℕ) := List (Variable × ComputationMethod p)
+
 --------- Bus Interactions ---------
 
 /-- A bus interaction. Typically, α is
@@ -104,6 +139,12 @@ structure ConstraintSystem (p : ℕ) where
   algebraicConstraints : List (Expression p)
   busInteractions : List (BusInteraction (Expression p))
 
+/-- The variables occurring anywhere in a constraint system. -/
+def ConstraintSystem.vars (cs : ConstraintSystem p) : List Variable :=
+  cs.algebraicConstraints.flatMap Expression.vars ++
+    cs.busInteractions.flatMap
+      (fun bi => bi.multiplicity.vars ++ bi.payload.flatMap Expression.vars)
+
 /-- The side effects of a constraint system under a given environment and bus semantics.
     The side effects are the tuples sent to the *stateful* buses.-/
 def ConstraintSystem.sideEffects (cs : ConstraintSystem p)
@@ -146,25 +187,60 @@ def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : B
     ∃ env', other.satisfies busSemantics env' ∧
       self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
 
+--------- Derived variables ---------
+
+/-- The `ComputationMethod` witness generation uses for `v`: the **last** one `ds` lists for it
+    (later derivations override earlier ones), or `none` if `v` is not derived. The tail (later
+    entries) takes precedence over the head. -/
+def Derivations.methodFor : Derivations p → Variable → Option (ComputationMethod p)
+  | [], _ => none
+  | (u, cm) :: rest, v =>
+      (Derivations.methodFor rest v).orElse (fun _ => if u = v then some cm else none)
+
+/-- Derived-variable reconstruction under `e`: every no-powdr-ID variable of `cs` is computed by
+    the method `ds` uses for it (`methodFor`, i.e. its last entry — duplicates are allowed, the
+    later one wins), reading only input (powdr-ID) columns. -/
+def ConstraintSystem.reconstructs (cs : ConstraintSystem p) (ds : Derivations p)
+    (e : Variable → ZMod p) : Prop :=
+  ∀ v ∈ cs.vars, v.powdrId? = none →
+    ∃ cm, Derivations.methodFor ds v = some cm ∧ (∀ x ∈ cm.vars, x.powdrId?.isSome) ∧ cm.eval e = e v
+
+/-- How the completeness witness `env'` of an output `out` is obtained from an assignment `env` of
+    the input `inp`, via derivations `ds`: every variable of `out` that carries a powdr ID is an
+    input column, present in `inp` with an unchanged value; every derived variable (no powdr ID) is
+    computed by a method in `ds` reading only input columns. This is exactly the data witness
+    generation needs to extend an input trace to an output trace. -/
+def ConstraintSystem.derivesWitness (out inp : ConstraintSystem p) (ds : Derivations p)
+    (env env' : Variable → ZMod p) : Prop :=
+  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ inp.vars ∧ env' v = env v) ∧
+  out.reconstructs ds env'
+
 /-- Like `implies`, but the obligation is only required for `self`'s **admissible** (real-trace)
-    assignments, and the produced witness is itself admissible. This is the *completeness*
-    direction of an optimization: the optimizer must reproduce every real trace, but may drop
-    spurious (non-trace) satisfying assignments. Delivering an admissible witness is what makes
-    `refines` transitive. -/
+    assignments, the produced witness is itself admissible, and — when `self`'s variables are all
+    genuine input columns — that witness additionally `derivesWitness`: it is reconstructible from
+    the input assignment via `ds`. This is the *completeness* direction of an optimization: it must
+    reproduce every real trace (dropping spurious satisfying assignments is fine) and say how
+    witness generation computes the columns it introduces. Delivering an admissible witness is what
+    makes `refines` transitive; the reconstruction is only demanded for all-input-column inputs
+    (the intended shape of a circuit fed to the optimizer — a column with no powdr ID cannot be
+    read from the input trace). -/
 def ConstraintSystem.impliesAdmissible (self other : ConstraintSystem p)
-    (busSemantics : BusSemantics p) : Prop :=
+    (busSemantics : BusSemantics p) (ds : Derivations p) : Prop :=
   ∀ env, self.admissible busSemantics env → self.satisfies busSemantics env →
     ∃ env', other.satisfies busSemantics env' ∧ other.admissible busSemantics env' ∧
-      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
+      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env' ∧
+      ((∀ v ∈ self.vars, v.powdrId?.isSome) → other.derivesWitness self ds env env')
 
-/-- Whether `self` is a valid **optimization** of `other` under a given bus semantics:
-    * **sound** — `self.implies other`: A satisfying assignment of `self` implies that there exists
-      a satisfying assignment of `other` with the same side effects.;
-    * **complete for admissible executions** — `other.impliesAdmissible self`: every *admissible*
-      (real-trace) satisfying assignment of `other` is reproduced by `self`. -/
-def ConstraintSystem.refines (self other : ConstraintSystem p) (busSemantics : BusSemantics p) :
-    Prop :=
-  self.implies other busSemantics ∧ other.impliesAdmissible self busSemantics
+/-- Whether `self` is a valid **optimization** of `other`, carrying the witness-reconstruction
+    data `ds`:
+    * **sound** — `self.implies other`: every satisfying assignment of `self` maps to one of
+      `other` with the same side effects;
+    * **complete for admissible executions** — `other.impliesAdmissible self ds`: every *admissible*
+      (real-trace) satisfying assignment of `other` is reproduced by `self`, with a witness that
+      `derivesWitness` via `ds`. -/
+def ConstraintSystem.refines (self other : ConstraintSystem p) (busSemantics : BusSemantics p)
+    (ds : Derivations p) : Prop :=
+  self.implies other busSemantics ∧ other.impliesAdmissible self busSemantics ds
 
 /-- Whether a constraint system stays within a degree bound. -/
 def ConstraintSystem.withinDegree (s : ConstraintSystem p) (b : DegreeBound) : Prop :=
@@ -191,11 +267,16 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
     The bus semantics is a *parameter*: quantifying over it (`∀ bs, optimizerMaintainsCorrectness
     bs opt`) recovers the "correct for every semantics" reading, while leaving it fixed lets a
     semantics-specific optimizer — one that bakes in bus knowledge sound only for its own
-    semantics, like the OpenVM optimizer — be an instance too. -/
+    semantics, like the OpenVM optimizer — be an instance too.
+
+    The optimizer additionally returns `Derivations`: `refines` demands that the completeness
+    witness be reconstructible from the input trace via them (`derivesWitness`), so witness
+    generation can fill the output's derived variables. -/
 def optimizerMaintainsCorrectness (busSemantics : BusSemantics p)
-    (optimizer : ConstraintSystem p → ConstraintSystem p) : Prop :=
+    (optimizer : ConstraintSystem p → ConstraintSystem p × Derivations p) : Prop :=
   (∀ constraintSystem : ConstraintSystem p,
-    ((optimizer constraintSystem).refines constraintSystem busSemantics) ∧
+    ((optimizer constraintSystem).1.refines constraintSystem busSemantics
+        (optimizer constraintSystem).2) ∧
     (constraintSystem.guaranteesInvariants busSemantics →
-      (optimizer constraintSystem).guaranteesInvariants busSemantics))
-  ∧ optimizerRespectsDegreeBound busSemantics optimizer
+      (optimizer constraintSystem).1.guaranteesInvariants busSemantics))
+  ∧ optimizerRespectsDegreeBound busSemantics (fun cs => (optimizer cs).1)

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -166,21 +166,19 @@ def Derivations.methodFor : Derivations p → Variable → Option (ComputationMe
       (Derivations.methodFor rest v).orElse (fun _ => if u = v then some cm else none)
 
 /-- Derived-variable reconstruction under `e`: every no-powdr-ID variable of `cs` is computed by
-    the method `ds` uses for it, reading only input (powdr-ID) columns. -/
+    the method `ds` uses for it, reading only input (powdr-ID) variables. -/
 def ConstraintSystem.reconstructs (cs : ConstraintSystem p) (ds : Derivations p)
     (e : Variable → ZMod p) : Prop :=
   ∀ v ∈ cs.vars, v.powdrId? = none →
     ∃ cm, Derivations.methodFor ds v = some cm ∧ (∀ x ∈ cm.vars, x.powdrId?.isSome) ∧ cm.eval e = e v
 
-/-- How the completeness witness `env'` of an output `out` is obtained from an assignment `env` of
-    the input `inp`, via derivations `ds`: every variable of `out` that carries a powdr ID is an
-    input column, present in `inp` with an unchanged value; every derived variable (no powdr ID) is
-    computed by a method in `ds` reading only input columns. This is exactly the data witness
-    generation needs to extend an input trace to an output trace. -/
-def ConstraintSystem.derivesWitness (out inp : ConstraintSystem p) (ds : Derivations p)
+/-- The `out` constraint system variable assignment `env'` can be completely derived from `inp`
+    constraint system assignment `env`: Either the variables are reused, or they are computed by
+    methods in `ds` reading only input variables. -/
+def ConstraintSystem.derivesWitnessFrom (out inp : ConstraintSystem p) (ds : Derivations p)
     (env env' : Variable → ZMod p) : Prop :=
-  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ inp.vars ∧ env' v = env v) ∧
-  out.reconstructs ds env'
+  out.reconstructs ds env' ∧
+  (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ inp.vars ∧ env' v = env v)
 
 --------- Constraint system implications ---------
 
@@ -218,28 +216,23 @@ def ConstraintSystem.implies (self other : ConstraintSystem p) (busSemantics : B
       self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
 
 /-- Like `implies`, but the obligation is only required for `self`'s **admissible** (real-trace)
-    assignments, the produced witness is itself admissible, and — when `self`'s variables are all
-    genuine input columns — that witness additionally `derivesWitness`: it is reconstructible from
-    the input assignment via `ds`. This is the *completeness* direction of an optimization: it must
-    reproduce every real trace (dropping spurious satisfying assignments is fine) and say how
-    witness generation computes the columns it introduces. Delivering an admissible witness is what
-    makes `refines` transitive; the reconstruction is only demanded for all-input-column inputs
-    (the intended shape of a circuit fed to the optimizer — a column with no powdr ID cannot be
-    read from the input trace). -/
+    assignments, the produced witness is itself admissible and it can be derived from a valid
+    witness for `self`.
+    This is the *completeness* direction of an optimization: the optimizer must reproduce every
+    real trace, but may drop spurious (non-trace) satisfying assignments. Delivering an admissible
+    witness is what makes `refines` transitive. -/
 def ConstraintSystem.impliesAdmissible (self other : ConstraintSystem p)
     (busSemantics : BusSemantics p) (ds : Derivations p) : Prop :=
   ∀ env, self.admissible busSemantics env → self.satisfies busSemantics env →
     ∃ env', other.satisfies busSemantics env' ∧ other.admissible busSemantics env' ∧
       self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env' ∧
-      ((∀ v ∈ self.vars, v.powdrId?.isSome) → other.derivesWitness self ds env env')
+      ((∀ v ∈ self.vars, v.powdrId?.isSome) → other.derivesWitnessFrom self ds env env')
 
-/-- Whether `self` is a valid **optimization** of `other`, carrying the witness-reconstruction
-    data `ds`:
-    * **sound** — `self.implies other`: every satisfying assignment of `self` maps to one of
-      `other` with the same side effects;
-    * **complete for admissible executions** — `other.impliesAdmissible self ds`: every *admissible*
-      (real-trace) satisfying assignment of `other` is reproduced by `self`, with a witness that
-      `derivesWitness` via `ds`. -/
+/-- Whether `self` is a valid **optimization** of `other` under a given bus semantics:
+    * **sound** — `self.implies other`: A satisfying assignment of `self` implies that there exists
+      a satisfying assignment of `other` with the same side effects.;
+    * **complete for admissible executions** — `other.impliesAdmissible self`: every *admissible*
+      (real-trace) satisfying assignment of `other` is reproduced by `self`. -/
 def ConstraintSystem.refines (self other : ConstraintSystem p) (busSemantics : BusSemantics p)
     (ds : Derivations p) : Prop :=
   self.implies other busSemantics ∧ other.impliesAdmissible self busSemantics ds

--- a/Leanr/Spec.lean
+++ b/Leanr/Spec.lean
@@ -274,8 +274,8 @@ def optimizerRespectsDegreeBound (busSemantics : BusSemantics p)
 def optimizerMaintainsCorrectness (busSemantics : BusSemantics p)
     (optimizer : ConstraintSystem p → ConstraintSystem p × Derivations p) : Prop :=
   (∀ constraintSystem : ConstraintSystem p,
-    ((optimizer constraintSystem).1.refines constraintSystem busSemantics
-        (optimizer constraintSystem).2) ∧
+    let (optimized, derivations) := optimizer constraintSystem
+    (optimized.refines constraintSystem busSemantics derivations) ∧
     (constraintSystem.guaranteesInvariants busSemantics →
-      (optimizer constraintSystem).1.guaranteesInvariants busSemantics))
+      optimized.guaranteesInvariants busSemantics))
   ∧ optimizerRespectsDegreeBound busSemantics (fun cs => (optimizer cs).1)

--- a/Leanr/Utils/Size.lean
+++ b/Leanr/Utils/Size.lean
@@ -32,13 +32,6 @@ variable {p : ℕ}
 
 /-! ## Collecting variables -/
 
-/-- All variable names occurring in an expression (with multiplicity / duplicates). -/
-def Expression.vars : Expression p → List Variable
-  | .const _ => []
-  | .var x => [x]
-  | .add a b => a.vars ++ b.vars
-  | .mul a b => a.vars ++ b.vars
-
 /-- All variable names occurring in a bus interaction (multiplicity and payload). -/
 def BusInteraction.vars (bi : BusInteraction (Expression p)) : List Variable :=
   bi.multiplicity.vars ++ bi.payload.flatMap Expression.vars

--- a/Main.lean
+++ b/Main.lean
@@ -115,7 +115,7 @@ def cmdRun (fileName : String) : IO Unit := do
   let t0 ← IO.monoMsNow
   -- IO.lazyPure sequences the pure optimizer run between the clock reads (the compiler is
   -- free to float a plain `let` across IO actions, which breaks the measurement).
-  let optimized ← IO.lazyPure (fun _ => openVmOptimizer busMap.toBusMap cs)
+  let optimized ← IO.lazyPure (fun _ => (openVmOptimizer busMap.toBusMap cs).1)
   let after ← IO.lazyPure (fun _ => statsOf optimized)
   let t1 ← IO.monoMsNow
   printStats (label := "before") (stats := before)
@@ -131,7 +131,7 @@ def cmdRun (fileName : String) : IO Unit := do
     diagnosing which variable classes the optimizer misses). -/
 def cmdVars (fileName : String) : IO Unit := do
   let (cs, busMap) ← parseFile fileName
-  let optimized ← IO.lazyPure (fun _ => openVmOptimizer busMap.toBusMap cs)
+  let optimized ← IO.lazyPure (fun _ => (openVmOptimizer busMap.toBusMap cs).1)
   let occurrences := optimized.algebraicConstraints.flatMap Expression.vars ++
     optimized.busInteractions.flatMap BusInteraction.vars
   let distinct := (occurrences.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList
@@ -141,7 +141,7 @@ def cmdVars (fileName : String) : IO Unit := do
 /-- Render the optimized system (for diagnosing residual constraints/interactions). -/
 def cmdRender (fileName : String) : IO Unit := do
   let (cs, busMap) ← parseFile fileName
-  let optimized ← IO.lazyPure (fun _ => openVmOptimizer busMap.toBusMap cs)
+  let optimized ← IO.lazyPure (fun _ => (openVmOptimizer busMap.toBusMap cs).1)
   IO.println (Leanr.Spec.Dsl.render optimized)
 
 def cmdPowdr (unoptFile : String) (optFile : String) : IO Unit := do
@@ -184,7 +184,7 @@ def circuitJson (cs : ConstraintSystem babyBear) : String :=
 def cmdReport (unoptFile optFile : String) : IO Unit := do
   let (cs, busMap) ← parseFile unoptFile
   let (csPowdr, _) ← parseFile optFile
-  let optimized := openVmOptimizer busMap.toBusMap cs
+  let optimized := (openVmOptimizer busMap.toBusMap cs).1
   IO.println ("{\"original\":" ++ circuitJson cs ++
     ",\"powdr\":" ++ circuitJson csPowdr ++
     ",\"leanr\":" ++ circuitJson optimized ++ "}")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Leanr is designed to have a small auditing surface. The audited files live direc
 [`Leanr/`](./Leanr); everything under [`Leanr/Implementation/`](./Leanr/Implementation) needs **no** audit — its correctness is guaranteed by
 the theorems below and. To audit
 Leanr, it should be sufficient to review:
-1. [`Leanr/Spec.lean`](./Leanr/Spec.lean): Defining the notion of circuit equivalence and optimizer correctness, including the `ComputationMethod`s (the extra `Derivations` output) by which witness generation computes the optimizer's newly-introduced (derived) variables from the input columns (`refines` / `derivesWitness`).
+1. [`Leanr/Spec.lean`](./Leanr/Spec.lean): Defining the notion of circuit equivalence and optimizer correctness.
 2. [`Leanr/OpenVmSemantics.lean`](./Leanr/OpenVmSemantics.lean): The OpenVM-specific semantics. These are needed for our OpenVM-specific optimizations. If you are instead interested in a different VM, you can skip this file, but must provide semantics for your VM in order to use Leanr.
 3. [`Leanr/MemoryBus.lean`](./Leanr/MemoryBus.lean): Utility used in the OpenVM semantics above (and likely useful for other VMs as well).
 4. The correctness theorems in [`Leanr/Optimizer.lean`](./Leanr/Optimizer.lean): `optimizerWithBusFacts_maintainsCorrectness` — the master statement that the optimizer maintains correctness for *any* proven bus facts — together with its two instances, `simpleOptimizer_maintainsCorrectness` (the fact-free optimizer) and `openVmOptimizer_maintainsCorrectness` (the `openVmOptimizer` the CLI actually runs). Audit the statements and check that the proofs are correct by running `lake build`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Leanr is designed to have a small auditing surface. The audited files live direc
 [`Leanr/`](./Leanr); everything under [`Leanr/Implementation/`](./Leanr/Implementation) needs **no** audit — its correctness is guaranteed by
 the theorems below and. To audit
 Leanr, it should be sufficient to review:
-1. [`Leanr/Spec.lean`](./Leanr/Spec.lean): Defining the notion of circuit equivalence and optimizer correctness.
+1. [`Leanr/Spec.lean`](./Leanr/Spec.lean): Defining the notion of circuit equivalence and optimizer correctness, including the `ComputationMethod`s (the extra `Derivations` output) by which witness generation computes the optimizer's newly-introduced (derived) variables from the input columns (`refines` / `derivesWitness`).
 2. [`Leanr/OpenVmSemantics.lean`](./Leanr/OpenVmSemantics.lean): The OpenVM-specific semantics. These are needed for our OpenVM-specific optimizations. If you are instead interested in a different VM, you can skip this file, but must provide semantics for your VM in order to use Leanr.
 3. [`Leanr/MemoryBus.lean`](./Leanr/MemoryBus.lean): Utility used in the OpenVM semantics above (and likely useful for other VMs as well).
 4. The correctness theorems in [`Leanr/Optimizer.lean`](./Leanr/Optimizer.lean): `optimizerWithBusFacts_maintainsCorrectness` — the master statement that the optimizer maintains correctness for *any* proven bus facts — together with its two instances, `simpleOptimizer_maintainsCorrectness` (the fact-free optimizer) and `openVmOptimizer_maintainsCorrectness` (the `openVmOptimizer` the CLI actually runs). Audit the statements and check that the proofs are correct by running `lake build`.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -26,7 +26,20 @@ Side effects are the messages on **stateful** buses, compared up to **net multip
 message (`≈`) — so an identical-payload send/receive pair cancels. `admissible` is an abstract
 per-VM predicate (`BusSemantics.admissible`) over the active stateful messages; it is where the
 "this is a real trace" assumption lives (see [Bus knowledge](#bus-knowledge) and the README's
-assumptions). `optimizerMaintainsCorrectness bs opt` bundles `refines`, preservation of
+assumptions).
+
+**Derived variables.** The optimizer returns not just a circuit but a `Derivations` list — a
+`ComputationMethod` (powdr's `Constant`/`QuotientOrZero`/`IfEqZero`, with an `eval`) for each
+variable it introduces. The completeness direction (folded into `refines` / `impliesAdmissible`) is
+strengthened accordingly: the reproduced witness must **`derivesWitness`** — every variable of the
+output that carries a powdr ID is an input column present in the input with an unchanged value, and
+every no-ID (derived) variable is computed by the method `Derivations` lists for it (`methodFor`,
+its last entry — duplicates are allowed, the later one wins) reading only input columns. This is
+exactly what lets witness generation extend an input trace to an output trace. (The requirement is
+only demanded when the input's columns all carry powdr IDs — the intended shape of an exported
+circuit; a variable with no powdr ID cannot be read from the input trace.)
+
+`optimizerMaintainsCorrectness bs opt` bundles `refines`, preservation of
 `guaranteesInvariants`, and staying within the VM's degree bound — for a *given* bus semantics
 `bs` (quantify over `bs` for the "correct for every semantics" reading; fixing it lets a
 semantics-specific optimizer be an instance).
@@ -36,9 +49,10 @@ semantics-specific optimizer be an instance).
 A **`VerifiedPass`** maps a system to a new one *bundled with a `PassCorrect` proof* (`refines` +
 invariant preservation) — so a pass cannot be written without discharging its obligations.
 
-- `andThen` composes passes (correctness by `refines_trans`); `iterateToFixpoint` runs a pass to a
-  fixpoint, proven to terminate on the well-founded lexicographic size key (see the pipeline
-  section); the top-level `*_maintainsCorrectness` theorems are just projections.
+- `andThen` composes passes (correctness by composing the per-pass `PassCorrect` proofs, with
+  derivations concatenating); `iterateToFixpoint` runs a pass to a fixpoint, proven to terminate on
+  the well-founded lexicographic size key (see the pipeline section); the top-level
+  `*_maintainsCorrectness` theorems are just projections.
 - `guardDegree` wraps each pass to fall back to its input if the output would exceed the degree
   bound — degree safety is compositional, with zero per-pass proof burden.
 - `VerifiedPassW` is a pass that may additionally consult proven `BusFacts` (below).


### PR DESCRIPTION
Adds **derived columns** to the optimizer: a way to say *how witness generation computes the
columns the optimizer introduces*, so a verified optimization that adds columns (like the
re-encoder) can be used end-to-end. Mirrors powdr's `ComputationMethod<T, E>`.

## What to review — the audited spec (`Leanr/Spec.lean`)

- **`ComputationMethod`** — `const` / `quotientOrZero` / `ifEqZero`, mirroring powdr's
  `Constant` / `QuotientOrZero` / `IfEqZero`. `eval` matches powdr's `evaluate_computation_method`
  (`quotientOrZero num den` is `num / den`, or `0` when `den = 0`; needs no primality since `ZMod`
  has `Inv` for all `p`).
- **`Derivations := List (Variable × ComputationMethod)`** — the optimizer's extra output. The
  optimizer type is now `ConstraintSystem → ConstraintSystem × Derivations`.
- **`reconstructs` / `derivesWitness` / `impliesAdmissibleD` / `refinesD`** strengthen the
  completeness direction. The reproduced witness `env'` must `derivesWitness`:
  - every output variable **with** a powdr ID is an input column, present in the input with an
    **unchanged value**;
  - every output variable **without** a powdr ID is computed by a `ComputationMethod` in
    `Derivations` that reads **only input columns**.
- **`optimizerMaintainsCorrectness`** now bundles `refinesD` (+ invariant preservation + degree
  bound), threading the returned `Derivations`.

The audited theorem statements in `Leanr/Optimizer.lean` are unchanged in shape
(`optimizerWithBusFacts_maintainsCorrectness` and its `simpleOptimizer` / `openVmOptimizer`
instances) — they just instantiate the strengthened `optimizerMaintainsCorrectness`.

## One substantive design decision — input-columns-only

`reconstructs` requires each method to read **only genuine input (powdr-ID) columns**, and the
obligation is demanded only when the input circuit's columns all carry powdr IDs (the intended
shape of an exported circuit — a column with no powdr ID cannot be read from the input trace).
This is simpler than a general "read previously-derived columns in a valid order" form and
composes cleanly (the threading base case `cs.reconstructs [] env` holds vacuously on an
all-input-column input). Flagging it since it is the one place the spec makes a real choice.

**`ComputationMethod` was sufficient** — powdr's enum did not need extending.

## Implementation (no audit surface)

- Every existing pass threads `Derivations`; passes that add no columns ship `[]`. The framework's
  `PassCorrect` now carries the reconstruction obligation, so a pass **cannot** introduce a column
  without also saying how to compute it.
- The re-encoder emits, for each fresh boolean bit, a decision-tree `ComputationMethod` (`ifEqZero`
  over the group's joint values) that inverts the interpolation, and proves it matches the forward
  witness by construction.
- `reencodeOut_vars_subset` proves the output-variable frame by construction, replacing two
  `cs.vars` scans that had regressed runtime on the large (~5k-variable) benchmark cases (one
  cleanup cycle on `apc_005`: 120s+ → 63s).

## Proof integrity

- `lake build` green; no `sorry` / `admit` / `native_decide` / new axioms.
- `#print axioms` on both master theorems shows only `[propext, Classical.choice, Quot.sound]`.
- The optimizer's circuit transformation is behavior-preserving vs. the pre-derived-columns
  baseline (verified per case on the small cases, e.g. `apc_001` 134→42, `apc_003` 468→133); the
  feature only adds the `Derivations` output. Full-benchmark aggregate is being confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaV2Btmhk3brMJkusD2g2J

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaV2Btmhk3brMJkusD2g2J)_