### PR TITLE
Add byte-check packing pass for bitwise-lookup bus

### DIFF
--- a/Leanr/Implementation/BusFacts.lean
+++ b/Leanr/Implementation/BusFacts.lean
@@ -96,6 +96,26 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
         m.multiplicity ≠ 1) →
       bs.admissible (A ++ S :: B ++ R :: C) →
       bs.admissible (A ++ B ++ C)
+  /-- Byte-check pairing on a bitwise-style *stateless* bus. If `bytePairBus busId = true` then the
+      bus is stateless and, for every pair of operand values and any multiplicity, the pair-check
+      message `[x, y, 0, 0]` is accepted exactly when the two single-value checks `[x, x, 0, 1]` and
+      `[y, y, 0, 1]` are. So two single-value byte checks pack losslessly into one pair check, with
+      the *same* satisfying set (each side imposes "both operands are bytes") — a bus-interaction
+      win. `trivial` sets it `false` (recovering fact-free behavior); the OpenVM instance proves it
+      for the bitwise-lookup bus against the concrete table (see `Leanr/Implementation/OpenVmFacts.lean`). -/
+  bytePairBus : (busId : Nat) → Bool
+  bytePairBus_sound :
+    ∀ (busId : Nat), bytePairBus busId = true →
+      bs.isStateful busId = false ∧
+      (∀ (x y : ZMod p),
+        bs.breaksInvariant { busId := busId, multiplicity := 1, payload := [x, y, 0, 0] } = false) ∧
+      ∀ (x y mult : ZMod p),
+        (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, y, 0, 0] }
+            = false ↔
+          bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, x, 0, 1] }
+              = false ∧
+            bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [y, y, 0, 1] }
+              = false)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -110,3 +130,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   memShape_stateful := by intro _ _ h; exact absurd h (by simp)
   admissible_sound := by intro _ _ _ _ h; exact absurd h (by simp)
   admissible_dropPair := by intro _ _ _ h; exact absurd h (by simp)
+  bytePairBus _ := false
+  bytePairBus_sound := by intro _ h; exact absurd h (by simp)

--- a/Leanr/Implementation/OpenVmFacts.lean
+++ b/Leanr/Implementation/OpenVmFacts.lean
@@ -255,5 +255,35 @@ def openVmFacts (p : ℕ) [NeZero p]
           decide_eq_false hne, Bool.false_eq_true, if_false]
       rw [heq]
       exact hadm_full busId' shape' hshape'
+  bytePairBus busId := match busMap busId with
+    | some .bitwiseLookup => true
+    | _ => false
+  bytePairBus_sound := by
+    intro busId h
+    -- `h` forces the bus to be the bitwise-lookup bus.
+    have hbus : busMap busId = some OpenVmBusType.bitwiseLookup := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    refine ⟨?_, ?_, ?_⟩
+    · -- the bitwise-lookup bus is stateless
+      show (match busMap busId with | some t => t.isStateful | none => false) = false
+      rw [hbus]; rfl
+    · -- a multiplicity-1 packed check never breaks an invariant
+      intro x y
+      show breaksInvariant busMap { busId := busId, multiplicity := 1, payload := [x, y, 0, 0] }
+        = false
+      unfold breaksInvariant; rw [hbus]; simp
+    · intro x y mult
+      -- `(0 : ZMod p).val = 0` and `(1 : ZMod p).val ≤ 1` reduce the `match op.val` branches;
+      -- `isByte` stays opaque — the accepted conditions on both sides coincide by boolean logic.
+      have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+      have h1le : (1 : ZMod p).val ≤ 1 := by
+        rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_le 1 p
+      show violates busMap { busId := busId, multiplicity := mult, payload := [x, y, 0, 0] } = false ↔
+        violates busMap { busId := busId, multiplicity := mult, payload := [x, x, 0, 1] } = false ∧
+        violates busMap { busId := busId, multiplicity := mult, payload := [y, y, 0, 1] } = false
+      unfold violates; rw [hbus]
+      rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1 <;> simp [h1, hv0]
 
 end Leanr.OpenVM

--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -14,6 +14,7 @@ import Leanr.Implementation.OptimizerPasses.MonicScale
 import Leanr.Implementation.OptimizerPasses.MemoryUnify
 import Leanr.Implementation.OptimizerPasses.BusUnify
 import Leanr.Implementation.OptimizerPasses.BusPairCancel
