### PR TITLE
Fix #64: derived-column methods no longer reference removed columns (unwire reencode)

### DIFF
--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -61,7 +61,22 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen tautoBusDropPass.withFacts.guardDegree
     |>.andThen busUnifyPass.guardDegree
     |>.andThen disconnectedComponentPass.withFacts.guardDegree
-    |>.andThen reencodePass.withFacts.guardDegree
+    -- NOTE: `reencodePass` is intentionally NOT wired into the shipped pipeline. It is the only
+    -- pass that emits `Derivations`, and every derivation it emits (a fresh bit's `bitCM`) reads
+    -- exactly the group columns `xs` that the pass substitutes OUT of the circuit
+    -- (`bitCM_vars : ∀ v ∈ (bitCM …).vars, v ∈ xs`). powdr's witness generator indexes derivation
+    -- methods by presence in the optimized machine's `main_columns` (constraints + bus
+    -- interactions) and panics on any removed column (see issue #64,
+    -- `evaluate_computation_method` in openvm cpu/mod.rs). The bits are irreducibly circular: the
+    -- only recorded substitution for `xs` is `xs → interp(bits)`, so composing a bit's method over
+    -- surviving columns yields the self-referential tautology `bit_j := bit_j` (evaluated against
+    -- the uninitialized bits at witgen time) — it cannot recover the real witness. The group value
+    -- lived only in the removed columns (powdr filled them from the dummy instruction trace), so no
+    -- surviving column determines the bits. Re-encoding is therefore incompatible with powdr's
+    -- current witgen contract; the pass and its correctness proof are kept in `Reencode.lean` (and
+    -- still build-checked via the import) for a future powdr-side fix, but not shipped.
+    -- (Removing it makes the optimizer emit zero derivations, so witgen never references a removed
+    -- column.)
 
 theorem cleanupCycle_respectsDeg : RespectsDeg (cleanupCycle (p := p)) := by
   repeat' apply VerifiedPassW.andThen_respectsDeg


### PR DESCRIPTION
## Problem (issue #64)

`openVmOptimizer` returns `(ConstraintSystem × Derivations)`, where `Derivations` are witgen hints for optimizer-introduced columns. The bug: those `ComputationMethod`s reference input columns the optimizer **removed** from the final circuit.

powdr's witgen (`evaluate_computation_method`, `openvm/.../cpu/mod.rs:231`) builds its column index from the optimized machine's `main_columns()` (constraints + bus interactions only) and does a panic-on-missing lookup `row_slice[apc_poly_id_to_index[&column_ref.id]]`. Derived columns are filled in list order after the surviving columns, so a method may reference surviving columns or earlier-in-list derived columns — never removed ones. Any reencode-firing circuit therefore panics witgen. It went unnoticed because the Fibonacci e2e guest produces 0 derived columns.

## Root cause and why it is irreducible

`reencodePass` is the **only** pass that emits derivations (every other pass emits `[]` via `PassCorrect.ofEnvEq`/`refl`). It eliminates a group of columns `xs` by substituting `xs → interp(bits)` over fresh boolean bits and drops the group-internal constraints. Each bit's derivation `bitCM` reads **exactly** the group columns `xs` (proven: `bitCM_vars : ∀ v ∈ (bitCM …).vars, v ∈ xs`) — the exact columns being removed.

The maintainer's "compose recorded substitutions until only surviving columns remain" approach **cannot** fix these. The only recorded substitution for a removed group column is `x → interp(bits)`, so composing `bit_j := bitCM_j(xs)` with `xs = interp(bits)` gives `bit_j := bitCM_j(interp(bits))`. This references only the surviving `bits`, so it *terminates* — but it is a **self-referential tautology**: `bitCM` finds the pattern `aβ` with `interp(aβ) = interp(bits)`, whose solution is `aβ = bits`, so `bit_j := bits[j] = b_j`. At witgen time the bits start at 0, so the composed method reads uninitialized bits and computes garbage (always the all-zero pattern), never recovering the real witness.

