### PR TITLE
Effectiveness: baseline comparison + per-PR top-10 quick bench

### DIFF
--- a/.github/workflows/effectiveness_bench.yml
+++ b/.github/workflows/effectiveness_bench.yml
@@ -2,14 +2,15 @@ name: Effectiveness Bench
 
 # Run the effectiveness benchmark (OpenVmBenchmarks/benchmark.py): the circuit size metrics —
 # variables / bus interactions / constraints, each `before / after` — for apc-optimizer vs powdr
-# over a benchmark set, and publish the summary table. Unlike Runtime Bench, the metrics are
-# deterministic circuit sizes, so there is no baseline run: to compare against main, dispatch
-# this on main and diff the tables.
+# over a benchmark set, and publish the summary table. By default the target is also compared
+# against `main`: the metrics are deterministic circuit sizes, so the comparison lists exactly
+# which cases changed and by how much.
 #
 # On demand only. Dispatch from the Actions UI or with, e.g.:
 #
-#   gh workflow run "Effectiveness Bench"            # dispatched branch, job summary only
-#   gh workflow run "Effectiveness Bench" -f pr=85   # bench PR #85's head, sticky-comment there
+#   gh workflow run "Effectiveness Bench"                    # dispatched branch vs main
+#   gh workflow run "Effectiveness Bench" -f pr=85           # PR #85's head vs main + sticky comment
+#   gh workflow run "Effectiveness Bench" -f pr=85 -f baseline=   # no comparison, target only
 
 on:
   workflow_dispatch:
@@ -18,6 +19,10 @@ on:
         description: "PR number: bench its head and post/update a sticky comment there (empty = bench the dispatched branch, job summary only)"
         required: false
         default: ""
+      baseline:
+        description: "ref to compare against (empty = no comparison)"
+        required: false
+        default: "main"
       benchmark:
         description: "benchmark set (a subdirectory of OpenVmBenchmarks/)"
         required: false
@@ -40,12 +45,36 @@ jobs:
         with:
           ref: ${{ inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr) || github.ref }}
       - uses: leanprover/lean-action@v1
-      - name: Benchmark effectiveness
+      - name: Benchmark effectiveness (target)
         run: |
           echo "BENCH_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "TARGET_REF=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          # The baseline checkout below replaces the working tree, so keep this version of the
+          # benchmark script (and its results) outside it.
+          cp OpenVmBenchmarks/benchmark.py "$RUNNER_TEMP/benchmark.py"
           N='${{ inputs.n }}'
           python3 OpenVmBenchmarks/benchmark.py '${{ inputs.benchmark }}' \
-            --md bench.md ${N:+--n "$N"}
+            --json "$RUNNER_TEMP/target.json" --md bench.md ${N:+--n "$N"}
+      - name: Benchmark effectiveness (baseline)
+        if: inputs.baseline != ''
+        run: |
+          git fetch --depth 1 origin '${{ inputs.baseline }}'
+          if [ "$(git rev-parse FETCH_HEAD)" = "$(git rev-parse HEAD)" ]; then
+            echo "baseline is the benched commit itself; skipping comparison"
+            exit 0
+          fi
+          echo "BASE_SHA=$(git rev-parse --short FETCH_HEAD)" >> "$GITHUB_ENV"
+          git checkout --force FETCH_HEAD
+          lake exe cache get || true
+          lake build
+          N='${{ inputs.n }}'
+          python3 "$RUNNER_TEMP/benchmark.py" '${{ inputs.benchmark }}' \
+            --repo "$GITHUB_WORKSPACE" --json "$RUNNER_TEMP/baseline.json" ${N:+--n "$N"}
+          python3 "$RUNNER_TEMP/benchmark.py" \
+            --compare "$RUNNER_TEMP/baseline.json" "$RUNNER_TEMP/target.json" --md bench.md
+          # Restore the target checkout: the report step below runs a local action, which must
+          # exist in the working tree (the baseline may predate it).
+          git checkout --force "$TARGET_REF"
       - name: Report
         uses: ./.github/actions/report-bench
         with:
@@ -53,6 +82,8 @@ jobs:
           marker: "<!-- effectiveness-bench -->"
           pr: ${{ inputs.pr }}
           note: >-
