### PR TITLE
Memory-pointer duplicate cleanup: two-root limb unification, syntactic dedup, flag unification

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -23,6 +23,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.HintCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.CarryBranch
 import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
 import ApcOptimizer.Implementation.OptimizerPasses.Dedup
+import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 
 set_option autoImplicit false
 
@@ -68,6 +69,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen zeroRegisterPass.guardDegree
     |>.andThen hintCollapsePass.guardDegree
     |>.andThen rootPairUnifyPass.guardDegree
+    |>.andThen flagUnifyPass.guardDegree
     |>.andThen dedupPass.withFacts.guardDegree
     |>.andThen trivialConstraintDropPass.withFacts.guardDegree
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -21,6 +21,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.DomainFold
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroRegister
 import ApcOptimizer.Implementation.OptimizerPasses.HintCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.CarryBranch
+import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
 
 set_option autoImplicit false
 
@@ -65,6 +66,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen constantFoldPass.withFacts.guardDegree
     |>.andThen zeroRegisterPass.guardDegree
     |>.andThen hintCollapsePass.guardDegree
+    |>.andThen rootPairUnifyPass.guardDegree
     |>.andThen trivialConstraintDropPass.withFacts.guardDegree
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree
     |>.andThen tautoBusDropPass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -22,6 +22,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.ZeroRegister
 import ApcOptimizer.Implementation.OptimizerPasses.HintCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.CarryBranch
 import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
+import ApcOptimizer.Implementation.OptimizerPasses.Dedup
 
 set_option autoImplicit false
 
@@ -67,6 +68,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen zeroRegisterPass.guardDegree
     |>.andThen hintCollapsePass.guardDegree
     |>.andThen rootPairUnifyPass.guardDegree
+    |>.andThen dedupPass.withFacts.guardDegree
     |>.andThen trivialConstraintDropPass.withFacts.guardDegree
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree
     |>.andThen tautoBusDropPass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
