### PR TITLE
Optimizer runtime: eliminate per-constraint rescans in hintCollapse and reencode

### DIFF
--- a/Leanr/Implementation/OptimizerPasses/HintCollapse.lean
+++ b/Leanr/Implementation/OptimizerPasses/HintCollapse.lean
@@ -470,28 +470,33 @@ theorem collapse_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSeman
 
 /-! ## Detection: find a collapsible reciprocal-witness group and discharge the facts -/
 
-/-- A witness variable `d` occurs (in the whole system) only in the target constraint `E`. -/
+/-- A witness variable `d` occurs (in the whole system) only in the target constraint `E`.
+    Decided with the allocation-free `Expression.mentions` (early-exit tree walk) rather than
+    `d ∉ ·.vars`, which would materialize every expression's variable list once per `(E, d)`
+    pair — this check runs inside the per-constraint candidate scan. -/
 def occursOnlyInTarget (cs : ConstraintSystem p) (E : Expression p) (d : Variable) : Bool :=
-  (cs.algebraicConstraints.all (fun c => decide (c = E) || decide (d ∉ c.vars))) &&
+  (cs.algebraicConstraints.all (fun c => decide (c = E) || !(c.mentions d))) &&
   (cs.busInteractions.all (fun bi =>
-    decide (d ∉ bi.multiplicity.vars) && bi.payload.all (fun e => decide (d ∉ e.vars))))
+    !(bi.multiplicity.mentions d) && bi.payload.all (fun e => !(e.mentions d))))
 
 theorem occursOnlyInTarget_constr {cs : ConstraintSystem p} {E : Expression p} {d : Variable}
     (h : occursOnlyInTarget cs E d = true) : ∀ c ∈ cs.algebraicConstraints, d ∈ c.vars → c = E := by
   intro c hc hdc
   simp only [occursOnlyInTarget, Bool.and_eq_true, List.all_eq_true] at h
   have hc' := h.1 c hc
-  simp only [Bool.or_eq_true, decide_eq_true_eq] at hc'
+  simp only [Bool.or_eq_true, decide_eq_true_eq, Bool.not_eq_true'] at hc'
   rcases hc' with h1 | h2
   · exact h1
-  · exact absurd hdc h2
+  · exact absurd hdc (mentions_false_not_mem_vars d c h2)
 
 theorem occursOnlyInTarget_bus {cs : ConstraintSystem p} {E : Expression p} {d : Variable}
     (h : occursOnlyInTarget cs E d = true) : ∀ bi ∈ cs.busInteractions,
       d ∉ bi.multiplicity.vars ∧ ∀ e ∈ bi.payload, d ∉ e.vars := by
   intro bi hbi
-  simp only [occursOnlyInTarget, Bool.and_eq_true, List.all_eq_true, decide_eq_true_eq] at h
-  exact h.2 bi hbi
+  simp only [occursOnlyInTarget, Bool.and_eq_true, List.all_eq_true, Bool.not_eq_true'] at h
+  obtain ⟨hm, hp⟩ := h.2 bi hbi
+  exact ⟨mentions_false_not_mem_vars d bi.multiplicity hm,
+    fun e he => mentions_false_not_mem_vars d e (hp e he)⟩
 
 /-- The single variable a coefficient reduces to: a bare `var a`, or `a·1` / `1·a` (the shape `peel`
     produces from a `aᵢ·dimᵢ` term). Returns `none` for anything else. -/
@@ -556,18 +561,27 @@ theorem coeffsByteOK_sound (B : Std.HashMap Variable Nat) (D : List Variable) :
       · exact ih hrec c hcs
 
 /-- Attempt the collapse with target constraint `E`: compute the once-in-`E` witnesses `D`, peel
-    their coefficients, and — if all checks pass — return the verified `PassResult`. -/
-def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    their coefficients, and — if all checks pass — return the verified `PassResult`.
+
+    Runtime shape (this runs once per constraint per pass invocation): the bounds map `Bm` and the
+    bus-occurring variable set `busVars` are built **once** per invocation and passed in. `busVars`
+    only short-circuits `occursOnlyInTarget` — a variable occurring in any bus interaction can
+    never pass it, so consulting the hash set first skips the full-system scan without changing
+    the filter's value. The certificate is one short-circuiting `&&` chain, so on the (vast
+    majority of) constraints with `D.length < 2` nothing else is evaluated. -/
+def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable)
     (E : Expression p) (hE : E ∈ cs.algebraicConstraints) : Option (PassResult cs bs) := by
   classical