-            Effectiveness bench of `${{ env.BENCH_SHA }}`. Circuit sizes are deterministic;
-            to compare against main, dispatch this workflow on main and diff the tables.
+            Effectiveness bench of
+            ${{ env.BASE_SHA && format('target `{0}` vs baseline `{1}`', env.BENCH_SHA, env.BASE_SHA)
+                 || format('`{0}`', env.BENCH_SHA) }}.
+            Circuit sizes are deterministic; any per-case change is real.
           token: ${{ github.token }}

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -25,9 +25,10 @@ jobs:
           path: .lake/build/bin/apc-optimizer
           retention-days: 30
 
-  # Quick runtime check on every PR: bench the top-10 cases with this PR's binary and with the
-  # binary from the latest successful main build, back-to-back on the same runner, and post the
-  # comparison as a sticky comment. Full-set benches stay on demand via the Runtime Bench workflow.
+  # Quick bench on every PR: effectiveness (circuit metrics) and runtime over the top-10 cases,
+  # this PR's binary vs the binary from the latest successful main build (nothing is rebuilt),
+  # posted as one sticky comment. Full-set benches stay on demand via the Effectiveness Bench and
+  # Runtime Bench workflows.
   quick-bench:
     if: github.event_name == 'pull_request'
     needs: build
@@ -43,27 +44,45 @@ jobs:
         with:
           name: apc-optimizer-bin
           path: bin-target
-      - name: Bench top-10 vs latest main binary
+      - name: Fetch baseline binary (latest main build)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "TARGET_SHA=$(cut -c1-7 <<< '${{ github.event.pull_request.head.sha }}')" \
             >> "$GITHUB_ENV"
           chmod +x bin-target/apc-optimizer
-          python3 OpenVmBenchmarks/runtime_bench.py --binary bin-target/apc-optimizer \
-            --n 10 --json target.json --md bench.md
           run_id=$(gh run list --workflow "Lean Action CI" --branch main --status success \
             --limit 1 --json databaseId -q '.[0].databaseId // empty')
           if [ -n "$run_id" ] && gh run download "$run_id" -n apc-optimizer-bin -D bin-base; then
             chmod +x bin-base/apc-optimizer
             echo "BASE_SHA=$(gh run view "$run_id" --json headSha -q .headSha | cut -c1-7)" \
               >> "$GITHUB_ENV"
-            python3 OpenVmBenchmarks/runtime_bench.py --binary bin-base/apc-optimizer \
-              --n 10 --json base.json
-            python3 OpenVmBenchmarks/runtime_bench.py --compare base.json target.json --md bench.md
           else
             echo "no apc-optimizer-bin artifact on the latest main run; reporting this PR only"
           fi
+      - name: Effectiveness, top-10 vs main
+        run: |
+          python3 OpenVmBenchmarks/benchmark.py --binary bin-target/apc-optimizer \
+            --n 10 --json eff-target.json --md eff.md
+          if [ -n "$BASE_SHA" ]; then
+            python3 OpenVmBenchmarks/benchmark.py --binary bin-base/apc-optimizer \
+              --n 10 --json eff-base.json
+            python3 OpenVmBenchmarks/benchmark.py \
+              --compare eff-base.json eff-target.json --md eff.md
+          fi
+      - name: Runtime, top-10 vs main
+        run: |
+          python3 OpenVmBenchmarks/runtime_bench.py --binary bin-target/apc-optimizer \
+            --n 10 --json rt-target.json --md rt.md
+          if [ -n "$BASE_SHA" ]; then
+            python3 OpenVmBenchmarks/runtime_bench.py --binary bin-base/apc-optimizer \
+              --n 10 --json rt-base.json
+            python3 OpenVmBenchmarks/runtime_bench.py --compare rt-base.json rt-target.json --md rt.md
+          fi
+          # Effectiveness first: it is the merge criterion; runtime breaks ties.
+          cat eff.md > bench.md
+          printf '\n' >> bench.md
+          cat rt.md >> bench.md
       - name: Report
         uses: ./.github/actions/report-bench
         with:
