### PR TITLE
Payload canonicalization + richer byte justification for memory chains

### DIFF
--- a/Leanr/Implementation/Optimizer.lean
+++ b/Leanr/Implementation/Optimizer.lean
@@ -20,6 +20,7 @@ import Leanr.Implementation.OptimizerPasses.Reencode
 import Leanr.Implementation.OptimizerPasses.DomainFold
 import Leanr.Implementation.OptimizerPasses.ZeroRegister
 import Leanr.Implementation.OptimizerPasses.HintCollapse
+import Leanr.Implementation.OptimizerPasses.PayloadCanon
 
 set_option autoImplicit false
 
@@ -68,6 +69,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen tautoBusDropPass.withFacts.guardDegree
     |>.andThen domainFoldPass.withFacts.guardDegree
     |>.andThen busUnifyPass.guardDegree
+    |>.andThen payloadCanonPass.withFacts.guardDegree
     |>.andThen (VerifiedPassW.guardDegree (iterateToFixpoint busPairCancelPass))
     |>.andThen (VerifiedPassW.guardDegree (iterateToFixpoint bytePackPass))
     |>.andThen disconnectedComponentPass.withFacts.guardDegree

--- a/Leanr/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/Leanr/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -316,21 +316,32 @@ theorem deepByteJustified_sound [Fact p.Prime] [NeZero p] (all : List (Expressio
 /-- Is `e` provably a byte under every assignment satisfying the remaining system? Either a
     constant `< 256`, a variable with a proven bus-fact bound `≤ 256` derived from the remaining
     interactions `rest` (e.g. another receive of the same word, or an explicit byte-check
-    lookup), or — when `deep` is set (prime `p` only) — a variable a constraint pins to a byte
-    on every point of its selector flags' finite domains (`deepBoundOk`). -/
+    lookup), or — when `deep` is set (prime `p` only) — a variable whose constraint-derived
+    finite domain (`findDomainAlg`, e.g. `x·(x−255) = 0`) contains only bytes, a variable a
+    constraint pins to a byte on every point of its selector flags' proven finite domains
+    (`deepBoundOk`), or (any expression) an explicit self-check `[e, e, 0, 1]` on a `byteCheck`
+    bus among the remaining interactions — the carrier the pass itself emits for
+    otherwise-unjustified slots, matched syntactically. -/
 def byteJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
     (e : Expression p) : Bool :=
   match e.constValue? with
   | some c => decide (c.val < 256)
   | none =>
-    match e with
-    | .var x =>
-      (match findVarBound bs facts rest x with
-       | some bound => decide (bound ≤ 256)
-       | none => false) ||
-      (deep && deepByteJustified all bs facts rest x)
-    | _ => false
+    (match e with
+     | .var x =>
+       (match findVarBound bs facts rest x with
+        | some bound => decide (bound ≤ 256)
+        | none => false) ||
+       (deep && ((match findDomainAlg all x with
+                  | some dom => dom.all (fun v => decide (v.val < 256))
+                  | none => false) ||
+                 deepByteJustified all bs facts rest x))
+     | _ => false) ||
+    (deep && rest.any (fun bi =>
+      facts.byteCheck bi.busId &&
+      decide (bi.multiplicity = (.const 1 : Expression p)) &&
+      decide (bi.payload = [e, e, (.const 0 : Expression p), (.const 1 : Expression p)])))
 
 theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (e : Expression p)
@@ -350,25 +361,54 @@ theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusS
   | none =>
     rw [hc] at h
     dsimp only at h
-    cases e with
-    | var x =>
-      dsimp only at h
-      show (env x).val < 256
-      rcases Bool.or_eq_true _ _ |>.mp h with h' | h'
-      · cases hb : findVarBound bs facts rest x with
-        | some bound =>
-          rw [hb] at h'
-          dsimp only at h'
-          exact lt_of_lt_of_le (findVarBound_sound bs facts rest x bound hb env hbus)
-            (of_decide_eq_true h')
-        | none => rw [hb] at h'; simp at h'
-      · rw [Bool.and_eq_true] at h'
-        haveI : Fact p.Prime := ⟨hdeep h'.1⟩
-        haveI : NeZero p := ⟨(hdeep h'.1).ne_zero⟩
-        exact deepByteJustified_sound all bs facts rest x h'.2 env hall hbus
-    | const n => simp at h
-    | add a b => simp at h
-    | mul a b => simp at h
+    rcases Bool.or_eq_true _ _ |>.mp h with h | hcarrier
+    · cases e with
+      | var x =>
+        dsimp only at h
+        show (env x).val < 256
+        rcases Bool.or_eq_true _ _ |>.mp h with h' | h'
+        · cases hb : findVarBound bs facts rest x with
+          | some bound =>
+            rw [hb] at h'
+            dsimp only at h'
+            exact lt_of_lt_of_le (findVarBound_sound bs facts rest x bound hb env hbus)
+              (of_decide_eq_true h')
+          | none => rw [hb] at h'; simp at h'
+        · rw [Bool.and_eq_true] at h'
+          haveI : Fact p.Prime := ⟨hdeep h'.1⟩
+          haveI : NeZero p := ⟨(hdeep h'.1).ne_zero⟩
+          rcases Bool.or_eq_true _ _ |>.mp h'.2 with hdom | hdeepb
+          · cases hd : findDomainAlg all x with
+            | some dom =>
+              rw [hd] at hdom
+              dsimp only at hdom
+              have hmem := findDomainAlg_sound all x dom hd env hall
+              exact of_decide_eq_true (List.all_eq_true.mp hdom _ hmem)
+            | none => rw [hd] at hdom; simp at hdom
+          · exact deepByteJustified_sound all bs facts rest x hdeepb env hall hbus
+      | const n => simp at h
+      | add a b => simp at h
+      | mul a b => simp at h
+    · -- an explicit self-check on a `byteCheck` bus among `rest` carries `e`'s byte obligation
+      rw [Bool.and_eq_true] at hcarrier
+      haveI : Fact (1 < p) := ⟨(hdeep hcarrier.1).one_lt⟩
+      obtain ⟨bi, hbi, hform⟩ := List.any_eq_true.1 hcarrier.2
+      rw [Bool.and_eq_true, Bool.and_eq_true] at hform
+      obtain ⟨⟨hbc, hmd⟩, hpayd⟩ := hform
+      have hmult : bi.multiplicity = (.const 1 : Expression p) := of_decide_eq_true hmd
+      have hpayload : bi.payload
+          = [e, e, (.const 0 : Expression p), (.const 1 : Expression p)] :=
+        of_decide_eq_true hpayd
+      obtain ⟨_, _, hviol⟩ := facts.byteCheck_sound bi.busId hbc
+      have hEv : bi.eval env
+          = { busId := bi.busId, multiplicity := (1 : ZMod p),
+              payload := [e.eval env, e.eval env, (0 : ZMod p), (1 : ZMod p)] } := by
+        unfold BusInteraction.eval
+        rw [hmult, hpayload]
+        rfl
+      have hok := hbus bi hbi (by rw [hEv]; exact one_ne_zero)
+      rw [hEv] at hok
+      exact (hviol (e.eval env) 1).mp hok
 
 /-- Are all of `R`'s payload entries at the declared byte slots justified from `rest`? -/
 def recvSlotsJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
@@ -941,16 +981,19 @@ def findCancelGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFac
         if B.all (midRefuted shape busId S) && A.all (preRefuted shape busId S) then
         -- Byte slots the remaining system does not justify are materialized as a single
         -- explicit self-check on the byte-check bus (more than one would not shrink the bus
-        -- count and would stall the cancellation loop); when the justification cannot pass
-        -- (≥ 2 unjustified slots, or no byte-check bus), skip the certificate re-check —
-        -- the justification scan is the expensive part.
+        -- count and would stall the cancellation loop). One check suffices whenever all the
+        -- unjustified slots carry the *same* expression (`byteJustified`'s carrier branch then
+        -- justifies each of them); when they don't, or there is no byte-check bus, skip the
+        -- certificate re-check — the justification scan is the expensive part.
         let unjust := unjustifiedSlots deep cs.algebraicConstraints bs facts (A ++ B ++ C)
           slots R
         let checks : List (BusInteraction (Expression p)) :=
-          match unjust, bcBus? with
-          | [slot], some bcBus => (R.payload[slot]?).elim [] (fun e =>
-              [{ busId := bcBus, multiplicity := .const 1,
-                 payload := [e, e, .const 0, .const 1] }])
+          match bcBus?, unjust.filterMap (fun slot => R.payload[slot]?) with
+          | some bcBus, e :: es =>
+              if es.all (fun e' => e' == e) then
+                [{ busId := bcBus, multiplicity := .const 1,
+                   payload := [e, e, .const 0, .const 1] }]
+              else []
           | _, _ => []
         if unjust.isEmpty || !checks.isEmpty then
         if hchk : checkCancel deep cs.algebraicConstraints bs facts shape busId slots

--- a/Leanr/Implementation/OptimizerPasses/PayloadCanon.lean
+++ b/Leanr/Implementation/OptimizerPasses/PayloadCanon.lean
@@ -1,0 +1,246 @@
+import Leanr.Implementation.OptimizerPasses.FactPass
+import Leanr.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # Bus payload canonicalization (`payloadCanonPass`)
+
+A bus payload entry is often a *defined* expression: some algebraic constraint `x - e = 0`
+(as built by `eqExpr`, e.g. the slot equalities `busUnifyPass` adds for consecutive
+same-address memory accesses) pins a variable `x` to the entry's value. This pass rewrites such
+payload entries `e` to the equal **variable** `x`.
+
+The value of every message is unchanged under any assignment satisfying the constraints (which
+the pass keeps untouched), so satisfaction, side effects, `admissible` and invariants all
+transfer with the *same* environment in both directions — a `PassCorrect.ofEnvEq` proof.
+
+Why it matters: passes that compare payload entries *syntactically* — most importantly
+`busPairCancelPass`, which cancels a matched send/receive pair only when the payloads are
+**equal** — are blocked when one side carries the defining expression and the other the defined
+variable (a memory write of a degree-2 value, read back as a fresh column: the write's payload
+holds the blend, the read's the variable, and the linking constraint cannot be inlined without
+raising degrees). Canonicalizing both to the variable makes the pair syntactically equal, and
+the (already-verified) cancellation machinery fires. It also lowers payload degrees, which can
+only help the degree guard.
+
+Only non-atomic entries are rewritten (`e` neither a variable nor a constant), so a rewrite
+strictly shrinks the payload's total AST size and the pass cannot oscillate under the pipeline's
+fixpoint iteration. Field-free and VM-agnostic; the constraints are not modified. -/
+
+variable {p : ℕ}
+
+/-! ## Recognizing defining constraints -/
+
+/-- Is the expression a variable or a constant? (Rewriting those would not shrink anything.) -/
+def Expression.isAtomic : Expression p → Bool
+  | .var _ => true
+  | .const _ => true
+  | _ => false
+
+/-- Extract a defining equality from a constraint of the syntactic shape `eqExpr` builds:
+    `x - e` (i.e. `.add (.var x) (.mul (.const (-1)) e)`) or `e - x`, giving `(e, x)` —
+    "payload entry `e` may be rewritten to `.var x`". -/
+def defPattern? : Expression p → Option (Expression p × Variable)
+  | .add (.var x) (.mul (.const k) e) => if k = -1 then some (e, x) else none
+  | .add e (.mul (.const k) (.var x)) => if k = -1 then some (e, x) else none
+  | _ => none
+
+/-- The checked certificate the correctness proof consumes: the defining constraint for `(e, x)`
+    is literally present (in either orientation). Holds by construction for pairs produced by
+    `defPattern?`, but re-checking keeps the proof independent of the builder. -/
+def defWitnessed (constraints : List (Expression p)) (d : Expression p × Variable) : Bool :=
+  constraints.any (fun c =>
+    decide (c = eqExpr (.var d.2) d.1) || decide (c = eqExpr d.1 (.var d.2)))
+
+theorem defWitnessed_eval (constraints : List (Expression p)) (d : Expression p × Variable)
+    (h : defWitnessed constraints d = true) (env : Variable → ZMod p)
+    (hzero : ∀ c ∈ constraints, c.eval env = 0) : env d.2 = d.1.eval env := by
+  obtain ⟨c, hc, hcform⟩ := List.any_eq_true.1 h
+  rcases Bool.or_eq_true _ _ |>.mp hcform with h' | h'
+  · have hceq : c = eqExpr (.var d.2) d.1 := of_decide_eq_true h'
+    have hz := hzero c hc
+    rw [hceq, eqExpr_eval] at hz
+    have := sub_eq_zero.mp hz
+    simpa [Expression.eval] using this
+  · have hceq : c = eqExpr d.1 (.var d.2) := of_decide_eq_true h'
+    have hz := hzero c hc
+    rw [hceq, eqExpr_eval] at hz
+    have := sub_eq_zero.mp hz
+    simpa [Expression.eval] using this.symm
+
+/-- The defining variable of a witnessed pair occurs in the witnessing constraint, hence in the
+    system. -/
+theorem defWitnessed_var_mem (cs : ConstraintSystem p) (d : Expression p × Variable)
+    (h : defWitnessed cs.algebraicConstraints d = true) : d.2 ∈ cs.vars := by
+  obtain ⟨c, hc, hcform⟩ := List.any_eq_true.1 h
+  rcases Bool.or_eq_true _ _ |>.mp hcform with h' | h'
+  · refine ConstraintSystem.mem_vars_of_constraint hc ?_
+    rw [of_decide_eq_true h']
+    simp [eqExpr, Expression.vars]
+  · refine ConstraintSystem.mem_vars_of_constraint hc ?_
+    rw [of_decide_eq_true h']
+    simp [eqExpr, Expression.vars]
+
+/-! ## The rewrite -/
+
+/-- Rewrite `e` to `.var x` when `(e, x)` is a recorded defining pair (first match wins);
+    otherwise leave it unchanged. Applied at the top level of each payload entry only. -/
+def canonRw (defs : List (Expression p × Variable)) (e : Expression p) : Expression p :=
+  match defs.find? (fun d => decide (d.1 = e)) with
+  | some d => .var d.2
+  | none => e
+
+theorem canonRw_eval (defs : List (Expression p × Variable))
+    (constraints : List (Expression p))
+    (hall : ∀ d ∈ defs, defWitnessed constraints d = true)
+    (env : Variable → ZMod p) (hzero : ∀ c ∈ constraints, c.eval env = 0) :
+    ∀ e : Expression p, (canonRw defs e).eval env = e.eval env := by
+  intro e
+  unfold canonRw
+  cases hf : defs.find? (fun d => decide (d.1 = e)) with
+  | none => rfl
+  | some d =>
+    have hmem : d ∈ defs := List.mem_of_find?_eq_some hf
+    have hde : d.1 = e := by have := List.find?_some hf; simpa using this
+    have hval := defWitnessed_eval constraints d (hall d hmem) env hzero
+    show (Expression.var d.2).eval env = e.eval env
+    rw [Expression.eval, hval, hde]
+
+/-- Every variable of a rewritten entry occurs in the original entry or is a defining variable. -/
+theorem canonRw_vars (defs : List (Expression p × Variable)) (e : Expression p) :
+    ∀ v ∈ (canonRw defs e).vars, v ∈ e.vars ∨ ∃ d ∈ defs, v = d.2 := by
+  intro v hv
+  unfold canonRw at hv
+  cases hf : defs.find? (fun d => decide (d.1 = e)) with
+  | none => rw [hf] at hv; exact Or.inl hv
+  | some d =>
+    rw [hf] at hv
+    simp only [Expression.vars, List.mem_singleton] at hv
+    exact Or.inr ⟨d, List.mem_of_find?_eq_some hf, hv⟩
+
+/-! ## The rewritten system -/
+
+/-- Apply `g` to every payload entry of a bus interaction (multiplicity untouched). -/
+def BusInteraction.mapPayload (bi : BusInteraction (Expression p))
+    (g : Expression p → Expression p) : BusInteraction (Expression p) :=
+  { busId := bi.busId, multiplicity := bi.multiplicity, payload := bi.payload.map g }
+
+/-- Rewrite every payload entry of every bus interaction; constraints untouched. -/
+def ConstraintSystem.mapPayload (cs : ConstraintSystem p)
+    (g : Expression p → Expression p) : ConstraintSystem p :=
+  { algebraicConstraints := cs.algebraicConstraints,
+    busInteractions := cs.busInteractions.map (·.mapPayload g) }
+
+section EnvFixed
+
+variable {g : Expression p → Expression p} {env : Variable → ZMod p}
+  (hg : ∀ e : Expression p, (g e).eval env = e.eval env)
+
+include hg
+
+/-- Under an eval-preserving-at-`env` rewrite, evaluated messages are unchanged. -/
+theorem BusInteraction.eval_mapPayload (bi : BusInteraction (Expression p)) :
+    (bi.mapPayload g).eval env = bi.eval env := by
+  simp only [BusInteraction.mapPayload, BusInteraction.eval, List.map_map]
+  congr 1
+  apply List.map_congr_left
+  intro e _
+  simp only [Function.comp_apply, hg]
+
+theorem ConstraintSystem.satisfies_mapPayload (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    (cs.mapPayload g).satisfies bs env ↔ cs.satisfies bs env := by
+  simp only [ConstraintSystem.satisfies, ConstraintSystem.mapPayload]
+  constructor
+  · rintro ⟨hc, hb⟩
+    refine ⟨hc, fun bi0 hbi0 => ?_⟩
+    have := hb _ (List.mem_map.2 ⟨bi0, hbi0, rfl⟩)
+    rwa [bi0.eval_mapPayload hg] at this
+  · rintro ⟨hc, hb⟩
+    refine ⟨hc, fun bi hbi => ?_⟩
+    obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+    rw [bi0.eval_mapPayload hg]
+    exact hb bi0 hbi0
+
+theorem ConstraintSystem.sideEffects_mapPayload (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    (cs.mapPayload g).sideEffects bs env = cs.sideEffects bs env := by
+  simp only [ConstraintSystem.sideEffects, ConstraintSystem.mapPayload]
+  induction cs.busInteractions with
+  | nil => rfl
+  | cons bi rest ih =>
+    simp only [List.map_cons, List.filter_cons]
+    have hbus : bs.isStateful (bi.mapPayload g).busId = bs.isStateful bi.busId := rfl
+    rw [hbus]
+    by_cases hstate : bs.isStateful bi.busId = true
+    · simp only [if_pos hstate, List.map_cons, ih, bi.eval_mapPayload hg]
+    · simp only [if_neg hstate, ih]
+
+theorem ConstraintSystem.admissible_mapPayload (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    (cs.mapPayload g).admissible bs env ↔ cs.admissible bs env := by
+  unfold ConstraintSystem.admissible
+  have hmap : (cs.mapPayload g).busInteractions.map (fun bi => bi.eval env)
+      = cs.busInteractions.map (fun bi => bi.eval env) := by
+    simp only [ConstraintSystem.mapPayload, List.map_map]
+    exact List.map_congr_left (fun bi _ => bi.eval_mapPayload hg)
+  rw [hmap]
+
+end EnvFixed
+
+/-! ## Correctness -/
+
+theorem payloadCanon_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (defs : List (Expression p × Variable))
+    (hall : defs.all (defWitnessed cs.algebraicConstraints) = true) :
+    PassCorrect cs (cs.mapPayload (canonRw defs)) [] bs := by
+  have hallmem : ∀ d ∈ defs, defWitnessed cs.algebraicConstraints d = true :=
+    fun d hd => List.all_eq_true.mp hall d hd
+  -- the rewritten system keeps the constraints, definitionally
+  have hcsame : (cs.mapPayload (canonRw defs)).algebraicConstraints
+      = cs.algebraicConstraints := rfl
+  refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+  · -- soundness: the same environment satisfies the input
+    intro env hsat
+    have hzero : ∀ c ∈ cs.algebraicConstraints, c.eval env = 0 := fun c hc =>
+      hsat.1 c (by rw [hcsame]; exact hc)
+    have hg := canonRw_eval defs cs.algebraicConstraints hallmem env hzero
+    exact ⟨env, (cs.satisfies_mapPayload hg bs).1 hsat,
+      by rw [cs.sideEffects_mapPayload hg bs]; exact BusState.equiv_refl _⟩
+  · -- invariant preservation
+    intro hinv env hsat bi hbi
+    have hzero : ∀ c ∈ cs.algebraicConstraints, c.eval env = 0 := fun c hc =>
+      hsat.1 c (by rw [hcsame]; exact hc)
+    have hg := canonRw_eval defs cs.algebraicConstraints hallmem env hzero
+    obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+    have h := hinv env ((cs.satisfies_mapPayload hg bs).1 hsat) bi0 hbi0
+    simpa only [bi0.eval_mapPayload hg] using h
+  · -- no new variables
+    intro v hv
+    rw [ConstraintSystem.mem_vars] at hv
+    rcases hv with ⟨c, hc, hxc⟩ | ⟨bi, hbi, hxbi⟩
+    · exact ConstraintSystem.mem_vars_of_constraint hc hxc
+    · obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+      rcases hxbi with hm | ⟨e, he, hxe⟩
+      · exact ConstraintSystem.mem_vars_of_mult hbi0 hm
+      · obtain ⟨e0, he0, rfl⟩ := List.mem_map.1 he
+        rcases canonRw_vars defs e0 v hxe with h | ⟨d, hd, rfl⟩
+        · exact ConstraintSystem.mem_vars_of_payload hbi0 he0 h
+        · exact defWitnessed_var_mem cs d (hallmem d hd)
+  · -- completeness: the same environment satisfies the output
+    intro env hadm hsat
+    have hg := canonRw_eval defs cs.algebraicConstraints hallmem env hsat.1
+    exact ⟨(cs.satisfies_mapPayload hg bs).2 hsat,
+      (cs.admissible_mapPayload hg bs).2 hadm,
+      by rw [cs.sideEffects_mapPayload hg bs]; exact BusState.equiv_refl _⟩
+
+/-! ## The pass -/
+
+/-- Canonicalize bus payload entries to their defining variables. The rewrite map is rebuilt
+    from the current constraints on each invocation; entries that are already atomic are never
+    keys, so every rewrite strictly shrinks payload AST size and the pass is trivially a no-op
+    at its own fixpoint. -/
+def payloadCanonPass : VerifiedPass p := fun cs bs =>
+  let defs := (cs.algebraicConstraints.filterMap defPattern?).filter
+    (fun d => !d.1.isAtomic)
+  if defs.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+  else if hall : defs.all (defWitnessed cs.algebraicConstraints) = true then
+    ⟨cs.mapPayload (canonRw defs), [], payloadCanon_correct cs bs defs hall⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -12,26 +12,31 @@ Only worth it if the flag-compression edge is judged not worth `reencode`'s comp
 pass would then also want a `bits ≥ vars` / large-group path (groups `reencode` skips) to claw some of
 it back. Left for Georg to decide.
 
-Effectiveness priority: **variables > bus interactions > constraints**. As of the byte-check
-packing pass (log entry 49), on the top-12 `openvm-eth` sample leanr and powdr are ~tied on
-variables (leanr wins the aggregate, powdr the geomean) and leanr leads on constraints; the
-remaining *systematic* gap is bus interactions. The bus gap now decomposes as: (a) range-check
-packing via the tuple range checker, (b) memory-pointer-limb 13-bit checks on memory-heavy blocks,
-(c) residual bitwise checks that are not self-XOR byte checks, (d) occasional missed memory
-send↔receive cancellations. See the `docs/log.md` entry 42/46/49 discussion for measurements.
+Effectiveness priority: **variables > bus interactions > constraints**. On the top-12
+`openvm-eth` sample leanr and powdr are ~tied on variables (leanr wins the aggregate, powdr the
+geomean) and leanr leads on constraints; the remaining *systematic* gap is bus interactions. After
+log entry 54 closed the missed memory send↔receive cancellations (same-register access chains),
+the bus gap decomposes as: (a) range-check packing via the tuple range checker,
+(b) memory-pointer-limb 13-bit checks on memory-heavy blocks, (c) residual bitwise checks that are
+not self-XOR byte checks — now including the self-checks entry 54's cancellations emit (see the
+loaded-byte idea below). The stale "drop never-violating PC lookups" idea is gone: all sampled
+outputs already carry **zero** bus-2 interactions (constant folding pins the lookup fields and
+`tautoBusDropPass` removes them).
 
-## Drop never-violating stateless lookups (close the residual pc-lookup bus gap)
+## Justify the loaded-byte columns to kill the emitted self-checks (bus interactions)
 
-After memory/exec send↔receive pair cancellation (log entry 46), leanr is at near-parity with powdr
-on bus interactions; the residual gap is essentially the **PC lookups** (bus 2): powdr removes them,
-leanr keeps them (never-violating model), so they inflate the bus count without affecting variables.
-
-A `VerifiedPass` that drops a stateless bus interaction whose multiplicity is provably `0`, or that
-is proven never-violating via `BusFacts.neverViolates`, would be sound (removing a
-never-violating, non-stateful interaction changes no stateful side effect) and would raise bus
-effectiveness without regressing variables — a clean win under the priority order
-(variables > bus interactions > constraints). Check the existing zero-multiplicity drop in
-`cleanupCycle` first; this may be an extension of it rather than a new pass.
+After the payload-canonicalization + chain-cancellation work (log entry 54), leanr matches powdr
+exactly on the memory bus for register access chains, but each cancelled pair whose loaded-byte
+column (`read_data__0_i`, the value a `loadb` writes) has no shallow/domain/deep justification
+costs one *emitted* self-check `[e, e, 0, 1]` — on apc_010 that leaves bitwise bus 19 vs powdr's 1.
+The columns are genuinely bytes (selected from byte-bounded words via one-hot shift flags), but the
+selection is **two** levels deep: `read_data = (1-f)·s₀ + f·s₁` with `sᵢ = shifted_read_data`
+columns that are themselves flag-selections of memory-word limbs. `deepBoundOk` follows one level
+("byte constant or byte-bounded variable" per branch); making it recurse once (or seeding
+`BoundsMap` with domain-derived bounds so the `sᵢ` become "byte-bounded variables") would justify
+them, drop the emissions, and close most of the residual bitwise gap. Note `byteJustified` (log 54)
+already accepts domain-derived all-byte variables (`findDomainAlg`) — it is the `shifted_*`
+intermediates that lack bounds.
 
 ## Range-check packing via the tuple range checker (bus interactions)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1378,3 +1378,56 @@ entry-45 note still applies (enumerate only the non-pinned variables of the doma
 it drops one send/receive pair per invocation and rescans the system per drop, so a chain of
 `k` cancellations costs `k` full `findCancel` sweeps (a batched variant would cancel a whole
 chain per sweep).
+
+### 54. Cancel same-register access chains: payload canonicalization (`PayloadCanon.lean`) + richer byte justification — memory-bus parity with powdr on chain-heavy blocks
+
+**The gap.** Per-bus comparison against powdr showed the largest single bus-interaction gap in
+missed memory send↔receive cancellations on same-register access chains: on apc_010, registers
+x44/x60/x64 are accessed 16/12/8 times and leanr kept every intermediate pair (memory bus 144 vs
+powdr's 78, +66). Two independent blockers, neither of which is the two-send unification (that
+worked — `busUnifyPass` had already added and propagated the slot equalities):
+
+1. **Syntactic payload mismatch.** A `loadb`-style write sends the degree-2 blend
+   `(1−f)·s₀ + f·s₁` while the next access's receive carries the fresh column `read_data__0_i`.
+   The linking constraint `read_data__0_i − blend = 0` is in the system (added by `busUnify`),
+   but it cannot be inlined (degree), and `busPairCancelPass` compares payloads syntactically —
+   so the pair never matches.
+2. **Byte-slot justification too weak.** Even syntactically equal pairs were skipped:
+   `byteJustified` handled only constants and variables with bus-fact bounds or one-level deep
+   selector analysis, so data limbs like `read_data__1_i` — pinned to `{0, 255}` by their own
+   domain constraint `x·(x−255) = 0` — and the genuinely-unbounded loaded-byte column made
+   **≥ 2** unjustified slots, and the emit fallback only covered exactly one.
+
+**Fix 1 — `payloadCanonPass` (new `VerifiedPass`, `PayloadCanon.lean`).** For every algebraic
+constraint of the syntactic shape `eqExpr` builds (`x − e` or `e − x`, `e` non-atomic), rewrite
+payload entries equal to `e` to the variable `x` — top-level entry rewrite only, constraints
+untouched, multiplicities untouched. Under any assignment satisfying the (unchanged) constraints
+every message evaluates identically, so `PassCorrect.ofEnvEq` applies with the *same* environment
+in both directions; the checked certificate (`defWitnessed`, the defining constraint is literally
+present) is all the proof consumes. Rewrites strictly shrink payload AST size (keys are
+non-atomic), so the pass cannot oscillate under the pipeline fixpoint. Wired between
+`busUnifyPass` and the `busPairCancelPass` drain, so enabled cancellations fire in the same
+cleanup cycle. Generic: nothing memory- or OpenVM-specific.
+
+**Fix 2 — byte justification (`BusPairCancel.lean`).** `byteJustified` gains two proven paths:
+(a) a variable whose constraint-derived finite domain (`findDomainAlg`, e.g. `x·(x−255) = 0`)
+contains only byte values, and (b) any expression carried by an explicit self-check
+`[e, e, 0, 1]` (constant multiplicity 1) on a `byteCheck` bus among the remaining interactions —
+the carrier the pass itself emits. With (b), the (proof-free) emit gate generalizes from
+"exactly one unjustified slot" to "all unjustified slots hold the same expression" — one emitted
+check then justifies them all, and a chain cancellation stays a strict bus win (−2 memory, ≤ +1
+bitwise, later halved by `bytePackPass`).
+
+**Measured.** apc_010: bus **314 → 257** (effectiveness 2.11× → **2.53×**, powdr 2.72×); the
+memory bus itself hits exact parity with powdr (78 = 78); vars 470 and constraints 255 unchanged
+(both still beat powdr's 498/331). apc_008: bus 74 → 69. apc_001, apc_003, apc_005, apc_028,
+apc_056: byte-for-byte unchanged. Top-12 sample: bus effectiveness **3.01× → 3.06×** aggregate
+(**2.53× → 2.59×** geomean), variables/constraints identical — a pure bus win under the priority
+order. The residual apc_010 gap is the emitted self-checks (bitwise 19 vs 1; see the new
+loaded-byte idea in `docs/ideas.md`) and the range-check class. The full 100-case sweep was still running at commit
+time; its aggregate numbers are appended in the follow-up commit.
+
+`lake build` green; `Scripts/check-proof-integrity.sh` passes —
+`optimizerWithBusFacts_maintainsCorrectness`, `simpleOptimizer_maintainsCorrectness`,
+`openVmOptimizer_maintainsCorrectness` all still `{propext, Classical.choice, Quot.sound}`-only;
+no `sorry`/`admit`/`axiom`/`native_decide`; degree bounds ok on all sampled outputs.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1431,3 +1431,12 @@ time; its aggregate numbers are appended in the follow-up commit.
 `optimizerWithBusFacts_maintainsCorrectness`, `simpleOptimizer_maintainsCorrectness`,
 `openVmOptimizer_maintainsCorrectness` all still `{propext, Classical.choice, Quot.sound}`-only;
 no `sorry`/`admit`/`axiom`/`native_decide`; degree bounds ok on all sampled outputs.
+
+**Follow-up: full `openvm-eth` sweep (100 cases), with this change included.** Variables
+**4.082× agg / 3.605× geo** (powdr 4.092× / 3.787×) — aggregate now within 0.01× of powdr on the
+top-priority metric (last recorded sweep, entry 51: 4.064× / 3.522×; the delta also includes
+entry 52's hint collapse). Bus interactions **2.946× agg / 2.464× geo** (powdr 3.480× / 2.822×).
+Constraints **8.801× agg / 9.918× geo**, still far ahead of powdr's 5.853× / 10.311× aggregate.
+Per-case on variables: 15 wins / 71 losses / 14 ties — most losses are ≤ a few variables on small
+blocks (the geomean gap); the loaded-byte and range-check ideas in `docs/ideas.md` target the
+remaining bus gap next.


### PR DESCRIPTION
## Summary

This PR adds two complementary optimizations to close the missed memory send↔receive cancellations gap on same-register access chains:

1. **`payloadCanonPass`** (new `VerifiedPass` in `PayloadCanon.lean`): Rewrites payload entries to their defining variables when a constraint pins them. Enables syntactically equal pairs that were previously blocked by degree-2 blend expressions vs. fresh column variables.

2. **Enhanced byte justification** in `BusPairCancel.lean`: Extends `byteJustified` to recognize variables with all-byte constraint-derived domains and any expression carried by an emitted self-check on a `byteCheck` bus, allowing the emit gate to generalize from "exactly one unjustified slot" to "all slots hold the same expression."

## Key Changes

- **`Leanr/Implementation/OptimizerPasses/PayloadCanon.lean`** (new file, 246 lines):
  - `defPattern?`: Extracts defining equalities from constraints of shape `x - e = 0`
  - `canonRw`: Rewrites payload entries `e` to `.var x` when `(e, x)` is a defining pair
  - `payloadCanonPass`: Top-level entry rewrite only; constraints and multiplicities untouched
  - Proof via `PassCorrect.ofEnvEq`: same environment satisfies both systems; rewrites strictly shrink AST size (keys are non-atomic), preventing oscillation under fixpoint iteration

- **`Leanr/Implementation/OptimizerPasses/BusPairCancel.lean`**:
  - `byteJustified`: Added two new justification paths:
    - (a) Variables whose constraint-derived finite domain (`findDomainAlg`) contains only bytes
    - (b) Any expression carried by an explicit self-check `[e, e, 0, 1]` on a `byteCheck` bus in remaining interactions
  - `findCancelGo`: Generalized emit gate from "exactly one unjustified slot" to "all unjustified slots hold the same expression"
  - Updated proofs to handle the new branches

- **`Leanr/Implementation/Optimizer.lean`**: Wired `payloadCanonPass` between `busUnifyPass` and `busPairCancelPass` drain

- **`docs/log.md`**: Entry 54 documents the gap, fixes, and measurements (apc_010: bus 314 → 257, memory bus achieves exact parity with powdr at 78)

- **`docs/ideas.md`**: Updated effectiveness priority discussion and added "loaded-byte columns" follow-up idea

## Measured Impact

- **apc_010**: bus **314 → 257** (effectiveness 2.11× → 2.53×); memory bus matches powdr exactly (78 = 78)
- **Top-12 sample**: bus effectiveness **3.01× → 3.06×** aggregate (**2.53× → 2.59×** geomean)
- **Full 100-case sweep**: variables **4.082× agg / 3.605× geo** (within 0.01× of powdr on top priority metric)
- Variables and constraints unchanged; pure bus win under priority order

## Implementation Notes

- `payloadCanonPass` is field-free and VM-agnostic; constraints are never modified
- The rewrite map is rebuilt from current constraints on each invocation; entries already atomic are never keys, so every rewrite strictly shrinks payload AST size
- Proof uses checked certificate (`defWitnessed`) to verify the defining constraint is literally present
- All proofs remain `{propext, Classical.choice, Quot.sound}`-only; no `sorry`/`admit`/`axiom`/`native_decide`

https://claude.ai/code/session_01EdcPm7FJFs7oFwX1qrqnmb