@@ -1,0 +1,171 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+
+set_option autoImplicit false
+
+/-! # Syntactic duplicate removal
+
+Two syntactically identical algebraic constraints impose the same equation twice; two identical
+*stateless* interactions impose the same lookup obligation twice. Keeping one of each changes
+neither the satisfying set, nor the (stateful-only) side effects, nor `admissible` — dropping
+the copies is a pure constraint- and bus-count win. Stateful duplicates are **not** touched: they
+are observable in `sideEffects` (two sends of the same message are two sends).
+
+Until the two-root unification landed (log entry 57) the optimized outputs contained no
+syntactic duplicates at all, so this pass would have been a no-op; unifying a duplicate
+decomposition's limbs turns its carry constraints and its raw-slot range check into literal
+copies of the survivor's, which this pass now collects.
+
+A `List.filter` cannot express "keep the first occurrence" — identical elements get identical
+predicate values — hence the explicit recursion carrying the kept-so-far list. Constraints use
+`List.dedup` (only membership matters for `satisfies`, so which occurrence survives is
+irrelevant). Field-free, fact-free. -/
+
+variable {p : ℕ}
+
+/-! ## Keep-first dedup of stateless interactions -/
+
+/-- Drop a stateless interaction if an identical one was already kept; keep every stateful
+    interaction unconditionally. -/
+def dedupStateless (bs : BusSemantics p) :
+    (seen : List (BusInteraction (Expression p))) → List (BusInteraction (Expression p)) →
+    List (BusInteraction (Expression p))
+  | _, [] => []
+  | seen, bi :: rest =>
+    if bs.isStateful bi.busId then bi :: dedupStateless bs seen rest
+    else if bi ∈ seen then dedupStateless bs seen rest
+    else bi :: dedupStateless bs (bi :: seen) rest
+
+theorem dedupStateless_subset (bs : BusSemantics p) :
+    ∀ (seen l : List (BusInteraction (Expression p))),
+      ∀ bi ∈ dedupStateless bs seen l, bi ∈ l := by
+  intro seen l
+  induction l generalizing seen with
+  | nil => intro bi h; simpa [dedupStateless] using h
+  | cons b rest ih =>
+    intro bi h
+    rw [dedupStateless] at h
+    split_ifs at h with h1 h2
+    · rcases List.mem_cons.1 h with rfl | h'
+      · exact List.mem_cons_self ..
+      · exact List.mem_cons_of_mem _ (ih seen bi h')
+    · exact List.mem_cons_of_mem _ (ih seen bi h)
+    · rcases List.mem_cons.1 h with rfl | h'
+      · exact List.mem_cons_self ..
+      · exact List.mem_cons_of_mem _ (ih (b :: seen) bi h')
+
+/-- Every original interaction is either kept or was already in `seen`. -/
+theorem dedupStateless_covers (bs : BusSemantics p) :
+    ∀ (seen l : List (BusInteraction (Expression p))),
+      ∀ bi ∈ l, bi ∈ dedupStateless bs seen l ∨ bi ∈ seen := by
+  intro seen l
+  induction l generalizing seen with
+  | nil => intro bi h; simp at h
+  | cons b rest ih =>
+    intro bi h
+    rw [dedupStateless]
+    split_ifs with h1 h2
+    · rcases List.mem_cons.1 h with rfl | h'
+      · exact Or.inl (List.mem_cons_self ..)
+      · exact (ih seen bi h').imp (List.mem_cons_of_mem _) id
+    · rcases List.mem_cons.1 h with rfl | h'
+      · exact Or.inr h2
+      · exact ih seen bi h'
+    · rcases List.mem_cons.1 h with rfl | h'
+      · exact Or.inl (List.mem_cons_self ..)
+      · rcases ih (b :: seen) bi h' with hk | hs
+        · exact Or.inl (List.mem_cons_of_mem _ hk)
+        · rcases List.mem_cons.1 hs with rfl | hs'
+          · exact Or.inl (List.mem_cons_self ..)
+          · exact Or.inr hs'
+
+/-- The stateful sublist is untouched (syntactically). -/
+theorem dedupStateless_statefulFilter (bs : BusSemantics p) :
+    ∀ (seen l : List (BusInteraction (Expression p))),
+      (dedupStateless bs seen l).filter (fun bi => bs.isStateful bi.busId)
+        = l.filter (fun bi => bs.isStateful bi.busId) := by
+  intro seen l
+  induction l generalizing seen with
+  | nil => rfl
+  | cons b rest ih =>
+    rw [dedupStateless]
+    split_ifs with h1 h2
+    · rw [List.filter_cons_of_pos (by simpa using h1),
+          List.filter_cons_of_pos (by simpa using h1), ih]
+    · rw [List.filter_cons_of_neg (by simpa using h1), ih]
+    · rw [List.filter_cons_of_neg (by simpa using h1),
+          List.filter_cons_of_neg (by simpa using h1), ih]
+
+/-- The active∧stateful *evaluated* message list is untouched (what `admissible` consults). -/
+theorem dedupStateless_evalFilter (bs : BusSemantics p) (env : Variable → ZMod p) :
+    ∀ (seen l : List (BusInteraction (Expression p))),
+      ((dedupStateless bs seen l).map (fun bi => bi.eval env)).filter
+          (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
+        = (l.map (fun bi => bi.eval env)).filter
+          (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId) := by
+  intro seen l
+  induction l generalizing seen with
+  | nil => rfl
+  | cons b rest ih =>
+    rw [dedupStateless]
+    have hbus : (b.eval env).busId = b.busId := rfl
+    split_ifs with h1 h2
+    · simp only [List.map_cons, List.filter_cons, hbus, h1, ih]
+    · -- dropped: its evaluated message fails the `isStateful` conjunct anyway
+      rw [List.map_cons,
+        List.filter_cons_of_neg (by have hf : bs.isStateful (b.eval env).busId = false := (by simpa using h1); simp [hf]), ih]
+    · rw [List.map_cons,
+        List.filter_cons_of_neg (by have hf : bs.isStateful (b.eval env).busId = false := (by simpa using h1); simp [hf]),
+        List.map_cons,
+        List.filter_cons_of_neg (by have hf : bs.isStateful (b.eval env).busId = false := (by simpa using h1); simp [hf]), ih]
+
+/-! ## The pass -/
+
+/-- The deduplicated system. -/
+def ConstraintSystem.dedup (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    ConstraintSystem p :=
+  { algebraicConstraints := cs.algebraicConstraints.dedup,
+    busInteractions := dedupStateless bs [] cs.busInteractions }
+
+/-- Dropping syntactic duplicates is equivalence- and invariant-preserving. -/
+theorem ConstraintSystem.dedup_correct (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    PassCorrect cs (cs.dedup bs) [] bs := by
+  have hiff : ∀ env, (cs.dedup bs).satisfies bs env ↔ cs.satisfies bs env := by
+    intro env
+    simp only [ConstraintSystem.satisfies, ConstraintSystem.dedup]
+    constructor
+    · rintro ⟨hc, hb⟩
+      refine ⟨fun c hcm => hc c (List.mem_dedup.2 hcm), fun bi hbm => ?_⟩
+      rcases dedupStateless_covers bs [] cs.busInteractions bi hbm with hk | hs
+      · exact hb bi hk
+      · simp at hs
+    · rintro ⟨hc, hb⟩
+      exact ⟨fun c hcm => hc c (List.mem_dedup.1 hcm),
+        fun bi hbm => hb bi (dedupStateless_subset bs [] cs.busInteractions bi hbm)⟩
+  have hside : ∀ env, (cs.dedup bs).sideEffects bs env = cs.sideEffects bs env := by
+    intro env
+    simp only [ConstraintSystem.sideEffects, ConstraintSystem.dedup]
+    rw [dedupStateless_statefulFilter bs [] cs.busInteractions]
+  have hadm : ∀ env, (cs.dedup bs).admissible bs env ↔ cs.admissible bs env := by
+    intro env
+    unfold ConstraintSystem.admissible
+    simp only [ConstraintSystem.dedup]
+    rw [dedupStateless_evalFilter bs env [] cs.busInteractions]
+  have hsub : ∀ v ∈ (cs.dedup bs).vars, v ∈ cs.vars := by
+    intro v hv
+    rw [ConstraintSystem.mem_vars] at hv ⊢
+    rcases hv with ⟨c, hc, hvc⟩ | ⟨bi, hbi, hvbi⟩
+    · exact Or.inl ⟨c, List.mem_dedup.1 hc, hvc⟩
+    · exact Or.inr ⟨bi, dedupStateless_subset bs [] cs.busInteractions bi hbi, hvbi⟩
+  refine PassCorrect.ofEnvEq ?_ ?_ hsub ?_
+  · intro env hsat
+    exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro hinv env hsat bi hbi
+    exact hinv env ((hiff env).1 hsat) bi
+      (dedupStateless_subset bs [] cs.busInteractions bi hbi)
+  · intro env hadm' hsat
+    exact ⟨(hiff env).2 hsat, (hadm env).2 hadm',
+      by rw [hside]; exact BusState.equiv_refl _⟩
+
+/-- The duplicate-removal pass. -/
+def dedupPass : VerifiedPass p := fun cs bs =>
+  ⟨cs.dedup bs, [], cs.dedup_correct bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -1,0 +1,375 @@
+import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
+
+set_option autoImplicit false
+
+/-! # Flag unification across duplicate scaled range checks
+
+After the two-root unification (`RootPairUnify.lean`) both the surviving and the eliminated
+memory access range-check the **same** low limb `x`, each through its own scaled slot
+`k·x + R` (`k` constant, `R` the access's flag polynomial times `−k`): the slot value `u`
+satisfies `x = k⁻¹·u + W` with `W = −k⁻¹·R` the flag-polynomial value. Two such checks on the
+same `x` force `W_X.val = W_Y.val` — both are the residue of `x.val` under `m = k⁻¹.val`
+(`residue_uniq`), given the slot bounds and per-point `W < m` — and the flag encoding is
+injective on its (tiny, provable) domain box, so the *individual flag variables* of the two
+accesses are provably equal. The entailed equalities feed the same `Solved`/`substF` machinery
+as the limb unification; once substituted, the two checks become syntactically identical and
+`dedupPass` collects the copy.
+
+Nothing here is memory-specific: the pass unifies variables pinned by any two scaled
+range-check slots of the same carrier variable whose offset parts agree pointwise on their
+finite domains. Prime `p` only (finite flag domains come from booleanity roots), re-checked at
+runtime. -/
+
+variable {p : ℕ}
+
+/-- Two summands below `M` that complete the same integer against multiples of `M` are equal. -/
+theorem residue_uniq (M A B w1 w2 : Nat) (h : M * A + w1 = M * B + w2)
+    (h1 : w1 < M) (h2 : w2 < M) : w1 = w2 := by
+  have e1 : (M * A + w1) % M = w1 := by rw [Nat.mul_add_mod]; exact Nat.mod_eq_of_lt h1
+  have e2 : (M * B + w2) % M = w2 := by rw [Nat.mul_add_mod]; exact Nat.mod_eq_of_lt h2
+  rw [← e1, h, e2]
+
+/-! ## The pair certificate -/
+
+/-- Decidable certificate that interactions `biX`, `biY` are scaled range checks of the same
+    carrier `x` whose offset parts pin `vy` (in `biY`'s flags) to `vx` (in `biX`'s flags):
+    both slots decompose as `k·x + R` with the same unit `k`, the slot values are fact-bounded,
+    every joint flag point keeps both offsets below `m = k⁻¹` (so the integer residue argument
+    applies), and every joint point with equal offset values has `vy = vx`. Re-checked inside
+    the adoption proof. -/
+def fuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Expression p))
+    (biX biY : BusInteraction (Expression p)) (x vx vy : Variable) : Bool :=
+  match biX.multiplicity.constValue?, biY.multiplicity.constValue? with
+  | some mx, some my =>
+    !(decide (mx = 0)) && !(decide (my = 0)) &&
+    (match biX.payload[0]?, biY.payload[0]? with
+     | some OX, some OY =>
+       (match facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0,
+              facts.slotBound biY.busId my (biY.payload.map Expression.constValue?) 0 with
+        | some bX, some bY =>
+          (match OX.splitAt x, OY.splitAt x with
+           | some (k, RX), some (k2, RY) =>
+             decide (k2 = k) && decide (k * k⁻¹ = 1) &&
+             decide (vx ∈ RX.vars) && decide (vy ∈ RY.vars) && !(decide (vy = vx)) &&
+             decide (vx ∈ biX.payload.flatMap Expression.vars) &&
+             decide (k⁻¹.val * (bX - 1) + (k⁻¹.val - 1) < p) &&
+             decide (k⁻¹.val * (bY - 1) + (k⁻¹.val - 1) < p) &&
+             (let jointVars := (RX.vars ++ RY.vars).eraseDups
+              let doms := jointVars.filterMap (fun v =>
+                (findDomainAlg domCs v).map (fun d => (v, d)))
+              decide (doms.map Prod.fst = jointVars) &&
+              decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+              (assignments doms).all (fun pt =>
+                decide (((-k⁻¹) * RX.eval (envOf pt)).val < k⁻¹.val) &&
+                decide (((-k⁻¹) * RY.eval (envOf pt)).val < k⁻¹.val) &&
+                (!(decide (((-k⁻¹) * RX.eval (envOf pt)).val
+                    = ((-k⁻¹) * RY.eval (envOf pt)).val))
+                  || decide (envOf pt vy = envOf pt vx))))
+           | _, _ => false)
+        | _, _ => false)
+     | _, _ => false)
+  | _, _ => false
+
+/-- Extract the `varsIn` membership from a passed certificate. -/
+theorem fuCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (biX biY : BusInteraction (Expression p))
+    (x vx vy : Variable) (h : fuCheck bs facts domCs biX biY x vx vy = true) :
+    vx ∈ biX.payload.flatMap Expression.vars := by
+  unfold fuCheck at h
+  cases hmx : biX.multiplicity.constValue? with
+  | none => rw [hmx] at h; simp at h
+  | some mx =>
+    cases hmy : biY.multiplicity.constValue? with
+    | none => rw [hmx, hmy] at h; simp at h
+    | some my =>
+      rw [hmx, hmy] at h
+      cases hOX : biX.payload[0]? with
+      | none => simp [hOX] at h
+      | some OX =>
+        cases hOY : biY.payload[0]? with
+        | none => simp [hOX, hOY] at h
+        | some OY =>
+          simp only [hOX, hOY] at h
+          cases hbX : facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0 with
+          | none => simp [hbX] at h
+          | some bX =>
+            cases hbY : facts.slotBound biY.busId my
+                (biY.payload.map Expression.constValue?) 0 with
+            | none => simp [hbX, hbY] at h
+            | some bY =>
+              simp only [hbX, hbY] at h
+              cases hsX : OX.splitAt x with
+              | none => simp [hsX] at h
+              | some kRX =>
+                obtain ⟨k, RX⟩ := kRX
+                cases hsY : OY.splitAt x with
+                | none => simp [hsX, hsY] at h
+                | some kRY =>
+                  obtain ⟨k2, RY⟩ := kRY
+                  simp only [hsX, hsY, Bool.and_eq_true, decide_eq_true_eq] at h
+                  exact h.2.1.1.1.2
+
+theorem fuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (biX biY : BusInteraction (Expression p))
+    (x vx vy : Variable) (h : fuCheck bs facts domCs biX biY x vx vy = true)
+    (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ domCs, c.eval env = 0)
+    (hobX : (biX.eval env).multiplicity ≠ 0 → bs.violatesConstraint (biX.eval env) = false)
+    (hobY : (biY.eval env).multiplicity ≠ 0 → bs.violatesConstraint (biY.eval env) = false) :
+    env vy = env vx := by
+  unfold fuCheck at h
+  cases hmx : biX.multiplicity.constValue? with
+  | none => rw [hmx] at h; simp at h
+  | some mx =>
+    cases hmy : biY.multiplicity.constValue? with
+    | none => rw [hmx, hmy] at h; simp at h
+    | some my =>
+      rw [hmx, hmy] at h
+      cases hOX : biX.payload[0]? with
+      | none => simp [hOX] at h
+      | some OX =>
+        cases hOY : biY.payload[0]? with
+        | none => simp [hOX, hOY] at h
+        | some OY =>
+          simp only [hOX, hOY] at h
+          cases hbX : facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0 with
+          | none => simp [hbX] at h
+          | some bX =>
+            cases hbY : facts.slotBound biY.busId my
+                (biY.payload.map Expression.constValue?) 0 with
+            | none => simp [hbX, hbY] at h
+            | some bY =>
+              simp only [hbX, hbY] at h
+              cases hsX : OX.splitAt x with
+              | none => simp [hsX] at h
+              | some kRX =>
+                obtain ⟨k, RX⟩ := kRX
+                cases hsY : OY.splitAt x with
+                | none => simp [hsX, hsY] at h
+                | some kRY =>
+                  obtain ⟨k2, RY⟩ := kRY
+                  simp only [hsX, hsY, Bool.and_eq_true, Bool.not_eq_true',
+                    decide_eq_true_eq, decide_eq_false_iff_not] at h
+                  obtain ⟨⟨hmx0, hmy0⟩,
+                    ⟨⟨⟨⟨⟨⟨⟨⟨hk2, hunit⟩, hvxR⟩, hvyR⟩, _hvyne⟩, _hvxpay⟩, hwrapX⟩, hwrapY⟩,
+                      ⟨⟨hcover, _hcap⟩, hpts⟩⟩⟩ := h
+                  -- acceptance and slot-value bounds
+                  have hmXe : (biX.eval env).multiplicity = mx :=
+                    biX.multiplicity.constValue?_sound mx hmx env
+                  have hmYe : (biY.eval env).multiplicity = my :=
+                    biY.multiplicity.constValue?_sound my hmy env
+                  have hviolX : bs.violatesConstraint (biX.eval env) = false :=
+                    hobX (by rw [hmXe]; exact hmx0)
+                  have hviolY : bs.violatesConstraint (biY.eval env) = false :=
+                    hobY (by rw [hmYe]; exact hmy0)
+                  have hgetX : (biX.eval env).payload[0]? = some (OX.eval env) := by
+                    show (biX.payload.map (fun e => e.eval env))[0]? = _
+                    rw [List.getElem?_map, hOX]; rfl
+                  have hgetY : (biY.eval env).payload[0]? = some (OY.eval env) := by
+                    show (biY.payload.map (fun e => e.eval env))[0]? = _
+                    rw [List.getElem?_map, hOY]; rfl
+                  have hbXv : (OX.eval env).val < bX :=
+                    facts.slotBound_sound (biX.eval env)
+                      (biX.payload.map Expression.constValue?) 0 bX (OX.eval env)
+                      (by rw [(rfl : (biX.eval env).busId = biX.busId), hmXe]; exact hbX)
+                      (matches_evalPattern biX.payload env) hviolX hgetX
+                  have hbYv : (OY.eval env).val < bY :=
+                    facts.slotBound_sound (biY.eval env)
+                      (biY.payload.map Expression.constValue?) 0 bY (OY.eval env)
+                      (by rw [(rfl : (biY.eval env).busId = biY.busId), hmYe]; exact hbY)
+                      (matches_evalPattern biY.payload env) hviolY hgetY
+                  -- field decomposition `x = m·u + W`, both sides
+                  set m := k⁻¹ with hm
+                  have hOXe : OX.eval env = k * env x + RX.eval env :=
+                    Expression.splitAt_eval x OX k RX hsX env
+                  have hOYe : OY.eval env = k * env x + RY.eval env := by
+                    have h0 := Expression.splitAt_eval x OY k2 RY hsY env
+                    rw [hk2] at h0; exact h0
+                  have hxX : env x = m * OX.eval env + (-m) * RX.eval env := by
+                    have h1 : m * OX.eval env = m * k * env x + m * RX.eval env := by
+                      rw [hOXe]; ring
+                    rw [mul_comm m k, hunit, one_mul] at h1
+                    linear_combination -h1
+                  have hxY : env x = m * OY.eval env + (-m) * RY.eval env := by
+                    have h1 : m * OY.eval env = m * k * env x + m * RY.eval env := by
+                      rw [hOYe]; ring
+                    rw [mul_comm m k, hunit, one_mul] at h1
+                    linear_combination -h1
+                  -- the environment restricted to the joint flag box is an enumerated point
+                  have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                      (findDomainAlg domCs v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+                    intro vd hvd
+                    obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+                    cases hfd : findDomainAlg domCs v with
+                    | none => rw [hfd] at hvd'; simp at hvd'
+                    | some d =>
+                      rw [hfd] at hvd'
+                      simp only [Option.map_some, Option.some.injEq] at hvd'
+                      obtain rfl := hvd'.symm
+                      exact findDomainAlg_sound domCs v d hfd env hdom
+                  have hpt := mem_assignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                    (findDomainAlg domCs v).map (fun d => (v, d)))) env hmemdoms
+                  have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
+                      envOf (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                        (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1))) v = env v := by
+                    intro v hv
+                    refine envOf_map _ env v ?_
+                    rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                      (findDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+                      = (RX.vars ++ RY.vars).eraseDups from hcover]
+                    exact hv
+                  have hRXagree : RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun vd => (vd.1, env vd.1)))) = RX.eval env :=
+                    Expression.eval_congr RX _ env (fun v hv =>
+                      hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
+                  have hRYagree : RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun vd => (vd.1, env vd.1)))) = RY.eval env :=
+                    Expression.eval_congr RY _ env (fun v hv =>
+                      hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+                  -- the per-point conditions, at the environment's own point
+                  have hptc := List.all_eq_true.mp hpts _ hpt
+                  rw [Bool.and_eq_true, Bool.and_eq_true] at hptc
+                  have hWXlt : ((-m) * RX.eval env).val < m.val := by
+                    rw [← hRXagree]; exact of_decide_eq_true hptc.1.1
+                  have hWYlt : ((-m) * RY.eval env).val < m.val := by
+                    rw [← hRYagree]; exact of_decide_eq_true hptc.1.2
+                  -- integer decomposition of `x.val` through both checks
+                  have hbX1 : (OX.eval env).val ≤ bX - 1 := by omega
+                  have hbY1 : (OY.eval env).val ≤ bY - 1 := by omega
+                  have hle1 : m.val * (OX.eval env).val ≤ m.val * (bX - 1) :=
+                    Nat.mul_le_mul_left _ hbX1
+                  have hle2 : m.val * (OY.eval env).val ≤ m.val * (bY - 1) :=
+                    Nat.mul_le_mul_left _ hbY1
+                  have hMuX : (m * OX.eval env).val = m.val * (OX.eval env).val :=
+                    ZMod.val_mul_of_lt (by omega)
+                  have hMuY : (m * OY.eval env).val = m.val * (OY.eval env).val :=
+                    ZMod.val_mul_of_lt (by omega)
+                  have hsumX : (m * OX.eval env).val + ((-m) * RX.eval env).val < p := by
+                    rw [hMuX]; omega
+                  have hsumY : (m * OY.eval env).val + ((-m) * RY.eval env).val < p := by
+                    rw [hMuY]; omega
+                  have hvalX : (env x).val
+                      = m.val * (OX.eval env).val + ((-m) * RX.eval env).val := by
+                    rw [hxX, ZMod.val_add_of_lt hsumX, hMuX]
+                  have hvalY : (env x).val
+                      = m.val * (OY.eval env).val + ((-m) * RY.eval env).val := by
+                    rw [hxY, ZMod.val_add_of_lt hsumY, hMuY]
+                  have hres : ((-m) * RX.eval env).val = ((-m) * RY.eval env).val :=
+                    residue_uniq m.val (OX.eval env).val (OY.eval env).val _ _
+                      (hvalX.symm.trans hvalY) hWXlt hWYlt
+                  -- resolve the point disjunction and pull the equality back to `env`
+                  have hor := hptc.2
+                  rw [Bool.or_eq_true] at hor
+                  rcases hor with hL | hR
+                  · rw [Bool.not_eq_true'] at hL
+                    have hXpt := hres
+                    rw [← hRXagree, ← hRYagree] at hXpt
+                    exact absurd hXpt (of_decide_eq_false hL)
+                  · rw [← hagree vy (List.mem_eraseDups.2 (List.mem_append_right _ hvyR)),
+                        ← hagree vx (List.mem_eraseDups.2 (List.mem_append_left _ hvxR))]
+                    exact of_decide_eq_true hR
+
+/-! ## The scan loop and the pass -/
+
+/-- A previously seen scaled-check candidate: the interaction (with membership), its carrier
+    variable, and the matching key `(busId, second-slot constant, k, carrier)`. -/
+structure FUSeen (p : ℕ) (cs : ConstraintSystem p) where
+  bi : BusInteraction (Expression p)
+  mem : bi ∈ cs.busInteractions
+  x : Variable
+  key : Nat × Option (ZMod p) × ZMod p × Variable
+
+/-- Scaled-check candidates of one interaction: carrier variables of the first payload slot
+    with a constant-coefficient decomposition and a *nonempty* offset part (raw checks have
+    nothing to unify). -/
+def fuCandidates (bi : BusInteraction (Expression p)) :
+    List (Variable × (Nat × Option (ZMod p) × ZMod p × Variable)) :=
+  match bi.payload[0]? with
+  | none => []
+  | some O =>
+    O.vars.eraseDups.filterMap (fun x =>
+      match O.splitAt x with
+      | some (k, R) =>
+        if R.vars.isEmpty then none
+        else some (x, (bi.busId, (bi.payload[1]?).bind Expression.constValue?, k, x))
+      | none => none)
+
+/-- Flag-target combinations for a matched pair: variables of the two offset parts. -/
+def fuTargets (biX biY : BusInteraction (Expression p)) (x : Variable) :
+    List (Variable × Variable) :=
+  match biX.payload[0]?, biY.payload[0]? with
+  | some OX, some OY =>
+    match OX.splitAt x, OY.splitAt x with
+    | some (_, RX), some (_, RY) =>
+      RY.vars.eraseDups.flatMap (fun vy => RX.vars.eraseDups.map (fun vx => (vy, vx)))
+    | _, _ => []
+  | _, _ => []
+
+/-- Scan the interactions: for each scaled-check candidate, look for an earlier twin with the
+    same key and adopt every flag pair the certificate confirms. The certificate is re-checked
+    inside the adoption proof, so the scan itself carries no obligations. -/
+def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) :
+    (pending : List (BusInteraction (Expression p))) →
+    (∀ bi ∈ pending, bi ∈ cs.busInteractions) →
+    List (FUSeen p cs) → Solved p cs bs → Solved p cs bs
+  | [], _, _, σ => σ
+  | c :: rest, hmem, seen, σ =>
+    have hc : c ∈ cs.busInteractions := hmem c (List.mem_cons_self ..)
+    let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
+    let cands := fuCandidates c
+    match cands.findSome? (fun xk =>
+        seen.findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
+    | some ex =>
+        let pairs := (fuTargets ex.1.bi c ex.2).filterMap (fun t =>
+          if fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1
+          then some (t.1, Expression.var t.2) else none)
+        have hpairs : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env := by
+          intro env hsat yt hyt
+          obtain ⟨t, _ht, hif⟩ := List.mem_filterMap.1 hyt
+          by_cases hck : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true
+          · rw [if_pos hck] at hif
+            simp only [Option.some.injEq] at hif
+            subst hif
+            show env t.1 = env t.2
+            exact fuCheck_sound bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hck env
+              (fun c' hc' => hsat.1 c' hc')
+              (fun hmult => hsat.2 ex.1.bi ex.1.mem hmult)
+              (fun hmult => hsat.2 c hc hmult)
+          · rw [if_neg hck] at hif
+            exact absurd hif (by simp)
+        have hpairsV : ∀ yt ∈ pairs, ∀ z ∈ yt.2.vars, z ∈ cs.vars := by
+          intro yt hyt z hz
+          obtain ⟨t, _ht, hif⟩ := List.mem_filterMap.1 hyt
+          by_cases hck : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true
+          · rw [if_pos hck] at hif
+            simp only [Option.some.injEq] at hif
+            subst hif
+            obtain rfl : z = t.2 := by simpa [Expression.vars] using hz
+            obtain ⟨e', he', hv'⟩ := List.mem_flatMap.1
+              (fuCheck_vars bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hck)
+            exact ConstraintSystem.mem_vars_of_payload ex.1.mem he' hv'
+          · rw [if_neg hck] at hif
+            exact absurd hif (by simp)
+        fuLoop cs bs facts rest hrest
+          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (σ.insertAll pairs hpairs hpairsV)
+    | none =>
+        fuLoop cs bs facts rest hrest
+          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+
+/-- Flag unification across duplicate scaled range checks. Prime `p` only (re-checked at
+    runtime). Runs after `rootPairUnifyPass` — the carrier limbs must already be shared — and
+    before `dedupPass`, which collects the checks this pass makes syntactically identical. -/
+def flagUnifyPass : VerifiedPassW p := fun cs bs facts =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    let σ := fuLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
+    if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+    else ⟨cs.substF σ.fn, [],
+      cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
+        (fun y t hyt => σ.varsIn y t hyt)⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -31,17 +31,22 @@ theorem residue_uniq (M A B w1 w2 : Nat) (h : M * A + w1 = M * B + w2)
 
 /-! ## The pair certificate -/
 
-/-- Decidable certificate that interactions `biX`, `biY` are scaled range checks of the same
-    carrier `x` whose offset parts pin `vy` (in `biY`'s flags) to `vx` (in `biX`'s flags):
-    both slots decompose as `k·x + R` with the same unit `k`, the slot values are fact-bounded,
-    every joint flag point keeps both offsets below `m = k⁻¹` (so the integer residue argument
-    applies), and every joint point with equal offset values has `vy = vx`. Re-checked inside
-    the adoption proof. -/
-def fuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Expression p))
-    (biX biY : BusInteraction (Expression p)) (x vx vy : Variable) : Bool :=
+/-- Pair-level certificate data: everything independent of the target flag pair. `pts` pairs
+    each enumerated joint flag point with whether the two offset values coincide there. -/
+structure FuData (p : ℕ) where
+  rxVars : List Variable
+  ryVars : List Variable
+  payXVars : List Variable
+  pts : List (List (Variable × ZMod p) × Bool)
+
+/-- The pair-level half of the certificate: slot decompositions, fact bounds, no-wrap checks,
+    domain cover, and the per-point offset bounds — computed **once per matched pair** (the
+    field inversion in particular is hoisted; it used to run dozens of times per target). -/
+def fuPairData? (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Expression p))
+    (biX biY : BusInteraction (Expression p)) (x : Variable) : Option (FuData p) :=
   match biX.multiplicity.constValue?, biY.multiplicity.constValue? with
   | some mx, some my =>