@@ -75,7 +94,8 @@ jobs:
           note: >-
             Top-10 quick bench on a CI runner
             (${{ env.BASE_SHA && format('PR `{0}` vs main `{1}`', env.TARGET_SHA, env.BASE_SHA)
-                 || format('PR `{0}`, no main baseline binary available', env.TARGET_SHA) }});
-            trust shares and orders of magnitude over exact numbers.
-            Full set: `gh workflow run "Runtime Bench" -f pr=${{ github.event.number }}`.
+                 || format('PR `{0}`, no main baseline binary available', env.TARGET_SHA) }}).
+            Circuit sizes are exact; for runtime, trust shares and orders of magnitude over exact
+            numbers. Full set: `gh workflow run "Effectiveness Bench" -f pr=${{ github.event.number }}`
+            or `gh workflow run "Runtime Bench" -f pr=${{ github.event.number }}`.
           token: ${{ github.token }}

--- a/OpenVmBenchmarks/benchmark.py
+++ b/OpenVmBenchmarks/benchmark.py
@@ -146,10 +146,109 @@ def load_asm(bench_dir):
             for e in man.get("entries", [])}
 
 
-def available_benchmarks():
-    """Benchmark names available: subdirectories of HERE that hold apc_*_pc*.json.gz cases."""
-    return sorted(d.name for d in HERE.iterdir()
+def available_benchmarks(bench_root):
+    """Benchmark names available: subdirectories of bench_root holding apc_*_pc*.json.gz cases."""
+    return sorted(d.name for d in bench_root.iterdir()
                   if d.is_dir() and any(d.glob("apc_*_pc*.json.gz")))
+
+
+def summarize(results):
+    """Aggregate effectiveness of a result list [(name, {role: {vars, constraints, bus}})]:
+    agg (Σbefore ⁄ Σafter) and geomean per role and measure, plus per-case wins/losses on the
+    primary metric (variables)."""
+    n = len(results)
+
+    def agg(role, mt):
+        sb = sum(m["before"][mt] for _, m in results)
+        sa = sum(m[role][mt] for _, m in results)
+        return sb / sa if sa else float("inf")
+
+    def geo(role, mt):
+        return math.exp(sum(math.log(_ratio(m["before"][mt], m[role][mt]))
+                            for _, m in results) / n)
+
+    summary = {
+        "n": n,
+        "wins": sum(1 for _, m in results if m["apc-optimizer"]["vars"] < m["powdr"]["vars"]),
+        "losses": sum(1 for _, m in results if m["apc-optimizer"]["vars"] > m["powdr"]["vars"]),
+    }
+    for role in ("apc-optimizer", "powdr"):
+        for mt in METRICS:
+            summary[f"{role}_{mt}_agg"] = agg(role, mt)
+            summary[f"{role}_{mt}_geo"] = geo(role, mt)
+    return summary
+
+
+def emit_summary_md(benchmark, summary, skipped):
+    """Markdown summary of one benchmark run (apc-optimizer vs powdr)."""
+    lines = [f"### Effectiveness — {benchmark}, {summary['n']} cases, apc-optimizer vs powdr", "",
+             "Effectiveness = size before / size after (larger is better); "
+             "priority: variables > bus interactions > constraints. "
+             "agg = Σbefore ⁄ Σafter, geo = geomean of per-case factors.", "",
+             "| measure | apc-optimizer (agg / geo) | powdr (agg / geo) | diff (agg) |",
+             "|---|---|---|---|"]
+    for mt in METRICS:
+        la, lg = summary[f"apc-optimizer_{mt}_agg"], summary[f"apc-optimizer_{mt}_geo"]
+        pa, pg = summary[f"powdr_{mt}_agg"], summary[f"powdr_{mt}_geo"]
+        lines.append(f"| {METRIC_LABEL[mt]} | {la:.3f}× / {lg:.3f}× "
+                     f"| {pa:.3f}× / {pg:.3f}× | {la - pa:+.3f}× |")
+    lines.append("")
+    lines.append(f"Per-case (by variables): apc-optimizer wins {summary['wins']}, "
+                 f"loses {summary['losses']}, "
+                 f"ties {summary['n'] - summary['wins'] - summary['losses']}.")
+    if skipped:
+        lines.append("")
+        lines.append(f"Skipped {len(skipped)}: "
+                     + ", ".join(f"{name} ({err})" for name, err in skipped) + ".")
+    return "\n".join(lines) + "\n"
+
+
+def emit_compare_md(base, target):
+    """Markdown comparison of two runs' apc-optimizer effectiveness (target vs baseline).
+    The metrics are deterministic circuit sizes, so any difference is a real change."""
+    common = sorted(set(base["results"]) & set(target["results"]))
+    dropped = (set(base["results"]) | set(target["results"])) - set(common)
+    t_results = [(name, target["results"][name]) for name in common]
+    b_results = [(name, base["results"][name]) for name in common]
+    ts, bs = summarize(t_results), summarize(b_results)
+
+    lines = [f"### Effectiveness — {target['benchmark']}, {len(common)} cases, "
+             "target vs baseline", "",
+             "Effectiveness = size before / size after (larger is better); "
+             "priority: variables > bus interactions > constraints. "
+             "agg = Σbefore ⁄ Σafter, geo = geomean; powdr shown for reference.", "",
+             "| measure | target (agg / geo) | baseline (agg / geo) | Δ (agg) "
+             "| powdr (agg / geo) |",
+             "|---|---|---|---|---|"]
+    for mt in METRICS:
+        ta, tg = ts[f"apc-optimizer_{mt}_agg"], ts[f"apc-optimizer_{mt}_geo"]
+        ba, bg = bs[f"apc-optimizer_{mt}_agg"], bs[f"apc-optimizer_{mt}_geo"]
+        pa, pg = ts[f"powdr_{mt}_agg"], ts[f"powdr_{mt}_geo"]
+        lines.append(f"| {METRIC_LABEL[mt]} | {ta:.3f}× / {tg:.3f}× | {ba:.3f}× / {bg:.3f}× "
+                     f"| {ta - ba:+.3f}× | {pa:.3f}× / {pg:.3f}× |")
+
+    changed = [name for name in common
+               if target["results"][name]["apc-optimizer"] != base["results"][name]["apc-optimizer"]]
+    lines.append("")
+    if not changed:
+        lines.append("Per-case circuit sizes are **identical** between target and baseline.")
+    else:
+        lines.append(f"Circuit sizes changed on {len(changed)} of {len(common)} cases "
+                     "(baseline → target):")
+        lines.append("")
+        lines.append("| case | variables | bus interactions | constraints |")
+        lines.append("|---|---|---|---|")
+        for name in changed:
+            t, b = target["results"][name]["apc-optimizer"], base["results"][name]["apc-optimizer"]
+            cells = []
+            for mt in METRICS:
+                cells.append(f"{b[mt]} → **{t[mt]}**" if t[mt] != b[mt] else str(t[mt]))
+            lines.append(f"| {name} | {cells[0]} | {cells[1]} | {cells[2]} |")
+    if dropped:
+        lines.append("")
+        lines.append("Cases present on only one side (not compared): "
+                     + ", ".join(sorted(dropped)) + ".")
+    return "\n".join(lines) + "\n"
 
 
 def main():
@@ -166,19 +265,42 @@ def main():
                     help="also write a self-contained interactive HTML report to this path")
     ap.add_argument("--md", type=Path, default=None, metavar="OUT.md",
                     help="also write the summary as markdown (for CI job summaries / PR comments)")
