### PR TITLE
Serialize optimizer derivations into derived_columns

### DIFF
--- a/Leanr/Ffi.lean
+++ b/Leanr/Ffi.lean
@@ -30,7 +30,7 @@ def leanrOptimizeJson (input : String) : String :=
   match parseJsonSystem (p := babyBear) input with
   | .error err => "{\"error\":" ++ escapeJson err ++ "}"
   | .ok (cs, busMap) =>
-    -- `.1` is the optimized circuit; `.2` are the `Derivations` for witness generation, not yet
-    -- threaded through the JSON serialization (would need a matching powdr-side format).
-    let optimized := (openVmOptimizer busMap.toBusMap cs).1
-    Leanr.Serialize.serializeSystem optimized
+    -- `.1` is the optimized circuit; `.2` are the `Derivations` (optimizer-introduced witness
+    -- columns paired with how powdr's witgen computes each), serialized under `derived_columns`.
+    let (optimized, ds) := openVmOptimizer busMap.toBusMap cs
+    Leanr.Serialize.serializeSystem optimized ds

--- a/Leanr/Implementation/JsonSerializer.lean
+++ b/Leanr/Implementation/JsonSerializer.lean
@@ -12,8 +12,9 @@ Turns a `ConstraintSystem p` back into the JSON that powdr's serde deserializes 
 
 Output schema (matched empirically against powdr's serde):
 - top level: `{"constraints":[expr...], "bus_interactions":[{"id","mult","args"}...],
-  "derived_columns":[]}` — a bare `SymbolicMachine` (`derived_columns` has no serde default,
-  so it must be present).
+  "derived_columns":[[is_new, "name@id", method]...]}` — a `SymbolicMachine` (`derived_columns`
+  has no serde default, so it must be present; each entry is a `DerivedVariable` 3-tuple and
+  `method` is an externally-tagged `ComputationMethod`).
 - an expression is:
   - a constant  → a JSON integer (powdr's `BabyBearField` serializes as a canonical `u32`);
   - a variable  → the string `"name@id"` (powdr's `AlgebraicReference` manual serde);
@@ -43,16 +44,20 @@ variable {p : ℕ}
 
 namespace Leanr.Serialize
 
-/-- Distinct variables occurring anywhere in the system. -/
-def distinctVars (cs : ConstraintSystem p) : List Variable :=
+/-- Distinct variables occurring anywhere in the system and (optionally) its derivations. The
+    derived columns are introduced witness variables plus whatever variables their computation
+    methods read; including them ensures each gets a stable fresh id, shared between its
+    constraint occurrences and its derived-column entry. -/
+def distinctVars (cs : ConstraintSystem p) (ds : Derivations p := []) : List Variable :=
   let occ := cs.algebraicConstraints.flatMap Expression.vars ++
-    cs.busInteractions.flatMap BusInteraction.vars
+    cs.busInteractions.flatMap BusInteraction.vars ++
+    ds.flatMap (fun (v, cm) => v :: cm.vars)
   (occ.foldl (init := (∅ : Std.HashSet Variable)) (·.insert ·)).toList
 
 /-- A renaming that assigns every fresh (id-less) variable a fresh id, taken strictly above the
     maximum id already present. Variables that already carry an id are absent from the map. -/
-def freshRenaming (cs : ConstraintSystem p) : Std.HashMap Variable Nat :=
-  let vars := distinctVars cs
+def freshRenaming (cs : ConstraintSystem p) (ds : Derivations p := []) : Std.HashMap Variable Nat :=
+  let vars := distinctVars cs ds
   let maxId := vars.foldl (fun m x => match x.powdrId? with
     | some i => Nat.max m i
     | none => m) 0
@@ -77,6 +82,30 @@ def serializeExpr (m : Std.HashMap Variable Nat) : Expression p → Json
   | .add a b => Json.arr #[serializeExpr m a, Json.str "+", serializeExpr m b]
   | .mul a b => Json.arr #[serializeExpr m a, Json.str "*", serializeExpr m b]
 
+/-- Serialize a computation method to powdr's externally-tagged `ComputationMethod` enum JSON
+    (derived `serde` on `enum ComputationMethod<T, E>` in
+    `constraint-solver/src/constraint_system.rs`):
+    `const c → {"Constant": c}`, `quotientOrZero num den → {"QuotientOrZero": [num, den]}`,
+    `ifEqZero cond thenM elseM → {"IfEqZero": [cond, thenM, elseM]}`. -/
+def serializeComputationMethod (m : Std.HashMap Variable Nat) :
+    ComputationMethod p → Json
+  | .const c => Json.mkObj [("Constant", constJson c)]
+  | .quotientOrZero num den =>
+      Json.mkObj [("QuotientOrZero", Json.arr #[serializeExpr m num, serializeExpr m den])]
+  | .ifEqZero cond thenM elseM =>
+      Json.mkObj [("IfEqZero", Json.arr #[
+        serializeExpr m cond,
+        serializeComputationMethod m thenM,
+        serializeComputationMethod m elseM])]
+
+/-- Serialize the optimizer's derivations to powdr's `derived_columns` JSON: a list of
+    `DerivedVariable` 3-tuples `[is_new, variable, computation_method]` (manual `serde` in
+    `constraint-solver/src/constraint_system.rs`). Every entry is an optimizer-introduced column,
+    so `is_new` is always `true`. -/
+def serializeDerivations (m : Std.HashMap Variable Nat) (ds : Derivations p) : Json :=
+  Json.arr (ds.map (fun (v, cm) =>
+    Json.arr #[Json.bool true, Json.str (refString m v), serializeComputationMethod m cm])).toArray
+
 /-- Serialize a bus interaction to a `{id, mult, args}` object. -/
 def serializeBus (m : Std.HashMap Variable Nat) (bi : BusInteraction (Expression p)) : Json :=
   Json.mkObj [
@@ -85,13 +114,15 @@ def serializeBus (m : Std.HashMap Variable Nat) (bi : BusInteraction (Expression
     ("args", Json.arr (bi.payload.map (serializeExpr m)).toArray)
   ]
 
-/-- Serialize a whole constraint system as a powdr `SymbolicMachine` JSON string. -/
-def serializeSystem (cs : ConstraintSystem p) : String :=
-  let m := freshRenaming cs
+/-- Serialize a whole constraint system, together with the optimizer's derivations, as a powdr
+    `SymbolicMachine` JSON string. Introduced (id-less) columns get a fresh id via `freshRenaming`
+    that is shared between their constraint occurrences and their `derived_columns` entry. -/
+def serializeSystem (cs : ConstraintSystem p) (ds : Derivations p := []) : String :=
+  let m := freshRenaming cs ds
   let machine := Json.mkObj [
     ("constraints", Json.arr (cs.algebraicConstraints.map (serializeExpr m)).toArray),
     ("bus_interactions", Json.arr (cs.busInteractions.map (serializeBus m)).toArray),
-    ("derived_columns", Json.arr #[])
+    ("derived_columns", serializeDerivations m ds)
   ]
   machine.compress
 


### PR DESCRIPTION
## What

The OpenVM optimizer returns `ConstraintSystem × Derivations`, where the second component describes optimizer-introduced witness columns (each `is_new`, `powdrId? = none`) and how powdr's witgen should compute them. Until now `Ffi.lean` dropped `.2` and `JsonSerializer.lean` hardcoded `"derived_columns": []`. This PR threads the derivations through the FFI into the powdr `SymbolicMachine` JSON export.

## Changes (implementation layer only — audited surface untouched)

- `JsonSerializer.serializeComputationMethod` — emits powdr's externally-tagged `ComputationMethod` enum (derived serde in `constraint-solver/src/constraint_system.rs`): `const c → {"Constant": c}`, `quotientOrZero num den → {"QuotientOrZero": [num, den]}`, `ifEqZero cond then else → {"IfEqZero": [cond, then, else]}` (recursive).
- `JsonSerializer.serializeDerivations` — emits each `DerivedVariable` as the 3-tuple `[is_new, "name@id", method]` (manual serde on `DerivedVariable`), with `is_new = true` for every entry.
- `JsonSerializer.serializeSystem` — now takes the derivations and emits them under `"derived_columns"`. `freshRenaming`/`distinctVars` also range over derivation variables so an introduced column receives the *same* fresh `@id` in its constraint occurrences and its derived-column entry.
- `Ffi.leanrOptimizeJson` — captures `(optimized, ds)` and serializes both.

## Verification

`lake build` green, no new sorries/axioms. Sanity-checked emission on `apc_002_pc0x4ecc48.json.gz`: 5 derivations, e.g.

```
[true,"rnc36_44_3_0@106",{"IfEqZero":[["flags__0_0@23","+",2013265920],{"IfEqZero":[...]}]}]
```

Consumed by the companion powdr PR #3784, where witgen fills these columns and the Fibonacci guest proof verifies end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)