### PR TITLE
Optimizer runtime: profile-guided speedups (effectiveness unchanged)

### DIFF
--- a/Leanr/Implementation/OptimizerPasses/BusUnify.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusUnify.lean
@@ -255,10 +255,13 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
     let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
     -- keep only equalities over existing columns, so the pass introduces no new variable
-    -- (the real slot equalities are built from `cs`'s payloads, so none are dropped)
+    -- (the real slot equalities are built from `cs`'s payloads, so none are dropped).
+    -- `csVars` is bound once here rather than recomputed for every variable of every candidate
+    -- (`cs.vars` rebuilds the whole occurrence list); the `let` zeta-reduces in the proof below.
+    let csVars := cs.vars
     let new := eqs.filter
       (fun c => !c.normalize.fold.isConstZero && !cs.algebraicConstraints.contains c
-        && c.vars.all (fun z => decide (z ∈ cs.vars)))
+        && c.vars.all (fun z => decide (z ∈ csVars)))
     if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else
       ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],

--- a/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainBatch.lean
@@ -176,46 +176,52 @@ def survivesAllM (bs : BusSemantics p) (es : List (Expression p))
   es.all (fun e => decide (e.eval (envOf a) = 0)) &&
     bis.all (fun bi => interactionSurvives bs bi a)
 