+    ap.add_argument("--json", type=Path, default=None, metavar="OUT.json",
+                    help="also dump the raw per-case metrics (input for --compare)")
+    ap.add_argument("--compare", nargs=2, default=None, metavar=("BASE.json", "TARGET.json"),
+                    help="don't bench; render a comparison of two --json dumps instead")
+    ap.add_argument("--binary", type=Path, default=None, metavar="EXE",
+                    help="use this apc-optimizer executable instead of building the repo's "
+                         "(e.g. a prebuilt CI artifact); implies no build")
+    ap.add_argument("--repo", type=Path, default=REPO, metavar="DIR",
+                    help="repository to build and bench (default: the one holding this script; "
+                         "lets a saved copy of the script bench another checkout, e.g. a baseline)")
     args = ap.parse_args()
 
-    bench_dir = HERE / args.benchmark
-    if not bench_dir.is_dir():
-        avail = ", ".join(available_benchmarks()) or "(none found)"
-        sys.exit(f"error: no benchmark {args.benchmark!r} under {HERE} (available: {avail})")
+    if args.compare is not None:
+        base, target = (json.loads(p.read_text()) for p in map(Path, args.compare))
+        md = emit_compare_md(base, target)
+        print(md)
+        if args.md is not None:
+            args.md.write_text(md)
+            print(f"wrote {args.md}", file=sys.stderr)
+        return
 
