### PR TITLE
CI: add merge_group trigger for the merge queue

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -2,7 +2,10 @@ name: Lean Action CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The repo now requires PRs, linear history, and merges through a merge queue. This adjusts CI accordingly:

- **Add `merge_group:` trigger.** The merge queue runs required checks on `merge_group` events. Without this trigger, once the `build` check is made required, PRs entering the queue would wait on a check that never starts and get ejected on timeout.
- **Restrict `push:` to `main`.** Previously every branch push ran CI in addition to the `pull_request` run, and the queue's temporary `gh-readonly-queue/main/*` branches would have triggered redundant push runs alongside the `merge_group` runs.

Note (repo settings, not addressable in this PR): branch protection on `main` currently has **no required status checks**, so the merge queue does not actually gate on CI — a queued PR merges without the Lean build / proof-integrity check passing on the merged result. `build` (the job in Lean Action CI) should be added as a required status check in the branch protection settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)