### PR TITLE
Carry-branch resolution: collapse one-sided adder carry products (variable effectiveness)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -20,6 +20,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.Reencode
 import ApcOptimizer.Implementation.OptimizerPasses.DomainFold
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroRegister
 import ApcOptimizer.Implementation.OptimizerPasses.HintCollapse
+import ApcOptimizer.Implementation.OptimizerPasses.CarryBranch
 
 set_option autoImplicit false
 
@@ -55,7 +56,8 @@ pass's own `PassCorrect`. -/
     scale every constraint's affine factors to monic form (zero-set preserving) and re-fold.
     Extend it by composing passes with `.andThen`. -/
 def cleanupCycle : VerifiedPassW p :=
-  gaussElimPass.withFacts.guardDegree
+  carryBranchPass.guardDegree
+    |>.andThen gaussElimPass.withFacts.guardDegree
     |>.andThen normalizePass.withFacts.guardDegree
     |>.andThen constantFoldPass.withFacts.guardDegree
     |>.andThen domainBatchPass.guardDegree

--- a/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
@@ -1,0 +1,277 @@
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # Carry-branch resolution (interval analysis on product factors)
+
+Byte-decomposed adders leave degree-2 *carry-branch* constraints of the shape
+`(b₀ − a₀) · (b₀ − a₀ − 256) = 0` — "the difference is either `0` or `256`". When both operands
+are provably bytes (via the proven bus-fact bounds: memory receives, bitwise checks, range
+checks), the second factor can *never* vanish: its value, viewed through the bounds, lies in the
+integer interval `[p − 511, p − 1]`, which excludes `0` and wraps past no multiple of `p`. The
+product then collapses to the linear factor `b₀ − a₀`, which the affine/Gauss passes substitute
+away — eliminating the whole copied word and its carry chain (the higher limbs' cross terms
+cancel once the lower limb is unified, so the chain cascades across cleanup iterations). The same
+lever collapses the `(L₁)·(L₂) = 0` carry constraints of memory-pointer-limb decompositions.
+
+The certificate (`splitSumMax`): normalize a factor to an affine form `c + Σ aᵢ·vᵢ`, give every
+variable a fact-derived bound `vᵢ.val < Bᵢ` (`BoundsMap`, built from `BusFacts.slotBound`), and
+choose per term the representation — positive `aᵢ·vᵢ` or negative `−((−aᵢ)·vᵢ)` — with the
+smaller maximal magnitude. With `maxNeg < c.val` and `c.val + maxPos < p`, the factor's value
+lies in `[c.val − maxNeg, c.val + maxPos] ⊆ (0, p)`, so it is never zero
+(`linNeverZeroSplit`; this generalizes `MemoryUnify.linNeverZero`, which handles only the
+all-negative case). Since `p` is prime (checked at runtime, like the other field-dependent
+passes), `f·g = 0` is then *equivalent* to `f = 0` — the rewrite preserves the satisfying set
+exactly, so both `PassCorrect` directions use the unchanged assignment.
+
+The pass is generic: it consumes only `BusFacts.slotBound` (any semantics), and degrades to the
+identity with `BusFacts.trivial` (no bounds ⇒ no certificate) or composite `p`. -/
+
+variable {p : ℕ}
+
+/-! ## The two-sided interval certificate -/
+
+/-- Interval split of a term list's possible values: `some (maxPos, maxNeg)` when every term's
+    variable carries a bound in `B`. Each term `a·v` contributes to `maxPos` as `a.val·(B−1)` or
+    to `maxNeg` as `(−a).val·(B−1)`, whichever is smaller — small positive coefficients count
+    positively, small negative ones negatively. The sum is then provably `P − N` with
+    `P.val ≤ maxPos` and `N.val ≤ maxNeg` (`splitSum_val`). -/
+def splitSumMax (B : Std.HashMap Variable Nat) :
+    List (Variable × ZMod p) → Option (Nat × Nat)
+  | [] => some (0, 0)
+  | (v, a) :: rest =>
+    match B[v]?, splitSumMax B rest with
+    | some bound, some acc =>
+      if 1 ≤ bound then
+        if a.val * (bound - 1) ≤ (-a).val * (bound - 1) then
+          some (a.val * (bound - 1) + acc.1, acc.2)
+        else
+          some (acc.1, (-a).val * (bound - 1) + acc.2)
+      else none
+    | _, _ => none
+
+theorem splitSum_val (B : Std.HashMap Variable Nat)
+    (terms : List (Variable × ZMod p)) (mp mn : Nat)
+    (h : splitSumMax B terms = some (mp, mn)) (hmp : mp < p) (hmn : mn < p)
+    (env : Variable → ZMod p)
+    (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
+    ∃ P N : ZMod p, (terms.map (fun t => t.2 * env t.1)).sum = P - N ∧
+      P.val ≤ mp ∧ N.val ≤ mn := by
+  induction terms generalizing mp mn with
+  | nil =>
+      simp only [splitSumMax, Option.some.injEq, Prod.mk.injEq] at h
+      refine ⟨0, 0, by simp, ?_, ?_⟩ <;> simp [← h.1, ← h.2]
+  | cons t rest ih =>
+      obtain ⟨v, a⟩ := t
+      rw [splitSumMax] at h
+      split at h
+      case _ bound acc hBd hrest =>
+        obtain ⟨mp', mn'⟩ := acc
+        have hv : (env v).val < bound := hB v bound hBd
+        split_ifs at h with hb1 hcmp
+        · -- positive branch: the head contributes `a.val·(bound−1)` to `maxPos`
+          simp only [Option.some.injEq, Prod.mk.injEq] at h
+          obtain ⟨rfl, rfl⟩ := h
+          obtain ⟨P', N', hsum', hP'le, hN'le⟩ := ih mp' mn' hrest (by omega) hmn
+          have hle : a.val * (env v).val ≤ a.val * (bound - 1) :=
+            Nat.mul_le_mul_left _ (by omega)
+          have hheadval : (a * env v).val = a.val * (env v).val :=
+            ZMod.val_mul_of_lt (by omega)
+          have haddlt : (a * env v).val + P'.val < p := by rw [hheadval]; omega
+          refine ⟨a * env v + P', N', ?_, ?_, hN'le⟩
+          · simp only [List.map_cons, List.sum_cons, hsum']; ring
+          · rw [ZMod.val_add_of_lt haddlt, hheadval]; omega
+        · -- negative branch: the head contributes `(−a).val·(bound−1)` to `maxNeg`
+          simp only [Option.some.injEq, Prod.mk.injEq] at h
+          obtain ⟨rfl, rfl⟩ := h
+          obtain ⟨P', N', hsum', hP'le, hN'le⟩ := ih mp' mn' hrest hmp (by omega)
+          have hle : (-a).val * (env v).val ≤ (-a).val * (bound - 1) :=
+            Nat.mul_le_mul_left _ (by omega)
+          have hheadval : ((-a) * env v).val = (-a).val * (env v).val :=
+            ZMod.val_mul_of_lt (by omega)
+          have haddlt : ((-a) * env v).val + N'.val < p := by rw [hheadval]; omega
+          refine ⟨P', (-a) * env v + N', ?_, hP'le, ?_⟩
+          · simp only [List.map_cons, List.sum_cons, hsum']; ring
+          · rw [ZMod.val_add_of_lt haddlt, hheadval]; omega
+      case _ => exact absurd h (by simp)
+
+/-- The never-zero certificate: an affine form whose bounded value interval
+    `[const.val − maxNeg, const.val + maxPos]` stays strictly inside `(0, p)` can never evaluate
+    to zero. Two-sided generalization of `linNeverZero`. -/
+theorem linNeverZeroSplit (B : Std.HashMap Variable Nat) (l : LinExpr p) (mp mn : Nat)
+    (hp : 0 < p) (h : splitSumMax B l.terms = some (mp, mn))
+    (hlo : mn < l.const.val) (hhi : l.const.val + mp < p)
+    (env : Variable → ZMod p)
+    (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
+    l.eval env ≠ 0 := by
+  intro h0
+  haveI : NeZero p := ⟨hp.ne'⟩
+  have hcp : l.const.val < p := ZMod.val_lt l.const
+  obtain ⟨P, N, hsum, hPle, hNle⟩ :=
+    splitSum_val B l.terms mp mn h (by omega) (by omega) env hB
+  have hPN : N = l.const + P := by
+    rw [LinExpr.eval, hsum] at h0
+    linear_combination -h0
+  have hval : (l.const + P).val = l.const.val + P.val :=
+    ZMod.val_add_of_lt (by omega)
+  rw [hPN, hval] at hNle
+  omega
+
+/-- The interval condition on one concrete normalized form. -/
+def intervalCert (B : Std.HashMap Variable Nat) (l : LinExpr p) : Bool :=
+  match splitSumMax B l.terms with
+  | none => false
+  | some acc =>
+    decide (acc.2 < l.const.val) && decide (l.const.val + acc.1 < p)
+
+theorem intervalCert_sound (hp : 0 < p) (B : Std.HashMap Variable Nat) (l : LinExpr p)
+    (h : intervalCert B l = true) (env : Variable → ZMod p)
+    (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
+    l.eval env ≠ 0 := by
+  unfold intervalCert at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i acc hacc
+    obtain ⟨mp, mn⟩ := acc
+    rw [Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq] at h
+    exact linNeverZeroSplit B l mp mn hp hacc h.1 h.2 env hB
+
+/-- Checked never-zero certificate for an expression: linearize, normalize, and verify the
+    interval condition against the bounds map — under a *candidate rescaling*. A factor's zero
+    set is invariant under scaling by a constant, but the interval certificate is not (the
+    mid-pipeline carry factors read `−1 + 256⁻¹·b₀ − 256⁻¹·a₀`, whose raw coefficient values
+    overflow every bound), so each coefficient's and the constant's field inverse is tried as a
+    scalar. Soundness needs nothing about the candidate: if the scaled form never vanishes,
+    neither does the original (`k·0 = 0`). -/
+def neverZeroB (B : Std.HashMap Variable Nat) (e : Expression p) : Bool :=
+  match linearize e with
+  | none => false
+  | some l =>
+    let n := l.norm
+    (1 :: n.const⁻¹ :: n.terms.map (fun t => t.2⁻¹)).any (fun k =>
+      intervalCert B ((n.scale k).norm))
+
+theorem neverZeroB_sound (hp : 0 < p) (B : Std.HashMap Variable Nat) (e : Expression p)
+    (h : neverZeroB B e = true) (env : Variable → ZMod p)
+    (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
+    e.eval env ≠ 0 := by
+  unfold neverZeroB at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i l hl
+    rw [List.any_eq_true] at h
+    obtain ⟨k, _, hcert⟩ := h
+    intro h0
+    have hs : ((l.norm.scale k).norm).eval env = 0 := by
+      rw [LinExpr.norm_eval, LinExpr.scale_eval, LinExpr.norm_eval,
+          ← linearize_eval e l hl, h0, mul_zero]
+    exact intervalCert_sound hp B _ hcert env hB hs
+
+/-! ## Resolving product constraints -/
+
+/-- Rewrite a constraint, collapsing products with a certified never-vanishing factor to the
+    other factor (recursively, so `c·f·g` also resolves). Non-products are left unchanged. -/
+def resolveExpr (B : Std.HashMap Variable Nat) : Expression p → Expression p
+  | .mul f g =>
+      if neverZeroB B g then resolveExpr B f
+      else if neverZeroB B f then resolveExpr B g
+      else .mul f g
+  | e => e
+
+theorem resolveExpr_vars (B : Std.HashMap Variable Nat) (e : Expression p) :
+    ∀ x ∈ (resolveExpr B e).vars, x ∈ e.vars := by
+  induction e with
+  | mul f g ihf ihg =>
+      intro x hx
+      simp only [resolveExpr] at hx
+      simp only [Expression.vars, List.mem_append]
+      split_ifs at hx with h1 h2
+      · exact Or.inl (ihf x hx)
+      · exact Or.inr (ihg x hx)
+      · simpa only [Expression.vars, List.mem_append] using hx
+  | const n => intro x hx; simpa only [resolveExpr] using hx
+  | var y => intro x hx; simpa only [resolveExpr] using hx
+  | add a b iha ihb => intro x hx; simpa only [resolveExpr] using hx
+
+/-- The resolution is an *equivalence* on satisfying assignments: with the bounds valid (bus
+    obligations hold) and `p` prime (so `ZMod p` has no zero divisors), `f·g = 0 ↔ f = 0`
+    whenever `g` is certified never-zero. -/
+theorem resolveExpr_eval_iff [Fact p.Prime] (B : Std.HashMap Variable Nat) (e : Expression p)
+    (env : Variable → ZMod p)
+    (hB : ∀ v bound, B[v]? = some bound → (env v).val < bound) :
+    (resolveExpr B e).eval env = 0 ↔ e.eval env = 0 := by
+  have hp : 0 < p := (Fact.out : p.Prime).pos
+  induction e with
+  | mul f g ihf ihg =>
+      simp only [resolveExpr]
+      split_ifs with h1 h2
+      · have hg : g.eval env ≠ 0 := neverZeroB_sound hp B g h1 env hB
+        refine ihf.trans ?_
+        show f.eval env = 0 ↔ f.eval env * g.eval env = 0
+        exact ⟨fun h => by rw [h, zero_mul], fun h => (mul_eq_zero.mp h).resolve_right hg⟩
+      · have hf : f.eval env ≠ 0 := neverZeroB_sound hp B f h2 env hB
+        refine ihg.trans ?_
+        show g.eval env = 0 ↔ f.eval env * g.eval env = 0
+        exact ⟨fun h => by rw [h, mul_zero], fun h => (mul_eq_zero.mp h).resolve_left hf⟩
+      · exact Iff.rfl
+  | const n => exact Iff.rfl
+  | var x => exact Iff.rfl
+  | add a b iha ihb => exact Iff.rfl
+
+/-! ## The pass -/
+
+/-- Rewriting every constraint through `resolveExpr` is `PassCorrect`: the satisfying set is
+    unchanged (both directions use the input assignment — the bus interactions, side effects, and
+    `admissible` are untouched), and no variable is introduced. -/
+theorem resolveMap_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (Bm : BoundsMap p cs bs) :
+    PassCorrect cs
+      { cs with algebraicConstraints := cs.algebraicConstraints.map (resolveExpr Bm.map) }
+      [] bs := by
+  have hsame : ∀ env, cs.satisfies bs env ↔
+      (ConstraintSystem.satisfies
+        { cs with algebraicConstraints := cs.algebraicConstraints.map (resolveExpr Bm.map) }
+        bs env) := by
+    intro env
+    constructor
+    · rintro ⟨hc, hb⟩
+      refine ⟨fun c' hc' => ?_, hb⟩
+      obtain ⟨c, hcmem, rfl⟩ := List.mem_map.1 hc'
+      exact (resolveExpr_eval_iff Bm.map c env
+        (Bm.sound env (fun bi hbi => hb bi hbi))).mpr (hc c hcmem)
+    · rintro ⟨hc, hb⟩
+      refine ⟨fun c hcmem => ?_, hb⟩
+      exact (resolveExpr_eval_iff Bm.map c env
+        (Bm.sound env (fun bi hbi => hb bi hbi))).mp
+        (hc _ (List.mem_map_of_mem hcmem))
+  refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+  · -- soundness: the same assignment satisfies the input
+    intro env hsat
+    exact ⟨env, (hsame env).mpr hsat, BusState.equiv_refl _⟩
+  · -- invariant preservation
+    intro hinv env hsat
+    exact hinv env ((hsame env).mpr hsat)
+  · -- no new variables
+    intro x hx
+    rw [ConstraintSystem.mem_vars] at hx
+    rcases hx with ⟨c', hc', hxc⟩ | ⟨bi, hbi, hxbi⟩
+    · obtain ⟨c, hcmem, rfl⟩ := List.mem_map.1 hc'
+      exact ConstraintSystem.mem_vars_of_constraint hcmem (resolveExpr_vars Bm.map c x hxc)
+    · rcases hxbi with hm | ⟨e, he, hxe⟩
+      · exact ConstraintSystem.mem_vars_of_mult hbi hm
+      · exact ConstraintSystem.mem_vars_of_payload hbi he hxe
+  · -- completeness: same assignment, same side effects, `admissible` untouched
+    intro env hadm hsat
+    exact ⟨(hsame env).mp hsat, hadm, BusState.equiv_refl _⟩
+
+/-- The carry-branch-resolution pass: collapse every product constraint with a certified
+    never-vanishing factor to its other factor. Needs prime `p` (zero divisors would break the
+    factoring); identity otherwise, and identity with `BusFacts.trivial` (no bounds ⇒ no
+    certificate ever fires). -/
+def carryBranchPass : VerifiedPassW p := fun cs bs facts =>
+  if hp : p.Prime then
+    haveI : Fact p.Prime := ⟨hp⟩
+    let Bm : BoundsMap p cs bs := BoundsMap.build facts
+    ⟨{ cs with algebraicConstraints := cs.algebraicConstraints.map (resolveExpr Bm.map) }, [],
+      resolveMap_correct cs bs Bm⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -700,6 +700,23 @@ def coveredBis (bs : BusSemantics p) (cs : ConstraintSystem p) (xs : List Variab
 /-- Work cap for one joint enumeration: box size × number of covered targets. -/
 def maxEnumWork : Nat := 524288
 
+/-- Can this covered interaction ever eliminate a box point? A payload of raw variables and
+    constants is usually the range/byte check that *defined* the box domains (probing it filters
+    nothing), so such interactions used to be skipped as uninformative wholesale. The exception —
+    measured on `[0, 0, z, 1]` XOR rows left behind by substitution, whose constant operands pin
+    `z = 0` — is a raw-variable slot that carries **no** fact bound from this very interaction
+    (`interactionBound = none`): the variable's domain came from elsewhere, so this interaction's
+    table can genuinely filter the box. Domain-defining checks bound every variable slot they
+    carry and stay excluded, preserving the gate's performance property. Heuristic only: it
+    selects enumeration targets, and the forced values that come out carry their own
+    certificates. -/
+def biInformative (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Bool :=
+  bi.payload.any (fun e => !(e.isVar || e.constValue?.isSome)) ||
+  bi.payload.any (fun e => match e with
+    | .var x => (interactionBound bs facts bi x).isNone
+    | _ => false)
+
 /-- Is this constraint *redundant* for enumeration — identically zero on the box of its own
     variables' domains (from `T`)? Such a constraint is then zero on every larger box that contains
     those variables, so it never eliminates a survivor and can be dropped from every joint
@@ -949,7 +966,8 @@ theorem scanNone_unsat {cs : ConstraintSystem p} {bs : BusSemantics p}
     survivor set while removing almost all of the per-box-point constraint evaluations. Covered
     obligations likewise omit stateful buses (`coveredBis`). Both are just sub-selections of the
     covered items, which `scanForced_sound` accepts (`hactive`/membership). -/
-def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable p cs bs)
+def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
+    (T : DomainTable p cs bs)
     (activeCs : List (Expression p)) (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints)
     (xs : List Variable) : List ((x : Variable) × { c : ZMod p //
       ∀ env, cs.satisfies bs env → env x = c }) :=
@@ -969,8 +987,7 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable 
       let esFull := coveredCs cs xs
       let bis := coveredBis bs cs xs
       let es := activeCs.filter (fun c => c.varsInF xs)
-      let informative := !esFull.isEmpty ||
-        bis.any (fun bi => bi.payload.any (fun e => !(e.isVar || e.constValue?.isSome)))
+      let informative := !esFull.isEmpty || bis.any (biInformative bs facts)
       if informative && boxSize * (esFull.length + bis.length) ≤ maxEnumWork then
         have hes : ∀ e ∈ es, e ∈ cs.algebraicConstraints ∧ e.varsIn xs = true :=
           fun e he => ⟨hactiveCs e (List.mem_filter.1 he).1,
@@ -1004,17 +1021,17 @@ def varSetKey (xs : List Variable) : String :=
 /-- Collect forced constants from joint enumerations of the given targets' variable sets,
     skipping variable sets already enumerated. `activeCs` (the non-redundant constraints) and its
     membership witness are threaded to `forcedOver`. -/
-def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p}
+def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
     (T : DomainTable p cs bs) (activeCs : List (Expression p))
     (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints) :
     List (List Variable) → Std.HashSet String → Solved p cs bs → Solved p cs bs
   | [], _, σ => σ
   | xs :: rest, seen, σ =>
     let key := varSetKey xs
-    if seen.contains key then collectForced T activeCs hactiveCs rest seen σ
+    if seen.contains key then collectForced facts T activeCs hactiveCs rest seen σ
     else
-      let found := forcedOver T activeCs hactiveCs xs
-      collectForced T activeCs hactiveCs rest (seen.insert key)
+      let found := forcedOver facts T activeCs hactiveCs xs
+      collectForced facts T activeCs hactiveCs rest (seen.insert key)
         (σ.insertAll (found.map (fun f => (f.1, .const f.2.val)))
           (by
             intro env hsat yt hyt
@@ -1040,7 +1057,8 @@ def domainBatchPass : VerifiedPassW p := fun cs bs facts =>
     let targets := cs.algebraicConstraints.map (fun e => e.vars.dedup) ++
       cs.busInteractions.map (fun bi => bi.vars.dedup)
     let activeCs := cs.algebraicConstraints.filter (fun c => !constraintRedundant T c)
-    let σ := collectForced T activeCs (fun _ h => (List.mem_filter.1 h).1) targets ∅ Solved.empty
+    let σ := collectForced facts T activeCs (fun _ h => (List.mem_filter.1 h).1) targets ∅
+      Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/Main.lean
+++ b/Main.lean
@@ -238,7 +238,8 @@ def cmdProfile (fileName : String) : IO Unit := do
   let bs := openVmBusSemantics babyBear busMap.toBusMap
   let facts := openVmFacts babyBear busMap.toBusMap
   let cleanupPasses : List (String × VerifiedPassW babyBear) :=
-    [ ("gauss", gaussElimPass.withFacts.guardDegree),
+    [ ("carryBranch", carryBranchPass.guardDegree),
+      ("gauss", gaussElimPass.withFacts.guardDegree),
       ("normalize1", normalizePass.withFacts.guardDegree),
       ("constFold1", constantFoldPass.withFacts.guardDegree),
       ("domainBatch", domainBatchPass.guardDegree),

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -12,13 +12,15 @@ Only worth it if the flag-compression edge is judged not worth `reencode`'s comp
 pass would then also want a `bits ≥ vars` / large-group path (groups `reencode` skips) to claw some of
 it back. Left for Georg to decide.
 
-Effectiveness priority: **variables > bus interactions > constraints**. As of the byte-check
-packing pass (log entry 49), on the top-12 `openvm-eth` sample apc-optimizer and powdr are ~tied on
-variables (apc-optimizer wins the aggregate, powdr the geomean) and apc-optimizer leads on constraints; the
-remaining *systematic* gap is bus interactions. The bus gap now decomposes as: (a) range-check
-packing via the tuple range checker, (b) memory-pointer-limb 13-bit checks on memory-heavy blocks,
-(c) residual bitwise checks that are not self-XOR byte checks, (d) occasional missed memory
-send↔receive cancellations. See the `docs/log.md` entry 42/46/49 discussion for measurements.
+Effectiveness priority: **variables > bus interactions > constraints**. As of carry-branch
+resolution (log entry 57), on the full 100-case `openvm-eth` benchmark apc-optimizer *wins* variables on
+aggregate (4.135× vs 4.092×) and trails on geomean (3.706× vs 3.787×; per-case: 17 wins / 52
+losses / 31 ties — the losses are a few variables each, dominated by the sltu-compare
+`diff_marker` family below) and leads clearly on constraints; the remaining *systematic* gap is
+bus interactions. The bus gap decomposes as: (a) range-check packing via the tuple range checker,
+(b) memory-pointer-limb 13-bit checks on memory-heavy blocks, (c) residual bitwise checks that
+are not self-XOR byte checks, (d) occasional missed memory send↔receive cancellations. See the
+`docs/log.md` entry 42/46/49/57 discussion for measurements.
 
 ## Drop never-violating stateless lookups (close the residual pc-lookup bus gap)
 
@@ -57,17 +59,27 @@ variable-neutral bus win.
 On memory-heavy blocks (e.g. apc_005) apc-optimizer keeps ~2× powdr's `mem_ptr_limbs` decompositions and
 their 13-bit range checks (the high/"page" limb is identical across same-base accesses but apc-optimizer
 re-decomposes and re-checks per access). The limbs are pinned by **degree-2 carry constraints**
-`(L₁)(L₂) = 0` whose roots are `base + offset` (parameterised by the base variable), so no linear
-(`gauss`/`affine`) or finite-*constant*-domain (`domainProp`/`domainBatch`/`reencode`) pass can
-touch them. Closing it needs a **carry-branch-resolution** step: use the proven byte/range bounds
-(`BusFacts.slotBound`) to show one factor of the product can't vanish, collapsing `(L₁)(L₂)=0` to
-the linear `Lᵢ=0` so Gauss can unify the shared limb and drop the duplicate check. This is the
-hardest of the current ideas — dropping a range check is sound only if the shared limb is *proven*
-equal (a bounded-no-wrap argument in the style of `MemoryUnify.boundedSumMax`) — and it is a bus
-win on an axis where apc-optimizer is already ~tied with powdr on variables, so lower leverage than the
-packing passes. **Update (log 50):** the base `mem_ptr_limbs` derive from *received* register
-words, whose limbs now carry proven byte bounds (`slotBound` on memory receives, since the
-receive-byte spec change) — the missing input bound for the no-wrap argument now exists.
+`(L₁)(L₂) = 0` whose roots are `base + offset` (parameterised by the base variable).
+**Update (log 57):** carry-branch resolution (`CarryBranch.lean`) is now landed and does *not*
+close this family — measured on apc_005, both factors' value intervals genuinely contain `0`
+(e.g. `300 + rs1₀ + 256·rs1₁ − mp₀` ranges over `[−65235, 65835]` with `mp₀ < 2^16`: the 16-bit
+wrap really happens on some traces), so no sound one-factor refutation exists and the constraint
+is irreducibly two-branched. Closing the gap instead needs **cross-access unification**: two
+accesses off the same base at close offsets have provably equal high limbs (`mp₁` differs only
+when the low-limb carry differs, a bounded-no-wrap argument in the style of
+`MemoryUnify.boundedSumMax`), so the duplicate decomposition + 13-bit check of the second access
+can be replaced by the first's limbs plus a small correction. Sound but needs the proven byte
+bounds on the base register word (present since the log-50 receive-byte spec change).
+
+## Widen `hintCollapse` to the sltu-style compare gadget (variables)
+
+On comparison blocks powdr collapses the per-limb `diff_marker` witnesses into one inverse hint;
+`hintCollapse` (entry 52) does this only when the constraint matches its exact `Σ aᵢ·dimᵢ + t = 0`
+shape with byte-bounded single-variable coefficients. The sltu-style gadget (most-significant
+difference selection, one marker per limb) doesn't match yet — apc_018 measured after
+carry-branch resolution (entry 57): ours 43 vars vs powdr 34; this family is the bulk of the
+residual. Generalizing the matcher (coefficients that are *differences* of byte-bounded
+variables, sign-split like `CarryBranch.splitSumMax`) should capture it.
 
 ## Is-zero / is-equal witness reduction (variables)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1532,3 +1532,83 @@ passes on the expensive cases (apc_037: 11.9 s / 8.8 s); the deep byte-justifica
 `substF`/`fold`/`linearize` still pays the entry-54 per-node `ZMod` instance-projection tax (a
 compiled/`evalFast`-style linearizer would cut it further), and `deepByteVars`'s `findVarBound`
 scan over the remaining interactions is recomputed per candidate.
+
+### 57. Carry-branch resolution (`CarryBranch.lean`): interval analysis collapses one-sided adder carry products — the main per-case variable win
+
+**The idea** (from the apc_039 variable diff against powdr): add/move blocks keep whole
+register data-word copies alive through unresolved **carry-branch constraints** — per limb, the
+byte-decomposed adder leaves `(b₀ − a₀)·(b₀ − a₀ − 256) = 0` ("the difference is 0 or 256").
+When both operands are provably bytes — `b₀` because it is a memory receive (the entry-50
+receive-byte spec change), `a₀` because it is bitwise-checked — the second factor's value lies
+in the integer interval `[p−511, p−1]`, so it can *never* vanish and the product is **equivalent**
+to the linear `b₀ = a₀`. Gauss then substitutes the `b` word away entirely (its memory receive
+carries the `a` limbs directly), and the higher limbs cascade: once `b₀ = a₀` is substituted and
+normalized, the limb-1 constraint's cross terms cancel and it becomes the same one-sided shape.
+No existing pass could do this: the roots are parameterized by another variable (`b₀ ∈
+{a₀, a₀+256}`), outside the constant-domain passes, and the constraint is degree 2, outside
+Gauss/affine.
+
+**Implementation** (`ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean`): a `VerifiedPassW`
+that maps each algebraic constraint through `resolveExpr`: on a product `f·g`, if either factor
+is certified never-zero, keep (recursively) the other. The certificate (`neverZeroB`) linearizes
+the factor, normalizes, and computes a **two-sided interval** from the proven bus-fact bounds
+(`BoundsMap`, built from `BusFacts.slotBound` exactly as in `hintCollapse`): each term picks the
+representation — positive `a·v` or negative `−((−a)·v)` — with the smaller magnitude
+(`splitSumMax`), and the form is refuted when `maxNeg < const.val ∧ const.val + maxPos < p`
+(`linNeverZeroSplit`, the two-sided generalization of `MemoryUnify.linNeverZero`). Two
+non-obvious points, both found by measurement:
+
+1. **Candidate rescaling.** Mid-pipeline (before the coda's `monicScale`) the carry factors read
+   `−1 + 256⁻¹·b₀ − 256⁻¹·a₀` — raw coefficient values overflow every interval. Since a factor's
+   zero set is scaling-invariant, the certificate tries the field inverse of each coefficient and
+   of the constant as a scalar and certifies any rescaling. Soundness needs nothing about the
+   candidate (if `k·l` never vanishes, `l = 0` would force `k·l = 0`), so the candidate list is
+   pure heuristic.
+2. **Placement: first in the cycle, *before* Gauss.** `iterateToFixpoint` only keeps a cycle
+   whose lexicographic `sizeKey` strictly drops. Resolution alone changes no count (the variables
+   still sit in the memory interactions), so with the pass placed after Gauss its rewrite was
+   *discarded* at the fixpoint — the linear constraint must be consumed by Gauss in the same
+   cycle to shrink the key. One cycle resolves one limb per word; the cascade converges in a few
+   extra cycles.
+
+Correctness: the rewrite is an *equivalence* on satisfying assignments (`resolveExpr_eval_iff`;
+`p` prime checked at runtime for `mul_eq_zero`, like the other field-dependent passes), so both
+`PassCorrect` directions use the unchanged assignment; bus interactions, side effects, and
+`admissible` are untouched, and no variable is introduced. With `BusFacts.trivial` no bound
+exists, no certificate fires, and the pass is the identity.
+
+**The regression it exposed, and the `domainBatch` fix.** The first full-set baseline
+comparison showed 51 of 100 cases improved but **apc_051 regressed** (482 → 485 vars,
+329 → 354 bus): the new pass changed Gauss's substitution orientation around a chained register
+word, and the final state stranded XOR rows `[0, 0, a__i, 1]` (constant operands — the table
+forces `a__i = 0`) plus an identical memory send/receive pair kept alive by those unpinned
+limbs. No pass could make progress on that state: nothing consumes `BusFacts.slotFun`, and
+`domainBatch` skipped the XOR rows as *uninformative* — its gate assumed any all-vars/constants
+payload is the range check that defined the box domains. The gate was sharpened
+(`biInformative`): an interaction is also informative when it has a raw-variable slot carrying
+**no** `interactionBound` from that same interaction (the XOR result slot) — its domain came
+from elsewhere, so the table can genuinely filter the box. Domain-defining range/byte/tuple
+checks bound every variable slot they carry and stay excluded, so the gate keeps its performance
+property; the change is heuristic-only (target selection — forced values still carry their own
+certificates). This recovered apc_051's variables exactly (482) and its bitwise count; 7
+identical send/receive pairs with compound (shift-gadget) payload slots remain uncancelled there
+(+14 bus on that one case, invisible in the aggregate) — `busPairCancel`'s byte justification
+does not cover compound slots, a known boundary-pair gap.
+
+**Impact** (full 100-case `openvm-eth` benchmark, target vs baseline vs powdr): variables
+**4.082× → 4.136× aggregate** (powdr 4.092× — apc-optimizer now wins the aggregate),
+**3.605× → 3.706× geomean** (powdr 3.787× — over half the remaining geomean gap closed);
+per-case variable losses to powdr **71 → 52** (wins 17, ties 31). Constraints improve to
+9.073×/11.190× agg/geo (powdr 5.853×/10.311×); bus interactions unchanged (2.922×/2.440× vs
+powdr 3.480×/2.822×). Per-case against baseline: **no case regressed in variables or
+constraints**; the only bus regression is apc_051's +14 above. Spot checks: apc_039 38 → 30 vars
+(= powdr), apc_011 59 → 51 (powdr 48), apc_090 50 → 46 (powdr 43). Runtime is *down* on the
+affected cases (apc_039 ~700 → ~400 ms — the resolved constraints leave later passes less
+work). `lake build` green; `check-proof-integrity.sh` passes; correctness axioms stay
+`{propext, Classical.choice, Quot.sound}`.
+
+Two negative findings recorded in `docs/ideas.md`: the apc_005-class `mem_ptr_limbs` carry
+products are **not** one-sided (the 16-bit wrap genuinely occurs on some traces — both factors'
+intervals contain 0), so that bus gap needs cross-access limb unification instead; and the
+apc_018 compare-block gap is the sltu-style `diff_marker` gadget that `hintCollapse`'s matcher
+does not cover yet (43 vs powdr 34 after this change).


### PR DESCRIPTION
## What

Implements **carry-branch resolution** (`ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean`), the highest-leverage idea from the variable-gap analysis on `claude/effectiveness-improvements-fdh484`: byte-decomposed adders leave degree-2 carry constraints `(b₀ − a₀)·(b₀ − a₀ − 256) = 0` that keep whole register data-word copies alive. When both operands are provably bytes (proven `BusFacts.slotBound` bounds: memory receives, bitwise checks, range checks), the second factor's value lies in `[p−511, p−1]` and can never vanish — the product is **equivalent** to the linear `b₀ = a₀`, which Gauss substitutes away; higher limbs cascade across cleanup iterations.

## How

- **Certificate** (`neverZeroB`): linearize the factor, normalize, and refute zero with a two-sided interval over the `BoundsMap` bounds — each term picks its smaller-magnitude sign representation (`splitSumMax`), and `maxNeg < const.val ∧ const.val + maxPos < p` proves the value stays in `(0, p)` (`linNeverZeroSplit`, the two-sided generalization of `MemoryUnify.linNeverZero`). Since the zero set is scaling-invariant but the interval is not, the field inverse of each coefficient and of the constant is tried as a rescaling candidate (mid-pipeline the carry factors are `256⁻¹`-scaled; soundness needs nothing about the candidate).
- **Pass**: maps each constraint through `resolveExpr` (keep the vanishing factor, recursively). The rewrite is an equivalence on satisfying assignments (`p` prime, runtime-checked, for `mul_eq_zero`), so both `PassCorrect` directions use the unchanged assignment; bus interactions, side effects, and `admissible` are untouched; no variable is introduced. With `BusFacts.trivial` the pass is the identity.
- **Placement**: first in `cleanupCycle`, *before* Gauss — `iterateToFixpoint` only keeps a cycle whose `sizeKey` strictly drops, so the resolved linear constraint must be consumed in the same cycle (measured pitfall: placed later, the rewrite was discarded at the fixpoint).
- **`domainBatch` gate fix** (`biInformative`): the first baseline comparison exposed one regression (apc_051) — the new substitution orientation stranded XOR rows `[0, 0, z, 1]` whose constant operands force `z = 0`, and `domainBatch`'s informativeness gate skipped them as presumed range checks. The gate now also enumerates interactions with a raw-variable slot carrying no `interactionBound` from that same interaction; domain-defining range/byte/tuple checks stay excluded (performance property preserved). Heuristic-only change: forced values still carry their own certificates.

## Effectiveness (full `openvm-eth` benchmark, 100 cases)

| measure | this PR (agg / geo) | baseline `main` (agg / geo) | powdr (agg / geo) |
|---|---|---|---|
| **variables** | **4.136× / 3.706×** | 4.082× / 3.605× | 4.092× / 3.787× |
| bus interactions | 2.922× / 2.440× | 2.922× / 2.440× | 3.480× / 2.822× |
| constraints | 9.073× / 11.190× | 8.801× / 9.918× | 5.853× / 10.311× |

- apc-optimizer now **beats powdr on aggregate variable effectiveness**; over half the geomean gap is closed. Per-case variable losses to powdr: **71 → 52** (wins 17, ties 31).
- Per-case vs baseline: 51 of 100 cases improved; **no case regresses in variables or constraints**. The only bus regression is apc_051 (+14: identical send/receive pairs with compound shift-gadget payload slots that `busPairCancel`'s byte justification can't discharge — aggregate-invisible, and the boundary-pair idea in `docs/ideas.md` covers it).
- Spot checks: apc_039 38 → 30 vars (= powdr), apc_011 59 → 51 (powdr 48), apc_090 50 → 46 (powdr 43). Runtime *drops* on affected cases (apc_039 ~700 → ~400 ms).

## Correctness

- No audited file touched (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`, `Basic.lean` glue all unchanged).
- `lake build` green; `Scripts/check-proof-integrity.sh` passes — correctness theorems depend only on `{propext, Classical.choice, Quot.sound}`.
- `docs/log.md` entry 56 documents the work, including two negative findings folded into `docs/ideas.md`: the apc_005-class `mem_ptr_limbs` carry products are genuinely two-sided (that bus gap needs cross-access limb unification instead), and the apc_018 compare gap is the sltu-style `diff_marker` gadget outside `hintCollapse`'s matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b6N4Wq8s1tF2NaPDMH7Ct

---
_Generated by [Claude Code](https://claude.ai/code/session_015b6N4Wq8s1tF2NaPDMH7Ct)_