-    os.chdir(REPO)
-    print("building apc-optimizer...", file=sys.stderr)
-    subprocess.run(["lake", "build"], check=True)
-    binary = REPO / ".lake" / "build" / "bin" / "apc-optimizer"
+    repo = args.repo.resolve()
+    bench_root = repo / "OpenVmBenchmarks"
+    bench_dir = bench_root / args.benchmark
+    if not bench_dir.is_dir():
+        avail = ", ".join(available_benchmarks(bench_root)) or "(none found)"
+        sys.exit(f"error: no benchmark {args.benchmark!r} under {bench_root} (available: {avail})")
+
+    binary = args.binary.resolve() if args.binary is not None else None
+    os.chdir(repo)
+    if binary is None:
+        print("building apc-optimizer...", file=sys.stderr)
+        subprocess.run(["lake", "build"], check=True)
+        binary = repo / ".lake" / "build" / "bin" / "apc-optimizer"
     if not binary.exists():
-        sys.exit(f"error: {binary} missing after build")
+        sys.exit(f"error: {binary} missing")
 
     cases = sorted(f for f in bench_dir.glob("apc_*_pc*.json.gz")
                    if not f.name.endswith(".powdr_opt.json.gz"))
@@ -205,26 +327,8 @@ def main():
         sys.exit("no results produced")
 
     n = len(results)
-
-    def agg(role, mt):  # aggregate effectiveness: sum of befores / sum of afters
-        sb = sum(m["before"][mt] for _, m in results)
-        sa = sum(m[role][mt] for _, m in results)
-        return sb / sa if sa else float("inf")
-
-    def geo(role, mt):  # geometric mean of the per-case shrink factors
-        return math.exp(sum(math.log(_ratio(m["before"][mt], m[role][mt]))
-                            for _, m in results) / n)
-
     # Wins/losses stay on the primary metric (variables).
