### PR TITLE
Add memory bus send/receive pair cancellation pass

### DIFF
--- a/Leanr/Implementation/BusFacts.lean
+++ b/Leanr/Implementation/BusFacts.lean
@@ -76,6 +76,26 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       ∀ (busId : Nat) (shape : MemoryBusShape), memShape busId = some shape →
         admissibleMemoryBus shape ((msgs.filter (fun m => m.busId = busId)).filter
           (fun m => decide (m.multiplicity ≠ 0)))
+  /-- Reverse bridge for pair cancellation (the completeness half). Dropping a matched, isolated
+      send→receive pair from a declared bus preserves `admissible`: given a send `S` and a later
+      receive `R` on `busId` with equal addresses, no active same-address message between them
+      (`B`), and no active same-address send before `S` (`A`), removing both from the active-stateful
+      message list keeps it admissible. Gated on `memShape busId = some shape`, so `trivial` (no
+      shapes) discharges it vacuously; for a VM whose `admissible` is the per-bus `admissibleMemoryBus`
+      conjunction it follows from `admissibleMemoryBus_dropPair`. Takes `1 ≠ 0` (the pass supplies
+      it; the degenerate `ZMod 1` is then out of the way). -/
+  admissible_dropPair :
+    (1 : ZMod p) ≠ 0 →
+    ∀ (busId : Nat) (shape : MemoryBusShape), memShape busId = some shape →
+    ∀ (A B C : List (BusInteraction (ZMod p))) (S R : BusInteraction (ZMod p)),
+      S.busId = busId → R.busId = busId →
+      S.multiplicity = 1 → R.multiplicity = -1 →
+      shape.address S = shape.address R →
+      (∀ m ∈ B, m.busId = busId → m.multiplicity ≠ 0 → shape.address m = shape.address S → False) →
+      (∀ m ∈ A, m.busId = busId → m.multiplicity ≠ 0 → shape.address m = shape.address S →
+        m.multiplicity ≠ 1) →
+      bs.admissible (A ++ S :: B ++ R :: C) →
+      bs.admissible (A ++ B ++ C)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -89,3 +109,4 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   memShape _ := none
   memShape_stateful := by intro _ _ h; exact absurd h (by simp)
   admissible_sound := by intro _ _ _ _ h; exact absurd h (by simp)
+  admissible_dropPair := by intro _ _ _ h; exact absurd h (by simp)