-  set Bm : BoundsMap p cs bs := BoundsMap.build facts with hBm
-  set D := E.vars.dedup.filter (fun v => occursOnlyInTarget cs E v) with hD
+  set D := E.vars.dedup.filter (fun v =>
+    !busVars.contains v && occursOnlyInTarget cs E v) with hD
   set inv : Variable := ⟨"hcinv#" ++ (D.headD ⟨"_", none⟩).name, none⟩ with hinvdef
-  by_cases hchk : 2 ≤ D.length ∧ coeffsByteOK Bm.map D (peel D E).1 = true ∧
-      (∀ d ∈ D, d ∉ (peel D E).2.vars) ∧
-      (∀ x ∈ (peel D E).2.vars, x.powdrId?.isSome = true) ∧
-      inv ∉ cs.vars ∧ (peel D E).1.length * 256 ≤ p
-  · obtain ⟨h2len, hbyteOK, hrfree, hrpow, hinvfresh, hfit⟩ := hchk
+  by_cases hchk : (decide (2 ≤ D.length) && (coeffsByteOK Bm.map D (peel D E).1 &&
+      (decide (∀ d ∈ D, d ∉ (peel D E).2.vars) &&
+      (decide (∀ x ∈ (peel D E).2.vars, x.powdrId?.isSome = true) &&
+      (decide (inv ∉ cs.vars) && decide ((peel D E).1.length * 256 ≤ p)))))) = true
+  · simp only [Bool.and_eq_true, decide_eq_true_eq] at hchk
+    obtain ⟨h2len, hbyteOK, hrfree, hrpow, hinvfresh, hfit⟩ := hchk
     have hEvarsub : ∀ x ∈ E.vars, x ∈ cs.vars := fun x hx =>
       ConstraintSystem.mem_vars_of_constraint hE hx
     have hcfree : ∀ c ∈ (peel D E).1, ∀ d ∈ D, d ∉ c.vars := by
@@ -604,11 +618,16 @@ def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
         (fun cd hcd => hallz cd.1 (List.of_mem_zip hcd).1)
       rw [peel_eval D E env, hfz, zero_add] at hE0
       exact hE0
+    have hDcert : ∀ d ∈ D, occursOnlyInTarget cs E d = true := by
+      intro d hd
+      have h := (List.mem_filter.1 (hD ▸ hd)).2
+      simp only [Bool.and_eq_true] at h
+      exact h.2
     have hDonce : ∀ d ∈ D, ∀ c ∈ cs.algebraicConstraints, d ∈ c.vars → c = E := fun d hd =>
-      occursOnlyInTarget_constr (List.mem_filter.1 (hD ▸ hd)).2
+      occursOnlyInTarget_constr (hDcert d hd)
     have hDbus : ∀ d ∈ D, ∀ bi ∈ cs.busInteractions,
         d ∉ bi.multiplicity.vars ∧ ∀ e ∈ bi.payload, d ∉ e.vars := fun d hd =>
-      occursOnlyInTarget_bus (List.mem_filter.1 (hD ▸ hd)).2
+      occursOnlyInTarget_bus (hDcert d hd)
     have hden_free : inv ∉ (sumExpr (peel D E).1).vars ∧ ∀ d ∈ D, d ∉ (sumExpr (peel D E).1).vars := by
       refine ⟨fun hx => ?_, fun d hd hx => ?_⟩
       · obtain ⟨c, hc, hxc⟩ := sumExpr_vars hx
@@ -631,20 +650,27 @@ def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
   · exact none
 
 /-- Scan a constraint sublist for the first collapsible target. -/
-def tryList [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs) :
+def tryList [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable) :
     (L : List (Expression p)) → (∀ E ∈ L, E ∈ cs.algebraicConstraints) → Option (PassResult cs bs)
   | [], _ => none
   | E :: rest, hmem =>