-    !(decide (mx = 0)) && !(decide (my = 0)) &&
+    if mx = 0 then none else if my = 0 then none else
     (match biX.payload[0]?, biY.payload[0]? with
      | some OX, some OY =>
        (match facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0,
@@ -49,26 +54,49 @@ def fuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Express
         | some bX, some bY =>
           (match OX.splitAt x, OY.splitAt x with
            | some (k, RX), some (k2, RY) =>
-             decide (k2 = k) && decide (k * k⁻¹ = 1) &&
-             decide (vx ∈ RX.vars) && decide (vy ∈ RY.vars) && !(decide (vy = vx)) &&
-             decide (vx ∈ biX.payload.flatMap Expression.vars) &&
-             decide (k⁻¹.val * (bX - 1) + (k⁻¹.val - 1) < p) &&
-             decide (k⁻¹.val * (bY - 1) + (k⁻¹.val - 1) < p) &&
-             (let jointVars := (RX.vars ++ RY.vars).eraseDups
-              let doms := jointVars.filterMap (fun v =>
-                (findDomainAlg domCs v).map (fun d => (v, d)))
-              decide (doms.map Prod.fst = jointVars) &&
-              decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
-              (assignments doms).all (fun pt =>
-                decide (((-k⁻¹) * RX.eval (envOf pt)).val < k⁻¹.val) &&
-                decide (((-k⁻¹) * RY.eval (envOf pt)).val < k⁻¹.val) &&
-                (!(decide (((-k⁻¹) * RX.eval (envOf pt)).val
-                    = ((-k⁻¹) * RY.eval (envOf pt)).val))
-                  || decide (envOf pt vy = envOf pt vx))))
-           | _, _ => false)
-        | _, _ => false)
-     | _, _ => false)
-  | _, _ => false
+             let m := k⁻¹
+             if k2 = k ∧ k * m = 1 ∧
+                 m.val * (bX - 1) + (m.val - 1) < p ∧
+                 m.val * (bY - 1) + (m.val - 1) < p then
+               let jointVars := (RX.vars ++ RY.vars).eraseDups
+               let doms := jointVars.filterMap (fun v =>
+                 (findDomainAlg domCs v).map (fun d => (v, d)))
+               if doms.map Prod.fst = jointVars ∧
+                   (doms.map (fun vd => vd.2.length)).prod ≤ 32 then
+                 let pts0 := assignments doms
+                 if pts0.all (fun pt =>
+                     decide (((-m) * RX.eval (envOf pt)).val < m.val) &&
+                     decide (((-m) * RY.eval (envOf pt)).val < m.val)) then
+                   some { rxVars := RX.vars, ryVars := RY.vars,
+                          payXVars := biX.payload.flatMap Expression.vars,
+                          pts := pts0.map (fun pt =>
+                            (pt, decide (((-m) * RX.eval (envOf pt)).val
+                              = ((-m) * RY.eval (envOf pt)).val))) }
+                 else none
+               else none
+             else none
+           | _, _ => none)
+        | _, _ => none)
+     | _, _ => none)
+  | _, _ => none
+
+/-- The per-target half: memberships, disequality, and pointwise flag agreement wherever the
+    offsets coincide. -/
+def fuCheckWith (d : FuData p) (vx vy : Variable) : Bool :=
+  decide (vx ∈ d.rxVars) && decide (vy ∈ d.ryVars) && !(decide (vy = vx)) &&
+  decide (vx ∈ d.payXVars) &&
+  d.pts.all (fun ptb => !ptb.2 || decide (envOf ptb.1 vy = envOf ptb.1 vx))
+
+/-- Decidable certificate that interactions `biX`, `biY` are scaled range checks of the same
+    carrier `x` whose offset parts pin `vy` (in `biY`'s flags) to `vx` (in `biX`'s flags).
+    Defined through `fuPairData?`/`fuCheckWith` so the scan can share the pair-level work
+    across targets with a *definitionally* identical value. Re-checked inside the adoption
+    proof. -/
+def fuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Expression p))
+    (biX biY : BusInteraction (Expression p)) (x vx vy : Variable) : Bool :=
+  match fuPairData? bs facts domCs biX biY x with
+  | some d => fuCheckWith d vx vy
+  | none => false
 
 /-- Extract the `varsIn` membership from a passed certificate. -/
 theorem fuCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -76,38 +104,52 @@ theorem fuCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     (x vx vy : Variable) (h : fuCheck bs facts domCs biX biY x vx vy = true) :
     vx ∈ biX.payload.flatMap Expression.vars := by
   unfold fuCheck at h
-  cases hmx : biX.multiplicity.constValue? with
-  | none => rw [hmx] at h; simp at h
-  | some mx =>
-    cases hmy : biY.multiplicity.constValue? with
-    | none => rw [hmx, hmy] at h; simp at h
-    | some my =>
-      rw [hmx, hmy] at h
-      cases hOX : biX.payload[0]? with
-      | none => simp [hOX] at h
-      | some OX =>
-        cases hOY : biY.payload[0]? with
-        | none => simp [hOX, hOY] at h
-        | some OY =>
-          simp only [hOX, hOY] at h
-          cases hbX : facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0 with
-          | none => simp [hbX] at h
-          | some bX =>
-            cases hbY : facts.slotBound biY.busId my
-                (biY.payload.map Expression.constValue?) 0 with
-            | none => simp [hbX, hbY] at h
-            | some bY =>
-              simp only [hbX, hbY] at h
-              cases hsX : OX.splitAt x with
-              | none => simp [hsX] at h
-              | some kRX =>
-                obtain ⟨k, RX⟩ := kRX
-                cases hsY : OY.splitAt x with
-                | none => simp [hsX, hsY] at h
-                | some kRY =>
-                  obtain ⟨k2, RY⟩ := kRY
-                  simp only [hsX, hsY, Bool.and_eq_true, decide_eq_true_eq] at h
-                  exact h.2.1.1.1.2
+  cases hd : fuPairData? bs facts domCs biX biY x with
+  | none => rw [hd] at h; simp at h
+  | some d =>
+    rw [hd] at h
+    -- the data's payload-vars field is the payload's variable list, by construction
+    have hpay : d.payXVars = biX.payload.flatMap Expression.vars := by
+      unfold fuPairData? at hd
+      cases hmx : biX.multiplicity.constValue? with
+      | none => rw [hmx] at hd; simp at hd
+      | some mx =>
+        cases hmy : biY.multiplicity.constValue? with
+        | none => rw [hmx, hmy] at hd; simp at hd
+        | some my =>
+          simp only [hmx, hmy] at hd
+          split_ifs at hd
+          cases hOX : biX.payload[0]? with
+          | none => simp [hOX] at hd
+          | some OX =>
+            cases hOY : biY.payload[0]? with
+            | none => simp [hOX, hOY] at hd
+            | some OY =>
+              simp only [hOX, hOY] at hd
+              cases hbX : facts.slotBound biX.busId mx
+                  (biX.payload.map Expression.constValue?) 0 with
+              | none => simp [hbX] at hd
+              | some bX =>
+                cases hbY : facts.slotBound biY.busId my
+                    (biY.payload.map Expression.constValue?) 0 with
+                | none => simp [hbX, hbY] at hd
+                | some bY =>
+                  simp only [hbX, hbY] at hd
+                  cases hsX : OX.splitAt x with
+                  | none => simp [hsX] at hd
+                  | some kRX =>
+                    obtain ⟨k, RX⟩ := kRX
+                    cases hsY : OY.splitAt x with
+                    | none => simp [hsX, hsY] at hd
+                    | some kRY =>
+                      obtain ⟨k2, RY⟩ := kRY
+                      simp only [hsX, hsY] at hd
+                      split_ifs at hd
+                      simp only [Option.some.injEq] at hd
+                      rw [← hd]
+    unfold fuCheckWith at h
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+    exact hpay ▸ h.1.2
 
 theorem fuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
     (domCs : List (Expression p)) (biX biY : BusInteraction (Expression p))
@@ -118,159 +160,188 @@ theorem fuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p b
     (hobY : (biY.eval env).multiplicity ≠ 0 → bs.violatesConstraint (biY.eval env) = false) :
     env vy = env vx := by
   unfold fuCheck at h