+import Leanr.Implementation.OptimizerPasses.BytePack
 import Leanr.Implementation.OptimizerPasses.DisconnectedComponent
 import Leanr.Implementation.OptimizerPasses.Reencode
 import Leanr.Implementation.OptimizerPasses.DomainFold
@@ -64,6 +65,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen domainFoldPass.withFacts.guardDegree
     |>.andThen busUnifyPass.guardDegree
     |>.andThen (VerifiedPassW.guardDegree (iterateToFixpoint busPairCancelPass))
+    |>.andThen (VerifiedPassW.guardDegree (iterateToFixpoint bytePackPass))
     |>.andThen disconnectedComponentPass.withFacts.guardDegree
     |>.andThen reencodePass.withFacts.guardDegree
 

--- a/Leanr/Implementation/OptimizerPasses/BytePack.lean
+++ b/Leanr/Implementation/OptimizerPasses/BytePack.lean
@@ -1,0 +1,245 @@
+import Leanr.Implementation.OptimizerPasses.FactPass
+
+set_option autoImplicit false
+-- `simp`'s unused-argument linter mis-flags lemmas that enable a rewrite another lemma then
+-- consumes (e.g. unfolding `Expression.vars` on a numeral); it is a style lint, not a soundness one.
+set_option linter.unusedSimpArgs false
+
+/-! # Byte-check packing (`bytePackPass`)
+
+On a bitwise-style lookup bus (OpenVM's `BitwiseLookup`), a single value is byte-range-checked by the
+self-XOR message `[e, e, 0, 1]` (op = 1: it asserts `e ⊕ e = 0`, which only forces both operands —
+here the same `e` — to be bytes). Two such single-value checks pack into **one** pair check
+`[e₁, e₂, 0, 0]` (op = 0: range-check both operands as bytes). The pair check imposes the *identical*
+obligation — "both operands are bytes" — so replacing a pair of single checks with one pair check is
+satisfaction-preserving. Because these lookups are **stateless**, the swap leaves every stateful side
+effect and the memory discipline untouched: a pure bus-interaction win (variables and constraints
+unchanged). This is exactly powdr's byte-check packing.
+
+The table equivalence is a proven `BusFacts` fact (`bytePairBus`, discharged for OpenVM in
+`Leanr/Implementation/OpenVmFacts.lean`); the pass here is VM-agnostic — with `BusFacts.trivial`
+(`bytePairBus = false`) it is a no-op. One pair is packed per invocation; `iterateToFixpoint` drains
+them (the bus length strictly drops by one each time). -/
+
+variable {p : ℕ}
+
+/-- Canonical single-value byte check `[e, e, 0, 1]` (multiplicity `1`). Constants are written with
+    `Expression.const` rather than numeral sugar so the file needs no numeral-notation import. -/
+def byteCheck1 (busId : Nat) (e : Expression p) : BusInteraction (Expression p) :=
+  { busId := busId, multiplicity := .const 1, payload := [e, e, .const 0, .const 1] }
+
+/-- Canonical packed pair byte check `[e₁, e₂, 0, 0]` (multiplicity `1`). -/
+def byteCheck2 (busId : Nat) (e₁ e₂ : Expression p) : BusInteraction (Expression p) :=
+  { busId := busId, multiplicity := .const 1, payload := [e₁, e₂, .const 0, .const 0] }
+
+theorem byteCheck1_eval (busId : Nat) (e : Expression p) (env : Variable → ZMod p) :
+    (byteCheck1 busId e).eval env
+      = { busId := busId, multiplicity := 1, payload := [e.eval env, e.eval env, 0, 1] } := rfl
+
+theorem byteCheck2_eval (busId : Nat) (e₁ e₂ : Expression p) (env : Variable → ZMod p) :
+    (byteCheck2 busId e₁ e₂).eval env
+      = { busId := busId, multiplicity := 1, payload := [e₁.eval env, e₂.eval env, 0, 0] } := rfl
+
+/-! ## Correctness of one packing step -/
+
+/-- Replacing a pair of single-value byte checks `A = [eA,eA,0,1]`, `B = [eB,eB,0,1]` (both on a
+    `bytePairBus`) by the packed check `C = [eA,eB,0,0]` is `PassCorrect`: the fact makes `C`'s
+    obligation equivalent to `A`'s and `B`'s together (same satisfying set), and all three are
+    stateless so side effects and `admissible` are unchanged. No new variables, no derivations. -/
+theorem mergeBytePair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (hbp : facts.bytePairBus busId = true)
+    (pre mid post : List (BusInteraction (Expression p))) (eA eB : Expression p)
+    (hsplit : cs.busInteractions
+        = pre ++ byteCheck1 busId eA :: mid ++ byteCheck1 busId eB :: post) :
+    PassCorrect cs
+      { cs with busInteractions := pre ++ byteCheck2 busId eA eB :: mid ++ post } [] bs := by
+  obtain ⟨hstate, hbrk, hbicond⟩ := facts.bytePairBus_sound busId hbp
+  set out : ConstraintSystem p :=
+    { cs with busInteractions := pre ++ byteCheck2 busId eA eB :: mid ++ post } with hout
+  have houtb : out.busInteractions = pre ++ byteCheck2 busId eA eB :: mid ++ post := rfl
+  -- all three interactions are stateless
+  have hstA : bs.isStateful (byteCheck1 busId eA).busId = false := hstate
+  have hstB : bs.isStateful (byteCheck1 busId eB).busId = false := hstate
+  have hstC : bs.isStateful (byteCheck2 busId eA eB).busId = false := hstate
+  -- per-env obligation equivalence: `P C ↔ P A ∧ P B`
+  have hkey : ∀ env,
+      (bs.violatesConstraint ((byteCheck2 busId eA eB).eval env) = false ↔
+        bs.violatesConstraint ((byteCheck1 busId eA).eval env) = false ∧
+          bs.violatesConstraint ((byteCheck1 busId eB).eval env) = false) := by
+    intro env
+    rw [byteCheck1_eval, byteCheck1_eval, byteCheck2_eval]
+    exact hbicond (eA.eval env) (eB.eval env) 1
+  -- the obligation predicate that appears in `satisfies`
+  set P : (Variable → ZMod p) → BusInteraction (Expression p) → Prop :=
+    fun env bi => (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false
+    with hP
+  have hPA : ∀ env, (P env (byteCheck1 busId eA) ↔
+      bs.violatesConstraint ((byteCheck1 busId eA).eval env) = false) := by
+    intro env
+    simp only [hP, byteCheck1_eval]
+    exact ⟨fun h => h hp1, fun h _ => h⟩
+  have hPB : ∀ env, (P env (byteCheck1 busId eB) ↔
+      bs.violatesConstraint ((byteCheck1 busId eB).eval env) = false) := by
+    intro env
+    simp only [hP, byteCheck1_eval]
+    exact ⟨fun h => h hp1, fun h _ => h⟩
+  have hPC : ∀ env, (P env (byteCheck2 busId eA eB) ↔
+      bs.violatesConstraint ((byteCheck2 busId eA eB).eval env) = false) := by
+    intro env
+    simp only [hP, byteCheck2_eval]
+    exact ⟨fun h => h hp1, fun h _ => h⟩
+  -- satisfaction equivalence
+  have hsatiff : ∀ env, cs.satisfies bs env ↔ out.satisfies bs env := by
+    intro env
+    have hbus : (∀ bi ∈ cs.busInteractions, P env bi) ↔
+        (∀ bi ∈ out.busInteractions, P env bi) := by
+      rw [hsplit, houtb]
+      simp only [List.forall_mem_append, List.forall_mem_cons]
+      have hc := hPC env; have ha := hPA env; have hb := hPB env
+      have hk := hkey env
+      tauto
+    constructor
+    · rintro ⟨hcons, hb⟩
+      exact ⟨hcons, (hbus.1 (fun bi hbi => hb bi hbi))⟩
+    · rintro ⟨hcons, hb⟩
+      exact ⟨hcons, (hbus.2 (fun bi hbi => hb bi hbi))⟩
+  -- the stateful-filtered interaction lists coincide (A, B, C are stateless)
+  have hfilt : cs.busInteractions.filter (fun bi => bs.isStateful bi.busId)
+      = out.busInteractions.filter (fun bi => bs.isStateful bi.busId) := by
+    rw [hsplit, houtb]
+    simp only [List.filter_append, List.filter_cons, hstA, hstB, hstC, Bool.false_eq_true,
+      if_false]
+  have hside : ∀ env, cs.sideEffects bs env = out.sideEffects bs env := by
+    intro env
+    simp only [ConstraintSystem.sideEffects, hfilt]
+  -- the active∧stateful evaluated messages coincide too (A, B, C are stateless)
+  have hadmarg : ∀ env,
+      (cs.busInteractions.map (fun bi => bi.eval env)).filter
+        (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
+      = (out.busInteractions.map (fun bi => bi.eval env)).filter
+        (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId) := by
+    intro env
+    rw [hsplit, houtb]
+    simp only [List.map_append, List.map_cons, List.filter_append, List.filter_cons,
+      byteCheck1_eval, byteCheck2_eval, hstate, Bool.and_false, Bool.false_eq_true, if_false]
+  have hadm : ∀ env, cs.admissible bs env ↔ out.admissible bs env := by
+    intro env
+    simp only [ConstraintSystem.admissible, hadmarg]
+  -- membership: `out`'s interactions come from `cs`'s payloads (C's vars come from eA/eB)
+  have hsub : ∀ v ∈ out.vars, v ∈ cs.vars := by
+    intro v hv
+    rw [ConstraintSystem.mem_vars] at hv ⊢
+    rcases hv with ⟨c, hc, hvc⟩ | ⟨bi, hbi, hvbi⟩
+    · exact Or.inl ⟨c, hc, hvc⟩
+    · rw [houtb] at hbi
+      simp only [List.mem_append, List.mem_cons] at hbi
+      rcases hbi with (h | rfl | h) | h
+      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
+      · -- `bi = C = byteCheck2 busId eA eB`; its vars come from eA or eB
+        have hnil0 : (Expression.const (0 : ZMod p)).vars = [] := rfl
+        have hab : v ∈ eA.vars ∨ v ∈ eB.vars := by
+          rcases hvbi with hm | ⟨e, he, hve⟩
+          · -- multiplicity `1` has no variables
+            exact absurd hm (by
+              rw [show (byteCheck2 busId eA eB).multiplicity.vars = [] from rfl]
+              simp)
+          · have he' : e = eA ∨ e = eB ∨ e = Expression.const (0 : ZMod p)
+                ∨ e = Expression.const (0 : ZMod p) := by simpa [byteCheck2] using he
+            rcases he' with rfl | rfl | rfl | rfl
+            · exact Or.inl hve
+            · exact Or.inr hve
+            · exact absurd hve (by rw [hnil0]; simp)
+            · exact absurd hve (by rw [hnil0]; simp)
+        have hpayA : eA ∈ (byteCheck1 busId eA).payload := by
+          show eA ∈ [eA, eA, Expression.const 0, Expression.const 1]; exact List.mem_cons_self ..
+        have hpayB : eB ∈ (byteCheck1 busId eB).payload := by
+          show eB ∈ [eB, eB, Expression.const 0, Expression.const 1]; exact List.mem_cons_self ..
+        rcases hab with h | h
+        · exact Or.inr ⟨byteCheck1 busId eA,
+            by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto,
+            Or.inr ⟨eA, hpayA, h⟩⟩
+        · exact Or.inr ⟨byteCheck1 busId eB,
+            by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto,
+            Or.inr ⟨eB, hpayB, h⟩⟩
+      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
+      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ hsub ?_
+  · intro env hsat
+    exact ⟨env, (hsatiff env).2 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro hinv env hsat bi hbi
+    rw [houtb] at hbi
+    simp only [List.mem_append, List.mem_cons] at hbi
+    rcases hbi with (h | rfl | h) | h
+    · exact hinv env ((hsatiff env).2 hsat) bi
+        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
+    · -- `bi = C`: a multiplicity-1 packed check never breaks an invariant
+      show ((byteCheck2 busId eA eB).eval env).multiplicity ≠ 0 →
+        bs.breaksInvariant ((byteCheck2 busId eA eB).eval env) = false
+      intro _
+      rw [byteCheck2_eval]; exact hbrk (eA.eval env) (eB.eval env)
+    · exact hinv env ((hsatiff env).2 hsat) bi
+        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
+    · exact hinv env ((hsatiff env).2 hsat) bi
+        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
+  · intro env hadmE hsat
+    exact ⟨(hsatiff env).1 hsat, (hadm env).1 hadmE, by rw [hside]; exact BusState.equiv_refl _⟩
+
+/-! ## The pass: find and pack one pair per invocation -/
+
+/-- If `bi` is a single-value byte check `[e, e, 0, 1]` (multiplicity `1`) on a `bytePairBus`,
+    return the checked value `e`. All fields are checked structurally, so a hit means
+    `bi = byteCheck1 bi.busId e`. -/
+def matchByteCheck {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  if facts.bytePairBus bi.busId then
+    match bi.multiplicity, bi.payload with
+    | .const c, [e, e', z, op] =>
+        if decide (c = 1) && decide (e = e') && decide (z = .const 0) && decide (op = .const 1)
+        then some e else none
+    | _, _ => none
+  else none
+
+/-- Scan for the next byte check on `busId`, returning the interior `mid`, its value `eB`, and the
+    remainder `post`. -/
+def findSecond {bs : BusSemantics p} (facts : BusFacts p bs) (busId : Nat) :
+    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
+    Option (List (BusInteraction (Expression p)) × Expression p ×
+      List (BusInteraction (Expression p)))
+  | _, [] => none
+  | revMid, b :: rest =>
+    match matchByteCheck facts b with
+    | some eB => if decide (b.busId = busId) then some (revMid.reverse, eB, rest)
+                 else findSecond facts busId (b :: revMid) rest
+    | none => findSecond facts busId (b :: revMid) rest
+
+/-- Fused scan for the first packable pair; the O(n) split-equation `decide` runs only for the
+    chosen candidate (mirrors `busPairCancel`). -/
+def findBytePackGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (revPre : List (BusInteraction (Expression p))) :
+    List (BusInteraction (Expression p)) → Option (PassResult cs bs)
+  | [] => none
+  | a :: rest =>
+    match matchByteCheck facts a with
+    | some eA =>
+      match findSecond facts a.busId [] rest with
+      | some (mid, eB, post) =>
+        if hbp : facts.bytePairBus a.busId = true then
+          if hsplit : cs.busInteractions
+              = revPre.reverse ++ byteCheck1 a.busId eA :: mid ++ byteCheck1 a.busId eB :: post then
+            some ⟨{ cs with busInteractions :=
+                      revPre.reverse ++ byteCheck2 a.busId eA eB :: mid ++ post }, [],
+                  mergeBytePair_correct cs bs facts hp1 a.busId hbp revPre.reverse mid post eA eB
+                    hsplit⟩
+          else findBytePackGo cs bs facts hp1 (a :: revPre) rest
+        else findBytePackGo cs bs facts hp1 (a :: revPre) rest
+      | none => findBytePackGo cs bs facts hp1 (a :: revPre) rest
+    | none => findBytePackGo cs bs facts hp1 (a :: revPre) rest
+
+/-- Pack one pair of single-value byte checks into a pair check. `iterateToFixpoint` drains all
+    packable pairs (the bus length strictly decreases each step). -/
+def bytePackPass : VerifiedPassW p := fun cs bs facts =>
+  if hp1 : (1 : ZMod p) ≠ 0 then
+    match findBytePackGo cs bs facts hp1 [] cs.busInteractions with
+    | some r => r
+    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -12,6 +12,14 @@ Only worth it if the flag-compression edge is judged not worth `reencode`'s comp
 pass would then also want a `bits ≥ vars` / large-group path (groups `reencode` skips) to claw some of
 it back. Left for Georg to decide.
 
+Effectiveness priority: **variables > bus interactions > constraints**. As of the byte-check
+packing pass (log entry 49), on the top-12 `openvm-eth` sample leanr and powdr are ~tied on
+variables (leanr wins the aggregate, powdr the geomean) and leanr leads on constraints; the
+remaining *systematic* gap is bus interactions. The bus gap now decomposes as: (a) range-check
+packing via the tuple range checker, (b) memory-pointer-limb 13-bit checks on memory-heavy blocks,
+(c) residual bitwise checks that are not self-XOR byte checks, (d) occasional missed memory
+send↔receive cancellations. See the `docs/log.md` entry 42/46/49 discussion for measurements.
+
 ## Drop never-violating stateless lookups (close the residual pc-lookup bus gap)
 
 After memory/exec send↔receive pair cancellation (log entry 46), leanr is at near-parity with powdr
@@ -25,28 +33,65 @@ effectiveness without regressing variables — a clean win under the priority or
 (variables > bus interactions > constraints). Check the existing zero-multiplicity drop in
 `cleanupCycle` first; this may be an extension of it rather than a new pass.
 
+## Range-check packing via the tuple range checker (bus interactions)
+
+powdr merges a byte check and an N-bit range check into a single `TupleRangeChecker` interaction
+`[x, y]` (checking `x < s1 ∧ y < s2`); leanr keeps them as two separate `variableRangeChecker`
+lookups. This is the same shape as the byte-check packing already landed (entry 49): add a
+`BusFacts` fact that a tuple-range message `[x, y]` is accepted iff the two single range checks
+`[x, bits1]`, `[y, bits2]` are, then a pass that pairs a byte check with a matching-width range
+check into one tuple interaction. Sound (identical satisfying set), stateless, variable-neutral —
+a clean bus win. Modest per case (~2–8 interactions), but general.
+
+## Extend byte-check packing to non-self and cross-form checks (bus interactions)
+
+`bytePackPass` (entry 49) recognises only the self-XOR byte check `[e, e, 0, 1]`. Some blocks
+(e.g. apc_008) keep bitwise interactions in other forms — genuine XOR `[x, y, z, 1]` with `x ≠ y`,
+or byte checks already half-packed — that it leaves alone, so its bitwise count stays above powdr's.
+Generalise the recogniser (and the `bytePairBus` fact) to pack any two messages that each impose a
+"this operand is a byte" obligation, regardless of the carrier form. Still a stateless, sound,
+variable-neutral bus win.
+
+## Eliminate memory-pointer-limb decompositions / redundant range checks (bus interactions)
+
+On memory-heavy blocks (e.g. apc_005) leanr keeps ~2× powdr's `mem_ptr_limbs` decompositions and
+their 13-bit range checks (the high/"page" limb is identical across same-base accesses but leanr
+re-decomposes and re-checks per access). The limbs are pinned by **degree-2 carry constraints**
+`(L₁)(L₂) = 0` whose roots are `base + offset` (parameterised by the base variable), so no linear
+(`gauss`/`affine`) or finite-*constant*-domain (`domainProp`/`domainBatch`/`reencode`) pass can
+touch them. Closing it needs a **carry-branch-resolution** step: use the proven byte/range bounds
+(`BusFacts.slotBound`) to show one factor of the product can't vanish, collapsing `(L₁)(L₂)=0` to
+the linear `Lᵢ=0` so Gauss can unify the shared limb and drop the duplicate check. This is the
+hardest of the current ideas — dropping a range check is sound only if the shared limb is *proven*
+equal (a bounded-no-wrap argument in the style of `MemoryUnify.boundedSumMax`) — and it is a bus
+win on an axis where leanr is already ~tied with powdr on variables, so lower leverage than the
+packing passes.
+
+## Is-zero / is-equal witness reduction (variables)
+
+An equality/is-zero gadget `cmp = [vector ≠ 0]` is encoded with one inverse-marker witness per limb
+(`diff_inv_marker__i`, in the single constraint `−cmp + Σ (a_i − b_i)·inv_i = 0`); powdr collapses
+the `k` markers to **one** by combining the byte-bounded limbs into a single value whose zeroness is
+equivalent (a weighted sum `Σ 256ⁱ (a_i − b_i)` is zero iff all limbs are, given byte bounds so the
+sum can't wrap). Reduces `k−1` variables per comparison. Sound but byte-bound-dependent (needs the
+`boundedSumMax`-style no-wrap argument and a transport via `reencode_correct_D`). Note: `cmp` itself
+must become a derived column (powdr's `QuotientOrZero`/`IfEqZero`, already in `ComputationMethod`),
+since a free `cmp` with the certificate dropped would be under-constrained. Small per case, and
+variables are ~tied overall — do the cheaper bus wins first.
+
 ## Smarter witnesses for `disconnectedComponentPass`
 
 `disconnectedComponentPass` (entry 43) removes a disconnected component only if the **all-zero**
-witness certifies it satisfiable (every dropped constraint evaluates to `0`, every dropped
-stateless interaction is non-violating). This captures dead range-checked auxiliaries (e.g. the
-`bit_shift_carry` limbs) but **not** the most common disconnected pattern in the benchmark: an
-orphaned register read, whose data limbs survive only in a bitwise byte-check
-`[K − Σ 256ⁱ·limbᵢ, limb₀, 0, 0]` plus range checks. There, `0` is not a satisfying assignment (the
-first bitwise slot is a large constant, not a byte); the satisfying witness is the base-256
-decomposition of `K` (~29 benchmark cases, 3 vars each).
+witness certifies it satisfiable. This misses the common orphaned-register-read pattern (data limbs
+surviving only in a bitwise byte-check `[K − Σ 256ⁱ·limbᵢ, limb₀, 0, 0]` plus range checks), where
+the satisfying witness is the base-256 decomposition of `K`, not `0`. A witness *finder* that solves
+the component's lookups (probe `violatesConstraint`) would capture them. Only the finder changes,
+not the proof. Phrase it as a general "solve the component's lookups" search, not hard-coded
+base-256, to avoid overfitting to the OpenVM limb structure.
 
-Capturing them needs a witness *finder* that solves a small system of range/byte lookups. The
-correctness machinery already supports any witness (it only re-checks `violatesConstraint`/`eval`
-at run time), so **only the finder needs to change**, not the proof. Caveat: a decomposition solver
-leans toward the OpenVM limb structure — phrase it as a general "solve the component's lookups"
-search (probe `violatesConstraint`) rather than hard-coding base-256, to avoid overfitting.
+## Batch pair cancellation in one traversal (performance)
 
-## Batch pair cancellation in one traversal
-
-`busPairCancelPass` (entry 46) drops one pair per invocation and is drained via `iterateToFixpoint`
-inside the cleanup cycle. On the largest blocks (~hundreds of pairs) this is the dominant per-pass
-cost. A single-traversal "drop all matched interior send/receive pairs per address" would be O(n)
-instead of O(pairs·n), but needs a multi-drop discipline lemma (the current proof is per-pair via
-`admissibleMemoryBus_dropOne` applied twice). Only worth it if the pass becomes a benchmark
-bottleneck.
+`busPairCancelPass` (entry 46) drops one pair per invocation and is drained via `iterateToFixpoint`;
+`bytePackPass` (entry 49) is the same shape. On the largest blocks this is O(pairs·n). A
+single-traversal multi-drop would be O(n) but needs a multi-drop discipline lemma. Only worth it if
+these passes become a benchmark bottleneck.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1147,3 +1147,45 @@ result is byte-identical to reencode-only on every case sampled (apc_002/003/004
 i.e. effectiveness-neutral but more general (and slightly fewer fixpoint cycles: apc_005 62.3 s → 58.4 s).
 The pass stands on its own if `reencode` is ever dropped (entry-47 option B → ~1939 on this class, keeping
 all flags, close to powdr's 1808).
+
+### 49. Byte-check packing (`BytePack.lean`) — bus-interaction effectiveness
+
+Closes most of the bitwise-lookup bus gap identified in entry 42/46. On OpenVM's `BitwiseLookup`
+bus a single value `e` is byte-range-checked by the self-XOR message `[e, e, 0, 1]` (op 1: asserts
+`e ⊕ e = 0`, forcing `e` to be a byte). powdr packs **two** such checks into one pair check
+`[e₁, e₂, 0, 0]` (op 0: range-check both operands), checking two bytes per interaction where leanr
+kept one per limb — so leanr carried ~2× powdr's bitwise interactions (e.g. apc_001 12 vs 6,
+apc_008 36 vs 10). `bytePackPass` performs the same packing.
+
+Why it is sound (no audited-surface change — `Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`,
+`Leanr/Optimizer.lean` untouched):
+- The two single checks and the packed check impose the **identical** obligation ("both operands
+  are bytes"), so the satisfying set is unchanged. This table equivalence — `violates [x,y,0,0] =
+  false ↔ violates [x,x,0,1] = false ∧ violates [y,y,0,1] = false` — is a new **proven `BusFacts`
+  field** `bytePairBus` (discharged for the bitwise bus in `OpenVmFacts.lean` against the concrete
+  `violates`; `trivial` sets it `false`, so the pass is a no-op without facts and stays
+  VM-agnostic). The field also carries `breaksInvariant [x,y,0,0] (mult 1) = false` (the new packed
+  interaction preserves invariants).
+- The three interactions are **stateless** (`isStateful = false`), so the swap leaves every stateful
+  side effect and the `admissible` discipline untouched (the stateful-filtered lists coincide). The
+  core `mergeBytePair_correct` is a `PassCorrect.ofEnvEq` (env' = env, no derivations); `out.vars ⊆
+  cs.vars` because the packed check's operands come from the two originals. One pair is packed per
+  invocation, drained by `iterateToFixpoint` (bus length strictly drops by one each step); the
+  candidate scan mirrors `busPairCancel` (the O(n) split-equation `decide` runs only for the chosen
+  candidate).
+
+`lake build` green; `openVmOptimizer_maintainsCorrectness` (and the `simpleOptimizer` /
+`optimizerWithBusFacts` variants) still `{propext, Classical.choice, Quot.sound}`-only; no
+`sorry`/`admit`/`axiom`/`native_decide`; all outputs within the degree bound (the packed check has
+degree ≤ the originals).
+
+**Impact (openvm-eth, top-12 `benchmark.py`, variables and constraints unchanged):** bus-interaction
+effectiveness **3.056× → 3.109× aggregate**, **2.406× → 2.559× geomean** (gap to powdr's 3.552× /
+2.888× narrowed from −0.496 to −0.443 aggregate). Variables **3.997× / 3.403×** and constraints
+**8.784× / 8.546×** are byte-for-byte identical (the pass touches neither). Per case: apc_001 bus
+**30 → 24**, reaching **full parity with powdr (24)**; apc_003 96 → 90; apc_008 89 → 77 (bitwise
+36 → 24). The residual bitwise gap on some blocks (apc_008) is non-self-XOR byte checks the
+recogniser skips; the remaining bus gap is otherwise the tuple-range packing and the memory-pointer
+13-bit checks (see `docs/ideas.md`). Note: variables are ~tied with powdr on this sample (leanr wins
+the aggregate, powdr the geomean and 7/12 cases), so bus interactions are the systematic gap this
+targets.


### PR DESCRIPTION
## Summary

Implements `bytePackPass`, an optimization that packs pairs of single-value byte checks into a single pair check on stateless bitwise-style buses. This closes most of the bitwise-lookup bus gap identified in earlier entries.

## Changes

**New pass implementation (`Leanr/Implementation/OptimizerPasses/BytePack.lean`)**
- Defines canonical single-value byte check `[e, e, 0, 1]` and pair check `[e₁, e₂, 0, 0]` patterns
- Implements `matchByteCheck` to recognize single-value byte checks on `bytePairBus` buses
- Implements `findSecond` to scan for a matching second byte check on the same bus
- Implements `findBytePackGo` to find and pack one pair per invocation (drained by `iterateToFixpoint`)
- Proves `mergeBytePair_correct`: replacing two single checks with one pair check is `PassCorrect`
  - The two single checks and the packed check impose identical obligations ("both operands are bytes")
  - All three interactions are stateless, so side effects and `admissible` discipline are unchanged
  - No new variables; the packed check's operands come from the originals

**Bus facts infrastructure (`Leanr/Implementation/BusFacts.lean`)**
- Adds `bytePairBus : (busId : Nat) → Bool` field to `BusFacts`
- Adds `bytePairBus_sound` theorem: if `bytePairBus busId = true`, then:
  - The bus is stateless
  - The pair-check message `[x, y, 0, 0]` is accepted exactly when both single-value checks `[x, x, 0, 1]` and `[y, y, 0, 1]` are
  - The packed check never breaks invariants
- Updates `BusFacts.trivial` to set `bytePairBus` to `false` (pass becomes a no-op without facts)

**OpenVM facts (`Leanr/Implementation/OpenVmFacts.lean`)**
- Discharges `bytePairBus` for the bitwise-lookup bus against the concrete `violates` predicate
- Proves the table equivalence: `violates [x, y, 0, 0] = false ↔ violates [x, x, 0, 1] = false ∧ violates [y, y, 0, 1] = false`

**Integration (`Leanr/Implementation/Optimizer.lean`)**
- Imports `BytePack` and adds `bytePackPass` to the cleanup cycle

**Documentation (`docs/ideas.md`, `docs/log.md`)**
- Updates ideas with refined effectiveness priorities and decomposition of remaining bus gaps
- Adds log entry 47 documenting the pass, its soundness, and measured impact

## Implementation Details

- **Soundness**: The pass is sound because the two single checks and the packed check impose identical obligations on the operands (both must be bytes), so the satisfying set is unchanged. The interactions are stateless, so the swap leaves every stateful side effect and the `admissible` discipline untouched.
- **Completeness**: One pair is packed per invocation; `iterateToFixpoint` drains all packable pairs (bus length strictly decreases by one each step).
- **Candidate scan**: Mirrors `busPairCancel`; the O(n) split-equation `decide` runs only for the chosen candidate.
- **VM-agnostic**: With `BusFacts.trivial` (setting `bytePairBus = false`), the pass is a no-op without facts, keeping the optimizer VM-agnostic.

## Impact

On the openvm-eth benchmark (top-12 cases):
- Bus-interaction effectiveness: **3.056× → 3.109× aggregate**, **2.406× → 2.559× geomean**
- Variables and constraints: unchanged (byte-for-byte identical)
- Per case: apc_001 bus **30 → 24** (full parity with pow

https://claude.ai/code/session_01WwVjq2MdKJryiL8XsVRzH8