-    match tryOne cs bs facts E (hmem E (List.mem_cons_self ..)) with
+    match tryOne cs bs Bm busVars E (hmem E (List.mem_cons_self ..)) with
     | some r => some r
-    | none => tryList cs bs facts rest (fun E' h => hmem E' (List.mem_cons_of_mem _ h))
+    | none => tryList cs bs Bm busVars rest (fun E' h => hmem E' (List.mem_cons_of_mem _ h))
 
 /-- The hint-collapse pass: replace the first bilinear reciprocal-witness constraint by a single
     derived inverse hint (needs prime `p` for the field inverse; identity otherwise, and identity
-    with `BusFacts.trivial` since no coefficient is byte-bounded). -/
+    with `BusFacts.trivial` since no coefficient is byte-bounded). The bounds map and the set of
+    bus-occurring variables are built once here, not once per scanned constraint. -/
 def hintCollapsePass : VerifiedPassW p := fun cs bs facts =>
   if hp : p.Prime then
     haveI : Fact p.Prime := ⟨hp⟩
-    (tryList cs bs facts cs.algebraicConstraints (fun _ h => h)).getD ⟨cs, [], PassCorrect.refl cs bs⟩
+    let Bm : BoundsMap p cs bs := BoundsMap.build facts
+    let busVars : Std.HashSet Variable := cs.busInteractions.foldl (init := ∅) fun s bi =>
+      bi.payload.foldl (fun s e => e.vars.foldl (·.insert ·) s)
+        (bi.multiplicity.vars.foldl (·.insert ·) s)
+    (tryList cs bs Bm busVars cs.algebraicConstraints (fun _ h => h)).getD
+      ⟨cs, [], PassCorrect.refl cs bs⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 

--- a/Leanr/Implementation/OptimizerPasses/Reencode.lean
+++ b/Leanr/Implementation/OptimizerPasses/Reencode.lean
@@ -1344,10 +1344,14 @@ def buildReencode (cs : ConstraintSystem p) (xs : List Variable) (freshBase : St
 def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p)
     (xs : List Variable) (freshBase : String) : PassResult cs bsem :=
   if hxs : xs.all (fun x => x.powdrId?.isSome) = true then
-  if hxsCs : xs.all (fun x => decide (x ∈ cs.vars)) = true then
   match hb : buildReencode cs xs freshBase with
   | none => ⟨cs, [], PassCorrect.refl cs bsem⟩
   | some (bits, hm) =>
+    -- The group-membership scan is checked only for the few groups `buildReencode` accepts, and
+    -- against a `cs.vars` bound once — the occurrence list is ~10⁴ entries, so materializing it
+    -- (×8) for every candidate group dominated this pass's runtime.
+    let csVars := cs.vars
+    if hxsCs : xs.all (fun x => decide (x ∈ csVars)) = true then
     if hxsB : xs.all (fun x => decide (x ∉ bits)) = true then
     if hbn : bits.all (fun b => decide (b.powdrId? = none)) = true then
     if hchk : checkReencode cs xs bits hm = true then

--- a/Main.lean
+++ b/Main.lean
@@ -244,10 +244,15 @@ def cmdProfile (fileName : String) : IO Unit := do
       ("domainBatch", domainBatchPass.guardDegree),
       ("normalize2", normalizePass.withFacts.guardDegree),
       ("constFold2", constantFoldPass.withFacts.guardDegree),
+      ("zeroRegister", zeroRegisterPass.guardDegree),
+      ("hintCollapse", hintCollapsePass.guardDegree),
       ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
       ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
       ("tautoBus", tautoBusDropPass.withFacts.guardDegree),
+      ("domainFold", domainFoldPass.withFacts.guardDegree),
       ("busUnify", busUnifyPass.guardDegree),
+      ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint busPairCancelPass)),
+      ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint bytePackPass)),
       ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
       ("reencode", reencodePass.withFacts.guardDegree) ]
   let t0 ← IO.monoMsNow

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -110,5 +110,7 @@ base-256, to avoid overfitting to the OpenVM limb structure.
 
 `busPairCancelPass` (entry 46) drops one pair per invocation and is drained via `iterateToFixpoint`;
 `bytePackPass` (entry 49) is the same shape. On the largest blocks this is O(pairs·n). A