Deeper reason: the bits encode *which valid group-combo is active*; that information lived **only** in the removed group columns (powdr filled them from the dummy instruction trace). After removal, that data is discarded and no surviving column determines the bits — `{group, bits}` form a mutually-determining SCC bootstrapped by nothing at witgen time. No ordering of derived columns breaks the cycle; retaining a strict subset of a one-hot group does not determine the combo; retaining the whole group is strictly *worse* for the variable metric than not re-encoding. **Re-encoding is incompatible with powdr's current witgen contract.**

Concrete cycle (reth_op): bit `rnc1944_1670_34_0@5833` appears in surviving constraints as `1 − bit` (the interpolation that replaced flags `830`/`831`) plus booleanity `bit·(bit−1)`; the flags `830`/`831` appear nowhere in the final circuit, yet the bit's `bitCM` reads them.

## Fix

Stop wiring `reencodePass` into the shipped `cleanupCycle` (implementation layer only). The pass and its full correctness proof stay in `Reencode.lean` (still build-checked via the import, documenting the sound-but-unwitgennable transform for a future powdr-side fix). With it removed the optimizer emits **zero** derivations, so witgen never references a removed column.

- No audited surface changed (`Spec.lean`, `Optimizer.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean` untouched).
- `lake build` fully green; no `sorry`/`admit`/new `axiom`.
- `#print axioms leanrOptimizeJson` = `[propext, Classical.choice, Quot.sound]`.
- No audited theorem weakened or made vacuous: `optimizerWithBusFacts_correct` / `openVmOptimizer_maintainsCorrectness` still prove `refines` for the (smaller) pipeline; the derivation clause was already discharged with `ds = []` whenever the input columns all carry powdr IDs, which is exactly the situation now.

I deliberately did **not** strengthen the audited `reconstructs`/`derivesWitnessFrom` (the "surviving-columns" property). That change forces compose-on-removal semantics through `PassCorrect.andThen`/`ofEnvEq`/`refl` for arbitrary threaded derivations — it breaks *every* pass's proof (even the trivial `ofEnvEq` ones), a re-architecture with real risk of not closing cleanly. Peer-reviewed and confirmed. See "Follow-up" below.

## Removed-reference counts (before → after)

| Fixture | derived columns | removed-ref occurrences | distinct removed ids |
|---|---|---|---|
| reth_op | 1 → **0** | 6 → **0** | 2 → **0** |
| apc_002 | 5 → **0** | 1372 → **0** | 11 → **0** |

(apc_005/apc_044 had ~200k such occurrences per #64; all become 0.)

## Verification

- **Analytic:** ran the optimizer on `apc_reth_op_bug.json` and `apc_002…json.gz`; every emitted derivation's every referenced id is checked against the final circuit's `main_columns` (constraints + bus). Result: 0 derivations → 0 removed refs on both.
- **Real witgen (no powdr source changes):** rebuilt the powdr FFI against this branch (`LEANR_DIR=<worktree>`, `POWDR_USE_LEAN_OPTIMIZER=1`) and ran `test_optimize_reth_op` through the real `optimize()` → Lean FFI → serde path. Output: reth_op `derived_columns` **1 → 0**, `main_columns` 549 → 579 (matches leanr's own serializer). With 0 derived columns, `evaluate_computation_method`'s panic site (the loop over `derived_columns`) is unreachable — no lookup of the missing ids 830/831. (Full guest-driven trace generation for reth_op needs the reth guest + inputs, which is not reconstructable here; the panic is structurally eliminated by the empty `columns_to_compute`.)

## Effectiveness impact (honest)

Removing reencode costs its variable savings where it fired: e.g. apc_002 goes 49 → 74 distinct variables (2.20× → 1.46×); apc_001 is unchanged (reencode contributed nothing there). This is a real regression on the size metric — but any reencode-firing circuit currently *panics* powdr witgen, so that "effectiveness" was unusable for real trace generation. Correctness before paper size.

## Follow-up (not in this PR)

To *recover* reencode's savings while staying witgen-correct would require a powdr-side change (e.g. teach witgen to fill re-encoded bits from the dummy instruction trace, or index removed source columns), or an audited durable guarantee (an additive theorem that the optimizer's emitted derivations reference only final-circuit columns — provable once no pass emits circular derivations, but requiring an `EmitsNoDerivs`-style thread through `VerifiedPassW`/`iterateToFixpoint`). Recommended as separate work.

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)