-  cases hmx : biX.multiplicity.constValue? with
-  | none => rw [hmx] at h; simp at h
-  | some mx =>
-    cases hmy : biY.multiplicity.constValue? with
-    | none => rw [hmx, hmy] at h; simp at h
-    | some my =>
-      rw [hmx, hmy] at h
-      cases hOX : biX.payload[0]? with
-      | none => simp [hOX] at h
-      | some OX =>
-        cases hOY : biY.payload[0]? with
-        | none => simp [hOX, hOY] at h
-        | some OY =>
-          simp only [hOX, hOY] at h
-          cases hbX : facts.slotBound biX.busId mx (biX.payload.map Expression.constValue?) 0 with
-          | none => simp [hbX] at h
-          | some bX =>
-            cases hbY : facts.slotBound biY.busId my
-                (biY.payload.map Expression.constValue?) 0 with
-            | none => simp [hbX, hbY] at h
-            | some bY =>
-              simp only [hbX, hbY] at h
-              cases hsX : OX.splitAt x with
-              | none => simp [hsX] at h
-              | some kRX =>
-                obtain ⟨k, RX⟩ := kRX
-                cases hsY : OY.splitAt x with
-                | none => simp [hsX, hsY] at h
-                | some kRY =>
-                  obtain ⟨k2, RY⟩ := kRY
-                  simp only [hsX, hsY, Bool.and_eq_true, Bool.not_eq_true',
-                    decide_eq_true_eq, decide_eq_false_iff_not] at h
-                  obtain ⟨⟨hmx0, hmy0⟩,
-                    ⟨⟨⟨⟨⟨⟨⟨⟨hk2, hunit⟩, hvxR⟩, hvyR⟩, _hvyne⟩, _hvxpay⟩, hwrapX⟩, hwrapY⟩,
-                      ⟨⟨hcover, _hcap⟩, hpts⟩⟩⟩ := h
-                  -- acceptance and slot-value bounds
-                  have hmXe : (biX.eval env).multiplicity = mx :=
-                    biX.multiplicity.constValue?_sound mx hmx env
-                  have hmYe : (biY.eval env).multiplicity = my :=
-                    biY.multiplicity.constValue?_sound my hmy env
-                  have hviolX : bs.violatesConstraint (biX.eval env) = false :=
-                    hobX (by rw [hmXe]; exact hmx0)
-                  have hviolY : bs.violatesConstraint (biY.eval env) = false :=
-                    hobY (by rw [hmYe]; exact hmy0)
-                  have hgetX : (biX.eval env).payload[0]? = some (OX.eval env) := by
-                    show (biX.payload.map (fun e => e.eval env))[0]? = _
-                    rw [List.getElem?_map, hOX]; rfl
-                  have hgetY : (biY.eval env).payload[0]? = some (OY.eval env) := by
-                    show (biY.payload.map (fun e => e.eval env))[0]? = _
-                    rw [List.getElem?_map, hOY]; rfl
-                  have hbXv : (OX.eval env).val < bX :=
-                    facts.slotBound_sound (biX.eval env)
-                      (biX.payload.map Expression.constValue?) 0 bX (OX.eval env)
-                      (by rw [(rfl : (biX.eval env).busId = biX.busId), hmXe]; exact hbX)
-                      (matches_evalPattern biX.payload env) hviolX hgetX
-                  have hbYv : (OY.eval env).val < bY :=
-                    facts.slotBound_sound (biY.eval env)
-                      (biY.payload.map Expression.constValue?) 0 bY (OY.eval env)
-                      (by rw [(rfl : (biY.eval env).busId = biY.busId), hmYe]; exact hbY)
-                      (matches_evalPattern biY.payload env) hviolY hgetY
-                  -- field decomposition `x = m·u + W`, both sides
-                  set m := k⁻¹ with hm
-                  have hOXe : OX.eval env = k * env x + RX.eval env :=
-                    Expression.splitAt_eval x OX k RX hsX env
-                  have hOYe : OY.eval env = k * env x + RY.eval env := by
-                    have h0 := Expression.splitAt_eval x OY k2 RY hsY env
-                    rw [hk2] at h0; exact h0
-                  have hxX : env x = m * OX.eval env + (-m) * RX.eval env := by
-                    have h1 : m * OX.eval env = m * k * env x + m * RX.eval env := by
-                      rw [hOXe]; ring
-                    rw [mul_comm m k, hunit, one_mul] at h1
-                    linear_combination -h1
-                  have hxY : env x = m * OY.eval env + (-m) * RY.eval env := by
-                    have h1 : m * OY.eval env = m * k * env x + m * RY.eval env := by
-                      rw [hOYe]; ring
-                    rw [mul_comm m k, hunit, one_mul] at h1
-                    linear_combination -h1
-                  -- the environment restricted to the joint flag box is an enumerated point
-                  have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                      (findDomainAlg domCs v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
-                    intro vd hvd
-                    obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-                    cases hfd : findDomainAlg domCs v with
-                    | none => rw [hfd] at hvd'; simp at hvd'
-                    | some d =>
-                      rw [hfd] at hvd'
-                      simp only [Option.map_some, Option.some.injEq] at hvd'
-                      obtain rfl := hvd'.symm
-                      exact findDomainAlg_sound domCs v d hfd env hdom
-                  have hpt := mem_assignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                    (findDomainAlg domCs v).map (fun d => (v, d)))) env hmemdoms
-                  have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
-                      envOf (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                        (findDomainAlg domCs v).map (fun d => (v, d)))).map
-                          (fun vd => (vd.1, env vd.1))) v = env v := by
-                    intro v hv
-                    refine envOf_map _ env v ?_
-                    rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                      (findDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
-                      = (RX.vars ++ RY.vars).eraseDups from hcover]
-                    exact hv
-                  have hRXagree : RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
-                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
-                        (fun vd => (vd.1, env vd.1)))) = RX.eval env :=
-                    Expression.eval_congr RX _ env (fun v hv =>
-                      hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
-                  have hRYagree : RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
-                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
-                        (fun vd => (vd.1, env vd.1)))) = RY.eval env :=
-                    Expression.eval_congr RY _ env (fun v hv =>
-                      hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
-                  -- the per-point conditions, at the environment's own point
-                  have hptc := List.all_eq_true.mp hpts _ hpt
-                  rw [Bool.and_eq_true, Bool.and_eq_true] at hptc
-                  have hWXlt : ((-m) * RX.eval env).val < m.val := by
-                    rw [← hRXagree]; exact of_decide_eq_true hptc.1.1
-                  have hWYlt : ((-m) * RY.eval env).val < m.val := by
-                    rw [← hRYagree]; exact of_decide_eq_true hptc.1.2
-                  -- integer decomposition of `x.val` through both checks
-                  have hbX1 : (OX.eval env).val ≤ bX - 1 := by omega
-                  have hbY1 : (OY.eval env).val ≤ bY - 1 := by omega
-                  have hle1 : m.val * (OX.eval env).val ≤ m.val * (bX - 1) :=
-                    Nat.mul_le_mul_left _ hbX1
-                  have hle2 : m.val * (OY.eval env).val ≤ m.val * (bY - 1) :=
-                    Nat.mul_le_mul_left _ hbY1
-                  have hMuX : (m * OX.eval env).val = m.val * (OX.eval env).val :=
-                    ZMod.val_mul_of_lt (by omega)
-                  have hMuY : (m * OY.eval env).val = m.val * (OY.eval env).val :=
-                    ZMod.val_mul_of_lt (by omega)
-                  have hsumX : (m * OX.eval env).val + ((-m) * RX.eval env).val < p := by
-                    rw [hMuX]; omega
-                  have hsumY : (m * OY.eval env).val + ((-m) * RY.eval env).val < p := by
-                    rw [hMuY]; omega
-                  have hvalX : (env x).val
-                      = m.val * (OX.eval env).val + ((-m) * RX.eval env).val := by
-                    rw [hxX, ZMod.val_add_of_lt hsumX, hMuX]
-                  have hvalY : (env x).val
-                      = m.val * (OY.eval env).val + ((-m) * RY.eval env).val := by
-                    rw [hxY, ZMod.val_add_of_lt hsumY, hMuY]
-                  have hres : ((-m) * RX.eval env).val = ((-m) * RY.eval env).val :=
-                    residue_uniq m.val (OX.eval env).val (OY.eval env).val _ _
-                      (hvalX.symm.trans hvalY) hWXlt hWYlt
-                  -- resolve the point disjunction and pull the equality back to `env`
-                  have hor := hptc.2
-                  rw [Bool.or_eq_true] at hor
-                  rcases hor with hL | hR
-                  · rw [Bool.not_eq_true'] at hL
-                    have hXpt := hres
-                    rw [← hRXagree, ← hRYagree] at hXpt
-                    exact absurd hXpt (of_decide_eq_false hL)
-                  · rw [← hagree vy (List.mem_eraseDups.2 (List.mem_append_right _ hvyR)),
-                        ← hagree vx (List.mem_eraseDups.2 (List.mem_append_left _ hvxR))]
-                    exact of_decide_eq_true hR
+  cases hd : fuPairData? bs facts domCs biX biY x with
+  | none => rw [hd] at h; simp at h
+  | some d =>
+    rw [hd] at h
+    unfold fuCheckWith at h
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+    obtain ⟨⟨⟨⟨hvxR', hvyR'⟩, _hne⟩, _hpay'⟩, hcw⟩ := h
+    unfold fuPairData? at hd
+    cases hmx : biX.multiplicity.constValue? with
+    | none => rw [hmx] at hd; simp at hd
+    | some mx =>
+      cases hmy : biY.multiplicity.constValue? with
+      | none => rw [hmx, hmy] at hd; simp at hd
+      | some my =>
+        simp only [hmx, hmy] at hd
+        split_ifs at hd with hmx0 hmy0
+        cases hOX : biX.payload[0]? with
+        | none => simp [hOX] at hd
+        | some OX =>
+          cases hOY : biY.payload[0]? with
+          | none => simp [hOX, hOY] at hd
+          | some OY =>
+            simp only [hOX, hOY] at hd
+            cases hbX : facts.slotBound biX.busId mx
+                (biX.payload.map Expression.constValue?) 0 with
+            | none => simp [hbX] at hd
+            | some bX =>
+              cases hbY : facts.slotBound biY.busId my
+                  (biY.payload.map Expression.constValue?) 0 with
+              | none => simp [hbX, hbY] at hd
+              | some bY =>
+                simp only [hbX, hbY] at hd
+                cases hsX : OX.splitAt x with
+                | none => simp [hsX] at hd
+                | some kRX =>
+                  obtain ⟨k, RX⟩ := kRX
+                  cases hsY : OY.splitAt x with
+                  | none => simp [hsX, hsY] at hd
+                  | some kRY =>
+                    obtain ⟨k2, RY⟩ := kRY
+                    simp only [hsX, hsY] at hd
+                    split_ifs at hd with hconds hcov hall
+                    obtain ⟨hk2, hunit, hwrapX, hwrapY⟩ := hconds
+                    obtain ⟨hcover, _hcap⟩ := hcov
+                    simp only [Option.some.injEq] at hd
+                    subst hd
+                    simp only at hvxR' hvyR' hcw
+                    -- acceptance and slot-value bounds
+                    have hmXe : (biX.eval env).multiplicity = mx :=
+                      biX.multiplicity.constValue?_sound mx hmx env
+                    have hmYe : (biY.eval env).multiplicity = my :=
+                      biY.multiplicity.constValue?_sound my hmy env
+                    have hviolX : bs.violatesConstraint (biX.eval env) = false :=
+                      hobX (by rw [hmXe]; exact hmx0)
+                    have hviolY : bs.violatesConstraint (biY.eval env) = false :=
+                      hobY (by rw [hmYe]; exact hmy0)
+                    have hgetX : (biX.eval env).payload[0]? = some (OX.eval env) := by
+                      show (biX.payload.map (fun e => e.eval env))[0]? = _
+                      rw [List.getElem?_map, hOX]; rfl
+                    have hgetY : (biY.eval env).payload[0]? = some (OY.eval env) := by
+                      show (biY.payload.map (fun e => e.eval env))[0]? = _
+                      rw [List.getElem?_map, hOY]; rfl
+                    have hbXv : (OX.eval env).val < bX :=
+                      facts.slotBound_sound (biX.eval env)
+                        (biX.payload.map Expression.constValue?) 0 bX (OX.eval env)
+                        (by rw [(rfl : (biX.eval env).busId = biX.busId), hmXe]; exact hbX)
+                        (matches_evalPattern biX.payload env) hviolX hgetX
+                    have hbYv : (OY.eval env).val < bY :=
+                      facts.slotBound_sound (biY.eval env)
+                        (biY.payload.map Expression.constValue?) 0 bY (OY.eval env)
+                        (by rw [(rfl : (biY.eval env).busId = biY.busId), hmYe]; exact hbY)
+                        (matches_evalPattern biY.payload env) hviolY hgetY
+                    -- field decomposition `x = m·u + W`, both sides
+                    set m := k⁻¹ with hm
+                    have hOXe : OX.eval env = k * env x + RX.eval env :=
+                      Expression.splitAt_eval x OX k RX hsX env
+                    have hOYe : OY.eval env = k * env x + RY.eval env := by
+                      have h0 := Expression.splitAt_eval x OY k2 RY hsY env
+                      rw [hk2] at h0; exact h0
+                    have hxX : env x = m * OX.eval env + (-m) * RX.eval env := by
+                      have h1 : m * OX.eval env = m * k * env x + m * RX.eval env := by
+                        rw [hOXe]; ring
+                      rw [mul_comm m k, hunit, one_mul] at h1
+                      linear_combination -h1
+                    have hxY : env x = m * OY.eval env + (-m) * RY.eval env := by
+                      have h1 : m * OY.eval env = m * k * env x + m * RY.eval env := by
+                        rw [hOYe]; ring
+                      rw [mul_comm m k, hunit, one_mul] at h1
+                      linear_combination -h1
+                    -- the environment restricted to the joint flag box is an enumerated point
+                    have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                        (findDomainAlg domCs v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+                      intro vd hvd
+                      obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+                      cases hfd : findDomainAlg domCs v with
+                      | none => rw [hfd] at hvd'; simp at hvd'
+                      | some dm =>
+                        rw [hfd] at hvd'
+                        simp only [Option.map_some, Option.some.injEq] at hvd'
+                        obtain rfl := hvd'.symm
+                        exact findDomainAlg_sound domCs v dm hfd env hdom
+                    have hpt := mem_assignments ((RX.vars ++ RY.vars).eraseDups.filterMap
+                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))) env hmemdoms
+                    have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
+                        envOf (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))) v = env v := by
+                      intro v hv
+                      refine envOf_map _ env v ?_
+                      rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                        (findDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+                        = (RX.vars ++ RY.vars).eraseDups from hcover]
+                      exact hv
+                    have hRXagree : RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                        (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1)))) = RX.eval env :=
+                      Expression.eval_congr RX _ env (fun v hv =>
+                        hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
+                    have hRYagree : RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                        (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1)))) = RY.eval env :=
+                      Expression.eval_congr RY _ env (fun v hv =>
+                        hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+                    -- pair-level point bounds, at the environment's own point
+                    have hpair := List.all_eq_true.mp hall _ hpt
+                    rw [Bool.and_eq_true] at hpair
+                    have hWXlt : ((-m) * RX.eval env).val < m.val := by
+                      rw [← hRXagree]; exact of_decide_eq_true hpair.1
+                    have hWYlt : ((-m) * RY.eval env).val < m.val := by
+                      rw [← hRYagree]; exact of_decide_eq_true hpair.2
+                    -- integer decomposition of `x.val` through both checks
+                    have hbX1 : (OX.eval env).val ≤ bX - 1 := by omega
+                    have hbY1 : (OY.eval env).val ≤ bY - 1 := by omega
+                    have hle1 : m.val * (OX.eval env).val ≤ m.val * (bX - 1) :=
+                      Nat.mul_le_mul_left _ hbX1
+                    have hle2 : m.val * (OY.eval env).val ≤ m.val * (bY - 1) :=
+                      Nat.mul_le_mul_left _ hbY1
+                    have hMuX : (m * OX.eval env).val = m.val * (OX.eval env).val :=
+                      ZMod.val_mul_of_lt (by omega)
+                    have hMuY : (m * OY.eval env).val = m.val * (OY.eval env).val :=
+                      ZMod.val_mul_of_lt (by omega)
+                    have hsumX : (m * OX.eval env).val + ((-m) * RX.eval env).val < p := by
+                      rw [hMuX]; omega
+                    have hsumY : (m * OY.eval env).val + ((-m) * RY.eval env).val < p := by
+                      rw [hMuY]; omega
+                    have hvalX : (env x).val
+                        = m.val * (OX.eval env).val + ((-m) * RX.eval env).val := by
+                      rw [hxX, ZMod.val_add_of_lt hsumX, hMuX]
+                    have hvalY : (env x).val
+                        = m.val * (OY.eval env).val + ((-m) * RY.eval env).val := by
+                      rw [hxY, ZMod.val_add_of_lt hsumY, hMuY]
+                    have hres : ((-m) * RX.eval env).val = ((-m) * RY.eval env).val :=
+                      residue_uniq m.val (OX.eval env).val (OY.eval env).val _ _
+                        (hvalX.symm.trans hvalY) hWXlt hWYlt
+                    -- the combo condition at the environment's point
+                    have hmempts : (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1)),
+                        decide (((-m) * RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val
+                          = ((-m) * RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val))
+                        ∈ (assignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d))))).map
+                            (fun pt => (pt, decide (((-m) * RX.eval (envOf pt)).val
+                              = ((-m) * RY.eval (envOf pt)).val))) :=
+                      List.mem_map.2 ⟨_, hpt, rfl⟩
+                    have horb := List.all_eq_true.mp hcw _ hmempts
+                    have hb : decide (((-m) * RX.eval (envOf (((RX.vars
+                        ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val
+                        = ((-m) * RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val) = true :=
+                      decide_eq_true (by rw [hRXagree, hRYagree]; exact hres)
+                    simp only [hb, Bool.not_true, Bool.false_or, decide_eq_true_eq] at horb
+                    rw [← hagree vy (List.mem_eraseDups.2 (List.mem_append_right _ hvyR')),
+                        ← hagree vx (List.mem_eraseDups.2 (List.mem_append_left _ hvxR'))]
+                    exact horb
 
 /-! ## The scan loop and the pass -/
 
@@ -324,18 +395,27 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     match cands.findSome? (fun xk =>
         seen.findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
+        -- pair-level work once per match; per-target checks share it (definitionally the
+        -- same value as `fuCheck` — see its definition)
+        match hdata : fuPairData? bs facts cs.algebraicConstraints ex.1.bi c ex.2 with
+        | none =>
+            fuLoop cs bs facts rest hrest
+              (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+        | some d =>
         let pairs := (fuTargets ex.1.bi c ex.2).filterMap (fun t =>
-          if fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1
+          if fuCheckWith d t.2 t.1
           then some (t.1, Expression.var t.2) else none)
         have hpairs : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env := by
           intro env hsat yt hyt
           obtain ⟨t, _ht, hif⟩ := List.mem_filterMap.1 hyt
-          by_cases hck : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true
+          by_cases hck : fuCheckWith d t.2 t.1 = true
           · rw [if_pos hck] at hif
             simp only [Option.some.injEq] at hif
             subst hif
             show env t.1 = env t.2
-            exact fuCheck_sound bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hck env
+            have hfc : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true := by
+              unfold fuCheck; rw [hdata]; exact hck
+            exact fuCheck_sound bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hfc env
               (fun c' hc' => hsat.1 c' hc')
               (fun hmult => hsat.2 ex.1.bi ex.1.mem hmult)
               (fun hmult => hsat.2 c hc hmult)
@@ -344,13 +424,15 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
         have hpairsV : ∀ yt ∈ pairs, ∀ z ∈ yt.2.vars, z ∈ cs.vars := by
           intro yt hyt z hz
           obtain ⟨t, _ht, hif⟩ := List.mem_filterMap.1 hyt
-          by_cases hck : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true
+          by_cases hck : fuCheckWith d t.2 t.1 = true
           · rw [if_pos hck] at hif
             simp only [Option.some.injEq] at hif
             subst hif
             obtain rfl : z = t.2 := by simpa [Expression.vars] using hz
+            have hfc : fuCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 = true := by
+              unfold fuCheck; rw [hdata]; exact hck
             obtain ⟨e', he', hv'⟩ := List.mem_flatMap.1
-              (fuCheck_vars bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hck)
+              (fuCheck_vars bs facts cs.algebraicConstraints ex.1.bi c ex.2 t.2 t.1 hfc)
             exact ConstraintSystem.mem_vars_of_payload ex.1.mem he' hv'
           · rw [if_neg hck] at hif
             exact absurd hif (by simp)

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -1,0 +1,602 @@
+import ApcOptimizer.Implementation.OptimizerPasses.Gauss
+import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+
+set_option autoImplicit false
+
+/-! # Two-root decomposition unification (bounded-integer reasoning)
+
+Memory-pointer decompositions pin each limb by a **two-root carry constraint**
+`(A + k·x) · (A + δ + k·x) = 0` — the two cases of the address wraparound — plus a range check
+keeping `x` inside a window smaller than the root gap. Two accesses at the *same* address
+produce two such constraints with the **same** `A`, `k`, `δ` but distinct limb variables `x`,
+`y`: each variable independently picks a root, so no purely algebraic pass can equate them. The
+bounded-integer argument closes it: both roots differ by `g = k⁻¹·δ`; if `x.val < B` and
+`y.val < B` with `B ≤ g.val` and `B ≤ p − g.val`, the field difference `x − y = ±g` is
+impossible over the integers, so `x = y`. powdr eliminates exactly these duplicates (apc_005:
+258 limb variables kept here vs powdr's 130 before this pass).
+
+The entailed equality `y = x` feeds the same proof-carrying `Solved` map as `Gauss.lean`
+(solutions are bare variables, so no degree gate and no resolution is needed) and one final
+`ConstraintSystem.substF`. Bounds come from retained range-check interactions via
+`findVarBound` (`DomainProp.lean`), conditional on the system's own satisfaction — every
+justifying interaction is retained, so `hsat.2` supplies acceptance. Prime `p` only (root
+membership needs an integral domain); the pass re-checks `decide p.Prime` at runtime like
+`busPairCancelPass`. -/
+
+variable {p : ℕ}
+
+/-! ## The core field lemmas -/
+
+/-- Membership in the root pair: a satisfied two-root constraint puts `x` at one of the two
+    roots, `g = k⁻¹·δ` apart. -/
+theorem twoRoot_mem [Fact p.Prime] (k a δ x : ZMod p) (hunit : k * k⁻¹ = 1)
+    (h : (a + k * x) * (a + δ + k * x) = 0) :
+    x = -(k⁻¹ * a) ∨ x = -(k⁻¹ * a) - k⁻¹ * δ := by
+  rcases mul_eq_zero.1 h with h0 | h0
+  · left; linear_combination k⁻¹ * h0 - x * hunit
+  · right; linear_combination k⁻¹ * h0 - x * hunit
+
+/-- Two values in the same root pair, both bounded below the root gap (and its complement),
+    are equal: their field difference is `0` or `±g`, and `±g` is out of integer reach. -/
+theorem rootPair_eq [Fact p.Prime] (r g x y : ZMod p)
+    (hx : x = r ∨ x = r - g) (hy : y = r ∨ y = r - g)
+    (B : Nat) (hxB : x.val < B) (hyB : y.val < B)
+    (h1 : B ≤ g.val) (h2 : B ≤ p - g.val) : x = y := by
+  have key : ∀ u v : ZMod p, u.val < B → v.val < B → u = v - g → False := by
+    intro u v hu hv huv
+    have hvg : v = u + g := by rw [huv]; ring
+    have hval : v.val = (u.val + g.val) % p := by rw [hvg, ZMod.val_add]
+    by_cases hlt : u.val + g.val < p
+    · rw [Nat.mod_eq_of_lt hlt] at hval
+      omega
+    · -- `u.val ≥ p − g.val ≥ B` contradicts `u.val < B`
+      have hgp : g.val < p := ZMod.val_lt g
+      omega
+  rcases hx with rfl | rfl
+  · rcases hy with h | h
+    · exact h.symm
+    · exact (key y x hyB hxB h).elim
+  · rcases hy with h | h
+    · exact (key (r - g) r hxB (h ▸ hyB) rfl).elim
+    · exact h.symm
+
+/-! ## Recognizing a two-root constraint -/
+
+/-- Two normalized linear forms with equal term lists evaluate a constant apart. -/
+theorem LinExpr.eval_of_terms_eq (a b : LinExpr p) (h : b.terms = a.terms)
+    (env : Variable → ZMod p) : b.eval env = a.eval env + (b.const - a.const) := by
+  simp only [LinExpr.eval, h]; ring
+
+/-- The two-root decomposition of a constraint relative to `x`: `some (k, A, δ)` when the
+    constraint is a product of two affine factors, both linear in `x` with the same nonzero
+    coefficient `k`, whose `x`-free parts differ by the constant `δ` — i.e. the constraint
+    evaluates as `(A.eval + k·x) · (A.eval + δ + k·x)`. -/
+def twoRootOf? (c : Expression p) (x : Variable) : Option (ZMod p × LinExpr p × ZMod p) :=
+  match c with
+  | .mul f1 f2 =>
+    match linearize f1, linearize f2 with
+    | some l1, some l2 =>
+      let k := l1.coeff x
+      let A := (l1.others x).norm
+      let A2 := (l2.others x).norm
+      if k ≠ 0 ∧ l2.coeff x = k ∧ A2.terms = A.terms then some (k, A, A2.const - A.const)
+      else none
+    | _, _ => none
+  | _ => none
+
+theorem twoRootOf?_sound [Fact p.Prime] (c : Expression p) (x : Variable)
+    (k : ZMod p) (A : LinExpr p) (δ : ZMod p) (h : twoRootOf? c x = some (k, A, δ))
+    (hk : k * k⁻¹ = 1) (env : Variable → ZMod p) (hc : c.eval env = 0) :
+    env x = -(k⁻¹ * A.eval env) ∨ env x = -(k⁻¹ * A.eval env) - k⁻¹ * δ := by
+  unfold twoRootOf? at h
+  split at h
+  case h_2 => exact absurd h (by simp)
+  case h_1 f1 f2 =>
+    cases hl1 : linearize f1 with
+    | none => rw [hl1] at h; exact absurd h (by simp)
+    | some l1 =>
+      cases hl2 : linearize f2 with
+      | none => rw [hl1, hl2] at h; simp at h
+      | some l2 =>
+        simp only [hl1, hl2] at h
+        split_ifs at h with hcond
+        obtain ⟨hk0, hcoeff, hterms⟩ := hcond
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl, rfl⟩ := h
+        -- both factors evaluate as `A.eval + (shift) + k·x`
+        have hf1 : f1.eval env = ((l1.others x).norm).eval env + l1.coeff x * env x := by
+          rw [linearize_eval f1 l1 hl1 env, l1.eval_split x]
+          have := LinExpr.norm_eval (l1.others x) env
+          rw [this]; ring
+        have hf2 : f2.eval env
+            = ((l1.others x).norm).eval env + ((l1.others x).norm.const - ((l2.others x).norm.const)
+              - ((l1.others x).norm.const - (l2.others x).norm.const)) * 0
+              + ((l2.others x).norm.const - (l1.others x).norm.const) + l1.coeff x * env x := by
+          rw [linearize_eval f2 l2 hl2 env, l2.eval_split x, hcoeff]
+          have h2 := LinExpr.norm_eval (l2.others x) env
+          have h3 := LinExpr.eval_of_terms_eq (l1.others x).norm (l2.others x).norm hterms env
+          rw [← h2, h3]
+          have h1 := LinExpr.norm_eval (l1.others x) env
+          ring
+        have hprod : (((l1.others x).norm).eval env + l1.coeff x * env x)
+            * (((l1.others x).norm).eval env + ((l2.others x).norm.const - (l1.others x).norm.const)
+              + l1.coeff x * env x) = 0 := by
+          rw [← hf1]
+          have : f2.eval env = ((l1.others x).norm).eval env
+              + ((l2.others x).norm.const - (l1.others x).norm.const)
+              + l1.coeff x * env x := by rw [hf2]; ring
+          rw [← this]
+          exact hc
+        exact twoRoot_mem (l1.coeff x) (((l1.others x).norm).eval env) _ (env x) hk hprod
+
+/-- `x` genuinely occurs in a recognized constraint (needed for `Solved.varsIn`). -/
+def twoRootVarsOk (c : Expression p) (x : Variable) : Bool :=
+  decide (x ∈ c.vars)
+
+/-! ## Constant-coefficient decomposition
+
+`e = k·x + r` with `k` a field constant and `r` an `x`-free expression — unlike `linearize`,
+the remainder may be *nonlinear* (the flag polynomial inside a scaled range-check slot), so
+this succeeds exactly where the affine machinery gives up. -/
+
+/-- Decompose `e` as `k·x + r`: `k` a field constant, `r` not mentioning `x` (by construction).
+    Succeeds iff every occurrence of `x` in `e` sits additively under multiplications by
+    constant-foldable factors. `x`-free subtrees are kept opaque (coefficient `0`). -/
+def Expression.splitAt (x : Variable) : Expression p → Option (ZMod p × Expression p)
+  | .const n => some (0, .const n)
+  | .var y => if y = x then some (1, .const 0) else some (0, .var y)
+  | .add a b =>
+      match a.splitAt x, b.splitAt x with
+      | some (ca, ra), some (cb, rb) => some (ca + cb, .add ra rb)
+      | _, _ => none
+  | .mul a b =>
+      if a.mentions x || b.mentions x then
+        match a.constValue? with
+        | some k =>
+            match b.splitAt x with
+            | some (cb, rb) => some (k * cb, .mul a rb)
+            | none => none
+        | none =>
+            match b.constValue? with
+            | some k =>
+                match a.splitAt x with
+                | some (ca, ra) => some (k * ca, .mul ra b)
+                | none => none
+            | none => none
+      else some (0, .mul a b)
+
+/-- The decomposition is exact: `e` evaluates as `k·x + r`. -/
+theorem Expression.splitAt_eval (x : Variable) (e : Expression p) (k : ZMod p)
+    (r : Expression p) (h : e.splitAt x = some (k, r)) (env : Variable → ZMod p) :
+    e.eval env = k * env x + r.eval env := by
+  induction e generalizing k r with
+  | const n =>
+      simp only [splitAt, Option.some.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl⟩ := h
+      simp [Expression.eval]
+  | var y =>
+      simp only [splitAt] at h
+      split_ifs at h with hyx
+      · simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        subst hyx
+        simp [Expression.eval]
+      · simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        simp [Expression.eval]
+  | add a b iha ihb =>
+      cases ha : a.splitAt x with
+      | none => simp [splitAt, ha] at h
+      | some pa =>
+          cases hb : b.splitAt x with
+          | none => simp [splitAt, ha, hb] at h
+          | some pb =>
+              obtain ⟨ca, ra⟩ := pa
+              obtain ⟨cb, rb⟩ := pb
+              simp only [splitAt, ha, hb, Option.some.injEq, Prod.mk.injEq] at h
+              obtain ⟨rfl, rfl⟩ := h
+              simp only [Expression.eval, iha ca ra ha, ihb cb rb hb]
+              ring
+  | mul a b iha ihb =>
+      simp only [splitAt] at h
+      split_ifs at h with hm
+      · cases hka : a.constValue? with
+        | some ka =>
+            cases hb : b.splitAt x with
+            | none => simp [hka, hb] at h
+            | some pb =>
+                obtain ⟨cb, rb⟩ := pb
+                simp only [hka, hb, Option.some.injEq, Prod.mk.injEq] at h
+                obtain ⟨rfl, rfl⟩ := h
+                have hae : a.eval env = ka := a.constValue?_sound ka hka env
+                simp only [Expression.eval, hae, ihb cb rb hb]
+                ring
+        | none =>
+            cases hkb : b.constValue? with
+            | none => simp [hka, hkb] at h
+            | some kb =>
+                cases ha : a.splitAt x with
+                | none => simp [hka, hkb, ha] at h
+                | some pa =>
+                    obtain ⟨ca, ra⟩ := pa
+                    simp only [hka, hkb, ha, Option.some.injEq, Prod.mk.injEq] at h
+                    obtain ⟨rfl, rfl⟩ := h
+                    have hbe : b.eval env = kb := b.constValue?_sound kb hkb env
+                    simp only [Expression.eval, hbe, iha ca ra ha]
+                    ring
+      · simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        simp [Expression.eval]
+
+
+/-! ## Bounds through scaled range checks
+
+The low mem-ptr limb's range check does not carry the limb raw: the checked slot is
+`4⁻¹·(x − F)` for a small flag polynomial `F`. The slot *value* is still fact-bounded, so
+`x = k⁻¹·slot − k⁻¹·R` is bounded once the offset part enumerates over its (tiny, provable)
+flag domains: `x.val < m.val·(bound−1) + Wmax + 1`, provided nothing wraps `p`. -/
+
+/-- `LinExpr.eval` only reads the term variables. -/
+theorem LinExpr.eval_congr_vars (l : LinExpr p) (f g : Variable → ZMod p)
+    (h : ∀ v ∈ l.terms.map Prod.fst, f v = g v) : l.eval f = l.eval g := by
+  simp only [LinExpr.eval]
+  congr 1
+  refine congrArg List.sum ?_
+  refine List.map_congr_left (fun t ht => ?_)
+  rw [h t.1 (List.mem_map.2 ⟨t, ht, rfl⟩)]
+
+/-- The seed is at most the `foldl max` accumulation. -/
+theorem init_le_foldl_max (l : List Nat) : ∀ b : Nat, b ≤ l.foldl max b := by
+  induction l with
+  | nil => intro b; simp
+  | cons c rest ih => intro b; exact le_trans (le_max_left b c) (ih (max b c))
+
+/-- Everything in a list is at most its `foldl max` accumulation. -/
+theorem le_foldl_max (l : List Nat) : ∀ (b : Nat), ∀ a ∈ l, a ≤ l.foldl max b := by
+  induction l with
+  | nil => intro b a ha; simp at ha
+  | cons c rest ih =>
+    intro b a ha
+    rcases List.mem_cons.1 ha with rfl | h
+    · exact le_trans (le_max_right b a) (init_le_foldl_max rest (max b a))
+    · exact ih (max b c) a h
+
+/-- Bound `x` through one interaction: find a slot whose expression is affine in `x` with a
+    unit coefficient and a bus-fact value bound; enumerate the remaining variables' proven
+    finite domains for the offset part. Returns `B` with `x.val < B` under acceptance. -/
+def scaledSlotBound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (bi : BusInteraction (Expression p)) (x : Variable) :
+    Option Nat :=
+  match bi.multiplicity.constValue? with
+  | none => none
+  | some mval =>
+    if mval = 0 then none else
+    (List.range bi.payload.length).findSome? (fun slot =>
+      match bi.payload[slot]? with
+      | none => none
+      | some O =>
+        match facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) slot with
+        | none => none
+        | some bound =>
+          match O.splitAt x with
+          | none => none
+          | some (k, R) =>
+            let m := k⁻¹
+            let others := R.vars.eraseDups
+            let doms := others.filterMap (fun v =>
+              (findDomainAlg domCs v).map (fun d => (v, d)))
+            if k * m = 1 ∧ doms.map Prod.fst = others ∧
+                (doms.map (fun vd => vd.2.length)).prod ≤ 16 then
+              if m.val * (bound - 1) + ((assignments doms).map
+                    (fun pt => ((-m) * R.eval (envOf pt)).val)).foldl max 0 < p then
+                some (m.val * (bound - 1) + ((assignments doms).map
+                  (fun pt => ((-m) * R.eval (envOf pt)).val)).foldl max 0 + 1)
+              else none
+            else none)
+
+theorem scaledSlotBound_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (bi : BusInteraction (Expression p)) (x : Variable)
+    (B : Nat) (h : scaledSlotBound bs facts domCs bi x = some B) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ domCs, c.eval env = 0)
+    (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
+    (env x).val < B := by
+  unfold scaledSlotBound at h
+  cases hmv : bi.multiplicity.constValue? with
+  | none => rw [hmv] at h; simp at h
+  | some mval =>
+    simp only [hmv] at h
+    split_ifs at h with hmz
+    obtain ⟨slot, _hslot, hs⟩ := List.exists_of_findSome?_eq_some h
+    cases hO : bi.payload[slot]? with
+    | none => simp [hO] at hs
+    | some O =>
+      simp only [hO] at hs
+      cases hfact : facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) slot with
+      | none => simp [hfact] at hs
+      | some bound =>
+        simp only [hfact] at hs
+        cases hlin : O.splitAt x with
+        | none => simp [hlin] at hs
+        | some kR =>
+          obtain ⟨k, R⟩ := kR
+          simp only [hlin] at hs
+          split_ifs at hs with hcond hwrap
+          simp only [Option.some.injEq] at hs
+          obtain ⟨hunit, hcover, _hcap⟩ := hcond
+          -- acceptance and the fact bound on the slot value
+          have hmeval : (bi.eval env).multiplicity = mval :=
+            bi.multiplicity.constValue?_sound mval hmv env
+          have hviol : bs.violatesConstraint (bi.eval env) = false :=
+            hob (by rw [hmeval]; exact hmz)
+          have hget : (bi.eval env).payload[slot]? = some (O.eval env) := by
+            show (bi.payload.map (fun e => e.eval env))[slot]? = _
+            rw [List.getElem?_map, hO]; rfl
+          have hOb : (O.eval env).val < bound := by
+            have := facts.slotBound_sound (bi.eval env)
+              (bi.payload.map Expression.constValue?) slot bound (O.eval env)
+              (by rw [(rfl : (bi.eval env).busId = bi.busId), hmeval]; exact hfact)
+              (matches_evalPattern bi.payload env) hviol hget
+            exact this
+          -- the field identity `x = m·O − m·R`
+          set m := k⁻¹ with hm
+          have hOx : O.eval env = k * env x + R.eval env :=
+            Expression.splitAt_eval x O k R hlin env
+          have hxid : env x = m * O.eval env + (-m) * R.eval env := by
+            have : m * O.eval env = m * k * env x + m * R.eval env := by
+              rw [hOx]; ring
+            rw [mul_comm m k] at this
+            rw [hunit, one_mul] at this
+            linear_combination -this
+          -- the offset part is one of the enumerated points
+          have hmemdoms : ∀ vd ∈ R.vars.eraseDups.filterMap (fun v =>
+              (findDomainAlg domCs v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+            intro vd hvd
+            obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+            cases hfd : findDomainAlg domCs v with
+            | none => rw [hfd] at hvd'; simp at hvd'
+            | some d =>
+              rw [hfd] at hvd'
+              simp only [Option.map_some, Option.some.injEq] at hvd'
+              obtain rfl := hvd'.symm
+              exact findDomainAlg_sound domCs v d hfd env hdom
+          have hpt := mem_assignments (R.vars.eraseDups.filterMap (fun v =>
+            (findDomainAlg domCs v).map (fun d => (v, d)))) env hmemdoms
+          have hWagree : R.eval (envOf ((R.vars.eraseDups.filterMap (fun v =>
+              (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                (fun vd => (vd.1, env vd.1)))) = R.eval env := by
+            refine Expression.eval_congr R _ env (fun v hv => ?_)
+            refine envOf_map _ env v ?_
+            rw [show ((R.vars.eraseDups.filterMap (fun v =>
+              (findDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+              = R.vars.eraseDups from hcover]
+            exact List.mem_eraseDups.2 hv
+          have hWle : ((-m) * R.eval env).val
+              ≤ ((assignments (R.vars.eraseDups.filterMap (fun v =>
+                (findDomainAlg domCs v).map (fun d => (v, d))))).map
+                  (fun pt => ((-m) * R.eval (envOf pt)).val)).foldl max 0 := by
+            refine le_foldl_max _ 0 _ ?_
+            refine List.mem_map.2 ⟨_, hpt, ?_⟩
+            rw [hWagree]
+          -- integer arithmetic without wraparound
+          have hu : (m * O.eval env).val = m.val * (O.eval env).val := by
+            refine ZMod.val_mul_of_lt ?_
+            calc m.val * (O.eval env).val ≤ m.val * (bound - 1) := by
+                  have := hOb; exact Nat.mul_le_mul_left _ (by omega)
+              _ < p := by omega
+          have hsum : (m * O.eval env).val + ((-m) * R.eval env).val < p := by
+            rw [hu]
+            have h1 : m.val * (O.eval env).val ≤ m.val * (bound - 1) :=
+              Nat.mul_le_mul_left _ (by omega)
+            omega
+          rw [hxid, ZMod.val_add_of_lt hsum, hu]
+          have h1 : m.val * (O.eval env).val ≤ m.val * (bound - 1) :=
+            Nat.mul_le_mul_left _ (by omega)
+          omega
+
+/-- Bound `x` from a raw slot (`findVarBound`) or, failing that, through a scaled slot. -/
+def anyVarBound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (Expression p))) (domCs : List (Expression p))
+    (x : Variable) : Option Nat :=
+  match findVarBound bs facts bis x with
+  | some B => some B
+  | none => bis.findSome? (fun bi => scaledSlotBound bs facts domCs bi x)
+
+theorem anyVarBound_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (Expression p))) (domCs : List (Expression p))
+    (x : Variable) (B : Nat) (h : anyVarBound bs facts bis domCs x = some B)
+    (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ domCs, c.eval env = 0)
+    (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false) : (env x).val < B := by
+  unfold anyVarBound at h
+  cases hfb : findVarBound bs facts bis x with
+  | some B' =>
+    simp only [hfb, Option.some.injEq] at h
+    exact h ▸ findVarBound_sound bs facts bis x B' hfb env hbus
+  | none =>
+    simp only [hfb] at h
+    obtain ⟨bi, hbi, hsb⟩ := List.exists_of_findSome?_eq_some h
+    exact scaledSlotBound_sound bs facts domCs bi x B hsb env hdom (hbus bi hbi)
+
+/-! ## The pair certificate -/
+
+/-- Decidable certificate that constraints `cX` (in `x`) and `cY` (in `y`) are two-root twins
+    and both variables are range-bounded below the root gap — hence provably equal under every
+    satisfying assignment. Re-checked inside the adoption proof, so the scan can stay
+    proof-free. -/
+def rpCheckPair (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (Expression p))) (domCs : List (Expression p))
+    (cX cY : Expression p) (x y : Variable) : Bool :=
+  match twoRootOf? cX x, twoRootOf? cY y with
+  | some (k, A, δ), some (k', A', δ') =>
+    decide (k' = k) && decide (A'.terms = A.terms) && decide (A'.const = A.const) &&
+    decide (δ' = δ) && decide (k * k⁻¹ = 1) &&
+    decide (x ∈ cX.vars) && decide (y ∈ cY.vars) &&
+    (match anyVarBound bs facts bis domCs x, anyVarBound bs facts bis domCs y with
+     | some Bx, some By =>
+       decide (max Bx By ≤ (k⁻¹ * δ).val) && decide (max Bx By ≤ p - (k⁻¹ * δ).val)
+     | _, _ => false)
+  | _, _ => false
+
+theorem rpCheckPair_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (Expression p))) (domCs : List (Expression p))
+    (cX cY : Expression p) (x y : Variable)
+    (h : rpCheckPair bs facts bis domCs cX cY x y = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ domCs, c.eval env = 0)
+    (hcX : cX.eval env = 0) (hcY : cY.eval env = 0)
+    (hbus : ∀ bi ∈ bis, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false) :
+    env x = env y := by
+  unfold rpCheckPair at h
+  cases hx : twoRootOf? cX x with
+  | none => rw [hx] at h; simp at h
+  | some t =>
+    obtain ⟨k, A, δ⟩ := t
+    cases hy : twoRootOf? cY y with
+    | none => rw [hx, hy] at h; simp at h
+    | some t' =>
+      obtain ⟨k', A', δ'⟩ := t'
+      rw [hx, hy] at h
+      cases hbx : anyVarBound bs facts bis domCs x with
+      | none => rw [hbx] at h; simp at h
+      | some Bx =>
+        cases hby : anyVarBound bs facts bis domCs y with
+        | none => rw [hbx, hby] at h; simp at h
+        | some By =>
+          rw [hbx, hby] at h
+          simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+          obtain ⟨⟨⟨⟨⟨⟨⟨hk', hAt⟩, hAc⟩, hδ'⟩, hunit⟩, _hxv⟩, _hyv⟩, hB1, hB2⟩ := h
+          have hxr := twoRootOf?_sound cX x k A δ hx hunit env hcX
+          have hyr := twoRootOf?_sound cY y k' A' δ' hy (by rw [hk']; exact hunit) env hcY
+          -- `A'` evaluates like `A` (equal terms and consts), so the root pairs coincide
+          have hAeq : A'.eval env = A.eval env := by
+            rw [LinExpr.eval_of_terms_eq A A' hAt env, hAc]; ring
+          rw [hk', hAeq, hδ'] at hyr
+          exact rootPair_eq (-(k⁻¹ * A.eval env)) (k⁻¹ * δ) (env x) (env y)
+            hxr hyr
+            (max Bx By)
+            (lt_of_lt_of_le (anyVarBound_sound bs facts bis domCs x Bx hbx env hdom hbus)
+              (le_max_left _ _))
+            (lt_of_lt_of_le (anyVarBound_sound bs facts bis domCs y By hby env hdom hbus)
+              (le_max_right _ _))
+            hB1 hB2
+
+/-- Extract the variable memberships from a passed certificate. -/
+theorem rpCheckPair_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (Expression p))) (domCs : List (Expression p))
+    (cX cY : Expression p) (x y : Variable)
+    (h : rpCheckPair bs facts bis domCs cX cY x y = true) : x ∈ cX.vars ∧ y ∈ cY.vars := by
+  unfold rpCheckPair at h
+  cases hx : twoRootOf? cX x with
+  | none => rw [hx] at h; simp at h
+  | some t =>
+    obtain ⟨k, A, δ⟩ := t
+    cases hy : twoRootOf? cY y with
+    | none => rw [hx, hy] at h; simp at h
+    | some t' =>
+      obtain ⟨k', A', δ'⟩ := t'
+      rw [hx, hy] at h
+      cases hbx : anyVarBound bs facts bis domCs x with
+      | none => rw [hbx] at h; simp at h
+      | some Bx =>
+        cases hby : anyVarBound bs facts bis domCs y with
+        | none => rw [hbx, hby] at h; simp at h
+        | some By =>
+          rw [hbx, hby] at h
+          simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+          exact ⟨h.1.1.2, h.1.2⟩
+
+/-! ## The scan loop and the pass -/
+
+/-- A previously seen two-root constraint: the constraint (with membership), its variable, and
+    the matching key `(k, A.terms, A.const, δ)`. Keys are compared before the (expensive)
+    certificate is attempted. -/
+structure RPSeen (p : ℕ) (cs : ConstraintSystem p) where
+  c : Expression p
+  mem : c ∈ cs.algebraicConstraints
+  x : Variable
+  key : ZMod p × List (Variable × ZMod p) × ZMod p × ZMod p
+
+/-- The two-root candidates of one constraint, with their matching keys. Candidates whose root
+    gap `g = k⁻¹·δ` is tiny are dropped up front: the pair condition `B ≤ min(g.val, p − g.val)`
+    can never hold for a useful bound `B`, and booleanity constraints `b(b−1) = 0` would
+    otherwise make every boolean variable a (never-unifiable, expensive-to-reject) candidate. -/
+def rpCandidates (c : Expression p) :
+    List (Variable × (ZMod p × List (Variable × ZMod p) × ZMod p × ZMod p)) :=
+  c.vars.eraseDups.filterMap (fun x =>
+    match twoRootOf? c x with
+    | some (k, A, δ) =>
+      if 256 ≤ min (k⁻¹ * δ).val (p - (k⁻¹ * δ).val) then
+        some (x, (k, A.terms, A.const, δ))
+      else none
+    | none => none)
+
+/-- Scan the constraints: for each two-root candidate, look for an earlier twin with the same
+    key whose pair certificate passes, and adopt the entailed equality into the solution map.
+    The certificate is re-checked inside the proof, so the scan itself carries no obligations. -/
+def rpLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (domCs : List (Expression p))
+    (hdomCs : ∀ c ∈ domCs, c ∈ cs.algebraicConstraints) :
+    (pending : List (Expression p)) → (∀ c ∈ pending, c ∈ cs.algebraicConstraints) →
+    List (RPSeen p cs) → Solved p cs bs → Solved p cs bs
+  | [], _, _, σ => σ
+  | c :: rest, hmem, seen, σ =>
+    have hc : c ∈ cs.algebraicConstraints := hmem c (List.mem_cons_self ..)
+    let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
+    let cands := rpCandidates c
+    match hfound : cands.findSome? (fun xk =>
+        seen.findSome? (fun e =>
+          if e.key == xk.2 && e.x != xk.1 &&
+              rpCheckPair bs facts cs.busInteractions domCs e.c c e.x xk.1
+          then some (e, xk.1) else none)) with
+    | some ex =>
+        have hcert : rpCheckPair bs facts cs.busInteractions domCs ex.1.c c ex.1.x ex.2 = true := by
+          obtain ⟨xk, _hxk, hinner⟩ := List.exists_of_findSome?_eq_some hfound
+          obtain ⟨e, _he, hif⟩ := List.exists_of_findSome?_eq_some hinner
+          by_cases hcnd : (e.key == xk.2 && e.x != xk.1 &&
+              rpCheckPair bs facts cs.busInteractions domCs e.c c e.x xk.1) = true
+          · rw [if_pos hcnd] at hif
+            simp only [Option.some.injEq] at hif
+            subst hif
+            rw [Bool.and_eq_true] at hcnd
+            exact hcnd.2
+          · rw [if_neg hcnd] at hif
+            exact absurd hif (by simp)
+        have hpairs : ∀ env, cs.satisfies bs env →
+            ∀ yt ∈ [(ex.2, Expression.var ex.1.x)], env yt.1 = yt.2.eval env := by
+          intro env hsat yt hyt
+          obtain rfl : yt = (ex.2, Expression.var ex.1.x) := by simpa using hyt
+          show env ex.2 = env ex.1.x
+          exact (rpCheckPair_sound bs facts cs.busInteractions domCs ex.1.c c ex.1.x ex.2
+            hcert env (fun c' hc' => hsat.1 c' (hdomCs c' hc'))
+            (hsat.1 ex.1.c ex.1.mem) (hsat.1 c hc)
+            (fun bi hbi hmult => hsat.2 bi hbi hmult)).symm
+        have hpairsV : ∀ yt ∈ [(ex.2, Expression.var ex.1.x)],
+            ∀ z ∈ yt.2.vars, z ∈ cs.vars := by
+          intro yt hyt z hz
+          obtain rfl : yt = (ex.2, Expression.var ex.1.x) := by simpa using hyt
+          obtain rfl : z = ex.1.x := by simpa [Expression.vars] using hz
+          exact ConstraintSystem.mem_vars_of_constraint ex.1.mem
+            (rpCheckPair_vars bs facts cs.busInteractions domCs ex.1.c c ex.1.x ex.2 hcert).1
+        rpLoop cs bs facts domCs hdomCs rest hrest
+          ((cands.filter (fun xk => xk.1 != ex.2)).map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (σ.insertAll [(ex.2, Expression.var ex.1.x)] hpairs hpairsV)
+    | none =>
+        rpLoop cs bs facts domCs hdomCs rest hrest
+          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+
+/-- Two-root decomposition unification. Prime `p` only (re-checked at runtime, as in
+    `busPairCancelPass`). One sweep; the cleanup fixpoint iterates the pass, so chains resolve
+    across cycles (the high limbs' root expressions become equal only after the low limbs
+    unify). Solutions are bare variables, so substitution can never grow a degree. -/
+def rootPairUnifyPass : VerifiedPassW p := fun cs bs facts =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    let σ := rpLoop cs bs facts cs.algebraicConstraints (fun _ h => h)
+      cs.algebraicConstraints (fun _ h => h) [] Solved.empty
+    if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+    else ⟨cs.substF σ.fn, [],
+      cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
+        (fun y t hyt => σ.varsIn y t hyt)⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+

--- a/Main.lean
+++ b/Main.lean
@@ -272,6 +272,7 @@ def cmdProfile (fileName : String) : IO Unit := do
       ("constFold2", constantFoldPass.withFacts.guardDegree),
       ("zeroRegister", zeroRegisterPass.guardDegree),
       ("hintCollapse", hintCollapsePass.guardDegree),
+      ("rootPairUnify", rootPairUnifyPass.guardDegree),
       ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
       ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
       ("tautoBus", tautoBusDropPass.withFacts.guardDegree),

--- a/Main.lean
+++ b/Main.lean
@@ -273,6 +273,7 @@ def cmdProfile (fileName : String) : IO Unit := do
       ("zeroRegister", zeroRegisterPass.guardDegree),
       ("hintCollapse", hintCollapsePass.guardDegree),
       ("rootPairUnify", rootPairUnifyPass.guardDegree),
+      ("flagUnify", flagUnifyPass.guardDegree),
       ("dedup", dedupPass.withFacts.guardDegree),
       ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
       ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),

--- a/Main.lean
+++ b/Main.lean
@@ -273,6 +273,7 @@ def cmdProfile (fileName : String) : IO Unit := do
       ("zeroRegister", zeroRegisterPass.guardDegree),
       ("hintCollapse", hintCollapsePass.guardDegree),
       ("rootPairUnify", rootPairUnifyPass.guardDegree),
+      ("dedup", dedupPass.withFacts.guardDegree),
       ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
       ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
       ("tautoBus", tautoBusDropPass.withFacts.guardDegree),

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -78,7 +78,7 @@ Generalise the recogniser (and the `bytePairBus` fact) to pack any two messages 
 "this operand is a byte" obligation, regardless of the carrier form. Still a stateless, sound,
 variable-neutral bus win.
 
-## Eliminate memory-pointer-limb decompositions / redundant range checks (bus interactions)
+## Memory-pointer-limb residuals: cross-offset chaining and duplicate cleanup
 
 On memory-heavy blocks (e.g. apc_005) apc-optimizer keeps ~2× powdr's `mem_ptr_limbs` decompositions and
 their 13-bit range checks (the high/"page" limb is identical across same-base accesses but apc-optimizer
@@ -104,6 +104,20 @@ difference selection, one marker per limb) doesn't match yet — apc_018 measure
 carry-branch resolution (entry 57): ours 43 vars vs powdr 34; this family is the bulk of the
 residual. Generalizing the matcher (coefficients that are *differences* of byte-bounded
 variables, sign-split like `CarryBranch.splitSumMax`) should capture it.
+**Update (log 57):** the equal-address half is landed — `rootPairUnifyPass` unifies duplicate
+same-address decompositions via the two-root/no-wrap argument (−128 vars on each of the
+apc_005-class blocks; apc-optimizer now leads powdr on aggregate variable effectiveness). Two
+residuals remain:
+
+1. **Duplicate-structure cleanup:** the unification leaves the eliminated decomposition's carry
+   constraints and range checks behind as *syntactically identical* copies of the survivor's.
+   A syntactic duplicate dropper (constraints: trivially entailed; stateless interactions: same
+   obligation twice — needs a fold-based keep-first, `filter` cannot distinguish identical
+   elements) would convert this into constraint- and bus-interaction wins. Duplicates did not
+   occur in optimized outputs before log 57, so this only became profitable now.
+2. **Cross-offset chaining** (`ptr` and `ptr+4` sharing the high limb): powdr-side this needs
+   reasoning that the low limb doesn't cross the 2¹⁶ page boundary, which is not statically
+   true — presumably a carry-witness argument. Harder, unclear value after (1).
 
 ## Is-zero / is-equal witness reduction (variables)
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -109,12 +109,11 @@ same-address decompositions via the two-root/no-wrap argument (−128 vars on ea
 apc_005-class blocks; apc-optimizer now leads powdr on aggregate variable effectiveness). Two
 residuals remain:
 
-1. **Duplicate-structure cleanup:** the unification leaves the eliminated decomposition's carry
-   constraints and range checks behind as *syntactically identical* copies of the survivor's.
-   A syntactic duplicate dropper (constraints: trivially entailed; stateless interactions: same
-   obligation twice — needs a fold-based keep-first, `filter` cannot distinguish identical
-   elements) would convert this into constraint- and bus-interaction wins. Duplicates did not
-   occur in optimized outputs before log 57, so this only became profitable now.
+1. **Duplicate-structure cleanup:** landed as `dedupPass` (log 58) — collects the unified
+   decomposition's carry constraints and raw-slot range check. The *scaled* low-limb check
+   survives: its flag polynomial differs per access, so the copies are not syntactic. Dropping
+   it needs entailment (the survivor's check plus flag domains imply the duplicate's obligation)
+   — the `filterBusEntailed_correct`-style argument over a per-access flag renaming.
 2. **Cross-offset chaining** (`ptr` and `ptr+4` sharing the high limb): powdr-side this needs
    reasoning that the low limb doesn't cross the 2¹⁶ page boundary, which is not statically
    true — presumably a carry-witness argument. Harder, unclear value after (1).

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -109,11 +109,13 @@ same-address decompositions via the two-root/no-wrap argument (−128 vars on ea
 apc_005-class blocks; apc-optimizer now leads powdr on aggregate variable effectiveness). Two
 residuals remain:
 
-1. **Duplicate-structure cleanup:** landed as `dedupPass` (log 58) — collects the unified
-   decomposition's carry constraints and raw-slot range check. The *scaled* low-limb check
-   survives: its flag polynomial differs per access, so the copies are not syntactic. Dropping
-   it needs entailment (the survivor's check plus flag domains imply the duplicate's obligation)
-   — the `filterBusEntailed_correct`-style argument over a per-access flag renaming.
+1. **Duplicate-structure cleanup:** landed as `dedupPass` (log 58) and `flagUnifyPass`
+   (log 59). Remaining: per unified pair, one flag component relates to the survivor's
+   *non-componentwise* (the encodings differ), so the scaled check never becomes a syntactic
+   duplicate. Unifying it needs a derived-variable substitution `b := f(a₀, a₁)` — interpolate
+   the relation over the ≤ 4-point joint box (the certificate data already exposes it) and
+   substitute a degree-≤ 2 solution, degree-guarded. Would remove the last per-pair flag var
+   and (via dedup) the duplicate scaled check: another ~−64 vars and −64 bus on apc_005-class.
 2. **Cross-offset chaining** (`ptr` and `ptr+4` sharing the high limb): powdr-side this needs
    reasoning that the low limb doesn't cross the 2¹⁶ page boundary, which is not statically
    true — presumably a carry-witness argument. Harder, unclear value after (1).

--- a/docs/log.md
+++ b/docs/log.md
@@ -1708,3 +1708,37 @@ constraints and range checks behind as *syntactically identical* copies — a du
 would convert the remaining redundancy into constraint/bus wins; and powdr's cross-offset
 chaining (`ptr+4` sharing the high limb) needs page-crossing reasoning beyond equal-address
 unification.
+
+### 58. Syntactic duplicate removal (`Dedup.lean`) — collect what unification leaves behind
+
+Entry 57's limb unification substitutes one variable for another, which turns the eliminated
+decomposition's two carry constraints and its raw-slot range check into **literal copies** of
+the survivor's. Nothing dropped them: `trivialConstraintDropPass` only removes identically-zero
+constraints, and a `List.filter` cannot express "keep the first occurrence" — identical elements
+get identical predicate values. (Before entry 57 the optimized outputs contained no syntactic
+duplicates at all, so this pass would have been a no-op — measured as part of the entry-56-era
+census on the old line.)
+
+**The pass (`Implementation/OptimizerPasses/Dedup.lean`, fact-free `VerifiedPass`).** Constraints
+dedup via `List.dedup` — `satisfies` only consults membership, so which occurrence survives is
+irrelevant and correctness is `List.mem_dedup`. Stateless interactions dedup by an explicit
+keep-first recursion carrying the kept-so-far list; three small lemmas discharge `PassCorrect`
+via `ofEnvEq`: every kept interaction is original (`dedupStateless_subset`), every original is
+kept or already seen (`dedupStateless_covers` — the dropped copy's obligation transfers from its
+kept twin), and both the syntactic stateful sublist and the active∧stateful *evaluated* message
+list are untouched (`_statefulFilter`/`_evalFilter` — so `sideEffects` stays *equal* and
+`admissible` transfers). Stateful duplicates are deliberately kept: two sends of the same
+message are two sends. Wired into `cleanupCycle` right after `rootPairUnifyPass`.
+
+`lake build` green; all three `maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** apc_005-class: **841 → 713 constraints (−128) and 829 → 765 bus interactions (−64)**
+per block at unchanged 1555 vars — the 64 unified pairs' two carry constraints and one raw-slot
+range check each (the flag-dependent scaled check survives: its flag polynomial differs per
+access, so the copies are not syntactic — see `docs/ideas.md`). 9-case sample across the other
+size classes byte-identical. Full 100-case sweep (before → after):
+
+- variables **4.222×/3.644× unchanged** (the pass is variable-neutral by construction)
+- **bus interactions: 2.924× → 3.006× aggregate (2.442× → 2.466× geomean)**
+- **constraints: 8.801× → 9.500× aggregate (9.918× → 10.144× geomean)**

--- a/docs/log.md
+++ b/docs/log.md
@@ -1655,3 +1655,56 @@ The residual keccak gap is now **variables** (3622 vs 2021): the read-data limbs
 (bitwise) interactions even after their memory pairs cancel. Closing it needs read-value
 unification (substitute a read limb by the value written to that cell, or by the XOR functional
 dependence `slotFun`) — recorded in `docs/ideas.md`.
+### 57. Two-root decomposition unification (`RootPairUnify.lean`) — bounded-integer reasoning, aggregate variable lead over powdr
+
+Memory-pointer decompositions pin each limb by a **two-root carry constraint**
+`(A + k·x)(A + δ + k·x) = 0` (the two address-wraparound cases) plus a range check keeping the
+limb inside a window smaller than the root gap. Two accesses at the *same* address produce two
+such constraints with the same `A, k, δ` but distinct limb variables — each variable
+independently picks a root, so no purely algebraic pass can equate them, and every
+finite-*constant*-domain pass is blocked by the parameterized roots (the gap diagnosed in
+`docs/ideas.md`'s mem-ptr item). apc-optimizer kept 258 `mem_ptr_limbs` on apc_005 vs powdr's 130.
+
+**The bounded-integer argument** (`rootPair_eq`): both roots differ by `g = k⁻¹·δ`; if
+`x.val < B` and `y.val < B` with `B ≤ g.val` and `B ≤ p − g.val`, the field difference
+`x − y = ±g` is impossible over the integers, so `x = y`. The entailed equality feeds the same
+proof-carrying `Solved` map as `Gauss.lean` (solutions are bare variables — no degree gate, no
+resolution) and one `ConstraintSystem.substF`. Prime `p` only (root membership needs an integral
+domain; re-checked at runtime as in `busPairCancelPass`).
+
+**Bound sources** (`anyVarBound`, env-conditional on the system's own satisfaction):
+1. raw range-check slots via `findVarBound` (`DomainProp`) — covers the high limbs (13-bit);
+2. **scaled slots** (`scaledSlotBound`): the low limb's checked slot is `4⁻¹·(x − F)` with `F` a
+   degree-2 flag polynomial, so `linearize` fails on it — a new constant-coefficient
+   decomposition `Expression.splitAt` (`e = k·x + r`, `r` opaque and possibly nonlinear) handles
+   it. The slot value is fact-bounded (`slotBound`), the offset part enumerates the flag
+   variables' proven finite domains (`findDomainAlg` booleanity, ≤ 16 points), and
+   `ZMod.val_add_of_lt`/`val_mul_of_lt` carry the no-wrap integer arithmetic:
+   `x.val < m.val·(bound−1) + Wmax + 1`.
+
+The scan groups two-root candidates by key `(k, A.terms, A.const, δ)` and re-checks a decidable
+pair certificate (`rpCheckPair`) inside the adoption proof, so the scan itself is proof-free.
+**Runtime trap**: booleanity `b(b−1) = 0` is itself two-root (gap 1), which made every boolean
+variable an expensive-to-reject candidate pair — the first run of apc_005 exceeded 35 minutes.
+A root-gap prefilter (`min(g.val, p − g.val) ≥ 256`, which the pair condition could never pass
+anyway) restores it to seconds. Wired into `cleanupCycle` after `hintCollapse`; the fixpoint
+chains the stages (high limbs key-match only after the low limbs unify, equal bases only form
+after busUnify/pairCancel — each next cycle picks up what the previous one exposed).
+
+`lake build` green; all three `maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** apc_005 / apc_044 / apc_067: **1683 → 1555 vars (−128 each**, the predicted 64 low
++ 64 high limb pairs; powdr keeps 1808); apc_005 wall-clock 14.2 s at this commit. A 10-case
+sample across the other size classes is byte-identical. Full 100-case sweep (before → after,
+baseline re-measured at this commit's parent):
+
+- **variables: 4.082× → 4.222× aggregate (3.605× → 3.644× geomean)** vs powdr's 4.092×/3.787×
+  — **apc-optimizer takes the aggregate variable lead for the first time**; per-case wins 15 → 17
+- bus interactions 2.922× → 2.924× (downstream cascade), constraints 8.801×/9.918× unchanged
+
+Left on the table (see `docs/ideas.md`): the unification leaves the duplicate's carry
+constraints and range checks behind as *syntactically identical* copies — a duplicate-dropper
+would convert the remaining redundancy into constraint/bus wins; and powdr's cross-offset
+chaining (`ptr+4` sharing the high limb) needs page-crossing reasoning beyond equal-address
+unification.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1774,3 +1774,43 @@ sample byte-identical. Full 100-case sweep (before → after):
 - **variables: 4.222× → 4.286× aggregate (3.644× → 3.655× geomean)** vs powdr's 4.092×/3.787×
 - **constraints: 9.500× → 9.854× aggregate (10.144× → 10.214× geomean)**
 - bus interactions 3.006×/2.466× unchanged
+
+### 60. Optimizer runtime: share `flagUnify`'s pair-level certificate work (effectiveness unchanged)
+
+Pure performance work in the entry-53 style. Profiling apc_005 put **`flagUnify` at 17.4 s of
+the 30.8 s total (57%)**; stage instrumentation (temporary `fuprof` command, since reverted)
+showed all of it inside `fuCheck` — 256 calls per cleanup iteration (64 matched pairs × 4 flag
+combos) at ~10–28 ms each, and iterations 3–6 spending ~10 s re-rejecting certificates that can
+never pass after the flags unify. Each call redid the *pair-level* work — the slot-bound
+probes (`payload.map constValue?` folds), both `splitAt`s, `findDomainAlg` over every
+constraint, the ≤32-point joint enumeration, and **dozens of runtime `ZMod` inversions** (every
+`k⁻¹` occurrence re-runs the extended-gcd inverse; entry-54's gotcha in a new costume).
+
+**Fix (value-identical by construction):** `fuCheck` is now *defined* as
+`fuPairData?` (all pair-level work, inversion hoisted into a single `let m := k⁻¹`, the
+enumerated point list bound once and reused for both the bound check and the `pts` table)
+composed with `fuCheckWith` (memberships, disequality, and the pointwise agreement scan). The
+scan calls `fuPairData?` once per matched pair and `fuCheckWith` per flag combo; the adoption
+proof re-checks `fuCheck` through the same definition, so the accepted set is unchanged
+definitionally. The `fuCheck_sound`/`fuCheck_vars` proofs re-thread through the split (same
+case chain, inverted on `fuPairData?`).
+
+A hash-prefilter for `rootPairUnify`'s seen-key scan was also tried and **measured zero**
+(3.06 s → 3.02 s ≈ noise — the scan is not where its time goes); it was reverted rather than
+landed. Written-in-advance cost models remain undefeated in their wrongness.
+
+**Validation:** A/B binaries (stash-built reference at the parent commit) byte-identical on the
+13-case entry-53 set (`apc_001/003/005/006/008/010/014/028/047/056/069/092/100` — vars,
+constraints, bus all equal) plus a **full-render diff on apc_005** (identical). `lake build`
+green; `check-proof-integrity.sh` passes; axioms unchanged.
+
+**Impact (profiler, apc_005):** flagUnify **17.4 s → 5.3 s (3.3×)**; end-to-end run
+**30.8 s → 18.0 s (1.7×)**. apc_006/apc_100 unaffected (flagUnify does not fire there).
+
+Remaining bottlenecks (documented for the next agent): `flagUnify` 5.3 s — the per-pair
+residual is `findDomainAlg` over the full constraint list (×4 vars) plus the plain
+`Expression.eval` per enumeration point (the entry-54 `evalWith` treatment applies), and
+iterations 3–6 still pay 64 pair-datas each for zero adoptions; `rootPairUnify` 3.0 s — *not*
+the seen-scan (measured), so likely `rpCandidates`'s per-variable `splitAt`+`LinExpr.norm`
+over every constraint every iteration; `domainFold` 3.4 s — the pre-existing
+`ImprovingRuntime.md` lead #1 (`constOnSurvs` still on per-node-instance `eval`).

--- a/docs/log.md
+++ b/docs/log.md
@@ -1742,3 +1742,35 @@ size classes byte-identical. Full 100-case sweep (before → after):
 - variables **4.222×/3.644× unchanged** (the pass is variable-neutral by construction)
 - **bus interactions: 2.924× → 3.006× aggregate (2.442× → 2.466× geomean)**
 - **constraints: 8.801× → 9.500× aggregate (9.918× → 10.144× geomean)**
+
+### 59. Flag unification across duplicate scaled range checks (`FlagUnify.lean`)
+
+Entry 58 left the unified decomposition's *scaled* low-limb check behind: its flag polynomial
+uses the eliminated access's own flag variables, so the copy is not syntactic — and it is not
+droppable either, since that check is exactly what pins those flags (the divisibility of the
+scaled slot). But the flags are provably *equal* to the survivor's: both checks decompose the
+**same** shared limb as `x = m·u + W` (`Expression.splitAt`, slot value `u` fact-bounded, `W`
+the flag-polynomial value), so `W_X.val = W_Y.val` — both are the residue of `x.val` under
+`m.val` (`residue_uniq`, `ZMod.val_add_of_lt`/`val_mul_of_lt` no-wrap arithmetic, per-point
+`W < m` over the joint flag box) — and on every joint flag point with equal offset values the
+certificate demands the target components agree (≤ 32 points, `findDomainAlg` booleanity
+domains). Certified equalities feed the same `Solved`/`substF` machinery; the pass runs between
+`rootPairUnifyPass` (which shares the carrier limb) and `dedupPass`.
+
+The certificate is deliberately *componentwise*: it only accepts a flag pair whose equality
+holds at every offset-equal point. Measured on apc_005-class blocks exactly **one of the two
+flag components certifies** per pair — the two accesses' encodings relate the other component
+non-componentwise — so the checks do not become fully syntactic duplicates and the bus count
+stays; the remaining component would need a derived-variable substitution `b := f(a₀, a₁)`
+(nonlinear solution, degree-guarded), noted in `docs/ideas.md`.
+
+`lake build` green; all three `maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** apc_005-class blocks: **1555 → 1491 vars (−64) and 649 constraints (−64**, the
+unified flags' booleanity copies collected by `dedupPass`); bus interactions unchanged. 9-case
+sample byte-identical. Full 100-case sweep (before → after):
+
+- **variables: 4.222× → 4.286× aggregate (3.644× → 3.655× geomean)** vs powdr's 4.092×/3.787×
+- **constraints: 9.500× → 9.854× aggregate (10.144× → 10.214× geomean)**
+- bus interactions 3.006×/2.466× unchanged


### PR DESCRIPTION
## What

Three verified passes (log entries 57–59) closing the duplicate memory-pointer-decomposition gap:

1. **`rootPairUnifyPass`** (entry 57): each memory access pins its pointer limbs with a two-root carry constraint `(A + k·x)(A + δ + k·x) = 0` plus a range check below the root gap. Same-address accesses produce twin constraints with distinct limb variables; the bounded-integer argument (`rootPair_eq`: two values below `min(g.val, p − g.val)` cannot differ by the root gap `±g` over the integers) proves the limbs equal. Bounds come from raw range checks (`findVarBound`) and scaled slots `4⁻¹·(x − F)` via a constant-coefficient decomposition `Expression.splitAt` + flag-domain enumeration + `ZMod` no-wrap val arithmetic.
2. **`dedupPass`** (entry 58): the unification turns the eliminated decomposition's carry constraints and raw-slot range check into literal copies — a keep-first dedup of syntactically identical constraints and *stateless* interactions collects them (stateful duplicates are observable in `sideEffects` and kept).
3. **`flagUnifyPass`** (entry 59): the surviving scaled check pins the eliminated access's flag variables; both checks decompose the *same* shared limb as `x = m·u + W`, so the flag-polynomial values are equal by integer residue uniqueness, and a ≤32-point joint flag-box enumeration certifies componentwise variable equality.

## Effectiveness (full 100-case openvm-eth sweep, tip vs merge base)

| axis | before | after | powdr |
|---|---|---|---|
| **variables** | 4.082× / 3.605× | **4.286× / 3.655×** | 4.092× / 3.787× |
| bus interactions | 2.922× / 2.440× | **3.006× / 2.466×** | 3.480× / 2.822× |
| constraints | 8.801× / 9.918× | **9.854× / 10.214×** | 5.853× / 10.311× |

- **First aggregate variable lead over powdr** (+0.194×); per-case wins 15 → 17, no per-case regressions (10-case sample across size classes byte-identical at each commit).
- apc_005 / apc_044 / apc_067 per block: **1683 → 1491 vars (−192), 841 → 649 constraints, 829 → 765 bus interactions**; powdr keeps 1808 vars on these.
- apc_005 wall-clock ~18 s (after the log-entry-60 runtime commit; was ~30 s).

## Correctness

- No changes to the audited surface; all three passes discharge `PassCorrect` (via `substF_correct` / `ofEnvEq`); prime `p` re-checked at runtime where needed, as in `busPairCancelPass`.
- `lake build` green at every commit; `Scripts/check-proof-integrity.sh` passes; all three `maintainsCorrectness` theorems remain `{propext, Classical.choice, Quot.sound}`-only.

Follow-ups recorded in `docs/ideas.md`: the last per-pair flag component relates non-componentwise (needs a derived-variable interpolation `b := f(a₀, a₁)`, worth ~−64 vars and −64 bus per apc_005-class block), and cross-offset chaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