-single-traversal multi-drop would be O(n) but needs a multi-drop discipline lemma. Only worth it if
-these passes become a benchmark bottleneck.
+single-traversal multi-drop would be O(n) but needs a multi-drop discipline lemma. As of entry 53
+it **is** a measured bottleneck: with the `hintCollapse`/`reencode` rescans fixed, `busPairCancel`
+is ~24 s of apc_005's 65 s optimizer time (second only to `domainBatch`, whose fix is sketched in
+entry 45's remaining-bottleneck note).

--- a/docs/log.md
+++ b/docs/log.md
@@ -1331,3 +1331,50 @@ removing the 3 surplus inverse-hint witnesses there; it is a **sound no-op** on 
 are byte-bounded only through the memory invariant (no in-block range check). Verified on top of
 entry 51: apc_001 38→35, apc_047 94→91; no change on apc_010/apc_028/apc_056/apc_069. The
 full-benchmark aggregate is left to the maintainer's run.
+
+### 53. Optimizer runtime: kill the per-constraint full-system rescans in `hintCollapse` and `reencode` (effectiveness unchanged)
+
+Pure **performance** work in the entry-45 style — every change is output-preserving, so
+effectiveness is untouched and only the optimizer's wall-clock cost drops. Verified by running
+baseline (pre-change) and new binaries on 13 benchmark cases spanning all size classes
+(apc_001/003/005/006/008/010/014/028/047/056/069/092/100): `vars/constraints/bus` are **identical
+on every case**. Nothing in the audited surface or `Basic.lean` changed; correctness axioms stay
+`{propext, Classical.choice, Quot.sound}`; `lake build` green, `check-proof-integrity.sh` passes.
+
+Re-profiled per-pass at HEAD (the `leanr profile` pass list was stale — it predated
+`zeroRegister`/`hintCollapse`/`domainFold`/`busPairCancel`/`bytePack`; synced it to the current
+`cleanupCycle` in `Main.lean`). The entry-52 `hintCollapse` dominated everything: 183 s of
+apc_005's 280 s (65%), 129 s of apc_100's 347 s (37%), with `reencode` second (38 s / 106 s).
+Both were paying for *recomputation inside the per-candidate scan*:
+
+1. **`hintCollapse` (`HintCollapse.lean`)** — `tryOne` runs once per constraint, and each call (a) rebuilt
+   `BoundsMap.build facts` (a full bus-interaction sweep), (b) decided `occursOnlyInTarget` per
+   variable by materializing every expression's `.vars` list (a full-system allocation storm per
+   `(E, d)` pair), and (c) eagerly evaluated the whole `Decidable` certificate conjunction —
+   including an `inv ∉ cs.vars` membership scan that rebuilds the ~10⁵-entry occurrence list —
+   even when the very first conjunct `2 ≤ D.length` already failed (it fails on essentially every
+   constraint). Fixes, each output-preserving: hoist `BoundsMap.build` and a new `busVars` hash set
+   (all variables occurring in any bus interaction) to the pass level, built once per invocation;
+   gate `occursOnlyInTarget` behind `!busVars.contains v` (a variable in any bus interaction can
+   never pass it, so the gate never changes the filter's value — it only skips the scan); decide
+   `occursOnlyInTarget` with the allocation-free `Expression.mentions` instead of `d ∉ ·.vars`;
+   and turn the certificate into one short-circuiting `&&` chain (`decide`d conjuncts) so nothing
+   after `2 ≤ D.length` is evaluated on unsuitable constraints. The proof consumes the same
+   certificates (`Bool.and_eq_true`/`decide_eq_true_eq` split them back into the six hypotheses).
+2. **`reencode` (`Reencode.lean`)** — `reencodeStep` checked `xs.all (· ∈ cs.vars)` *before*
+   `buildReencode`, so every candidate group (hundreds per invocation, ×8 variables each)
+   materialized the full occurrence list; `buildReencode` rejects almost all of them anyway.
+   Moved the check after `buildReencode` succeeds (all failure branches return the same identity
+   `PassResult`, so this is a pure branch reorder) and bound `cs.vars` once with a `let`.
+
+**Impact (solo runs, same machine, output identical):** apc_005 **280.5 s → 75.3 s (3.7×)**,
+apc_100 **320.0 s → 155.7 s (2.1×)**, apc_010 14.6 s → 8.8 s (1.7×), apc_008 17.2 s → 16.5 s;
+small register-only cases unchanged (they never hit the hot paths). Per-pass on apc_005
+(profiler): `hintCollapse` **182.9 s → 0.2 s (~900×)**, `reencode` **37.7 s → 5.2 s (7.3×)**.
+
+Remaining bottlenecks (documented for future work): `domainBatch` (24.7 s on apc_005) — the
+entry-45 note still applies (enumerate only the non-pinned variables of the domain box, needs
+`forcedFromSurvivors_sound` reproven against the reduced box); and `busPairCancel` (23.6 s) —
+it drops one send/receive pair per invocation and rescans the system per drop, so a chain of
+`k` cancellations costs `k` full `findCancel` sweeps (a batched variant would cancel a whole
+chain per sweep).


### PR DESCRIPTION
## Summary

Pure performance optimization (entry 53) that eliminates redundant full-system rescans in `hintCollapse` and `reencode` passes. All changes are output-preserving — effectiveness is unchanged, only wall-clock optimizer time drops. Verified on 13 benchmark cases (apc_001/003/005/006/008/010/014/028/047/056/069/092/100): variable/constraint/bus counts are identical on every case.

## Key Changes

**`HintCollapse.lean`:**
- Hoist `BoundsMap.build` and a new `busVars` hash set (all variables in any bus interaction) to pass level, built once per invocation instead of once per constraint
- Gate `occursOnlyInTarget` behind `!busVars.contains v` — variables in bus interactions can never pass the check, so this short-circuits the full-system scan without changing the filter's value
- Replace `d ∉ ·.vars` membership checks with allocation-free `Expression.mentions` (early-exit tree walk) in `occursOnlyInTarget`
- Convert the certificate conjunction into a short-circuiting `&&` chain so conjuncts after `2 ≤ D.length` (which fails on ~99% of constraints) are never evaluated
- Update proofs to consume the same certificates via `Bool.and_eq_true`/`decide_eq_true_eq` decomposition and new `mentions_false_not_mem_vars` lemma

**`Reencode.lean`:**
- Move the `xs.all (· ∈ cs.vars)` membership check after `buildReencode` succeeds (pure branch reorder — all failure paths return the same identity result)
- Bind `cs.vars` once with a `let` to avoid materializing the ~10⁴-entry occurrence list for every candidate group

**`Main.lean`:**
- Sync the stale `leanr profile` pass list to current `cleanupCycle` (add `zeroRegister`, `hintCollapse`, `domainFold`, `busPairCancel`, `bytePack`)

**`docs/log.md` and `docs/ideas.md`:**
- Document the performance analysis, fixes, and measured impact
- Update bottleneck notes: `busPairCancel` is now a measured bottleneck (24 s on apc_005)

## Impact

**Solo runs (same machine, output identical):**
- apc_005: **280.5 s → 75.3 s (3.7×)**
- apc_100: **320.0 s → 155.7 s (2.1×)**
- apc_010: 14.6 s → 8.8 s (1.7×)
- Per-pass on apc_005: `hintCollapse` **182.9 s → 0.2 s (~900×)**, `reencode` **37.7 s → 5.2 s (7.3×)**

Small register-only cases unchanged (they never hit the hot paths).

## Implementation Details

The fixes are output-preserving because:
1. `busVars` short-circuit only skips the scan when the result would be `false` anyway
2. `mentions` is equivalent to `∉ ·.vars` (proven via `mentions_false_not_mem_vars`)
3. Moving the `reencode` membership check after `buildReencode` is a pure branch reorder
4. The certificate `&&` chain is logically equivalent to the original conjunction — it just short-circuits earlier

Correctness axioms remain `{propext, Classical.choice, Quot.sound}`; `lake build` passes and `check-proof-integrity.sh` passes.

https://claude.ai/code/session_01Wm6YUkLPPZJj8uALRyPZCq