-/-- The checked certificate: every surviving assignment gives `x = c`. -/
-def checkForcedM (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
-    (es : List (Expression p)) (bis : List (BusInteraction (Expression p)))
-    (x : Variable) (c : ZMod p) : Bool :=
-  (assignments doms).all
-    (fun a => !survivesAllM bs es bis a || decide (envOf a x = c))
-
-/-- Candidate search (proof-free; `checkForcedM` re-verifies): all variables on which the
-    surviving assignments agree, with the agreed value. -/
-def pickForcedM (bs : BusSemantics p) (doms : List (Variable × List (ZMod p)))
-    (es : List (Expression p)) (bis : List (BusInteraction (Expression p))) :
-    List (Variable × ZMod p) :=
-  match (assignments doms).filter (survivesAllM bs es bis) with
-  | [] => (doms.map Prod.fst).map (fun x => (x, 0))
-  | a₀ :: survivors =>
-    (doms.map Prod.fst).filterMap (fun x =>
-      if survivors.all (fun a => decide (envOf a x = envOf a₀ x)) then some (x, envOf a₀ x)
-      else none)
-
-/-- The constraints of the system whose variables all lie in `xs`. -/
+/-- The constraints of the system whose variables all lie in `xs`. Uses the allocation-free
+    `Expression.varsIn` (equivalent to `c.vars.all (· ∈ xs)`) so the per-target covered-item scan
+    does not rebuild every constraint's variable list. -/
 def coveredCs (cs : ConstraintSystem p) (xs : List Variable) : List (Expression p) :=
-  cs.algebraicConstraints.filter (fun c => c.vars.all (fun v => xs.contains v))
+  cs.algebraicConstraints.filter (fun c => c.varsIn xs)
 
-/-- The interactions of the system whose variables all lie in `xs`. -/
+/-- The interactions of the system whose variables all lie in `xs` (allocation-free, as `coveredCs`). -/
 def coveredBis (cs : ConstraintSystem p) (xs : List Variable) :
     List (BusInteraction (Expression p)) :=
-  cs.busInteractions.filter (fun bi => bi.vars.all (fun v => xs.contains v))
+  cs.busInteractions.filter (fun bi => bi.varsIn xs)
 
-theorem checkForcedM_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
+/-- Work cap for one joint enumeration: box size × number of covered targets. -/
+def maxEnumWork : Nat := 524288
+
+/-- Candidate forced values read off a **precomputed** survivor list (the enumerated assignments
+    that satisfy every covered constraint/obligation): the variables on which all survivors agree,
+    with the agreed value; when there are no survivors, every domain variable is (vacuously) forced
+    to `0`. Taking the survivor list as input (rather than recomputing it) is what lets `forcedOver`
+    enumerate + filter the box **once** per target rather than once per candidate variable. -/
+def forcedFromSurvivors (doms : List (Variable × List (ZMod p)))
+    (survivors : List (List (Variable × ZMod p))) : List (Variable × ZMod p) :=
+  match survivors with
+  | [] => (doms.map Prod.fst).map (fun x => (x, 0))
+  | a₀ :: rest =>
+    (doms.map Prod.fst).filterMap (fun x =>
+      if rest.all (fun a => decide (envOf a x = envOf a₀ x)) then some (x, envOf a₀ x) else none)
+
+/-- Soundness of the survivor-based certificate: if every surviving assignment (an enumerated
+    assignment that passes all covered constraints/obligations) assigns `c` to `x`, then `x = c` is
+    entailed. The restriction of a satisfying `env` to the domains is an enumerated assignment that
+    survives, so it is one of the `survivors`; the certificate ranges only over the (precomputed)
+    survivors, so `forcedOver` does not re-enumerate per candidate. -/
+theorem forcedFromSurvivors_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
     (T : DomainTable p cs bs) (xs : List Variable) (doms : List (Variable × List (ZMod p)))
-    (hdoms : T.doms xs = some doms) (x : Variable) (c : ZMod p)
-    (hx : x ∈ doms.map Prod.fst)
-    (hchk : checkForcedM bs doms (coveredCs cs xs) (coveredBis cs xs) x c = true)
+    (hdoms : T.doms xs = some doms)
+    (es : List (Expression p)) (bis : List (BusInteraction (Expression p)))
+    (hes : es = coveredCs cs xs) (hbis : bis = coveredBis cs xs)
+    (x : Variable) (c : ZMod p) (hx : x ∈ doms.map Prod.fst)
+    (hforced : ((assignments doms).filter (survivesAllM bs es bis)).all
+        (fun a => decide (envOf a x = c)) = true)
     (env : Variable → ZMod p) (hsat : cs.satisfies bs env) : env x = c := by
+  subst hes; subst hbis
   have hkeys : doms.map Prod.fst = xs := T.doms_fst xs doms hdoms
-  -- the restriction of `env` to the domains is an enumerated assignment
   have hmem : doms.map (fun yd => (yd.1, env yd.1)) ∈ assignments doms :=
     mem_assignments doms env (T.doms_sound xs doms hdoms env hsat)
   set a₀ := doms.map (fun yd => (yd.1, env yd.1)) with ha₀
-  -- it survives every covered constraint and obligation
   have hsurv : survivesAllM bs (coveredCs cs xs) (coveredBis cs xs) a₀ = true := by
     unfold survivesAllM
     rw [Bool.and_eq_true]
@@ -226,8 +232,7 @@ theorem checkForcedM_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
       obtain ⟨hein, hall⟩ := hemem
       have hevars : ∀ v ∈ e.vars, v ∈ doms.map Prod.fst := by
         rw [hkeys]
-        intro v hv
-        exact List.contains_iff_mem.mp (List.all_eq_true.mp hall v hv)
+        exact Expression.varsIn_sound xs e hall
       have : e.eval (envOf a₀) = e.eval env :=
         Expression.eval_congr e _ _ (fun y hy => envOf_map doms env y (hevars y hy))
       rw [decide_eq_true_iff, this]
@@ -238,8 +243,7 @@ theorem checkForcedM_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
       obtain ⟨hbiin, hbiall⟩ := hbimem
       have hbivars : ∀ v ∈ bi.vars, v ∈ doms.map Prod.fst := by
         rw [hkeys]
-        intro v hv
-        exact List.contains_iff_mem.mp (List.all_eq_true.mp hbiall v hv)
+        exact BusInteraction.varsIn_sound xs bi hbiall
       have heval : bi.eval (envOf a₀) = bi.eval env :=
         BusInteraction.eval_congr bi _ _ (fun y hy => envOf_map doms env y (hbivars y hy))
       unfold interactionSurvives
@@ -247,18 +251,11 @@ theorem checkForcedM_sound {cs : ConstraintSystem p} {bs : BusSemantics p}
       by_cases hm : (bi.eval env).multiplicity = 0
       · simp [hm]
       · simp [hm, hsat.2 bi hbiin hm]
-  -- consume the certificate at the restriction
-  have hcert := List.all_eq_true.mp hchk a₀ hmem
-  rcases (Bool.or_eq_true _ _).mp hcert with hbad | hgood
-  · rw [Bool.not_eq_true'] at hbad
-    rw [hsurv] at hbad
-    exact absurd hbad (by simp)
-  · have hxc := of_decide_eq_true hgood
-    rw [envOf_map doms env _ hx] at hxc
-    exact hxc
-
-/-- Work cap for one joint enumeration: box size × number of covered targets. -/
-def maxEnumWork : Nat := 524288
+  have ha0mem : a₀ ∈ (assignments doms).filter
+      (survivesAllM bs (coveredCs cs xs) (coveredBis cs xs)) := List.mem_filter.2 ⟨hmem, hsurv⟩
+  have hxc := of_decide_eq_true (List.all_eq_true.mp hforced a₀ ha0mem)
+  rw [envOf_map doms env _ hx] at hxc
+  exact hxc
 
 /-- All checked forced constants over the variable set `xs` (the vars of one target
     constraint or interaction): enumerate the domain box once against everything the set
@@ -278,11 +275,15 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable 
       let informative := !es.isEmpty ||
         bis.any (fun bi => bi.payload.any (fun e => !(e.isVar || e.constValue?.isSome)))
       if informative && boxSize * (es.length + bis.length) ≤ maxEnumWork then
-        (pickForcedM bs doms es bis).filterMap (fun xc =>
+        -- Enumerate the box and filter to survivors **once**, then read off each candidate and
+        -- re-check it against that survivor list — rather than re-enumerating the whole box once
+        -- per candidate variable.
+        let survivors := (assignments doms).filter (survivesAllM bs es bis)
+        (forcedFromSurvivors doms survivors).filterMap (fun xc =>
           if hx : xc.1 ∈ doms.map Prod.fst then
-            if hchk : checkForcedM bs doms es bis xc.1 xc.2 = true then
+            if hchk : survivors.all (fun a => decide (envOf a xc.1 = xc.2)) = true then
               some ⟨xc.1, xc.2, fun env hsat =>
-                checkForcedM_sound T xs doms hdoms xc.1 xc.2 hx hchk env hsat⟩
+                forcedFromSurvivors_sound T xs doms hdoms es bis rfl rfl xc.1 xc.2 hx hchk env hsat⟩
             else none
           else none)
       else []

--- a/Leanr/Implementation/OptimizerPasses/DomainProp.lean
+++ b/Leanr/Implementation/OptimizerPasses/DomainProp.lean
@@ -68,6 +68,58 @@ theorem BusInteraction.eval_congr (bi : BusInteraction (Expression p))
         exact Or.inr ⟨e, he, hx⟩))
   simp only [BusInteraction.eval, hmult, hpay]
 
+/-! ## Allocation-free "all variables lie in a set" checks
+
+`Expression.vars` materializes a fresh list on every call; predicates like "are all of `c`'s
+variables in `xs`?" that are probed once *per target* (the covered-item scans in `DomainBatch`,
+the group scans in `Reencode`) then rebuild that list for every (target, item) pair — an
+allocation storm on large machines. `Expression.varsIn` / `BusInteraction.varsIn` decide the same
+predicate by recursion, allocating nothing. Their soundness (`… = true → every variable is in
+`xs`) is all the enumeration proofs consume. -/
+
+/-- Do all the expression's variables lie in `xs`? (No allocation — recurses over the tree.) -/
+def Expression.varsIn (xs : List Variable) : Expression p → Bool
+  | .const _ => true
+  | .var y => xs.contains y
+  | .add a b => a.varsIn xs && b.varsIn xs
+  | .mul a b => a.varsIn xs && b.varsIn xs
+
+theorem Expression.varsIn_sound (xs : List Variable) (e : Expression p)
+    (h : e.varsIn xs = true) : ∀ v ∈ e.vars, v ∈ xs := by
+  induction e with
+  | const n => simp [Expression.vars]
+  | var y =>
+      intro v hv
+      simp only [Expression.vars, List.mem_singleton] at hv
+      subst hv
+      exact List.contains_iff_mem.mp (by simpa [Expression.varsIn] using h)
+  | add a b iha ihb =>
+      rw [Expression.varsIn, Bool.and_eq_true] at h
+      intro v hv
+      rcases List.mem_append.1 hv with hv | hv
+      · exact iha h.1 v hv
+      · exact ihb h.2 v hv
+  | mul a b iha ihb =>
+      rw [Expression.varsIn, Bool.and_eq_true] at h
+      intro v hv
+      rcases List.mem_append.1 hv with hv | hv
+      · exact iha h.1 v hv
+      · exact ihb h.2 v hv
+
+/-- Do all a bus interaction's variables (multiplicity and payload) lie in `xs`? (No allocation.) -/
+def BusInteraction.varsIn (xs : List Variable) (bi : BusInteraction (Expression p)) : Bool :=
+  bi.multiplicity.varsIn xs && bi.payload.all (fun e => e.varsIn xs)
+
+theorem BusInteraction.varsIn_sound (xs : List Variable) (bi : BusInteraction (Expression p))
+    (h : bi.varsIn xs = true) : ∀ v ∈ bi.vars, v ∈ xs := by
+  rw [BusInteraction.varsIn, Bool.and_eq_true] at h
+  intro v hv
+  rw [BusInteraction.vars, List.mem_append] at hv
+  rcases hv with hv | hv
+  · exact Expression.varsIn_sound xs bi.multiplicity h.1 v hv
+  · obtain ⟨e, he, hev⟩ := List.mem_flatMap.1 hv
+    exact Expression.varsIn_sound xs e (List.all_eq_true.mp h.2 e he) v hev
+
 /-! ## Deriving a finite domain for a variable from one constraint -/
 
 /-- Root list for the equation `c + Σ terms = 0`: `[]` for a nonzero constant (never zero),

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -419,35 +419,6 @@ def Expression.hasVar : Expression p → Bool
   | .add a b => a.hasVar || b.hasVar
   | .mul a b => a.hasVar || b.hasVar
 
-/-- Do all the expression's variables lie in `xs`? (No allocation.) -/
-def Expression.varsIn (xs : List Variable) : Expression p → Bool
-  | .const _ => true
-  | .var y => xs.contains y
-  | .add a b => a.varsIn xs && b.varsIn xs
-  | .mul a b => a.varsIn xs && b.varsIn xs
-
-theorem Expression.varsIn_sound (xs : List Variable) (e : Expression p)
-    (h : e.varsIn xs = true) : ∀ v ∈ e.vars, v ∈ xs := by
-  induction e with
-  | const n => simp [Expression.vars]
-  | var y =>
-      intro v hv
-      simp only [Expression.vars, List.mem_singleton] at hv
-      subst hv
-      exact List.contains_iff_mem.mp (by simpa [Expression.varsIn] using h)
-  | add a b iha ihb =>
-      rw [Expression.varsIn, Bool.and_eq_true] at h
-      intro v hv
-      rcases List.mem_append.1 hv with hv | hv
-      · exact iha h.1 v hv
-      · exact ihb h.2 v hv
-  | mul a b iha ihb =>
-      rw [Expression.varsIn, Bool.and_eq_true] at h
-      intro v hv
-      rcases List.mem_append.1 hv with hv | hv
-      · exact iha h.1 v hv
-      · exact ihb h.2 v hv
-
 /-- Constraints whose (nonempty) variable set lies inside the group. -/
 def coveredBy (xs : List Variable) (c : Expression p) : Bool :=
   c.hasVar && c.varsIn xs
@@ -714,11 +685,13 @@ def coveredCsOf (cs : ConstraintSystem p) (xs : List Variable) : List (Expressio
   cs.algebraicConstraints.filter (coveredBy xs)
 
 /-- The surviving group values: enumerated over the group's domains, filtered by the covered
-    constraints. -/
+    constraints. The covered set is bound outside the filter so it is computed **once**, not once
+    per enumerated assignment (the `let` zeta-reduces away in proofs, so this is transparent). -/
 def groupSurvivors (cs : ConstraintSystem p) (xs : List Variable)
     (doms : List (Variable × List (ZMod p))) : List (List (Variable × ZMod p)) :=
+  let es := coveredCsOf cs xs
   (assignments doms).filter
-    (fun a => (coveredCsOf cs xs).all (fun c => decide (c.eval (envOf a) = 0)))
+    (fun a => es.all (fun c => decide (c.eval (envOf a) = 0)))
 
 /-- All checked side conditions for one re-encoding step. -/
 def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
@@ -726,8 +699,14 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
   match groupDoms (coveredCsOf cs xs) xs with
   | none => false
   | some doms =>
+    -- Bind these once rather than recomputing them inside the checks below: `groupSurvivors` and
+    -- `assignments (bitBox …)` each appear twice, and `coveredCsOf` was rebuilt once per bit
+    -- pattern. The `let`s zeta-reduce away in `checkReencode_sound_D`, so this is transparent.
+    let survs := groupSurvivors cs xs doms
+    let patts := assignments (bitBox bits)
+    let es := coveredCsOf cs xs
     decide ((doms.map (fun yd => yd.2.length)).prod ≤ 256) &&
-    decide (2 ≤ (groupSurvivors cs xs doms).length) &&
+    decide (2 ≤ survs.length) &&
     decide (bits.length < xs.length) &&
     decide (bits.Nodup) &&
     -- freshness: no bit occurs anywhere in the system
@@ -739,11 +718,11 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
     xs.all (fun x =>
       ((Expression.var x).substF (groupSubst xs hm)).vars.all (fun v => bits.contains v)) &&
     -- completeness: every surviving group value is hit by some bit pattern
-    (groupSurvivors cs xs doms).all (fun s => (assignments (bitBox bits)).any (fun aβ =>
+    survs.all (fun s => patts.any (fun aβ =>
       xs.all (fun x =>
         decide (((Expression.var x).substF (groupSubst xs hm)).eval (envOf aβ) = envOf s x)))) &&
     -- soundness: every bit pattern's image satisfies the covered constraints
-    (assignments (bitBox bits)).all (fun aβ => (coveredCsOf cs xs).all (fun c =>
+    patts.all (fun aβ => es.all (fun c =>
       decide ((c.substF (groupSubst xs hm)).eval (envOf aβ) = 0)))
 
 /-! ## Derived-variable methods for the fresh bits
@@ -1365,8 +1344,9 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p
     if hxsB : xs.all (fun x => decide (x ∉ bits)) = true then
     if hbn : bits.all (fun b => decide (b.powdrId? = none)) = true then
     if hchk : checkReencode cs xs bits hm = true then
-      if (reencodeOut cs xs bits hm).withinDegreeB bsem.degreeBound then
-        ⟨reencodeOut cs xs bits hm,
+      let ro := reencodeOut cs xs bits hm
+      if ro.withinDegreeB bsem.degreeBound then
+        ⟨ro,
          bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)),
          checkReencode_sound_D cs bsem xs bits hm
            (fun x hx => by simpa using List.all_eq_true.mp hxs x hx)
@@ -1389,14 +1369,25 @@ def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
     let r2 := reencodeLoop bsem rest (idx + 1) r1.out
     ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
+/-- `List.dedup` computed in linear time via a hash set, with the **identical** result: an element
+    is kept at its last-occurrence position (exactly `List.dedup`'s order), so swapping this in is a
+    pure speedup — `reencodeLoop`'s correctness is independent of the target list, and its
+    (order-sensitive, greedy) behaviour is unchanged because the list itself is unchanged. -/
+def dedupHash {α : Type} [BEq α] [Hashable α] (l : List α) : List α :=
+  (l.reverse.foldl (fun (st : List α × Std.HashSet α) t =>
+    if st.2.contains t then st else (t :: st.1, st.2.insert t))
+    (([], ∅) : List α × Std.HashSet α)).1
+
 /-- The witness re-encoding pass: for every constraint's (small) all-input-column variable group
     whose covered constraints allow only a few joint values, re-encode the group with `⌈log₂ m⌉`
     fresh booleans and ship each bit's derived-variable method. Prime `p` only; identity otherwise. -/
 def reencodePass : VerifiedPass p := fun cs bsem =>
   if hpr : p.Prime then
     haveI : Fact p.Prime := ⟨hpr⟩
-    let targets := (cs.algebraicConstraints.filterMap (fun c =>
+    -- `dedupHash` replaces the quadratic `List.dedup` over the (up to thousands of) target
+    -- variable-sets, producing the identical list in linear time.
+    let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
       let vs := c.vars.dedup
-      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none)).dedup
+      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none))
     reencodeLoop bsem targets 0 cs
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/Main.lean
+++ b/Main.lean
@@ -1,5 +1,6 @@
 import Leanr.Implementation.JsonParser
 import Leanr.Optimizer
+import Leanr.Implementation.Optimizer
 import Leanr.Utils.Size
 import Leanr.Utils.Dsl
 import Leanr.OpenVmSemantics
@@ -189,8 +190,83 @@ def cmdReport (unoptFile optFile : String) : IO Unit := do
     ",\"powdr\":" ++ circuitJson csPowdr ++
     ",\"leanr\":" ++ circuitJson optimized ++ "}")
 
+open Leanr.OpenVM in
+/-- Profiling helper: apply one fact-aware pass, forcing full evaluation, and return the new
+    system plus the elapsed milliseconds. -/
+def applyTimed (pass : VerifiedPassW babyBear) (cs : ConstraintSystem babyBear)
+    (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs) :
+    IO (ConstraintSystem babyBear × Nat) := do
+  let t0 ← IO.monoMsNow
+  let out ← IO.lazyPure (fun _ => (pass cs bs facts).out)
+  -- Force the whole output structure (varCount traverses every expression node).
+  let _ ← IO.lazyPure (fun _ =>
+    out.varCount + out.algebraicConstraints.length + out.busInteractions.length)
+  let t1 ← IO.monoMsNow
+  pure (out, t1 - t0)
+
+open Leanr.OpenVM in
+/-- Run one cleanup cycle's passes in order, accumulating per-pass elapsed time. -/
+partial def runCycleTimed (passes : List (String × VerifiedPassW babyBear))
+    (cs : ConstraintSystem babyBear) (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs)
+    (acc : Std.HashMap String Nat) : IO (ConstraintSystem babyBear × Std.HashMap String Nat) := do
+  let mut c := cs
+  let mut a := acc
+  for (name, pass) in passes do
+    let (c', dt) ← applyTimed pass c bs facts
+    c := c'
+    a := a.insert name (a.getD name 0 + dt)
+  pure (c, a)
+
+open Leanr.OpenVM in
+/-- Iterate the cleanup cycle to a fixpoint (mirroring `iterateToFixpoint`), accumulating per-pass
+    time and counting iterations. -/
+partial def profileLoop (passes : List (String × VerifiedPassW babyBear))
+    (cs : ConstraintSystem babyBear) (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs)
+    (acc : Std.HashMap String Nat) (iter : Nat) :
+    IO (ConstraintSystem babyBear × Std.HashMap String Nat × Nat) := do
+  let (cs', acc') ← runCycleTimed passes cs bs facts acc
+  if cs'.sizeKey < cs.sizeKey then
+    profileLoop passes cs' bs facts acc' (iter + 1)
+  else
+    pure (cs, acc', iter)
+
+open Leanr.OpenVM in
+/-- `profile <file>`: run the OpenVM pipeline with per-pass timing, reporting the cumulative time
+    spent in each pass across all fixpoint iterations. -/
+def cmdProfile (fileName : String) : IO Unit := do
+  let (cs, busMap) ← parseFile fileName
+  let bs := openVmBusSemantics babyBear busMap.toBusMap
+  let facts := openVmFacts babyBear busMap.toBusMap
+  let cleanupPasses : List (String × VerifiedPassW babyBear) :=
+    [ ("gauss", gaussElimPass.withFacts.guardDegree),
+      ("normalize1", normalizePass.withFacts.guardDegree),
+      ("constFold1", constantFoldPass.withFacts.guardDegree),
+      ("domainBatch", domainBatchPass.guardDegree),
+      ("normalize2", normalizePass.withFacts.guardDegree),
+      ("constFold2", constantFoldPass.withFacts.guardDegree),
+      ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
+      ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
+      ("tautoBus", tautoBusDropPass.withFacts.guardDegree),
+      ("busUnify", busUnifyPass.guardDegree),
+      ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
+      ("reencode", reencodePass.withFacts.guardDegree) ]
+  let t0 ← IO.monoMsNow
+  -- pipeline prelude: constantFold
+  let (cs, acc) ← runCycleTimed [("constFold0", constantFoldPass.withFacts.guardDegree)] cs bs facts ∅
+  let (cs, acc, iters) ← profileLoop cleanupPasses cs bs facts acc 0
+  -- pipeline coda: monicScale, constantFold
+  let (_, acc) ← runCycleTimed
+    [("monicScale", monicScalePass.withFacts.guardDegree),
+     ("constFoldEnd", constantFoldPass.withFacts.guardDegree)] cs bs facts acc
+  let t1 ← IO.monoMsNow
+  IO.println s!"profile {fileName}: {iters} cleanup iterations, {t1 - t0} ms total"
+  let sorted := acc.toList.toArray.qsort (fun a b => a.2 > b.2)
+  for (name, ms) in sorted do
+    IO.println s!"  {name}: {ms} ms"
+
 def usage : String :=
   "usage: leanr run <file.json[.gz]>\n" ++
+  "       leanr profile <file.json[.gz]>  (per-pass optimizer timing)\n" ++
   "       leanr powdr <unopt.json[.gz]> <opt.json[.gz]>\n" ++
   "       leanr compare <unopt.json[.gz]> <opt.json[.gz]>\n" ++
   "       leanr report  <unopt.json[.gz]> <opt.json[.gz]>  (JSON: stats + render x3)\n\n" ++
@@ -201,6 +277,7 @@ def usage : String :=
 def main (args : List String) : IO Unit := do
   match args with
   | ["run", fileName] => cmdRun (fileName := fileName)
+  | ["profile", fileName] => cmdProfile (fileName := fileName)
   | ["vars", fileName] => cmdVars (fileName := fileName)
   | ["render", fileName] => cmdRender (fileName := fileName)
   | ["powdr", unoptFile, optFile] => cmdPowdr (unoptFile := unoptFile) (optFile := optFile)

--- a/docs/log.md
+++ b/docs/log.md
@@ -985,3 +985,52 @@ apc_001 42/18/38, apc_100 1003/601/1866). Also removed the `iters`/`--iters` CLI
 `benchmark.py`, the READMEs, the architecture doc, and CLAUDE.md. The FFI entry point `Leanr/Ffi.lean`
 drops its now-stale `openVmOptimizer … 32 …` iters argument (the serializer's own `Variable`-struct
 reconciliation landed separately on `main`).
+
+### 45. Optimizer runtime: profile-guided speedups (effectiveness unchanged)
+
+Pure **performance** work — the optimizer's *output* is unchanged (every change is
+output-preserving, verified by re-running the whole benchmark and comparing `vars/constraints/bus`
+per case: identical on all 100, e.g. apc_100 stays `1003/601/1866`), so effectiveness is identical
+and only the wall-clock cost of running the optimizer drops. Nothing in the audited surface,
+`Basic.lean`, or the spec changed; correctness axioms stay `{propext, Classical.choice, Quot.sound}`;
+`lake build` green, no `sorry`/`native_decide`.
+
+Profiled per-pass on the slowest cases (added a `leanr profile <file>` CLI command that times each
+pass across the fixpoint loop). Three passes dominated — `domainBatch`, `reencode`, `busUnify` — and
+each turned out to be paying for a *recomputation inside a loop* rather than doing irreducible work.
+Fixes, each preserving the exact output:
+
+1. **`coveredCs`/`coveredBis` allocation (`DomainBatch.lean`)** — the per-target covered-item scan used
+   `c.vars.all (· ∈ xs)`, which *materializes* every constraint/interaction's variable list once per
+   target. Replaced with an allocation-free `Expression.varsIn`/`BusInteraction.varsIn` (added to
+   `DomainProp.lean`, shared with `Reencode`, which dropped its private copy); same boolean, so the
+   filtered list — hence the output — is identical.
+2. **`reencode` target dedup (`Reencode.lean`)** — the target variable-sets were deduped with the
+   quadratic `List.dedup`; replaced with a linear hash-set `dedupHash` returning the identical list
+   (each element kept at its last-occurrence position, exactly `List.dedup`).
+3. **`domainBatch` enumeration (`forcedOver`)** — `checkForcedM` re-enumerated the domain box and
+   re-ran `survivesAllM` *once per candidate variable*. Now the surviving assignments are computed
+   **once** per target (`forcedFromSurvivors` + `forcedFromSurvivors_sound`) and every candidate is
+   checked against that precomputed list; `forcedFromSurvivors` reproduces the old candidates exactly.
+   Removed the now-dead `pickForcedM`/`checkForcedM`/`checkForcedM_sound`.
+4. **recompute-in-lambda hoists (`Reencode.lean`)** — `groupSurvivors` rebuilt `coveredCsOf cs xs`
+   *inside* its filter (once per enumerated assignment, ≤256×); `checkReencode` recomputed
+   `groupSurvivors`, `assignments (bitBox …)` (twice each) and `coveredCsOf` (once per bit pattern).
+   Bound each once with a `let`; the `let` zeta-reduces during elaboration, so the soundness proofs are
+   untouched. Also compute `reencodeOut` once (it was built twice for accepted groups).
+5. **`busUnify` (`BusUnify.lean`)** — the new-equation filter tested `z ∈ cs.vars` per variable, and
+   `cs.vars` rebuilds the whole ~10⁵-entry occurrence list on every reference. Bound `cs.vars` once
+   with a `let` (zeta-transparent in the proof) — the single biggest per-pass win.
+
+**Impact (openvm-eth, all 100 cases, optimizer time only, `leanr run`):**
+total **3,393,648 ms → 1,978,903 ms (1.72×, −41.7%)**; geometric-mean per-case speedup **1.64×**;
+slowest case apc_037 **258,362 ms → 165,964 ms (1.56×, −35.8%)** (apc_100 229,950 → 171,924). Per-pass
+on apc_100 (profiler): domainBatch 135.7s→94.0s, reencode 78.3s→59.1s, busUnify 18.3s→3.4s.
+
+Remaining bottleneck (documented for future work): `domainBatch`/`reencode` spend the balance in the
+finite-domain **enumeration** — building `assignments doms` and evaluating covered constraints under
+the list-based `envOf`, whose lookup is linear in the assignment size. The expensive targets are large
+variable-sets that are mostly *pinned* (domain-1) with a few free vars, so each `envOf` lookup is over
+a long assignment. Excluding pinned domain-1 vars from the enumerated box (substituting their constants
+into the covered constraints, enumerating only the free vars) would shrink the assignments sharply, but
+needs `forcedOver`'s soundness reproven against the reduced box — left as a follow-up.


### PR DESCRIPTION
Pure **performance** work — the optimizer's *output* is unchanged (every change is output-preserving), so effectiveness is identical and only the wall-clock cost of running the optimizer drops. Nothing in the audited surface, `Basic.lean`, or the spec changed; correctness axioms remain `{propext, Classical.choice, Quot.sound}`; `lake build` green, no `sorry`/`native_decide`.

Profiled per-pass on the slowest cases (added a `leanr profile <file>` CLI command that times each pass across the fixpoint loop). Three passes dominated — `domainBatch`, `reencode`, `busUnify` — and each turned out to be paying for a *recomputation inside a loop* rather than doing irreducible work. Fixes, each preserving the exact output:

1. **`coveredCs`/`coveredBis` allocation (`DomainBatch.lean`)** — the per-target covered-item scan used `c.vars.all (· ∈ xs)`, which *materializes* every constraint/interaction's variable list once per target. Replaced with an allocation-free `Expression.varsIn`/`BusInteraction.varsIn` (added to `DomainProp.lean`, shared with `Reencode`, which dropped its private copy); same boolean, so the filtered list — hence the output — is identical.

2. **`reencode` target dedup (`Reencode.lean`)** — the target variable-sets were deduped with the quadratic `List.dedup`; replaced with a linear hash-set `dedupHash` returning the identical list (each element kept at its last-occurrence position, exactly `List.dedup`).

3. **`domainBatch` enumeration (`forcedOver`)** — `checkForcedM` re-enumerated the domain box and re-ran `survivesAllM` *once per candidate variable*. Now the surviving assignments are computed **once** per target (`forcedFromSurvivors` + `forcedFromSurvivors_sound`) and every candidate is checked against that precomputed list; `forcedFromSurvivors` reproduces the old candidates exactly. Removed the now-dead `pickForcedM`/`checkForcedM`/`checkForcedM_sound`.

4. **Recompute-in-lambda hoists (`Reencode.lean`)** — `groupSurvivors` rebuilt `coveredCsOf cs xs` *inside* its filter (once per enumerated assignment, ≤256×); `checkReencode` recomputed `groupSurvivors`, `assignments (bitBox …)` (twice each) and `coveredCsOf` (once per bit pattern). Bound each once with a `let`; the `let` zeta-reduces during elaboration, so the soundness proofs are untouched. Also compute `reencodeOut` once (it was built twice for accepted groups).

5. **`busUnify` (`BusUnify.lean`)** — the new-equation filter tested `z ∈ cs.vars` per variable, and `cs.vars` rebuilds the whole ~10⁵-entry occurrence list on every reference. Bound `cs.vars` once with a `let` (zeta-transparent in the proof) — the single biggest per-pass win.

**Impact (openvm-eth, all 100 cases, optimizer time only, `leanr run`):**
total **3,393,648 ms → 1,978,903 ms (1.72×, −41.7%)**; geometric-mean per-case speedup **1.64×**;
slowest case apc_037 **258,362 ms → 165,964 ms (1.56×, −35.8%)** (apc_100 229,950 → 171,924). Per-pass on apc_100 (profiler): domainBatch 135.7s→94.0s, reencode 78.3s→59.1s, busUnify 18.3s→3.4s.

https://claude.ai/code/session_01DExAU9ckxXEB5mXWXE1Jpw