--- a/Leanr/Implementation/MemoryBusDrop.lean
+++ b/Leanr/Implementation/MemoryBusDrop.lean
@@ -1,0 +1,118 @@
+import Leanr.MemoryBus
+
+set_option autoImplicit false
+
+/-! # Dropping matched send/receive pairs preserves `admissibleMemoryBus`
+
+The `MemoryBus`-level machinery behind the pair-cancellation pass (`OptimizerPasses/BusPairCancel`).
+When a memory access chain leaves a *send* `S` (multiplicity `1`) and a later *receive* `R`
+(multiplicity `-1`) carrying the same payload — the write of one access and the read of the next —
+the two contribute `0` to every message's net multiplicity, so both can be dropped. The completeness
+half needs the VM's `admissible` predicate to survive that drop; these lemmas discharge that at the
+concrete-discipline level (`admissibleMemoryBus`).
+
+Kept out of the audit surface (`MemoryBus.lean`): these are consequences of the discipline, not part
+of it. The reverse bridge that lets a *generic* pass rebuild the abstract `bs.admissible` from these
+is the `admissible_dropPair` field of `BusFacts`. -/
+
+variable {p : ℕ}
+
+/-- Removing a single interaction `e` from an `admissibleMemoryBus` list preserves the discipline,
+    provided `e` is inactive or **no active same-address send precedes it**. The only new
+    consecutive pair a removal can expose sits across `e`'s position; a fresh *send→receive* pair
+    there would need an active same-address send before `e`, which the side condition forbids. -/
+theorem admissibleMemoryBus_dropOne (shape : MemoryBusShape) (hp1 : (1 : ZMod p) ≠ 0)
+    (P Q : List (BusInteraction (ZMod p))) (e : BusInteraction (ZMod p))
+    (hadm : admissibleMemoryBus shape (P ++ e :: Q))
+    (hcond : e.multiplicity = 0 ∨
+       ∀ m ∈ P, m.multiplicity ≠ 0 → shape.address m = shape.address e → m.multiplicity ≠ 1) :
+    admissibleMemoryBus shape (P ++ Q) := by
+  intro pre mid post S R hsplit hS hR haddr hmid
+  have hsplit2 : P ++ Q = pre ++ (S :: (mid ++ R :: post)) := by
+    rw [hsplit]; simp only [List.append_assoc, List.cons_append]
+  rcases List.append_eq_append_iff.mp hsplit2 with ⟨a', hpre, hQ⟩ | ⟨c', hP, hT⟩
+  · -- Case A: `pre = P ++ a'`, `Q = a' ++ S :: (mid ++ R :: post)`; `e` lands in the prefix.
+    refine hadm (P ++ e :: a') mid post S R ?_ hS hR haddr hmid
+    rw [hQ]; simp only [List.append_assoc, List.cons_append]
+  · -- Case B: `P = pre ++ c'`, `S :: (mid ++ R :: post) = c' ++ Q`.
+    rcases c' with _ | ⟨c0, c''⟩
+    · -- `c' = []`: `e` lands just before `S`.
+      simp only [List.append_nil] at hP
+      simp only [List.nil_append] at hT
+      refine hadm (pre ++ [e]) mid post S R ?_ hS hR haddr hmid
+      rw [hP, ← hT]; simp only [List.append_assoc, List.cons_append, List.nil_append]
+    · -- `c' = c0 :: c''`, so `c0 = S` and `mid ++ R :: post = c'' ++ Q`.
+      rw [List.cons_append, List.cons.injEq] at hT
+      obtain ⟨rfl, hT2⟩ := hT
+      have hSP : S ∈ P := by rw [hP]; exact List.mem_append_right pre (List.mem_cons_self ..)
+      have hSne : S.multiplicity ≠ 0 := by rw [hS]; exact hp1
+      have hEobl : e.multiplicity ≠ 0 → shape.address e = shape.address S → False := by
+        intro hene haddreS
+        rcases hcond with h0 | h1
+        · exact hene h0
+        · exact h1 S hSP hSne haddreS.symm hS
+      rcases List.append_eq_append_iff.mp hT2 with ⟨w, hc''w, hRpw⟩ | ⟨w, hmidw, hQw⟩
+      · -- `c'' = mid ++ w`, `R :: post = w ++ Q`; `e` lands at/after `R`.
+        rcases w with _ | ⟨w0, w'⟩
+        · -- `w = []`: `e` lands just before `R`.
+          simp only [List.append_nil] at hc''w
+          simp only [List.nil_append] at hRpw
+          refine hadm pre (mid ++ [e]) post S R ?_ hS hR haddr ?_
+          · rw [hP, hc''w, ← hRpw]; simp only [List.append_assoc, List.cons_append, List.nil_append]
+          · intro m hm hmne hmaddr
+            rw [List.mem_append] at hm
+            rcases hm with hmm | hme
+            · exact hmid m hmm hmne hmaddr
+            · rcases List.mem_cons.mp hme with rfl | hcon
+              · exact hEobl hmne hmaddr
+              · exact absurd hcon (by simp)
+        · -- `w = w0 :: w'`, so `w0 = R` and `post = w' ++ Q`; `e` lands in the suffix.
+          rw [List.cons_append, List.cons.injEq] at hRpw
+          obtain ⟨rfl, hpost2⟩ := hRpw
+          refine hadm pre mid (w' ++ e :: Q) S R ?_ hS hR haddr hmid
+          rw [hP, hc''w]; simp only [List.append_assoc, List.cons_append]
+      · -- `mid = c'' ++ w`, `Q = w ++ R :: post`; `e` lands inside the middle.
+        refine hadm pre (c'' ++ e :: w) post S R ?_ hS hR haddr ?_
+        · rw [hP, hQw]; simp only [List.append_assoc, List.cons_append]
+        · intro m hm hmne hmaddr
+          rw [List.mem_append] at hm
+          rcases hm with hmc | hme
+          · exact hmid m (by rw [hmidw]; exact List.mem_append_left w hmc) hmne hmaddr
+          · rcases List.mem_cons.mp hme with rfl | hmw
+            · exact hEobl hmne hmaddr
+            · exact hmid m (by rw [hmidw]; exact List.mem_append_right c'' hmw) hmne hmaddr
+
+/-- Dropping a matched consecutive send→receive pair (`S₀` a send, `R₀` a later receive, no active
+    same-address message between them) preserves `admissibleMemoryBus`, provided `S₀` is the
+    earliest active send to its address (`hearliest`). Proved by removing `S₀` then `R₀`, each a
+    `dropOne` whose side condition is met: no active same-address send precedes `S₀` (`hearliest`),
+    and none precedes `R₀` either (`hearliest` for the `A` part, `hcons` for the `B` part). -/
+theorem admissibleMemoryBus_dropPair (shape : MemoryBusShape) (hp1 : (1 : ZMod p) ≠ 0)
+    (A B C : List (BusInteraction (ZMod p))) (S₀ R₀ : BusInteraction (ZMod p))
+    (hadm : admissibleMemoryBus shape (A ++ S₀ :: B ++ R₀ :: C))
+    (hcons : ∀ m ∈ B, m.multiplicity ≠ 0 → shape.address m = shape.address S₀ → False)
+    (hearliest : ∀ m ∈ A, m.multiplicity ≠ 0 → shape.address m = shape.address S₀ →
+        m.multiplicity ≠ 1)
+    (haddrEq : shape.address S₀ = shape.address R₀) :
+    admissibleMemoryBus shape (A ++ B ++ C) := by
+  -- Step 1: remove `S₀`. `A ++ S₀ :: B ++ R₀ :: C = A ++ S₀ :: (B ++ R₀ :: C)`.
+  have hadm1 : admissibleMemoryBus shape (A ++ S₀ :: (B ++ R₀ :: C)) := by
+    have : A ++ S₀ :: B ++ R₀ :: C = A ++ S₀ :: (B ++ R₀ :: C) := by
+      simp only [List.append_assoc, List.cons_append]
+    rwa [this] at hadm
+  have h1 : admissibleMemoryBus shape (A ++ (B ++ R₀ :: C)) :=
+    admissibleMemoryBus_dropOne shape hp1 A (B ++ R₀ :: C) S₀ hadm1 (Or.inr hearliest)
+  -- Step 2: remove `R₀`. `A ++ (B ++ R₀ :: C) = (A ++ B) ++ R₀ :: C`.
+  have h2 : admissibleMemoryBus shape ((A ++ B) ++ R₀ :: C) := by
+    have : A ++ (B ++ R₀ :: C) = (A ++ B) ++ R₀ :: C := by
+      simp only [List.append_assoc]
+    rwa [this] at h1
+  have h3 : admissibleMemoryBus shape ((A ++ B) ++ C) := by
+    refine admissibleMemoryBus_dropOne shape hp1 (A ++ B) C R₀ h2 (Or.inr ?_)
+    intro m hm hmne hmaddr
+    rw [List.mem_append] at hm
+    have hmaddrS : shape.address m = shape.address S₀ := hmaddr.trans haddrEq.symm
+    rcases hm with hmA | hmB
+    · exact hearliest m hmA hmne hmaddrS
+    · exact absurd (hcons m hmB hmne hmaddrS) not_false
+  simpa only [List.append_assoc] using h3

--- a/Leanr/Implementation/OpenVmFacts.lean
+++ b/Leanr/Implementation/OpenVmFacts.lean
@@ -1,5 +1,6 @@
 import Leanr.Implementation.BusFacts
 import Leanr.OpenVmSemantics
+import Leanr.Implementation.MemoryBusDrop
 
 set_option autoImplicit false
 
@@ -221,5 +222,38 @@ def openVmFacts (p : ℕ) [NeZero p]
       · rw [hb, hstateful]; simp
       · simp [hb]
     rwa [hlist] at hd
+  admissible_dropPair := by
+    -- `openVmBusSemantics.admissible` is the per-declared-bus `admissibleMemoryBus` conjunction.
+    intro hp1 busId shape hshape A B C S R hSbus hRbus hSm hRm haddrEq hcons hearliest hadm_full
+      busId' shape' hshape'
+    by_cases hbb : busId' = busId
+    · subst busId'
+      obtain rfl : shape = shape' := Option.some.inj (hshape.symm.trans hshape')
+      have hgoal : (A ++ B ++ C).filter (fun m => m.busId = busId)
+          = A.filter (fun m => m.busId = busId) ++ B.filter (fun m => m.busId = busId)
+            ++ C.filter (fun m => m.busId = busId) := by
+        simp only [List.filter_append]
+      rw [hgoal]
+      have hfull := hadm_full busId shape hshape
+      have hfiltFull : (A ++ S :: B ++ R :: C).filter (fun m => m.busId = busId)
+          = A.filter (fun m => m.busId = busId) ++ S :: B.filter (fun m => m.busId = busId)
+            ++ R :: C.filter (fun m => m.busId = busId) := by
+        simp only [List.filter_append, List.filter_cons, hSbus, hRbus, decide_true, if_true]
+      rw [hfiltFull] at hfull
+      refine admissibleMemoryBus_dropPair shape hp1 _ _ _ S R hfull ?_ ?_ haddrEq
+      · intro m hm hmne hmaddr
+        rw [List.mem_filter] at hm
+        exact hcons m hm.1 (of_decide_eq_true hm.2) hmne hmaddr
+      · intro m hm hmne hmaddr
+        rw [List.mem_filter] at hm
+        exact hearliest m hm.1 (of_decide_eq_true hm.2) hmne hmaddr
+    · -- `busId' ≠ busId`: `S`, `R` are on `busId`, so they drop out and the filter is unchanged.
+      have hne : busId ≠ busId' := fun h => hbb h.symm
+      have heq : (A ++ B ++ C).filter (fun m => m.busId = busId')
+          = (A ++ S :: B ++ R :: C).filter (fun m => m.busId = busId') := by
+        simp only [List.filter_append, List.filter_cons, hSbus, hRbus,
+          decide_eq_false hne, Bool.false_eq_true, if_false]
+      rw [heq]
+      exact hadm_full busId' shape' hshape'
 
 end Leanr.OpenVM

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -13,6 +13,7 @@ import Leanr.Implementation.OptimizerPasses.TautoBus
 import Leanr.Implementation.OptimizerPasses.MonicScale
 import Leanr.Implementation.OptimizerPasses.MemoryUnify
 import Leanr.Implementation.OptimizerPasses.BusUnify
+import Leanr.Implementation.OptimizerPasses.BusPairCancel
 import Leanr.Implementation.OptimizerPasses.DisconnectedComponent
 import Leanr.Implementation.OptimizerPasses.Reencode
 
@@ -60,6 +61,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree
     |>.andThen tautoBusDropPass.withFacts.guardDegree
     |>.andThen busUnifyPass.guardDegree
+    |>.andThen (VerifiedPassW.guardDegree (iterateToFixpoint busPairCancelPass))
     |>.andThen disconnectedComponentPass.withFacts.guardDegree
     |>.andThen reencodePass.withFacts.guardDegree
 

--- a/Leanr/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1,0 +1,381 @@
+import Leanr.Implementation.OptimizerPasses.BusUnify
+import Leanr.Implementation.MemoryBusDrop
+
+set_option autoImplicit false
+
+/-! # Cancelling matched send/receive pairs on a memory bus
+
+After `busUnifyPass` and the affine/Gauss machinery, a memory access chain leaves the bus with a
+*send* `S` (multiplicity `1`) and a later *receive* `R` (multiplicity `-1`) carrying the **same
+payload** — the write of one access and the read of the next, unified to the same tuple. These two
+messages have opposite multiplicity on the same tuple, so they contribute `0` to every message's
+net multiplicity: dropping **both** leaves the bus state (`≈`) unchanged and shrinks the circuit.
+It is exactly powdr's memory-interaction cancellation.
+
+Under the frozen spec this is sound because:
+
+* **soundness** (`out.implies cs`): the dropped pair is on a `neverViolates` bus, so re-adding it to
+  reach a witness of `cs` imposes no obligation, and the pair's net side-effect contribution is `0`;
+* **completeness** (`cs.impliesAdmissible out`): removing the pair preserves the VM's `admissible`
+  predicate (`admissible_dropPair`), provided `S` is the *earliest* active send to its address —
+  otherwise the removal could expose a fresh consecutive send→receive pair with mismatched payloads.
+  This side condition holds for the standard receive-before-send access discipline. -/
+
+variable {p : ℕ}
+
+/-! ## Net-multiplicity bookkeeping -/
+
+/-- Net multiplicity is additive over concatenation of bus states. -/
+theorem multiplicitySum_append (msg : BusMessage p) (s t : BusState p) :
+    multiplicitySum msg (s ++ t) = multiplicitySum msg s + multiplicitySum msg t := by
+  induction s with
+  | nil => simp [multiplicitySum]
+  | cons hd tl ih =>
+      simp only [List.cons_append, multiplicitySum, ih]
+      ring
+
+/-- The stateful side-effect state of a raw interaction list under `env` (what `sideEffects`
+    computes). -/
+def toBusState (bs : BusSemantics p) (env : Variable → ZMod p)
+    (L : List (BusInteraction (Expression p))) : BusState p :=
+  (L.filter (fun bi => bs.isStateful bi.busId)).map
+    (fun bi => let m := bi.eval env; ((m.busId, m.payload), m.multiplicity))
+
+theorem toBusState_append (bs : BusSemantics p) (env : Variable → ZMod p)
+    (L1 L2 : List (BusInteraction (Expression p))) :
+    toBusState bs env (L1 ++ L2) = toBusState bs env L1 ++ toBusState bs env L2 := by
+  simp only [toBusState, List.filter_append, List.map_append]
+
+theorem toBusState_cons_stateful (bs : BusSemantics p) (env : Variable → ZMod p)
+    (bi : BusInteraction (Expression p)) (L : List (BusInteraction (Expression p)))
+    (h : bs.isStateful bi.busId = true) :
+    toBusState bs env (bi :: L)
+    = (let m := bi.eval env; ((m.busId, m.payload), m.multiplicity)) :: toBusState bs env L := by
+  simp only [toBusState]
+  rw [List.filter_cons_of_pos (p := fun b : BusInteraction (Expression p) => bs.isStateful b.busId) h,
+    List.map_cons]
+
+/-- Dropping a matched send/receive pair (equal evaluated message, opposite multiplicities) leaves
+    every message's net multiplicity unchanged: the `+1` and `-1` contributions cancel. -/
+theorem sideEffects_dropPair_equiv (bs : BusSemantics p) (env : Variable → ZMod p)
+    (A B C : List (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
+    (hSstate : bs.isStateful S.busId = true) (hRstate : bs.isStateful R.busId = true)
+    (hSm : (S.eval env).multiplicity = 1) (hRm : (R.eval env).multiplicity = -1)
+    (hbusEq : (S.eval env).busId = (R.eval env).busId)
+    (hpay : (S.eval env).payload = (R.eval env).payload) :
+    toBusState bs env (A ++ S :: B ++ R :: C) ≈ toBusState bs env (A ++ B ++ C) := by
+  intro msg
+  have hstructFull : A ++ S :: B ++ R :: C = (A ++ S :: B) ++ (R :: C) := by
+    simp only [List.append_assoc, List.cons_append]
+  have hstructOut : A ++ B ++ C = (A ++ B) ++ C := rfl
+  rw [hstructFull, toBusState_append, toBusState_cons_stateful bs env R C hRstate,
+    toBusState_append, toBusState_cons_stateful bs env S B hSstate]
+  rw [hstructOut, toBusState_append, toBusState_append]
+  have hmsgEq : ((S.eval env).busId, (S.eval env).payload)
+      = ((R.eval env).busId, (R.eval env).payload) := by rw [hbusEq, hpay]
+  simp only [multiplicitySum_append, multiplicitySum, hmsgEq, hSm, hRm]
+  split_ifs <;> ring
+
+/-! ## The active∧stateful evaluated messages (what `admissible` inspects) -/
+
+/-- The active, stateful evaluated messages of a raw interaction list — the argument
+    `ConstraintSystem.admissible` passes to `bs.admissible`. -/
+def activeStatefulMsgs (bs : BusSemantics p) (env : Variable → ZMod p)
+    (L : List (BusInteraction (Expression p))) : List (BusInteraction (ZMod p)) :=
+  (L.map (fun bi => bi.eval env)).filter
+    (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
+
+theorem activeStatefulMsgs_append (bs : BusSemantics p) (env : Variable → ZMod p)
+    (L1 L2 : List (BusInteraction (Expression p))) :
+    activeStatefulMsgs bs env (L1 ++ L2)
+    = activeStatefulMsgs bs env L1 ++ activeStatefulMsgs bs env L2 := by
+  simp only [activeStatefulMsgs, List.map_append, List.filter_append]
+
+theorem activeStatefulMsgs_cons_survive (bs : BusSemantics p) (env : Variable → ZMod p)
+    (bi : BusInteraction (Expression p)) (L : List (BusInteraction (Expression p)))
+    (h : (decide ((bi.eval env).multiplicity ≠ 0) && bs.isStateful (bi.eval env).busId) = true) :
+    activeStatefulMsgs bs env (bi :: L) = bi.eval env :: activeStatefulMsgs bs env L := by
+  simp only [activeStatefulMsgs, List.map_cons]
+  rw [List.filter_cons_of_pos
+    (p := fun m : BusInteraction (ZMod p) => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId) h]
+
+theorem mem_activeStatefulMsgs (bs : BusSemantics p) (env : Variable → ZMod p)
+    (L : List (BusInteraction (Expression p))) (m : BusInteraction (ZMod p))
+    (hm : m ∈ activeStatefulMsgs bs env L) :
+    ∃ m0 ∈ L, m0.eval env = m := by
+  unfold activeStatefulMsgs at hm
+  obtain ⟨hmem, _⟩ := List.mem_filter.mp hm
+  obtain ⟨m0, hm0, hev⟩ := List.mem_map.mp hmem
+  exact ⟨m0, hm0, hev⟩
+
+/-! ## The core correctness of dropping a matched pair -/
+
+/-- **Correctness of dropping one matched consecutive send/receive pair.** `S` (a send) and `R`
+    (a later receive) carry the same payload (`hpay`), are on a `neverViolates` bus `busId` with a
+    declared `shape`, with no active same-address message between them (`hmidEval`) and no active
+    same-address send before `S` (`hpreEval`). Dropping both is `PassCorrect`. -/
+theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0)
+    (A B C : List (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
+    (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
+    (hnv : facts.neverViolates busId = true)
+    (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C)
+    (hSbus : S.busId = busId) (hRbus : R.busId = busId)
+    (hSm : S.multiplicity.constValue? = some 1) (hRm : R.multiplicity.constValue? = some (-1))
+    (hpay : S.payload = R.payload)
+    (hmidEval : ∀ (env : Variable → ZMod p), ∀ m0 ∈ B, (m0.eval env).busId = busId →
+        (m0.eval env).multiplicity ≠ 0 →
+        shape.address (m0.eval env) = shape.address (S.eval env) → False)
+    (hpreEval : ∀ (env : Variable → ZMod p), ∀ m0 ∈ A, (m0.eval env).busId = busId →
+        (m0.eval env).multiplicity ≠ 0 →
+        shape.address (m0.eval env) = shape.address (S.eval env) → (m0.eval env).multiplicity ≠ 1) :
+    PassCorrect cs { cs with busInteractions := A ++ B ++ C } [] bs := by
+  set out : ConstraintSystem p := { cs with busInteractions := A ++ B ++ C } with hout
+  have houtb : out.busInteractions = A ++ B ++ C := rfl
+  -- Common facts.
+  have hStateful : bs.isStateful busId = true := facts.memShape_stateful busId shape hshape
+  have hSstate : bs.isStateful S.busId = true := hSbus ▸ hStateful
+  have hRstate : bs.isStateful R.busId = true := hRbus ▸ hStateful
+  have hSmEv : ∀ env, (S.eval env).multiplicity = 1 :=
+    fun env => S.multiplicity.constValue?_sound 1 hSm env
+  have hRmEv : ∀ env, (R.eval env).multiplicity = -1 :=
+    fun env => R.multiplicity.constValue?_sound (-1) hRm env
+  have hSactive : ∀ env, (S.eval env).multiplicity ≠ 0 := fun env => by rw [hSmEv env]; exact hp1
+  have hRactive : ∀ env, (R.eval env).multiplicity ≠ 0 :=
+    fun env => by rw [hRmEv env]; exact neg_ne_zero.mpr hp1
+  have hpayEv : ∀ env, (S.eval env).payload = (R.eval env).payload := fun env => by
+    show S.payload.map (fun e => e.eval env) = R.payload.map (fun e => e.eval env); rw [hpay]
+  have haddrEv : ∀ env, shape.address (S.eval env) = shape.address (R.eval env) := fun env => by
+    simp only [MemoryBusShape.address, hpayEv env]
+  -- Membership: `out`'s interactions are among `cs`'s.
+  have hmem_out_cs : ∀ bi, bi ∈ out.busInteractions → bi ∈ cs.busInteractions := by
+    intro bi hbi
+    rw [houtb] at hbi
+    rw [hsplit]
+    simp only [List.mem_append, List.mem_cons] at hbi ⊢; tauto
+  -- The dropped pair never violates.
+  have hnvS : ∀ env, bs.violatesConstraint (S.eval env) = false := fun env =>
+    facts.neverViolates_sound (S.eval env) (by show facts.neverViolates S.busId = true; rw [hSbus]; exact hnv)
+  have hnvR : ∀ env, bs.violatesConstraint (R.eval env) = false := fun env =>
+    facts.neverViolates_sound (R.eval env) (by show facts.neverViolates R.busId = true; rw [hRbus]; exact hnv)
+  -- Side effects are `≈`-equal (the pair contributes `0` net).
+  have hSE : ∀ env, cs.sideEffects bs env ≈ out.sideEffects bs env := by
+    intro env
+    have e1 : cs.sideEffects bs env = toBusState bs env (A ++ S :: B ++ R :: C) := by
+      show toBusState bs env cs.busInteractions = toBusState bs env (A ++ S :: B ++ R :: C)
+      rw [hsplit]
+    have e2 : out.sideEffects bs env = toBusState bs env (A ++ B ++ C) := rfl
+    rw [e1, e2]
+    exact sideEffects_dropPair_equiv bs env A B C S R hSstate hRstate (hSmEv env) (hRmEv env)
+      (by rw [show (S.eval env).busId = busId from hSbus, show (R.eval env).busId = busId from hRbus])
+      (hpayEv env)
+  -- `cs.satisfies` implies `out.satisfies` (out has fewer obligations).
+  have hsat_cs_out : ∀ env, cs.satisfies bs env → out.satisfies bs env := by
+    intro env hsat
+    refine ⟨hsat.1, fun bi hbi => hsat.2 bi (hmem_out_cs bi hbi)⟩
+  -- `out.satisfies` implies `cs.satisfies` (the extra pair never violates).
+  have hsat_out_cs : ∀ env, out.satisfies bs env → cs.satisfies bs env := by
+    intro env hsat
+    refine ⟨hsat.1, ?_⟩
+    intro bi hbi
+    rw [hsplit] at hbi
+    simp only [List.mem_append, List.mem_cons] at hbi
+    rcases hbi with (hbi | rfl | hbi) | (rfl | hbi)
+    · exact hsat.2 bi (by rw [houtb]; simp only [List.mem_append]; tauto)
+    · exact fun _ => hnvS env
+    · exact hsat.2 bi (by rw [houtb]; simp only [List.mem_append]; tauto)
+    · exact fun _ => hnvR env
+    · exact hsat.2 bi (by rw [houtb]; simp only [List.mem_append]; tauto)
+  -- `admissible` is preserved (completeness).
+  have hadm_cs_out : ∀ env, cs.admissible bs env → out.admissible bs env := by
+    intro env hadm
+    have hSsurv : (decide ((S.eval env).multiplicity ≠ 0) && bs.isStateful (S.eval env).busId) = true := by
+      rw [show bs.isStateful (S.eval env).busId = true from hSstate, Bool.and_true, decide_eq_true_eq]
+      exact hSactive env
+    have hRsurv : (decide ((R.eval env).multiplicity ≠ 0) && bs.isStateful (R.eval env).busId) = true := by
+      rw [show bs.isStateful (R.eval env).busId = true from hRstate, Bool.and_true, decide_eq_true_eq]
+      exact hRactive env
+    -- Rewrite both admissible arguments into split form.
+    have hasmFull : activeStatefulMsgs bs env cs.busInteractions
+        = activeStatefulMsgs bs env A ++ (S.eval env) :: activeStatefulMsgs bs env B
+          ++ (R.eval env) :: activeStatefulMsgs bs env C := by
+      rw [hsplit, show A ++ S :: B ++ R :: C = (A ++ S :: B) ++ (R :: C) from by
+            simp only [List.append_assoc, List.cons_append],
+        activeStatefulMsgs_append, activeStatefulMsgs_cons_survive bs env R C hRsurv,
+        activeStatefulMsgs_append, activeStatefulMsgs_cons_survive bs env S B hSsurv]
+    have hasmOut : activeStatefulMsgs bs env out.busInteractions
+        = activeStatefulMsgs bs env A ++ activeStatefulMsgs bs env B
+          ++ activeStatefulMsgs bs env C := by
+      show activeStatefulMsgs bs env (A ++ B ++ C) = _
+      rw [show A ++ B ++ C = (A ++ B) ++ C from rfl, activeStatefulMsgs_append,
+        activeStatefulMsgs_append]
+    have hadm' : bs.admissible (activeStatefulMsgs bs env A ++ (S.eval env)
+        :: activeStatefulMsgs bs env B ++ (R.eval env) :: activeStatefulMsgs bs env C) := by
+      have : bs.admissible (activeStatefulMsgs bs env cs.busInteractions) := hadm
+      rwa [hasmFull] at this
+    show bs.admissible (activeStatefulMsgs bs env out.busInteractions)
+    rw [hasmOut]
+    refine facts.admissible_dropPair hp1 busId shape hshape _ _ _ (S.eval env) (R.eval env)
+      hSbus hRbus (hSmEv env) (hRmEv env) (haddrEv env) ?_ ?_ hadm'
+    · intro m hm hbid hmne hmaddr
+      obtain ⟨m0, hm0, rfl⟩ := mem_activeStatefulMsgs bs env B m hm
+      exact hmidEval env m0 hm0 hbid hmne hmaddr
+    · intro m hm hbid hmne hmaddr
+      obtain ⟨m0, hm0, rfl⟩ := mem_activeStatefulMsgs bs env A m hm
+      exact hpreEval env m0 hm0 hbid hmne hmaddr
+  -- Variables only shrink (the pair is dropped, no new variables introduced).
+  have hsub : ∀ v ∈ out.vars, v ∈ cs.vars := by
+    intro v hv
+    rw [ConstraintSystem.mem_vars] at hv ⊢
+    rcases hv with ⟨c, hc, hvc⟩ | ⟨bi, hbi, hbiv⟩
+    · exact Or.inl ⟨c, hc, hvc⟩
+    · exact Or.inr ⟨bi, hmem_out_cs bi hbi, hbiv⟩
+  -- Assemble via `ofEnvEq` (completeness witness is the input assignment; no derivations).
+  exact PassCorrect.ofEnvEq
+    (fun env hsat => ⟨env, hsat_out_cs env hsat, BusState.equiv_symm (hSE env)⟩)
+    (fun hinv env hsat bi hbi => hinv env (hsat_out_cs env hsat) bi (hmem_out_cs bi hbi))
+    hsub
+    (fun env hadm hsat => ⟨hsat_cs_out env hsat, hadm_cs_out env hadm, hSE env⟩)
+
+/-! ## The pass: detect and drop matched pairs -/
+
+/-- Scan for the first matching receive `R` for a send `S`: constant `-1` multiplicity, on `busId`,
+    carrying `S`'s payload. Returns `(B, R, C)` — the scanned prefix `B`, the receive `R`, and the
+    remainder `C`. -/
+def findMatchRecv (busId : Nat) (S : BusInteraction (Expression p)) :
+    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
+    Option (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
+      × List (BusInteraction (Expression p)))
+  | _, [] => none
+  | revB, R :: rest =>
+      if decide (multConst R = some (-1)) && decide (R.busId = busId)
+         && decide (S.payload = R.payload) then
+        some (revB.reverse, R, rest)
+      else findMatchRecv busId S (R :: revB) rest
+
+/-- Refute `m` as an active same-address message on `busId` (the "between" region test). -/
+def midRefuted (shape : MemoryBusShape) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
+  decide (m.busId ≠ busId) || decide (multConst m = some 0) || addrConstsNeq shape S m
+
+/-- Refute `m` as an active same-address *send* on `busId` (the "before" region test: earliest-send). -/
+def preRefuted (shape : MemoryBusShape) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
+  midRefuted shape busId S m ||
+    (match multConst m with | some c => decide (c ≠ 1) | none => false)
+
+theorem midRefuted_sound (shape : MemoryBusShape) (busId : Nat) (S m : BusInteraction (Expression p))
+    (h : midRefuted shape busId S m = true) (env : Variable → ZMod p)
+    (hbid : (m.eval env).busId = busId) (hmne : (m.eval env).multiplicity ≠ 0)
+    (hmaddr : shape.address (m.eval env) = shape.address (S.eval env)) : False := by
+  unfold midRefuted at h
+  rw [Bool.or_eq_true, Bool.or_eq_true] at h
+  rcases h with (h | h) | h
+  · exact absurd hbid (of_decide_eq_true h)
+  · exact hmne (m.multiplicity.constValue?_sound 0 (of_decide_eq_true h) env)
+  · exact addrConstsNeq_sound shape S m h env hmaddr.symm
+
+theorem preRefuted_sound (shape : MemoryBusShape) (busId : Nat) (S m : BusInteraction (Expression p))
+    (h : preRefuted shape busId S m = true) (env : Variable → ZMod p)
+    (hbid : (m.eval env).busId = busId) (hmne : (m.eval env).multiplicity ≠ 0)
+    (hmaddr : shape.address (m.eval env) = shape.address (S.eval env)) :
+    (m.eval env).multiplicity ≠ 1 := by
+  unfold preRefuted at h
+  rw [Bool.or_eq_true] at h
+  rcases h with h | h
+  · exact (midRefuted_sound shape busId S m h env hbid hmne hmaddr).elim
+  · cases hc : multConst m with
+    | none => rw [hc] at h; exact absurd h (by simp)
+    | some c =>
+      rw [hc] at h
+      have heval : (m.eval env).multiplicity = c := m.multiplicity.constValue?_sound c hc env
+      rw [heval]
+      exact of_decide_eq_true h
+
+/-- The per-candidate check (address/multiplicity/payload of the pair, plus the between/before
+    region tests). The split equation `cs.busInteractions = A ++ S :: B ++ R :: C` is *not* checked
+    here — it is supplied separately (decided once for the chosen candidate) to avoid an O(n)
+    whole-list comparison per candidate. -/
+def checkCancel (shape : MemoryBusShape) (busId : Nat)
+    (A : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
+    (B : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p)) : Bool :=
+  decide (S.busId = busId) && decide (R.busId = busId) &&
+  decide (multConst S = some 1) && decide (multConst R = some (-1)) &&
+  decide (S.payload = R.payload) &&
+  B.all (midRefuted shape busId S) &&
+  A.all (preRefuted shape busId S)
+
+/-- A passing `checkCancel` (with the split equation) yields `PassCorrect` via `dropPair_correct`. -/
+theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (shape : MemoryBusShape)
+    (hshape : facts.memShape busId = some shape) (hnv : facts.neverViolates busId = true)
+    (A : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
+    (B : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
+    (C : List (BusInteraction (Expression p)))
+    (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C)
+    (h : checkCancel shape busId A S B R = true) :
+    PassCorrect cs { cs with busInteractions := A ++ B ++ C } [] bs := by
+  unfold checkCancel at h
+  simp only [Bool.and_eq_true] at h
+  obtain ⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hmid⟩, hpre⟩ := h
+  refine dropPair_correct cs bs facts hp1 A B C S R busId shape hshape hnv hsplit
+    (of_decide_eq_true hSb) (of_decide_eq_true hRb)
+    (of_decide_eq_true hSm) (of_decide_eq_true hRm) (of_decide_eq_true hpay) ?_ ?_
+  · intro env m0 hm0 hbid hmne hmaddr
+    exact midRefuted_sound shape busId S m0 (List.all_eq_true.mp hmid m0 hm0) env hbid hmne hmaddr
+  · intro env m0 hm0 hbid hmne hmaddr
+    exact preRefuted_sound shape busId S m0 (List.all_eq_true.mp hpre m0 hm0) env hbid hmne hmaddr
+
+/-- Fused left-to-right scan for the first droppable pair on `busId`: at each send `S` (accumulating
+    the reversed prefix `revA`), find its matching receive and run the cheap `checkCancel`; the O(n)
+    split-equation decide runs only when `checkCancel` passes. Stops at the first hit, so each pass
+    invocation is linear (no eager materialization of all candidates). -/
+def findCancelGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (shape : MemoryBusShape)
+    (hshape : facts.memShape busId = some shape) (hnv : facts.neverViolates busId = true)
+    (revA : List (BusInteraction (Expression p))) :
+    List (BusInteraction (Expression p)) →
+    Option (PassResult cs bs)
+  | [] => none
+  | S :: rest =>
+    if decide (multConst S = some 1) && decide (S.busId = busId) then
+      match findMatchRecv busId S [] rest with
+      | some (B, R, C) =>
+        if hchk : checkCancel shape busId revA.reverse S B R = true then
+          if hsplit : cs.busInteractions = revA.reverse ++ S :: B ++ R :: C then
+            some ⟨{ cs with busInteractions := revA.reverse ++ B ++ C }, [],
+                  checkCancel_sound cs bs facts hp1 busId shape hshape hnv revA.reverse S B R C
+                    hsplit hchk⟩
+          else findCancelGo cs bs facts hp1 busId shape hshape hnv (S :: revA) rest
+        else findCancelGo cs bs facts hp1 busId shape hshape hnv (S :: revA) rest
+      | none => findCancelGo cs bs facts hp1 busId shape hshape hnv (S :: revA) rest
+    else findCancelGo cs bs facts hp1 busId shape hshape hnv (S :: revA) rest
+
+/-- Search one declared bus for a droppable pair. -/
+def findCancelForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (shape : MemoryBusShape)
+    (hshape : facts.memShape busId = some shape) (hnv : facts.neverViolates busId = true) :
+    Option (PassResult cs bs) :=
+  findCancelGo cs bs facts hp1 busId shape hshape hnv [] cs.busInteractions
+
+/-- Search all declared buses. -/
+def findCancel (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) :
+    List Nat → Option (PassResult cs bs)
+  | [] => none
+  | busId :: rest =>
+    match hshape : facts.memShape busId with
+    | some shape =>
+      if hnv : facts.neverViolates busId = true then
+        match findCancelForBus cs bs facts hp1 busId shape hshape hnv with
+        | some r => some r
+        | none => findCancel cs bs facts hp1 rest
+      else findCancel cs bs facts hp1 rest
+    | none => findCancel cs bs facts hp1 rest
+
+/-- Drop one matched consecutive send/receive pair on a declared, `neverViolates` memory bus. The
+    cleanup loop iterates it to cancel a whole access chain. -/
+def busPairCancelPass : VerifiedPassW p := fun cs bs facts =>
+  if hp1 : (1 : ZMod p) ≠ 0 then
+    match findCancel cs bs facts hp1 ((cs.busInteractions.map (fun bi => bi.busId)).dedup) with
+    | some r => r
+    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,11 +1,10 @@
 # Ideas for future optimization passes
 
-## Drop never-violating stateless lookups (bus-interaction effectiveness)
+## Drop never-violating stateless lookups (close the residual pc-lookup bus gap)
 
-The new bus-interaction metric (log entry 42) shows leanr well behind powdr on bus interactions
-(~1.4× vs ~2.5× on a small sample), while at variable parity. powdr removes PC lookups and other
-stateless lookups that are proven never to violate; leanr keeps them (never-violating model), so
-they inflate the bus count without affecting variables.
+After memory/exec send↔receive pair cancellation (log entry 46), leanr is at near-parity with powdr
+on bus interactions; the residual gap is essentially the **PC lookups** (bus 2): powdr removes them,
+leanr keeps them (never-violating model), so they inflate the bus count without affecting variables.
 
 A `VerifiedPass` that drops a stateless bus interaction whose multiplicity is provably `0`, or that
 is proven never-violating via `BusFacts.neverViolates`, would be sound (removing a
@@ -30,3 +29,12 @@ correctness machinery already supports any witness (it only re-checks `violatesC
 at run time), so **only the finder needs to change**, not the proof. Caveat: a decomposition solver
 leans toward the OpenVM limb structure — phrase it as a general "solve the component's lookups"
 search (probe `violatesConstraint`) rather than hard-coding base-256, to avoid overfitting.
+
+## Batch pair cancellation in one traversal
+
+`busPairCancelPass` (entry 46) drops one pair per invocation and is drained via `iterateToFixpoint`
+inside the cleanup cycle. On the largest blocks (~hundreds of pairs) this is the dominant per-pass
+cost. A single-traversal "drop all matched interior send/receive pairs per address" would be O(n)
+instead of O(pairs·n), but needs a multi-drop discipline lemma (the current proof is per-pair via
+`admissibleMemoryBus_dropOne` applied twice). Only worth it if the pass becomes a benchmark
+bottleneck.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1034,3 +1034,43 @@ variable-sets that are mostly *pinned* (domain-1) with a few free vars, so each 
 a long assignment. Excluding pinned domain-1 vars from the enumerated box (substituting their constants
 into the covered constraints, enumerating only the free vars) would shrink the assignments sharply, but
 needs `forcedOver`'s soundness reproven against the reduced box — left as a follow-up.
+
+### 46. Memory/exec-bus send↔receive pair cancellation (`BusPairCancel.lean`) — bus-interaction effectiveness
+
+Georg's "Memory optimizer" hint (log entry 14), realizable under the entry-38+ `refines`/`admissible`
+spec (its earlier block is gone). After `busUnifyPass` unifies a consecutive send `S` (mult `1`) and
+receive `R` (mult `-1`) on a memory bus to the **same payload**, the two are the same message with
+opposite multiplicity — net-zero on the bus — so dropping **both** is equivalence-preserving. Exactly
+powdr's memory-interaction cancellation; it improves the **bus-interaction** metric (entry 42) without
+touching the variable count.
+
+Why it is sound (no audit-surface change — `Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`
+untouched):
+- **soundness** (`out.implies cs`): the pair is on a `neverViolates` bus, so re-adding it to build a
+  `cs` witness imposes no `violatesConstraint` obligation, and the identical-payload/opposite-mult
+  pair adds `0` to every message's net multiplicity (`≈` preserved).
+- **completeness** (`cs.impliesAdmissible out`): removing the pair preserves the VM's `admissible`
+  predicate — **provided `S` is the earliest active send to its address** (else the drop could expose a
+  fresh consecutive send→receive pair with mismatched payloads). Proved at the `admissibleMemoryBus`
+  level (`admissibleMemoryBus_dropPair` in `Implementation/MemoryBusDrop.lean`, a single-element
+  `dropOne` applied twice), bridged to the abstract `bs.admissible` by a new proven `BusFacts` field
+  `admissible_dropPair` (definitional for OpenVM; vacuous for `trivial`, gated on `memShape`).
+
+The pass drops no variables, so it is a `PassCorrect.ofEnvEq` (env' = env) with **no derivations**;
+`out.vars ⊆ cs.vars` because the pair is removed. It scans each declared `neverViolates` memory bus
+for the earliest cancelable pair (fused linear scan; the O(n) split-equation `decide` runs only for
+the chosen candidate) and is drained to a fixpoint within one cleanup cycle via
+`iterateToFixpoint busPairCancelPass` (bus length strictly decreases each drop). A whole access chain
+collapses to its endpoints (first receive `R1` reading the context's prior value; last send `Sn`, the
+final write — neither can cancel). Also fires on the execution bridge (empty-address shape),
+cancelling the pc/timestamp chain likewise.
+
+`lake build` green; `openVmOptimizer_maintainsCorrectness` (and the `simpleOptimizer`/`optimizerWithBusFacts`
+variants) still `{propext, Classical.choice, Quot.sound}`-only; no `sorry`/`admit`/`axiom`/`native_decide`;
+all outputs within the degree bound.
+
+**Impact (bus interactions; variables unchanged):** apc_003 209 → **96** (2.18×; was 150 before this
+pass, powdr 85). Across a sample (apc_001–008; the small cases re-confirmed identical post-rebase),
+bus interactions total 5839 → **leanr 1894** (3.08×) vs **powdr 1637** (3.57×), with variables
+unchanged (leanr keeps ≤ powdr's on every sampled case). The remaining leanr-vs-powdr bus gap is the PC lookups (bus 2),
+which powdr removes and leanr keeps (never-violating model) — a separate follow-up (`docs/ideas.md`).


### PR DESCRIPTION
## Summary

Implements `busPairCancelPass`, an optimization that cancels matched consecutive send/receive pairs on memory buses. After `busUnifyPass` unifies a send `S` (multiplicity 1) and receive `R` (multiplicity -1) to the same payload, they form a net-zero message pair that can be safely dropped, reducing bus interactions without affecting circuit semantics.

## Key Changes

- **New pass: `BusPairCancel.lean`** (379 lines)
  - Core theorem `dropPair_correct`: proves correctness of dropping one matched pair under conditions that `S` is the earliest active send to its address
  - Scanning logic (`findCancelGo`, `findMatchRecv`, `checkCancel`): O(n) left-to-right search for the first droppable pair per declared bus
  - Net-multiplicity bookkeeping (`sideEffects_dropPair_equiv`): proves the pair contributes 0 to every message's multiplicity
  - Active/stateful message tracking: ensures `admissible` predicate is preserved

- **New discipline lemma: `MemoryBusDrop.lean`** (118 lines)
  - `admissibleMemoryBus_dropOne`: removing an inactive or earliest-send-guarded interaction preserves the memory discipline
  - `admissibleMemoryBus_dropPair`: dropping a matched pair preserves `admissibleMemoryBus` by applying `dropOne` twice
  - Bridges concrete discipline to abstract `bs.admissible` via `BusFacts.admissible_dropPair`

- **Extended `BusFacts` structure** (`BusFacts.lean`)
  - New field `admissible_dropPair`: reverse bridge for pair cancellation, gated on `memShape` (vacuous for `trivial`, proven for OpenVM)

- **OpenVM instance** (`OpenVM/Facts.lean`)
  - Implements `admissible_dropPair` by filtering interactions per bus and applying `admissibleMemoryBus_dropPair`

- **Integration** (`Optimizer.lean`)
  - Imports and chains `busPairCancelPass` into the cleanup cycle via `.andThen … |>.guardDegree`

- **Documentation** (`docs/log.md`, `docs/ideas.md`)
  - Entry 42: detailed design, soundness/completeness argument, impact metrics (apc_003: 150→96 interactions; total: 5839→1894)
  - Future ideas: stateless-interaction dropping, batch pair cancellation

## Implementation Details

- **Soundness** (`out.implies cs`): the dropped pair is on a `neverViolates` bus, so re-adding it imposes no `violatesConstraint` obligation; identical payload and opposite multiplicity means net contribution is 0 (`≈` preserved)
- **Completeness** (`cs.impliesAdmissible out`): the "earliest send" side condition (`hpreEval`) ensures no fresh consecutive send→receive pair with mismatched payloads is exposed by the drop
- **Efficiency**: single-traversal O(n) scan per bus; drained to fixpoint within one cleanup cycle, collapsing entire access chains to endpoints
- **No audit-surface changes**: `Spec.lean`, `MemoryBus.lean`, `OpenVM/Semantics.lean` untouched; `BusFacts` is outside the audit surface
- **Proof only**: no `sorry`, `admit`, `axiom`, or `native_decide`; all outputs within degree bound

## Impact

Bus interactions reduced significantly (apc_003: 150→96; total across apc_001–008: 5839→1894), bringing leanr within ~16% of powdr's baseline. Variable count unchanged; metric-neutral for constraints.

https://claude.ai/code/session_01EbLQQ9Eg8XTQktjzyJrTfe