-    summary = {
-        "n": n,
-        "wins": sum(1 for _, m in results if m["apc-optimizer"]["vars"] < m["powdr"]["vars"]),
-        "losses": sum(1 for _, m in results if m["apc-optimizer"]["vars"] > m["powdr"]["vars"]),
-    }
-    for role in ("apc-optimizer", "powdr"):
-        for mt in METRICS:
-            summary[f"{role}_{mt}_agg"] = agg(role, mt)
-            summary[f"{role}_{mt}_geo"] = geo(role, mt)
+    summary = summarize(results)
 
     print(f"\n=== {args.benchmark}: apc-optimizer vs powdr over {n} cases ===")
     print("effectiveness = size before / size after (larger is better); "
@@ -242,26 +346,13 @@ def main():
         for name, err in skipped:
             print(f"  {name}: {err}", file=sys.stderr)
 
+    if args.json is not None:
+        args.json.write_text(json.dumps({"benchmark": args.benchmark,
+                                         "results": dict(results),
+                                         "skipped": skipped}))
+        print(f"wrote {args.json}", file=sys.stderr)
     if args.md is not None:
-        lines = [f"### Effectiveness — {args.benchmark}, {n} cases, apc-optimizer vs powdr", "",
-                 "Effectiveness = size before / size after (larger is better); "
-                 "priority: variables > bus interactions > constraints. "
-                 "agg = Σbefore ⁄ Σafter, geo = geomean of per-case factors.", "",
-                 "| measure | apc-optimizer (agg / geo) | powdr (agg / geo) | diff (agg) |",
-                 "|---|---|---|---|"]
-        for mt in METRICS:
-            la, lg = summary[f"apc-optimizer_{mt}_agg"], summary[f"apc-optimizer_{mt}_geo"]
-            pa, pg = summary[f"powdr_{mt}_agg"], summary[f"powdr_{mt}_geo"]
-            lines.append(f"| {METRIC_LABEL[mt]} | {la:.3f}× / {lg:.3f}× "
-                         f"| {pa:.3f}× / {pg:.3f}× | {la - pa:+.3f}× |")
-        lines.append("")
-        lines.append(f"Per-case (by variables): apc-optimizer wins {summary['wins']}, "
-                     f"loses {summary['losses']}, ties {n - summary['wins'] - summary['losses']}.")
-        if skipped:
-            lines.append("")
-            lines.append(f"Skipped {len(skipped)}: "
-                         + ", ".join(f"{name} ({err})" for name, err in skipped) + ".")
-        args.md.write_text("\n".join(lines) + "\n")
+        args.md.write_text(emit_summary_md(args.benchmark, summary, skipped))
         print(f"wrote {args.md}", file=sys.stderr)
 
     if want_report:

--- a/README.md
+++ b/README.md
@@ -53,18 +53,21 @@ OpenVmBenchmarks/benchmark.py --n 20         # top 20 by cost rank
 OpenVmBenchmarks/benchmark.py --n 10 --report report.html   # + interactive HTML report
 ```
 
-The on-demand `Effectiveness Bench` CI workflow runs the same script from GitHub
-(`gh workflow run "Effectiveness Bench"`, optionally `-f pr=<N>` to post the summary table on a
-PR as a sticky comment).
+The on-demand `Effectiveness Bench` CI workflow runs the same script from GitHub, by default also
+benching `main` for a per-case comparison — sizes are deterministic, so it lists exactly which
+circuits changed (`gh workflow run "Effectiveness Bench"`, optionally `-f pr=<N>` to bench a PR
+head and post the table there as a sticky comment).
 
 To bench the optimizer's *runtime* instead — the wall time of each optimizer call plus per-pass
-attribution (`apc-optimizer profile`) — use `runtime_bench.py`. CI runs it at two tiers, always
-benching both sides on the same runner (cross-runner timings don't compare) and posting the result
-as a sticky PR comment: every PR gets a top-10 quick bench of the PR's CI-built binary against the
-binary from the latest main build (no rebuild), and the on-demand `Runtime Bench` workflow
-(`gh workflow run "Runtime Bench" -f pr=<N>`) benches the full set from source against `main`:
+attribution (`apc-optimizer profile`) — use `runtime_bench.py`; the on-demand `Runtime Bench`
+workflow (`gh workflow run "Runtime Bench" -f pr=<N>`) benches the full set from source against
+`main`, both sides on the same runner (cross-runner timings don't compare):
 
 ```bash
 OpenVmBenchmarks/runtime_bench.py            # all openvm-eth cases, serial (stable timings)
 OpenVmBenchmarks/runtime_bench.py --n 20 --repeat 3   # top 20, best-of-3 per case
 ```
+
+On top of that, every PR gets a quick top-10 bench of both — effectiveness and runtime, this PR's
+CI-built binary vs the binary from the latest main build (nothing is rebuilt) — posted as one
+sticky comment.


### PR DESCRIPTION
Follow-up to #85 (these changes were pushed to that branch minutes after it was merged, so they never made it into a PR).

- `OpenVmBenchmarks/benchmark.py` gains `--json` (raw per-case metrics), `--compare base.json target.json` (target vs baseline: agg/geo effectiveness per measure with powdr for reference, plus — since circuit sizes are deterministic — the exact list of cases whose sizes changed, baseline → target), `--binary` (bench a prebuilt executable) and `--repo`, mirroring `runtime_bench.py`.
- **`Effectiveness Bench` workflow** gains a `baseline` input (default `main`), same flow as Runtime Bench: bench the target (dispatched branch or `-f pr=<N>`), check out and build the baseline, bench it, render the comparison; skipped when the baseline resolves to the benched commit, `-f baseline=` for target-only.
- **Per-PR quick bench extended**: the top-10 quick-bench job now reports *both* effectiveness and runtime — PR binary vs latest main binary, nothing rebuilt — in one sticky comment, effectiveness first (it's the merge criterion; runtime breaks ties).

No optimizer code is touched; the audited surface is untouched.

**Validation:** `--md`/`--json`/`--compare` (identical and changed-case paths) verified locally. This PR's own quick-bench run is the end-to-end test of the extended job — expected: "per-case circuit sizes are identical" and runtime ≈1.00×, and it's the first run with a main binary artifact available, so it exercises the comparison path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)