### PR TITLE
XOR flag fold: entailed nonlinear substitution, box-certified rewriting, pointwise bus dedup

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -24,6 +24,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.CarryBranch
 import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
 import ApcOptimizer.Implementation.OptimizerPasses.Dedup
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
+import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 
 set_option autoImplicit false
 
@@ -70,6 +71,7 @@ def cleanupCycle : VerifiedPassW p :=
     |>.andThen hintCollapsePass.guardDegree
     |>.andThen rootPairUnifyPass.guardDegree
     |>.andThen flagUnifyPass.guardDegree
+    |>.andThen flagFoldPass'.guardDegree
     |>.andThen dedupPass.withFacts.guardDegree
     |>.andThen trivialConstraintDropPass.withFacts.guardDegree
     |>.andThen zeroMultBusDropPass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -1,0 +1,394 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
+
+set_option autoImplicit false
+
+/-! # Box-certified multilinear rewriting
+
+The missing piece of log entry 64: after substituting a degree-2 flag interpolation, the
+stateful address payloads and the data-selection constraints hold expressions that exceed the
+degree bound *syntactically* while being pointwise equal to legal forms — `b² → b` on the
+boolean flags reduces them back within bound. This pass rewrites every **over-bound** expression
+of the system to its multilinear reduction, accepting the rewrite only under a decidable
+certificate: on every point of the (small) joint domain box of the expression's small-domain
+variables, the two expressions **partially evaluate to the same affine form** in the remaining
+(symbolic, e.g. data) variables.
+
+The reduction itself is heuristic data — sparse monomial expansion with exponent capping on the
+known-small-domain variables — and carries no proof; the certificate re-verifies pointwise.
+Expressions with fewer than two distinct variables are never rewritten (they are the
+`findDomainAlg` domain sources, giving non-circularity exactly as in `FlagFold.lean`). -/
+
+variable {p : ℕ}
+
+/-! ## The heuristic reducer -/
+
+/-- Merge-insert a monomial into a sorted association list. -/
+def addMono (m : List Variable) (c : ZMod p) :
+    List (List Variable × ZMod p) → List (List Variable × ZMod p)
+  | [] => [(m, c)]
+  | (m', c') :: rest =>
+    if m' = m then (m', c' + c) :: rest else (m', c') :: addMono m c rest
+
+/-- Multiply two variable multisets, capping exponents of `boolSet` members at one.
+    Keeps lists sorted by name for canonical merging. -/
+def mulMono (boolSet : List Variable) (a b : List Variable) : List Variable :=
+  ((a ++ b).mergeSort (fun u v => decide (u.name ≤ v.name))).foldl
+    (fun acc v =>
+      match acc.head? with
+      | some w => if w = v ∧ v ∈ boolSet then acc else v :: acc
+      | none => [v]) []
+
+/-- Sparse monomial expansion (with boolean exponent capping); `none` when the monomial count
+    exceeds the cap. Heuristic only. -/
+def polyOf (boolSet : List Variable) : Expression p →
+    Option (List (List Variable × ZMod p))
+  | .const c => some [([], c)]
+  | .var v => some [([v], 1)]
+  | .add a b => do
+    let pa ← polyOf boolSet a
+    let pb ← polyOf boolSet b
+    let r := pb.foldl (fun acc mc => addMono mc.1 mc.2 acc) pa
+    if r.length ≤ 64 then some r else none
+  | .mul a b => do
+    let pa ← polyOf boolSet a
+    let pb ← polyOf boolSet b
+    let r := pa.foldl (fun acc ma =>
+      pb.foldl (fun acc2 mb =>
+        addMono (mulMono boolSet ma.1 mb.1) (ma.2 * mb.2) acc2) acc) []
+    if r.length ≤ 64 then some r else none
+
+/-- One monomial as an expression. -/
+def monoExpr (mc : List Variable × ZMod p) : Expression p :=
+  mc.1.foldl (fun m v => Expression.mul m (Expression.var v)) (Expression.const mc.2)
+
+/-- Rebuild an expression from monomials (dropping zero coefficients). -/
+def exprOfPoly (ms : List (List Variable × ZMod p)) : Expression p :=
+  match ms.filter (fun mc => !(mc.2 == 0)) with
+  | [] => Expression.const 0
+  | mc :: rest => rest.foldl (fun acc mc' => Expression.add acc (monoExpr mc')) (monoExpr mc)
+
+/-- The heuristic multilinear reduction. -/
+def reduceExpr (boolSet : List Variable) (e : Expression p) : Option (Expression p) :=
+  (polyOf boolSet e).map exprOfPoly
+
+/-! ## The certificate -/
+
+/-- Constant-solution map for a box point (used with `substF`). -/
+def ptFun (pt : List (Variable × ZMod p)) : Variable → Option (Expression p) :=
+  fun v => if pt.any (fun t => t.1 == v) then some (.const (envOf pt v)) else none
+
+/-- Canonical equality of normalized linear forms: equal constants and equal name-sorted term
+    lists. -/
+def canonEq (l1 l2 : LinExpr p) : Bool :=
+  l1.const == l2.const &&
+  l1.terms.mergeSort (fun a b => decide (a.1.name ≤ b.1.name))
+    == l2.terms.mergeSort (fun a b => decide (a.1.name ≤ b.1.name))
+
+/-- Certificate: on every point of the joint small-domain box, both expressions partially
+    evaluate to the same affine form in the remaining symbolic variables. -/
+def brCert (all : List (Expression p)) (e e' : Expression p) : Bool :=
+  2 ≤ e.vars.eraseDups.length &&
+  (let jv := (e.vars ++ e'.vars).eraseDups
+   let boxed := jv.filter (fun v =>
+     match findDomainAlg (singleVarCs all) v with
+     | some d => d.length ≤ 2
+     | none => false)
+   let doms := boxed.filterMap (fun v =>
+     (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = boxed) &&
+   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 16) &&
+   (assignments doms).all (fun pt =>
+     match linearize (e.substF (ptFun pt)), linearize (e'.substF (ptFun pt)) with
+     | some l1, some l2 => canonEq l1.norm l2.norm
+     | _, _ => false))
+
+/-- `envF` over a point map is the identity when the point is the environment's own
+    restriction. -/
+theorem envF_ptFun_self (doms : List (Variable × List (ZMod p))) (env : Variable → ZMod p) :
+    envF (ptFun (doms.map (fun vd => (vd.1, env vd.1)))) env = env := by
+  funext v
+  unfold envF ptFun
+  by_cases hin : (doms.map (fun vd => (vd.1, env vd.1))).any (fun t => t.1 == v) = true
+  · rw [if_pos hin]
+    show (envOf (doms.map (fun vd => (vd.1, env vd.1))) v) = env v
+    refine envOf_map doms env v ?_
+    obtain ⟨t, ht, htv⟩ := List.any_eq_true.1 hin
+    obtain ⟨vd, hvd, rfl⟩ := List.mem_map.1 ht
+    have : vd.1 = v := eq_of_beq htv
+    rw [← this]
+    exact List.mem_map.2 ⟨vd, hvd, rfl⟩
+  · rw [if_neg hin]
+
+theorem brCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expression p)
+    (h : brCert all e e' = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : e.eval env = e'.eval env := by
+  unfold brCert at h
+  rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h
+  obtain ⟨_h2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := h
+  have hcover' := of_decide_eq_true hcover
+  -- the environment restricted to the box is an enumerated point
+  set boxed := ((e.vars ++ e'.vars).eraseDups.filter (fun v =>
+    match findDomainAlg (singleVarCs all) v with
+    | some d => d.length ≤ 2
+    | none => false)) with hboxed
+  set doms := (boxed.filterMap (fun v =>
+    (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))) with hdoms
+  have hmemdoms : ∀ vd ∈ doms, env vd.1 ∈ vd.2 := by
+    intro vd hvd
+    rw [hdoms] at hvd
+    obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+    cases hfd : findDomainAlg (singleVarCs all) v with
+    | none => rw [hfd] at hvd'; simp at hvd'
+    | some d =>
+      rw [hfd] at hvd'
+      simp only [Option.map_some, Option.some.injEq] at hvd'
+      obtain rfl := hvd'.symm
+      exact findDomainAlg_sound (singleVarCs all) v d hfd env hdom
+  have hpt := mem_assignments doms env hmemdoms
+  have hcond := List.all_eq_true.mp hall _ hpt
+  cases hl1 : linearize (e.substF (ptFun (doms.map (fun vd => (vd.1, env vd.1))))) with
+  | none => rw [hl1] at hcond; simp at hcond
+  | some l1 =>
+    cases hl2 : linearize (e'.substF (ptFun (doms.map (fun vd => (vd.1, env vd.1))))) with
+    | none => rw [hl1, hl2] at hcond; simp at hcond
+    | some l2 =>
+      rw [hl1, hl2] at hcond
+      unfold canonEq at hcond
+      rw [Bool.and_eq_true] at hcond
+      obtain ⟨hconst, hterms⟩ := hcond
+      -- partial evaluation agrees with full evaluation
+      have hs1 : (e.substF (ptFun (doms.map (fun vd => (vd.1, env vd.1))))).eval env
+          = e.eval env := by
+        rw [Expression.eval_substF, envF_ptFun_self]
+      have hs2 : (e'.substF (ptFun (doms.map (fun vd => (vd.1, env vd.1))))).eval env
+          = e'.eval env := by
+        rw [Expression.eval_substF, envF_ptFun_self]
+      -- the two affine forms evaluate equally (equal constants, permuted equal terms)
+      have hsum : ((l1.norm.terms.map (fun t => t.2 * env t.1)).sum)
+          = ((l2.norm.terms.map (fun t => t.2 * env t.1)).sum) := by
+        have hp1 : List.Perm (l1.norm.terms.map (fun t => t.2 * env t.1))
+            ((l1.norm.terms.mergeSort (fun a b => decide (a.1.name ≤ b.1.name))).map
+              (fun t => t.2 * env t.1)) :=
+          ((List.mergeSort_perm l1.norm.terms _).symm).map _
+        have hp2 : List.Perm ((l2.norm.terms.mergeSort
+              (fun a b => decide (a.1.name ≤ b.1.name))).map (fun t => t.2 * env t.1))
+            (l2.norm.terms.map (fun t => t.2 * env t.1)) :=
+          (List.mergeSort_perm l2.norm.terms _).map _
+        rw [hp1.sum_eq, eq_of_beq hterms, hp2.sum_eq]
+      have hev : l1.norm.eval env = l2.norm.eval env := by
+        show l1.norm.const + _ = l2.norm.const + _
+        rw [eq_of_beq hconst, hsum]
+      rw [← hs1, ← hs2, linearize_eval _ l1 hl1 env, linearize_eval _ l2 hl2 env,
+          ← LinExpr.norm_eval l1 env, ← LinExpr.norm_eval l2 env]
+      exact hev
+
+/-! ## The pass -/
+
+/-- Per-expression rewrite: only over-bound expressions, only when the reduction is within
+    bound, introduces no variable, and is certified. -/
+def brRw (all : List (Expression p)) (bound : Nat) (e : Expression p) : Expression p :=
+  if e.degree ≤ bound then e
+  else
+    let boolSet := e.vars.eraseDups.filter (fun v =>
+      match findDomainAlg (singleVarCs all) v with
+      | some d => d.length ≤ 2
+      | none => false)
+    match reduceExpr boolSet e with
+    | some e' =>
+      if e'.degree ≤ bound && e'.vars.all (fun v => v ∈ e.vars) && brCert all e e'
+      then e' else e
+    | none => e
+
+theorem brRw_sound [Fact p.Prime] (all : List (Expression p)) (bound : Nat)
+    (e : Expression p) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) :
+    (brRw all bound e).eval env = e.eval env := by
+  simp only [brRw]
+  split_ifs with hd
+  · rfl
+  · cases hr : reduceExpr (e.vars.eraseDups.filter (fun v =>
+        match findDomainAlg (singleVarCs all) v with
+        | some d => d.length ≤ 2
+        | none => false)) e with
+    | none => simp only [hr]
+    | some e' =>
+      simp only [hr]
+      split_ifs with hok
+      · rw [Bool.and_eq_true, Bool.and_eq_true] at hok
+        exact (brCert_sound all e e' hok.2 env hdom).symm
+      · rfl
+
+theorem brRw_vars (all : List (Expression p)) (bound : Nat) (e : Expression p) :
+    ∀ v ∈ (brRw all bound e).vars, v ∈ e.vars := by
+  intro v hv
+  simp only [brRw] at hv
+  split_ifs at hv with hd
+  · exact hv
+  · cases hr : reduceExpr (e.vars.eraseDups.filter (fun v =>
+        match findDomainAlg (singleVarCs all) v with
+        | some d => d.length ≤ 2
+        | none => false)) e with
+    | none => simp only [hr] at hv; exact hv
+    | some e' =>
+      simp only [hr] at hv
+      split_ifs at hv with hok
+      · rw [Bool.and_eq_true, Bool.and_eq_true] at hok
+        exact of_decide_eq_true (List.all_eq_true.mp hok.1.2 v hv)
+      · exact hv
+
+/-- A single-variable expression is never rewritten (the certificate's ≥ 2-variables guard),
+    keeping the domain sources intact. -/
+theorem brRw_singleVar (all : List (Expression p)) (bound : Nat) (c : Expression p)
+    (hs : c.vars.eraseDups.length ≤ 1) : brRw all bound c = c := by
+  simp only [brRw]
+  split_ifs with hd
+  · rfl
+  · cases hr : reduceExpr (c.vars.eraseDups.filter (fun v =>
+        match findDomainAlg (singleVarCs all) v with
+        | some d => d.length ≤ 2
+        | none => false)) c with
+    | none => simp only [hr]
+    | some e' =>
+      simp only [hr]
+      have hcert : brCert all c e' = false := by
+        unfold brCert
+        have h2 : (2 ≤ c.vars.eraseDups.length : Bool) = false := by
+          simp only [decide_eq_false_iff_not]
+          omega
+        rw [h2, Bool.false_and]
+      rw [hcert, Bool.and_false, if_neg (by simp)]
+
+/-- The per-interaction rewrite (bus id untouched). -/
+def brBi (all : List (Expression p)) (db : DegreeBound)
+    (bi : BusInteraction (Expression p)) : BusInteraction (Expression p) :=
+  { busId := bi.busId,
+    multiplicity := brRw all db.busInteractions bi.multiplicity,
+    payload := bi.payload.map (brRw all db.busInteractions) }
+
+/-- Rewrite every over-bound expression of the system to its certified reduction. -/
+def ConstraintSystem.boxRewrite (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    ConstraintSystem p :=
+  { algebraicConstraints := cs.algebraicConstraints.map
+      (brRw cs.algebraicConstraints bs.degreeBound.identities),
+    busInteractions := cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound) }
+
+theorem brBi_eval [Fact p.Prime] (all : List (Expression p)) (db : DegreeBound)
+    (bi : BusInteraction (Expression p)) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) :
+    (brBi all db bi).eval env = bi.eval env := by
+  unfold brBi BusInteraction.eval
+  simp only [BusInteraction.mk.injEq]
+  refine ⟨trivial, brRw_sound all _ _ env hdom, ?_⟩
+  rw [List.map_map]
+  exact List.map_congr_left (fun e _ => brRw_sound all _ e env hdom)
+
+theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
+    (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    PassCorrect cs (cs.boxRewrite bs) [] bs := by
+  -- single-variable domain sources survive verbatim
+  have hsingle : ∀ c ∈ singleVarCs cs.algebraicConstraints,
+      c ∈ (cs.boxRewrite bs).algebraicConstraints := by
+    intro c hc
+    have hmem := List.mem_of_mem_filter hc
+    have hs : c.vars.eraseDups.length ≤ 1 := by
+      have h1 := (List.mem_filter.1 hc).2
+      have h2 : c.vars.eraseDups.length = 1 := by simpa using h1
+      omega
+    exact List.mem_map.2 ⟨c, hmem, brRw_singleVar _ _ c hs⟩
+  have hdomOut : ∀ env, (cs.boxRewrite bs).satisfies bs env →
+      ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 :=
+    fun env hsat c hc => hsat.1 c (hsingle c hc)
+  have hdomIn : ∀ env, cs.satisfies bs env →
+      ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 :=
+    fun env hsat c hc => hsat.1 c (List.mem_of_mem_filter hc)
+  have hiff : ∀ env, (cs.boxRewrite bs).satisfies bs env ↔ cs.satisfies bs env := by
+    intro env
+    constructor
+    · intro hsat
+      have hdom := hdomOut env hsat
+      refine ⟨fun c hc => ?_, fun bi hbim => ?_⟩
+      · have h0 := hsat.1 _ (List.mem_map.2 ⟨c, hc, rfl⟩)
+        rw [brRw_sound _ _ c env hdom] at h0
+        exact h0
+      · have h0 := hsat.2 _ (List.mem_map.2 ⟨bi, hbim, rfl⟩)
+        rw [brBi_eval _ _ bi env hdom] at h0
+        exact h0
+    · intro hsat
+      have hdom := hdomIn env hsat
+      refine ⟨fun c' hc' => ?_, fun bi' hbi' => ?_⟩
+      · obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
+        rw [brRw_sound _ _ c env hdom]
+        exact hsat.1 c hc
+      · obtain ⟨bi, hbim, rfl⟩ := List.mem_map.1 hbi'
+        show (BusInteraction.eval _ env).multiplicity ≠ 0 → _
+        rw [brBi_eval _ _ bi env hdom]
+        exact hsat.2 bi hbim
+  have hside : ∀ env, (∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0) →
+      (cs.boxRewrite bs).sideEffects bs env = cs.sideEffects bs env := by
+    intro env hdom
+    unfold ConstraintSystem.sideEffects
+    show ((cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound)).filter
+      (fun bi => bs.isStateful bi.busId)).map _ = _
+    induction cs.busInteractions with
+    | nil => rfl
+    | cons bi rest ih =>
+      simp only [List.map_cons, List.filter_cons]
+      have hb : bs.isStateful (brBi cs.algebraicConstraints bs.degreeBound bi).busId
+          = bs.isStateful bi.busId := rfl
+      rw [hb]
+      by_cases hst : bs.isStateful bi.busId = true
+      · simp only [hst, if_pos]
+        rw [List.map_cons, List.map_cons, ih]
+        congr 1
+        simp only [brBi_eval _ _ bi env hdom]
+      · simp only [hst]
+        exact ih
+  have hadmEq : ∀ env, (∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0) →
+      ((cs.boxRewrite bs).admissible bs env ↔ cs.admissible bs env) := by
+    intro env hdom
+    unfold ConstraintSystem.admissible
+    have hmap : (cs.boxRewrite bs).busInteractions.map (fun bi => bi.eval env)
+        = cs.busInteractions.map (fun bi => bi.eval env) := by
+      show (cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound)).map
+        (fun bi => bi.eval env) = _
+      rw [List.map_map]
+      exact List.map_congr_left (fun bi _ => brBi_eval _ _ bi env hdom)
+    rw [hmap]
+  refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+  · intro env hsat
+    refine ⟨env, (hiff env).1 hsat, ?_⟩
+    rw [hside env (hdomOut env hsat)]
+    exact BusState.equiv_refl _
+  · intro hinv env hsat bi hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+    rw [brBi_eval _ _ bi0 env (hdomOut env hsat)]
+    exact hinv env ((hiff env).1 hsat) bi0 hbi0
+  · intro v hv
+    rw [ConstraintSystem.mem_vars] at hv ⊢
+    rcases hv with ⟨c', hc', hvc⟩ | ⟨bi', hbi', hvbi⟩
+    · obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
+      exact Or.inl ⟨c, hc, brRw_vars _ _ c v hvc⟩
+    · obtain ⟨bi, hbim, rfl⟩ := List.mem_map.1 hbi'
+      rcases hvbi with hm | ⟨e', he', hve⟩
+      · exact Or.inr ⟨bi, hbim, Or.inl (brRw_vars _ _ bi.multiplicity v hm)⟩
+      · obtain ⟨e, he, rfl⟩ := List.mem_map.1 he'
+        exact Or.inr ⟨bi, hbim, Or.inr ⟨e, he, brRw_vars _ _ e v hve⟩⟩
+  · intro env hadm hsat
+    refine ⟨(hiff env).2 hsat, ?_, ?_⟩
+    · exact (hadmEq env (hdomIn env hsat)).2 hadm
+    · rw [hside env (hdomIn env hsat)]
+      exact BusState.equiv_refl _
+
+/-- The rewriter as a standalone (unguarded) pass; prime `p` re-checked at runtime. -/
+def boxRewritePass : VerifiedPass p := fun cs bs =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    ⟨cs.boxRewrite bs, [], cs.boxRewrite_correct bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-- The completed composite (supersedes the `FlagFold.lean` version): substitute the XOR
+    component, rewrite the over-bound survivors multilinearly, then collect the tautologies and
+    pointwise duplicates. Wired under a single degree guard. -/
+def flagFoldPass' : VerifiedPassW p :=
+  fxSubstPass.andThen boxRewritePass.withFacts |>.andThen boxTautoDropPass.withFacts
+    |>.andThen pointwiseDupDropPass.withFacts

--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -86,15 +86,15 @@ def canonEq (l1 l2 : LinExpr p) : Bool :=
 
 /-- Certificate: on every point of the joint small-domain box, both expressions partially
     evaluate to the same affine form in the remaining symbolic variables. -/
-def brCert (all : List (Expression p)) (e e' : Expression p) : Bool :=
+def brCert (singles : List (Expression p)) (e e' : Expression p) : Bool :=
   2 ≤ e.vars.eraseDups.length &&
   (let jv := (e.vars ++ e'.vars).eraseDups
    let boxed := jv.filter (fun v =>
-     match findDomainAlg (singleVarCs all) v with
+     match findDomainAlg (singles) v with
      | some d => d.length ≤ 2
      | none => false)
    let doms := boxed.filterMap (fun v =>
-     (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
+     (findDomainAlg (singles) v).map (fun d => (v, d)))
    decide (doms.map Prod.fst = boxed) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 16) &&
    (assignments doms).all (fun pt =>
@@ -119,31 +119,31 @@ theorem envF_ptFun_self (doms : List (Variable × List (ZMod p))) (env : Variabl
     exact List.mem_map.2 ⟨vd, hvd, rfl⟩
   · rw [if_neg hin]
 
-theorem brCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expression p)
-    (h : brCert all e e' = true) (env : Variable → ZMod p)
-    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : e.eval env = e'.eval env := by
+theorem brCert_sound [Fact p.Prime] (singles : List (Expression p)) (e e' : Expression p)
+    (h : brCert singles e e' = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singles, c.eval env = 0) : e.eval env = e'.eval env := by
   unfold brCert at h
   rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h
   obtain ⟨_h2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := h
   have hcover' := of_decide_eq_true hcover
   -- the environment restricted to the box is an enumerated point
   set boxed := ((e.vars ++ e'.vars).eraseDups.filter (fun v =>
-    match findDomainAlg (singleVarCs all) v with
+    match findDomainAlg (singles) v with
     | some d => d.length ≤ 2
     | none => false)) with hboxed
   set doms := (boxed.filterMap (fun v =>
-    (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))) with hdoms
+    (findDomainAlg (singles) v).map (fun d => (v, d)))) with hdoms
   have hmemdoms : ∀ vd ∈ doms, env vd.1 ∈ vd.2 := by
     intro vd hvd
     rw [hdoms] at hvd
     obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-    cases hfd : findDomainAlg (singleVarCs all) v with
+    cases hfd : findDomainAlg (singles) v with
     | none => rw [hfd] at hvd'; simp at hvd'
     | some d =>
       rw [hfd] at hvd'
       simp only [Option.map_some, Option.some.injEq] at hvd'
       obtain rfl := hvd'.symm
-      exact findDomainAlg_sound (singleVarCs all) v d hfd env hdom
+      exact findDomainAlg_sound (singles) v d hfd env hdom
   have hpt := mem_assignments doms env hmemdoms
   have hcond := List.all_eq_true.mp hall _ hpt
   cases hl1 : linearize (e.substF (ptFun (doms.map (fun vd => (vd.1, env vd.1))))) with
@@ -186,28 +186,28 @@ theorem brCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expressi
 
 /-- Per-expression rewrite: only over-bound expressions, only when the reduction is within
     bound, introduces no variable, and is certified. -/
-def brRw (all : List (Expression p)) (bound : Nat) (e : Expression p) : Expression p :=
+def brRw (singles : List (Expression p)) (bound : Nat) (e : Expression p) : Expression p :=
   if e.degree ≤ bound then e
   else
     let boolSet := e.vars.eraseDups.filter (fun v =>
-      match findDomainAlg (singleVarCs all) v with
+      match findDomainAlg (singles) v with
       | some d => d.length ≤ 2
       | none => false)
     match reduceExpr boolSet e with
     | some e' =>
-      if e'.degree ≤ bound && e'.vars.all (fun v => v ∈ e.vars) && brCert all e e'
+      if e'.degree ≤ bound && e'.vars.all (fun v => v ∈ e.vars) && brCert singles e e'
       then e' else e
     | none => e
 
-theorem brRw_sound [Fact p.Prime] (all : List (Expression p)) (bound : Nat)
+theorem brRw_sound [Fact p.Prime] (singles : List (Expression p)) (bound : Nat)
     (e : Expression p) (env : Variable → ZMod p)
-    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) :
-    (brRw all bound e).eval env = e.eval env := by
+    (hdom : ∀ c ∈ singles, c.eval env = 0) :
+    (brRw singles bound e).eval env = e.eval env := by
   simp only [brRw]
   split_ifs with hd
   · rfl
   · cases hr : reduceExpr (e.vars.eraseDups.filter (fun v =>
-        match findDomainAlg (singleVarCs all) v with
+        match findDomainAlg (singles) v with
         | some d => d.length ≤ 2
         | none => false)) e with
     | none => simp only [hr]
@@ -215,17 +215,17 @@ theorem brRw_sound [Fact p.Prime] (all : List (Expression p)) (bound : Nat)
       simp only [hr]
       split_ifs with hok
       · rw [Bool.and_eq_true, Bool.and_eq_true] at hok
-        exact (brCert_sound all e e' hok.2 env hdom).symm
+        exact (brCert_sound singles e e' hok.2 env hdom).symm
       · rfl
 
-theorem brRw_vars (all : List (Expression p)) (bound : Nat) (e : Expression p) :
-    ∀ v ∈ (brRw all bound e).vars, v ∈ e.vars := by
+theorem brRw_vars (singles : List (Expression p)) (bound : Nat) (e : Expression p) :
+    ∀ v ∈ (brRw singles bound e).vars, v ∈ e.vars := by
   intro v hv
   simp only [brRw] at hv
   split_ifs at hv with hd
   · exact hv
   · cases hr : reduceExpr (e.vars.eraseDups.filter (fun v =>
-        match findDomainAlg (singleVarCs all) v with
+        match findDomainAlg (singles) v with
         | some d => d.length ≤ 2
         | none => false)) e with
     | none => simp only [hr] at hv; exact hv
@@ -238,19 +238,19 @@ theorem brRw_vars (all : List (Expression p)) (bound : Nat) (e : Expression p) :
 
 /-- A single-variable expression is never rewritten (the certificate's ≥ 2-variables guard),
     keeping the domain sources intact. -/
-theorem brRw_singleVar (all : List (Expression p)) (bound : Nat) (c : Expression p)
-    (hs : c.vars.eraseDups.length ≤ 1) : brRw all bound c = c := by
+theorem brRw_singleVar (singles : List (Expression p)) (bound : Nat) (c : Expression p)
+    (hs : c.vars.eraseDups.length ≤ 1) : brRw singles bound c = c := by
   simp only [brRw]
   split_ifs with hd
   · rfl
   · cases hr : reduceExpr (c.vars.eraseDups.filter (fun v =>
-        match findDomainAlg (singleVarCs all) v with
+        match findDomainAlg (singles) v with
         | some d => d.length ≤ 2
         | none => false)) c with
     | none => simp only [hr]
     | some e' =>
       simp only [hr]
-      have hcert : brCert all c e' = false := by
+      have hcert : brCert singles c e' = false := by
         unfold brCert
         have h2 : (2 ≤ c.vars.eraseDups.length : Bool) = false := by
           simp only [decide_eq_false_iff_not]
@@ -259,28 +259,29 @@ theorem brRw_singleVar (all : List (Expression p)) (bound : Nat) (c : Expression
       rw [hcert, Bool.and_false, if_neg (by simp)]
 
 /-- The per-interaction rewrite (bus id untouched). -/
-def brBi (all : List (Expression p)) (db : DegreeBound)
+def brBi (singles : List (Expression p)) (db : DegreeBound)
     (bi : BusInteraction (Expression p)) : BusInteraction (Expression p) :=
   { busId := bi.busId,
-    multiplicity := brRw all db.busInteractions bi.multiplicity,
-    payload := bi.payload.map (brRw all db.busInteractions) }
+    multiplicity := brRw singles db.busInteractions bi.multiplicity,
+    payload := bi.payload.map (brRw singles db.busInteractions) }
 
 /-- Rewrite every over-bound expression of the system to its certified reduction. -/
 def ConstraintSystem.boxRewrite (cs : ConstraintSystem p) (bs : BusSemantics p) :
     ConstraintSystem p :=
+  let singles := singleVarCs cs.algebraicConstraints
   { algebraicConstraints := cs.algebraicConstraints.map
-      (brRw cs.algebraicConstraints bs.degreeBound.identities),
-    busInteractions := cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound) }
+      (brRw singles bs.degreeBound.identities),
+    busInteractions := cs.busInteractions.map (brBi singles bs.degreeBound) }
 
-theorem brBi_eval [Fact p.Prime] (all : List (Expression p)) (db : DegreeBound)
+theorem brBi_eval [Fact p.Prime] (singles : List (Expression p)) (db : DegreeBound)
     (bi : BusInteraction (Expression p)) (env : Variable → ZMod p)
-    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) :
-    (brBi all db bi).eval env = bi.eval env := by
+    (hdom : ∀ c ∈ singles, c.eval env = 0) :
+    (brBi singles db bi).eval env = bi.eval env := by
   unfold brBi BusInteraction.eval
   simp only [BusInteraction.mk.injEq]
-  refine ⟨trivial, brRw_sound all _ _ env hdom, ?_⟩
+  refine ⟨trivial, brRw_sound singles _ _ env hdom, ?_⟩
   rw [List.map_map]
-  exact List.map_congr_left (fun e _ => brRw_sound all _ e env hdom)
+  exact List.map_congr_left (fun e _ => brRw_sound singles _ e env hdom)
 
 theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
     (cs : ConstraintSystem p) (bs : BusSemantics p) :
@@ -327,13 +328,13 @@ theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
       (cs.boxRewrite bs).sideEffects bs env = cs.sideEffects bs env := by
     intro env hdom
     unfold ConstraintSystem.sideEffects
-    show ((cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound)).filter
+    show ((cs.busInteractions.map (brBi (singleVarCs cs.algebraicConstraints) bs.degreeBound)).filter
       (fun bi => bs.isStateful bi.busId)).map _ = _
     induction cs.busInteractions with
     | nil => rfl
     | cons bi rest ih =>
       simp only [List.map_cons, List.filter_cons]
-      have hb : bs.isStateful (brBi cs.algebraicConstraints bs.degreeBound bi).busId
+      have hb : bs.isStateful (brBi (singleVarCs cs.algebraicConstraints) bs.degreeBound bi).busId
           = bs.isStateful bi.busId := rfl
       rw [hb]
       by_cases hst : bs.isStateful bi.busId = true
@@ -349,7 +350,7 @@ theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
     unfold ConstraintSystem.admissible
     have hmap : (cs.boxRewrite bs).busInteractions.map (fun bi => bi.eval env)
         = cs.busInteractions.map (fun bi => bi.eval env) := by
-      show (cs.busInteractions.map (brBi cs.algebraicConstraints bs.degreeBound)).map
+      show (cs.busInteractions.map (brBi (singleVarCs cs.algebraicConstraints) bs.degreeBound)).map
         (fun bi => bi.eval env) = _
       rw [List.map_map]
       exact List.map_congr_left (fun bi _ => brBi_eval _ _ bi env hdom)

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
@@ -1,3 +1,4 @@
+import ApcOptimizer.Implementation.OptimizerPasses.Gauss
 import ApcOptimizer.Implementation.OptimizerPasses.Normalize
 import ApcOptimizer.Implementation.OptimizerPasses.TautoBus
 import ApcOptimizer.Implementation.OptimizerPasses.FactPass
@@ -211,14 +212,19 @@ theorem rootsIn_sound [Fact p.Prime] (x : Variable) (e : Expression p) (roots : 
         · exact List.mem_append.2 (Or.inr (ihb rb hrb hz))
       all_goals exact absurd h (by simp)
 
-/-- The finite domain of `x` derived from the first constraint that bounds it. -/
+/-- The finite domain of `x` derived from the first constraint that bounds it. Constraints not
+    mentioning `x` are skipped without linearizing (`rootsIn` runs `linearize` per constraint —
+    the ungated scan dominated whole passes); a non-mentioning constraint can only produce a
+    root list via the unsatisfiable-constant case, so the gate never loses a live domain. -/
 def findDomainAlg (all : List (Expression p)) (x : Variable) : Option (List (ZMod p)) :=
   match all with
   | [] => none
   | c :: rest =>
-    match rootsIn x c with
-    | some d => some d
-    | none => findDomainAlg rest x
+    if c.mentions x then
+      match rootsIn x c with
+      | some d => some d
+      | none => findDomainAlg rest x
+    else findDomainAlg rest x
 
 theorem findDomainAlg_sound [Fact p.Prime] (all : List (Expression p)) (x : Variable)
     (d : List (ZMod p)) (h : findDomainAlg all x = some d) (env : Variable → ZMod p)
@@ -227,14 +233,16 @@ theorem findDomainAlg_sound [Fact p.Prime] (all : List (Expression p)) (x : Vari
   | nil => exact absurd h (by simp [findDomainAlg])
   | cons c rest ih =>
     rw [findDomainAlg] at h
-    cases hr : rootsIn x c with
-    | some d' =>
-        rw [hr] at h
-        simp only [Option.some.injEq] at h
-        exact h ▸ rootsIn_sound x c d' hr env (hall c (List.mem_cons_self ..))
-    | none =>
-        rw [hr] at h
-        exact ih h (fun c' hc' => hall c' (List.mem_cons_of_mem _ hc'))
+    split_ifs at h with hm
+    · cases hr : rootsIn x c with
+      | some d' =>
+          rw [hr] at h
+          simp only [Option.some.injEq] at h
+          exact h ▸ rootsIn_sound x c d' hr env (hall c (List.mem_cons_self ..))
+      | none =>
+          rw [hr] at h
+          exact ih h (fun c' hc' => hall c' (List.mem_cons_of_mem _ hc'))
+    · exact ih h (fun c' hc' => hall c' (List.mem_cons_of_mem _ hc'))
 
 /-! ## Deriving a finite domain from a bus obligation and a proven fact -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -28,55 +28,90 @@ def singleVarCs (all : List (Expression p)) : List (Expression p) :=
 /-- Certificate: `c` mentions ≥ 2 distinct variables, every one carries a proven finite domain
     (from the single-variable constraints), the joint box is small, and `c` vanishes on all of
     it. -/
-def btCert (all : List (Expression p)) (c : Expression p) : Bool :=
+def btCert (singles : List (Expression p)) (c : Expression p) : Bool :=
   2 ≤ c.vars.eraseDups.length &&
   (let doms := c.vars.eraseDups.filterMap (fun v =>
-     (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
+     (findDomainAlg singles v).map (fun d => (v, d)))
    decide (doms.map Prod.fst = c.vars.eraseDups) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (assignments doms).all (fun pt => decide (c.eval (envOf pt) = 0)))
 
-/-- Replace certified box tautologies by the trivial constraint. -/
-def ConstraintSystem.boxTautoReplace (cs : ConstraintSystem p) : ConstraintSystem p :=
+/-- Cheap mirror of `btCert` over a precomputed (pure, memoized) domain lookup — a prefilter
+    only; accepted candidates re-run the real certificate, so the proofs consume `btCert`
+    alone. -/
+def btPre (domOf : Variable → Option (List (ZMod p))) (c : Expression p) : Bool :=
+  2 ≤ c.vars.eraseDups.length &&
+  (let doms := c.vars.eraseDups.filterMap (fun v => (domOf v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+   (assignments doms).all (fun pt => decide (c.eval (envOf pt) = 0)))
+
+/-- The replacement condition: the memoized prefilter gates the (expensive) certificate.
+    `singles` and `domOf` are computed once per pass invocation and passed in — a def-local
+    `let` would be re-evaluated per constraint by arity expansion. -/
+def btKeep (singles : List (Expression p)) (domOf : Variable → Option (List (ZMod p)))
+    (c : Expression p) : Bool :=
+  btPre domOf c && btCert singles c
+
+theorem btKeep_cert {singles : List (Expression p)}
+    {domOf : Variable → Option (List (ZMod p))} {c : Expression p}
+    (h : btKeep singles domOf c = true) : btCert singles c = true := by
+  unfold btKeep at h
+  rw [Bool.and_eq_true] at h
+  exact h.2
+
+theorem btKeep_of_cert_false {singles : List (Expression p)}
+    {domOf : Variable → Option (List (ZMod p))} {c : Expression p}
+    (h : btCert singles c = false) : btKeep singles domOf c = false := by
+  unfold btKeep
+  rw [h, Bool.and_false]
+
+/-- Replace certified box tautologies by the trivial constraint (parameterized over the
+    precomputed prefilter inputs). -/
+def ConstraintSystem.boxTautoReplaceWith (cs : ConstraintSystem p)
+    (singles : List (Expression p)) (domOf : Variable → Option (List (ZMod p))) :
+    ConstraintSystem p :=
   { cs with algebraicConstraints := cs.algebraicConstraints.map (fun c =>
-      if btCert cs.algebraicConstraints c then Expression.const 0 else c) }
+      if btKeep singles domOf c then Expression.const 0 else c) }
 
 /-- A single-variable constraint is never replaced (it fails the ≥ 2 guard), so it survives
     verbatim into the output — which is what lets the box justification stand on the output's
     own satisfaction. -/
-theorem singleVar_mem_boxTautoReplace (cs : ConstraintSystem p) (c : Expression p)
+theorem singleVar_mem_boxTautoReplace (cs : ConstraintSystem p)
+    (domOf : Variable → Option (List (ZMod p))) (c : Expression p)
     (hc : c ∈ cs.algebraicConstraints) (hs : (c.vars.eraseDups.length == 1) = true) :
-    c ∈ (cs.boxTautoReplace).algebraicConstraints := by
-  have himg : (if btCert cs.algebraicConstraints c then Expression.const 0 else c) = c := by
-    have : btCert cs.algebraicConstraints c = false := by
-      unfold btCert
-      have h1 : ¬ (2 ≤ c.vars.eraseDups.length) := by
-        have := of_decide_eq_true hs
-        omega
-      simp [h1]
-    rw [this]; simp
-  exact List.mem_map.2 ⟨c, hc, himg⟩
+    c ∈ (cs.boxTautoReplaceWith (singleVarCs cs.algebraicConstraints) domOf).algebraicConstraints := by
+  have hcf : btCert (singleVarCs cs.algebraicConstraints) c = false := by
+    unfold btCert
+    have h1 : ¬ (2 ≤ c.vars.eraseDups.length) := by
+      have := of_decide_eq_true hs
+      omega
+    simp [h1]
+  refine List.mem_map.2 ⟨c, hc, ?_⟩
+  rw [btKeep_of_cert_false hcf]
+  simp
 
 theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
-    (cs : ConstraintSystem p) (bs : BusSemantics p) :
-    PassCorrect cs (cs.boxTautoReplace) [] bs := by
+    (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (domOf : Variable → Option (List (ZMod p))) :
+    PassCorrect cs (cs.boxTautoReplaceWith (singleVarCs cs.algebraicConstraints) domOf) [] bs := by
   -- every replaced constraint is zero under any assignment satisfying the output
-  have hzero : ∀ env, (cs.boxTautoReplace).satisfies bs env →
-      ∀ c ∈ cs.algebraicConstraints, btCert cs.algebraicConstraints c = true →
+  have hzero : ∀ env, (cs.boxTautoReplaceWith (singleVarCs cs.algebraicConstraints)
+      domOf).satisfies bs env →
+      ∀ c ∈ cs.algebraicConstraints, btCert (singleVarCs cs.algebraicConstraints) c = true →
       c.eval env = 0 := by
     intro env hsat c _hc hcert
     unfold btCert at hcert
     rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at hcert
     obtain ⟨_h2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := hcert
     have hcover' := of_decide_eq_true hcover
-    -- the environment's restriction to the box is an enumerated point
     have hdom : ∀ c' ∈ singleVarCs cs.algebraicConstraints, c'.eval env = 0 := by
       intro c' hc'
       simp only [singleVarCs] at hc'
       have hmem := List.mem_of_mem_filter hc'
       have hsingle : (c'.vars.eraseDups.length == 1) = true :=
         (List.mem_filter.1 hc').2
-      exact hsat.1 c' (singleVar_mem_boxTautoReplace cs c' hmem hsingle)
+      exact hsat.1 c' (singleVar_mem_boxTautoReplace cs domOf c' hmem hsingle)
     have hmemdoms : ∀ vd ∈ c.vars.eraseDups.filterMap (fun v =>
         (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d))),
         env vd.1 ∈ vd.2 := by
@@ -90,7 +125,8 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
         obtain rfl := hvd'.symm
         exact findDomainAlg_sound (singleVarCs cs.algebraicConstraints) v d hfd env hdom
     have hpt := mem_assignments (c.vars.eraseDups.filterMap (fun v =>
-      (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))) env hmemdoms
+      (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))) env
+      hmemdoms
     have hptz := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
     have hagree : c.eval (envOf ((c.vars.eraseDups.filterMap (fun v =>
         (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))).map
@@ -102,22 +138,23 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
           Prod.fst) = c.vars.eraseDups from hcover']
       exact List.mem_eraseDups.2 hv
     rw [← hagree]; exact hptz
-  have hiff : ∀ env, (cs.boxTautoReplace).satisfies bs env ↔ cs.satisfies bs env := by
+  have hiff : ∀ env, (cs.boxTautoReplaceWith (singleVarCs cs.algebraicConstraints)
+      domOf).satisfies bs env ↔ cs.satisfies bs env := by
     intro env
     constructor
     · intro hsat
       refine ⟨fun c hc => ?_, hsat.2⟩
-      by_cases hcert : btCert cs.algebraicConstraints c = true
-      · exact hzero env hsat c hc hcert
+      by_cases hcond : btKeep (singleVarCs cs.algebraicConstraints) domOf c = true
+      · exact hzero env hsat c hc (btKeep_cert hcond)
       · have h0 := hsat.1 _ (List.mem_map.2 ⟨c, hc, rfl⟩)
-        rw [if_neg hcert] at h0
+        rw [if_neg hcond] at h0
         exact h0
     · intro hsat
       refine ⟨fun c' hc' => ?_, hsat.2⟩
       obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
-      by_cases hcert : btCert cs.algebraicConstraints c = true
-      · rw [if_pos hcert]; rfl
-      · rw [if_neg hcert]; exact hsat.1 c hc
+      by_cases hcond : btKeep (singleVarCs cs.algebraicConstraints) domOf c = true
+      · rw [if_pos hcond]; rfl
+      · rw [if_neg hcond]; exact hsat.1 c hc
   refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
   · intro env hsat
     exact ⟨env, (hiff env).1 hsat, BusState.equiv_refl _⟩
@@ -127,9 +164,9 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
     rw [ConstraintSystem.mem_vars] at hv ⊢
     rcases hv with ⟨c', hc', hvc⟩ | h
     · obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
-      by_cases hcert : btCert cs.algebraicConstraints c = true
-      · rw [if_pos hcert] at hvc; simp [Expression.vars] at hvc
-      · rw [if_neg hcert] at hvc; exact Or.inl ⟨c, hc, hvc⟩
+      by_cases hcond : btKeep (singleVarCs cs.algebraicConstraints) domOf c = true
+      · rw [if_pos hcond] at hvc; simp [Expression.vars] at hvc
+      · rw [if_neg hcond] at hvc; exact Or.inl ⟨c, hc, hvc⟩
     · exact Or.inr h
   · intro env hadm hsat
     exact ⟨(hiff env).2 hsat, hadm, BusState.equiv_refl _⟩
@@ -138,7 +175,12 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
 def boxTautoDropPass : VerifiedPass p := fun cs bs =>
   if hp : (decide p.Prime) = true then
     haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
-    ⟨cs.boxTautoReplace, [], cs.boxTautoReplace_correct bs⟩
+    let singles := singleVarCs cs.algebraicConstraints
+    let cache : Std.HashMap Variable (Option (List (ZMod p))) :=
+      (cs.algebraicConstraints.flatMap Expression.vars).eraseDups.foldl
+        (fun m v => m.insert v (findDomainAlg singles v)) ∅
+    ⟨cs.boxTautoReplaceWith singles (fun v => cache.getD v none), [],
+     cs.boxTautoReplace_correct bs (fun v => cache.getD v none)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-! ## Part C: pointwise-duplicate stateless check removal -/
@@ -207,41 +249,93 @@ theorem ConstraintSystem.filterBusEntailed_correct (cs : ConstraintSystem p)
       by rw [hside]; exact BusState.equiv_refl _⟩
 
 
+/-- Joint-box agreement: every joint variable of `R`/`R'` has a proven finite domain, the box
+    is small, and the two expressions agree at every box point. -/
+def boxAgree (singles : List (Expression p)) (R R' : Expression p) : Bool :=
+  let jv := (R.vars ++ R'.vars).eraseDups
+  let doms := jv.filterMap (fun v =>
+    (findDomainAlg singles v).map (fun d => (v, d)))
+  decide (doms.map Prod.fst = jv) &&
+  decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+  (assignments doms).all (fun pt =>
+    decide (R.eval (envOf pt) = R'.eval (envOf pt)))
+
 /-- Slot-pair certificate: the two expressions are syntactically equal, or they decompose over
     the same carrier with the same constant coefficient and their offset difference vanishes on
-    the joint (proven, small) domain box of the offset variables. -/
-def slotEqCert (all : List (Expression p)) (e e' : Expression p) : Bool :=
+    the joint (proven, small) domain box of the offset variables. The carrier must appear in
+    both expressions — the `mentions` gate is ZMod-free, so the ubiquitous disjoint-variable
+    pair costs plain tree walks, never `splitAt`'s per-node ring arithmetic (a carrier absent
+    from `e'` could only certify through a fully cancelled coefficient in `e`, which the
+    constant folding and normalization ahead of this pass never leave behind). -/
+def slotEqCert (singles : List (Expression p)) (e e' : Expression p) : Bool :=
   e == e' ||
   e.vars.eraseDups.any (fun x =>
+    e'.mentions x &&
     match e.splitAt x, e'.splitAt x with
-    | some (k, R), some (k2, R') =>
-      k2 == k &&
-      (let jv := (R.vars ++ R'.vars).eraseDups
-       let doms := jv.filterMap (fun v =>
-         (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
-       decide (doms.map Prod.fst = jv) &&
-       decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
-       (assignments doms).all (fun pt =>
-         decide (R.eval (envOf pt) = R'.eval (envOf pt))))
+    | some (k, R), some (k2, R') => k2 == k && boxAgree singles R R'
     | _, _ => false)
 
 /-- Full-message certificate: same bus, same constant multiplicity, pointwise-equal payloads. -/
-def msgEqCert (all : List (Expression p)) (bi bi' : BusInteraction (Expression p)) : Bool :=
+def msgEqCert (singles : List (Expression p)) (bi bi' : BusInteraction (Expression p)) : Bool :=
   bi.busId == bi'.busId &&
   (match bi.multiplicity.constValue?, bi'.multiplicity.constValue? with
    | some m, some m' => m == m'
    | _, _ => false) &&
   bi.payload.length == bi'.payload.length &&
-  (bi.payload.zip bi'.payload).all (fun ee => slotEqCert all ee.1 ee.2)
+  (bi.payload.zip bi'.payload).all (fun ee => slotEqCert singles ee.1 ee.2)
 
-theorem slotEqCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expression p)
-    (h : slotEqCert all e e' = true) (env : Variable → ZMod p)
-    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : e.eval env = e'.eval env := by
+theorem boxAgree_sound [Fact p.Prime] (singles : List (Expression p)) (R R' : Expression p)
+    (h : boxAgree singles R R' = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singles, c.eval env = 0) : R.eval env = R'.eval env := by
+  unfold boxAgree at h
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨⟨hcover, _hcap⟩, hall⟩ := h
+  have hmemdoms : ∀ vd ∈ (R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+      (findDomainAlg singles v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+    intro vd hvd
+    obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+    cases hfd : findDomainAlg singles v with
+    | none => rw [hfd] at hvd'; simp at hvd'
+    | some d =>
+      rw [hfd] at hvd'
+      simp only [Option.map_some, Option.some.injEq] at hvd'
+      obtain rfl := hvd'.symm
+      exact findDomainAlg_sound singles v d hfd env hdom
+  have hpt := mem_assignments ((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+    (findDomainAlg singles v).map (fun d => (v, d)))) env hmemdoms
+  have hagree : ∀ v, v ∈ (R.vars ++ R'.vars).eraseDups →
+      envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+        (findDomainAlg singles v).map (fun d => (v, d)))).map
+          (fun vd => (vd.1, env vd.1))) v = env v := by
+    intro v hv
+    refine envOf_map _ env v ?_
+    rw [show (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+      (findDomainAlg singles v).map (fun d => (v, d)))).map Prod.fst)
+      = (R.vars ++ R'.vars).eraseDups from hcover]
+    exact hv
+  have hRR := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
+  have hRa : R.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+      (findDomainAlg singles v).map (fun d => (v, d)))).map
+        (fun vd => (vd.1, env vd.1)))) = R.eval env :=
+    Expression.eval_congr R _ env (fun v hv =>
+      hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
+  have hRa' : R'.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+      (findDomainAlg singles v).map (fun d => (v, d)))).map
+        (fun vd => (vd.1, env vd.1)))) = R'.eval env :=
+    Expression.eval_congr R' _ env (fun v hv =>
+      hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+  rw [← hRa, ← hRa', hRR]
+
+theorem slotEqCert_sound [Fact p.Prime] (singles : List (Expression p)) (e e' : Expression p)
+    (h : slotEqCert singles e e' = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singles, c.eval env = 0) : e.eval env = e'.eval env := by
   unfold slotEqCert at h
   rw [Bool.or_eq_true] at h
   rcases h with heq | hany
   · rw [eq_of_beq heq]
   · obtain ⟨x, _hx, hx⟩ := List.any_eq_true.1 hany
+    rw [Bool.and_eq_true] at hx
+    obtain ⟨_hm, hx⟩ := hx
     cases hsX : e.splitAt x with
     | none => rw [hsX] at hx; simp at hx
     | some kR =>
@@ -250,50 +344,16 @@ theorem slotEqCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expr
       | none => rw [hsX, hsY] at hx; simp at hx
       | some kR' =>
         obtain ⟨k2, R'⟩ := kR'
-        simp only [hsX, hsY, Bool.and_eq_true, decide_eq_true_eq] at hx
-        obtain ⟨hk2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := hx
-        have hmemdoms : ∀ vd ∈ (R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
-          intro vd hvd
-          obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-          cases hfd : findDomainAlg (singleVarCs all) v with
-          | none => rw [hfd] at hvd'; simp at hvd'
-          | some d =>
-            rw [hfd] at hvd'
-            simp only [Option.map_some, Option.some.injEq] at hvd'
-            obtain rfl := hvd'.symm
-            exact findDomainAlg_sound (singleVarCs all) v d hfd env hdom
-        have hpt := mem_assignments ((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-          (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))) env hmemdoms
-        have hagree : ∀ v, v ∈ (R.vars ++ R'.vars).eraseDups →
-            envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-              (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
-                (fun vd => (vd.1, env vd.1))) v = env v := by
-          intro v hv
-          refine envOf_map _ env v ?_
-          rw [show (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map Prod.fst)
-            = (R.vars ++ R'.vars).eraseDups from hcover]
-          exact hv
-        have hRR := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
-        have hRa : R.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
-              (fun vd => (vd.1, env vd.1)))) = R.eval env :=
-          Expression.eval_congr R _ env (fun v hv =>
-            hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
-        have hRa' : R'.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
-              (fun vd => (vd.1, env vd.1)))) = R'.eval env :=
-          Expression.eval_congr R' _ env (fun v hv =>
-            hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+        simp only [hsX, hsY, Bool.and_eq_true] at hx
+        obtain ⟨hk2, hba⟩ := hx
         rw [Expression.splitAt_eval x e k R hsX env,
             Expression.splitAt_eval x e' k2 R' hsY env, eq_of_beq hk2,
-            ← hRa, ← hRa', hRR]
+            boxAgree_sound singles R R' hba env hdom]
 
-theorem msgEqCert_sound [Fact p.Prime] (all : List (Expression p))
-    (bi bi' : BusInteraction (Expression p)) (h : msgEqCert all bi bi' = true)
+theorem msgEqCert_sound [Fact p.Prime] (singles : List (Expression p))
+    (bi bi' : BusInteraction (Expression p)) (h : msgEqCert singles bi bi' = true)
     (env : Variable → ZMod p)
-    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : bi.eval env = bi'.eval env := by
+    (hdom : ∀ c ∈ singles, c.eval env = 0) : bi.eval env = bi'.eval env := by
   unfold msgEqCert at h
   rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h
   obtain ⟨⟨⟨hbus, hmult⟩, hlen⟩, hslots⟩ := h
@@ -322,33 +382,33 @@ theorem msgEqCert_sound [Fact p.Prime] (all : List (Expression p))
       exact List.getElem_mem _
     have hcert := List.all_eq_true.mp hslots _ hz
     simp only [List.getElem_map]
-    exact slotEqCert_sound all _ _ hcert env hdom
+    exact slotEqCert_sound singles _ _ hcert env hdom
   show bi.eval env = bi'.eval env
   unfold BusInteraction.eval
   rw [eq_of_beq hbus, hmm, hpay]
 
 /-- Is `bi` the first of its pointwise class (no earlier certified twin)? -/
-def pdFirst (bs : BusSemantics p) (all : List (Expression p))
+def pdFirst (bs : BusSemantics p) (singles : List (Expression p))
     (bis : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
   match bis.findIdx? (fun b => b == bi) with
   | none => true
-  | some i => (bis.take i).all (fun b => bs.isStateful b.busId || !(msgEqCert all b bi))
+  | some i => (bis.take i).all (fun b => bs.isStateful b.busId || !(msgEqCert singles b bi))
 
 /-- Keep unless a *first-of-class* earlier stateless twin exists (depth-1 rule: the twin that
     justifies a drop is itself provably kept, so no chain induction is needed). -/
-def pdKeep (bs : BusSemantics p) (all : List (Expression p))
+def pdKeep (bs : BusSemantics p) (singles : List (Expression p))
     (bis : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
   bs.isStateful bi.busId ||
   (match bis.findIdx? (fun b => b == bi) with
    | none => true
    | some i =>
-     !((bis.take i).any (fun b => !bs.isStateful b.busId && msgEqCert all b bi
-         && pdFirst bs all bis b)))
+     !((bis.take i).any (fun b => !bs.isStateful b.busId && msgEqCert singles b bi
+         && pdFirst bs singles bis b)))
 
 /-- A first-of-class interaction is always kept — the depth-1 justification for `pdKeep`. -/
-theorem pdFirst_keep (bs : BusSemantics p) (all : List (Expression p))
+theorem pdFirst_keep (bs : BusSemantics p) (singles : List (Expression p))
     (bis : List (BusInteraction (Expression p))) (b : BusInteraction (Expression p))
-    (h : pdFirst bs all bis b = true) : pdKeep bs all bis b = true := by
+    (h : pdFirst bs singles bis b = true) : pdKeep bs singles bis b = true := by
   unfold pdKeep
   rw [Bool.or_eq_true]
   right
@@ -361,9 +421,9 @@ theorem pdFirst_keep (bs : BusSemantics p) (all : List (Expression p))
     rw [Bool.not_eq_true']
     by_contra hany
     have hany' : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
-        && msgEqCert all b' b && pdFirst bs all bis b')) = true := by
+        && msgEqCert singles b' b && pdFirst bs singles bis b')) = true := by
       by_cases hh : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
-          && msgEqCert all b' b && pdFirst bs all bis b')) = true
+          && msgEqCert singles b' b && pdFirst bs singles bis b')) = true
       · exact hh
       · exact absurd (by simpa using hh) hany
     obtain ⟨b'', hb''mem, hb''⟩ := List.any_eq_true.1 hany'
@@ -381,11 +441,13 @@ theorem pdFirst_keep (bs : BusSemantics p) (all : List (Expression p))
 
 /-- Part C as a standalone (unguarded) pass: drop stateless interactions pointwise-equal to an
     earlier first-of-class one. -/
-def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
-    ⟨cs.filterBus (pdKeep bs cs.algebraicConstraints cs.busInteractions), [],
-     cs.filterBusEntailed_correct bs _
+theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
+    (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    PassCorrect cs
+      (cs.filterBus
+        (pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions))
+      [] bs :=
+  cs.filterBusEntailed_correct bs _
        (by
          intro bi _ hkf
          unfold pdKeep at hkf
@@ -405,19 +467,27 @@ def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
            rw [Bool.and_eq_true, Bool.and_eq_true] at hb
            obtain ⟨⟨hnst, hcert⟩, hfirst⟩ := hb
            have hbcs : b ∈ cs.busInteractions := List.mem_of_mem_take hbmem
-           have hbkeep : pdKeep bs cs.algebraicConstraints cs.busInteractions b = true :=
-             pdFirst_keep bs cs.algebraicConstraints cs.busInteractions b hfirst
+           have hbkeep : pdKeep bs (singleVarCs cs.algebraicConstraints)
+               cs.busInteractions b = true :=
+             pdFirst_keep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions b hfirst
            have hbout : b ∈ (cs.filterBus
-               (pdKeep bs cs.algebraicConstraints cs.busInteractions)).busInteractions :=
+               (pdKeep bs (singleVarCs cs.algebraicConstraints)
+                 cs.busInteractions)).busInteractions :=
              List.mem_filter.2 ⟨hbcs, hbkeep⟩
            have hdom : ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 := by
              intro c hc
              exact hsat.1 c (List.mem_of_mem_filter hc)
            have heq : b.eval env = bi.eval env :=
-             msgEqCert_sound cs.algebraicConstraints b bi hcert env hdom
+             msgEqCert_sound (singleVarCs cs.algebraicConstraints) b bi hcert env hdom
            have hob := hsat.2 b hbout
            rw [heq] at hob
-           exact hob hm)⟩
+           exact hob hm)
+
+def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    ⟨cs.filterBus (pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions), [],
+     cs.pointwiseDupDrop_correct bs⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-! ## Part A: the entailed nonlinear substitution -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -1,0 +1,795 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
+
+set_option autoImplicit false
+
+/-! # Folding the XOR flag component (composite pass, part B: box tautologies)
+
+Log entry 63: the last flag component of each unified scaled-check pair relates to the
+survivors by XOR — degree 2 as a field polynomial — so substituting it away pushes the
+substituted booleanity to degree 4 and the substituted check payload to degree 3. The
+composite `flagFoldPass` therefore chains three unguarded sub-passes under a single degree
+guard: (A) the entailed nonlinear substitution, (B) **this file's section**: replace multi-
+variable constraints that vanish on their variables' proven finite domain box by `0` (the
+substituted booleanity `E(E−1)` vanishes on the boolean box), and (C) drop stateless checks
+whose message is pointwise equal to a retained one on the box.
+
+Non-circularity for (B): only constraints with **at least two distinct variables** are ever
+replaced, and the domain box is justified exclusively from **single-variable** constraints
+(`findDomainAlg` sources) — which are therefore never replaced themselves. -/
+
+variable {p : ℕ}
+
+/-! ## Part B: box-tautology replacement -/
+
+/-- The single-variable constraints of a list (the only `findDomainAlg` sources). -/
+def singleVarCs (all : List (Expression p)) : List (Expression p) :=
+  all.filter (fun c => c.vars.eraseDups.length == 1)
+
+/-- Certificate: `c` mentions ≥ 2 distinct variables, every one carries a proven finite domain
+    (from the single-variable constraints), the joint box is small, and `c` vanishes on all of
+    it. -/
+def btCert (all : List (Expression p)) (c : Expression p) : Bool :=
+  2 ≤ c.vars.eraseDups.length &&
+  (let doms := c.vars.eraseDups.filterMap (fun v =>
+     (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+   (assignments doms).all (fun pt => decide (c.eval (envOf pt) = 0)))
+
+/-- Replace certified box tautologies by the trivial constraint. -/
+def ConstraintSystem.boxTautoReplace (cs : ConstraintSystem p) : ConstraintSystem p :=
+  { cs with algebraicConstraints := cs.algebraicConstraints.map (fun c =>
+      if btCert cs.algebraicConstraints c then Expression.const 0 else c) }
+
+/-- A single-variable constraint is never replaced (it fails the ≥ 2 guard), so it survives
+    verbatim into the output — which is what lets the box justification stand on the output's
+    own satisfaction. -/
+theorem singleVar_mem_boxTautoReplace (cs : ConstraintSystem p) (c : Expression p)
+    (hc : c ∈ cs.algebraicConstraints) (hs : (c.vars.eraseDups.length == 1) = true) :
+    c ∈ (cs.boxTautoReplace).algebraicConstraints := by
+  have himg : (if btCert cs.algebraicConstraints c then Expression.const 0 else c) = c := by
+    have : btCert cs.algebraicConstraints c = false := by
+      unfold btCert
+      have h1 : ¬ (2 ≤ c.vars.eraseDups.length) := by
+        have := of_decide_eq_true hs
+        omega
+      simp [h1]
+    rw [this]; simp
+  exact List.mem_map.2 ⟨c, hc, himg⟩
+
+theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
+    (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    PassCorrect cs (cs.boxTautoReplace) [] bs := by
+  -- every replaced constraint is zero under any assignment satisfying the output
+  have hzero : ∀ env, (cs.boxTautoReplace).satisfies bs env →
+      ∀ c ∈ cs.algebraicConstraints, btCert cs.algebraicConstraints c = true →
+      c.eval env = 0 := by
+    intro env hsat c _hc hcert
+    unfold btCert at hcert
+    rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at hcert
+    obtain ⟨_h2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := hcert
+    have hcover' := of_decide_eq_true hcover
+    -- the environment's restriction to the box is an enumerated point
+    have hdom : ∀ c' ∈ singleVarCs cs.algebraicConstraints, c'.eval env = 0 := by
+      intro c' hc'
+      simp only [singleVarCs] at hc'
+      have hmem := List.mem_of_mem_filter hc'
+      have hsingle : (c'.vars.eraseDups.length == 1) = true :=
+        (List.mem_filter.1 hc').2
+      exact hsat.1 c' (singleVar_mem_boxTautoReplace cs c' hmem hsingle)
+    have hmemdoms : ∀ vd ∈ c.vars.eraseDups.filterMap (fun v =>
+        (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d))),
+        env vd.1 ∈ vd.2 := by
+      intro vd hvd
+      obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+      cases hfd : findDomainAlg (singleVarCs cs.algebraicConstraints) v with
+      | none => rw [hfd] at hvd'; simp at hvd'
+      | some d =>
+        rw [hfd] at hvd'
+        simp only [Option.map_some, Option.some.injEq] at hvd'
+        obtain rfl := hvd'.symm
+        exact findDomainAlg_sound (singleVarCs cs.algebraicConstraints) v d hfd env hdom
+    have hpt := mem_assignments (c.vars.eraseDups.filterMap (fun v =>
+      (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))) env hmemdoms
+    have hptz := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
+    have hagree : c.eval (envOf ((c.vars.eraseDups.filterMap (fun v =>
+        (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))).map
+          (fun vd => (vd.1, env vd.1)))) = c.eval env := by
+      refine Expression.eval_congr c _ env (fun v hv => ?_)
+      refine envOf_map _ env v ?_
+      rw [show ((c.vars.eraseDups.filterMap (fun v =>
+        (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d)))).map
+          Prod.fst) = c.vars.eraseDups from hcover']
+      exact List.mem_eraseDups.2 hv
+    rw [← hagree]; exact hptz
+  have hiff : ∀ env, (cs.boxTautoReplace).satisfies bs env ↔ cs.satisfies bs env := by
+    intro env
+    constructor
+    · intro hsat
+      refine ⟨fun c hc => ?_, hsat.2⟩
+      by_cases hcert : btCert cs.algebraicConstraints c = true
+      · exact hzero env hsat c hc hcert
+      · have h0 := hsat.1 _ (List.mem_map.2 ⟨c, hc, rfl⟩)
+        rw [if_neg hcert] at h0
+        exact h0
+    · intro hsat
+      refine ⟨fun c' hc' => ?_, hsat.2⟩
+      obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
+      by_cases hcert : btCert cs.algebraicConstraints c = true
+      · rw [if_pos hcert]; rfl
+      · rw [if_neg hcert]; exact hsat.1 c hc
+  refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+  · intro env hsat
+    exact ⟨env, (hiff env).1 hsat, BusState.equiv_refl _⟩
+  · intro hinv env hsat bi hbi
+    exact hinv env ((hiff env).1 hsat) bi hbi
+  · intro v hv
+    rw [ConstraintSystem.mem_vars] at hv ⊢
+    rcases hv with ⟨c', hc', hvc⟩ | h
+    · obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
+      by_cases hcert : btCert cs.algebraicConstraints c = true
+      · rw [if_pos hcert] at hvc; simp [Expression.vars] at hvc
+      · rw [if_neg hcert] at hvc; exact Or.inl ⟨c, hc, hvc⟩
+    · exact Or.inr h
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat, hadm, BusState.equiv_refl _⟩
+
+/-- Part B as a standalone (unguarded) verified pass; prime `p` re-checked at runtime. -/
+def boxTautoDropPass : VerifiedPass p := fun cs bs =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    ⟨cs.boxTautoReplace, [], cs.boxTautoReplace_correct bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-! ## Part C: pointwise-duplicate stateless check removal -/
+
+/-- Dropping bus interactions that are (a) stateless and (b) accepted under every assignment
+    *satisfying the filtered system* is equivalence- and invariant-preserving. Generalizes
+    `ConstraintSystem.filterBusStateless_correct` (whose `hok` is unconditional); the
+    satisfaction halves are re-proved with the hypothesis threaded through. -/
+theorem ConstraintSystem.filterBusEntailed_correct (cs : ConstraintSystem p)
+    (bs : BusSemantics p) (keep : BusInteraction (Expression p) → Bool)
+    (hstateless : ∀ bi ∈ cs.busInteractions, keep bi = false →
+      bs.isStateful bi.busId = false)
+    (hok : ∀ bi ∈ cs.busInteractions, keep bi = false → ∀ env,
+      (cs.filterBus keep).satisfies bs env →
+      (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false) :
+    PassCorrect cs (cs.filterBus keep) [] bs := by
+  have hiff : ∀ env, (cs.filterBus keep).satisfies bs env ↔ cs.satisfies bs env := by
+    intro env
+    simp only [ConstraintSystem.satisfies]
+    constructor
+    · intro hsat
+      obtain ⟨hc, hb⟩ := hsat
+      refine ⟨hc, fun bi hbimem => ?_⟩
+      by_cases hk : keep bi = true
+      · exact hb bi (List.mem_filter.2 ⟨hbimem, hk⟩)
+      · intro hm; exact hok bi hbimem (by simpa using hk) env ⟨hc, hb⟩ hm
+    · rintro ⟨hc, hb⟩
+      exact ⟨hc, fun bi hbimem => hb bi (List.mem_filter.1 hbimem).1⟩
+  have hfilter : ∀ (bis : List (BusInteraction (Expression p))),
+      (∀ bi ∈ bis, keep bi = false → bs.isStateful bi.busId = false) →
+      (bis.filter keep).filter (fun bi => bs.isStateful bi.busId)
+        = bis.filter (fun bi => bs.isStateful bi.busId) := by
+    intro bis
+    induction bis with
+    | nil => intro _; rfl
+    | cons bi rest ih =>
+      intro hall
+      have hrest := ih (fun b hb hkf => hall b (List.mem_cons_of_mem _ hb) hkf)
+      by_cases hk : keep bi = true
+      · rw [List.filter_cons_of_pos hk]
+        by_cases hst : bs.isStateful bi.busId = true
+        · rw [List.filter_cons_of_pos (by simpa using hst),
+              List.filter_cons_of_pos (by simpa using hst), hrest]
+        · rw [List.filter_cons_of_neg (by simpa using hst),
+              List.filter_cons_of_neg (by simpa using hst), hrest]
+      · have hst : bs.isStateful bi.busId = false :=
+          hall bi (List.mem_cons_self ..) (by simpa using hk)
+        rw [List.filter_cons_of_neg hk,
+            List.filter_cons_of_neg (by simp [hst]), hrest]
+  have hside : ∀ env, (cs.filterBus keep).sideEffects bs env = cs.sideEffects bs env := by
+    intro env
+    simp only [ConstraintSystem.sideEffects, ConstraintSystem.filterBus]
+    rw [hfilter cs.busInteractions hstateless]
+  refine PassCorrect.ofEnvEq ?_ ?_ (cs.filterBus_vars_subset keep) ?_
+  · intro env hsat
+    exact ⟨env, (hiff env).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
+  · intro hinv env hsat bi hbi
+    have hbimem : bi ∈ cs.busInteractions :=
+      (List.mem_filter.1 (by simpa only [ConstraintSystem.filterBus] using hbi)).1
+    exact hinv env ((hiff env).1 hsat) bi hbimem
+  · intro env hadm hsat
+    exact ⟨(hiff env).2 hsat,
+      (cs.admissible_filterBus bs keep env
+        (fun bi hbi hkf => Or.inr (hstateless bi hbi hkf))).2 hadm,
+      by rw [hside]; exact BusState.equiv_refl _⟩
+
+
+/-- Slot-pair certificate: the two expressions are syntactically equal, or they decompose over
+    the same carrier with the same constant coefficient and their offset difference vanishes on
+    the joint (proven, small) domain box of the offset variables. -/
+def slotEqCert (all : List (Expression p)) (e e' : Expression p) : Bool :=
+  e == e' ||
+  e.vars.eraseDups.any (fun x =>
+    match e.splitAt x, e'.splitAt x with
+    | some (k, R), some (k2, R') =>
+      k2 == k &&
+      (let jv := (R.vars ++ R'.vars).eraseDups
+       let doms := jv.filterMap (fun v =>
+         (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))
+       decide (doms.map Prod.fst = jv) &&
+       decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+       (assignments doms).all (fun pt =>
+         decide (R.eval (envOf pt) = R'.eval (envOf pt))))
+    | _, _ => false)
+
+/-- Full-message certificate: same bus, same constant multiplicity, pointwise-equal payloads. -/
+def msgEqCert (all : List (Expression p)) (bi bi' : BusInteraction (Expression p)) : Bool :=
+  bi.busId == bi'.busId &&
+  (match bi.multiplicity.constValue?, bi'.multiplicity.constValue? with
+   | some m, some m' => m == m'
+   | _, _ => false) &&
+  bi.payload.length == bi'.payload.length &&
+  (bi.payload.zip bi'.payload).all (fun ee => slotEqCert all ee.1 ee.2)
+
+theorem slotEqCert_sound [Fact p.Prime] (all : List (Expression p)) (e e' : Expression p)
+    (h : slotEqCert all e e' = true) (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : e.eval env = e'.eval env := by
+  unfold slotEqCert at h
+  rw [Bool.or_eq_true] at h
+  rcases h with heq | hany
+  · rw [eq_of_beq heq]
+  · obtain ⟨x, _hx, hx⟩ := List.any_eq_true.1 hany
+    cases hsX : e.splitAt x with
+    | none => rw [hsX] at hx; simp at hx
+    | some kR =>
+      obtain ⟨k, R⟩ := kR
+      cases hsY : e'.splitAt x with
+      | none => rw [hsX, hsY] at hx; simp at hx
+      | some kR' =>
+        obtain ⟨k2, R'⟩ := kR'
+        simp only [hsX, hsY, Bool.and_eq_true, decide_eq_true_eq] at hx
+        obtain ⟨hk2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := hx
+        have hmemdoms : ∀ vd ∈ (R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+          intro vd hvd
+          obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+          cases hfd : findDomainAlg (singleVarCs all) v with
+          | none => rw [hfd] at hvd'; simp at hvd'
+          | some d =>
+            rw [hfd] at hvd'
+            simp only [Option.map_some, Option.some.injEq] at hvd'
+            obtain rfl := hvd'.symm
+            exact findDomainAlg_sound (singleVarCs all) v d hfd env hdom
+        have hpt := mem_assignments ((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+          (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))) env hmemdoms
+        have hagree : ∀ v, v ∈ (R.vars ++ R'.vars).eraseDups →
+            envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+              (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
+                (fun vd => (vd.1, env vd.1))) v = env v := by
+          intro v hv
+          refine envOf_map _ env v ?_
+          rw [show (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map Prod.fst)
+            = (R.vars ++ R'.vars).eraseDups from hcover]
+          exact hv
+        have hRR := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
+        have hRa : R.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
+              (fun vd => (vd.1, env vd.1)))) = R.eval env :=
+          Expression.eval_congr R _ env (fun v hv =>
+            hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
+        have hRa' : R'.eval (envOf (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
+            (findDomainAlg (singleVarCs all) v).map (fun d => (v, d)))).map
+              (fun vd => (vd.1, env vd.1)))) = R'.eval env :=
+          Expression.eval_congr R' _ env (fun v hv =>
+            hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+        rw [Expression.splitAt_eval x e k R hsX env,
+            Expression.splitAt_eval x e' k2 R' hsY env, eq_of_beq hk2,
+            ← hRa, ← hRa', hRR]
+
+theorem msgEqCert_sound [Fact p.Prime] (all : List (Expression p))
+    (bi bi' : BusInteraction (Expression p)) (h : msgEqCert all bi bi' = true)
+    (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ singleVarCs all, c.eval env = 0) : bi.eval env = bi'.eval env := by
+  unfold msgEqCert at h
+  rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h
+  obtain ⟨⟨⟨hbus, hmult⟩, hlen⟩, hslots⟩ := h
+  have hmm : bi.multiplicity.eval env = bi'.multiplicity.eval env := by
+    cases hm : bi.multiplicity.constValue? with
+    | none => rw [hm] at hmult; simp at hmult
+    | some m =>
+      cases hm' : bi'.multiplicity.constValue? with
+      | none => rw [hm, hm'] at hmult; simp at hmult
+      | some m' =>
+        rw [hm, hm'] at hmult
+        rw [bi.multiplicity.constValue?_sound m hm env,
+            bi'.multiplicity.constValue?_sound m' hm' env, eq_of_beq hmult]
+  have hpay : bi.payload.map (fun e => e.eval env)
+      = bi'.payload.map (fun e => e.eval env) := by
+    have hlen' : bi.payload.length = bi'.payload.length := by
+      simpa using hlen
+    refine List.ext_getElem (by simpa) (fun i h1 h2 => ?_)
+    have hi1 : i < bi.payload.length := by simpa using h1
+    have hi2 : i < bi'.payload.length := by simpa using h2
+    have hz : (bi.payload[i]'hi1, bi'.payload[i]'hi2) ∈ bi.payload.zip bi'.payload := by
+      have hzi : (bi.payload.zip bi'.payload)[i]'(by rw [List.length_zip]; omega)
+          = (bi.payload[i]'hi1, bi'.payload[i]'hi2) := by
+        simp [List.getElem_zip]
+      rw [← hzi]
+      exact List.getElem_mem _
+    have hcert := List.all_eq_true.mp hslots _ hz
+    simp only [List.getElem_map]
+    exact slotEqCert_sound all _ _ hcert env hdom
+  show bi.eval env = bi'.eval env
+  unfold BusInteraction.eval
+  rw [eq_of_beq hbus, hmm, hpay]
+
+/-- Is `bi` the first of its pointwise class (no earlier certified twin)? -/
+def pdFirst (bs : BusSemantics p) (all : List (Expression p))
+    (bis : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
+  match bis.findIdx? (fun b => b == bi) with
+  | none => true
+  | some i => (bis.take i).all (fun b => bs.isStateful b.busId || !(msgEqCert all b bi))
+
+/-- Keep unless a *first-of-class* earlier stateless twin exists (depth-1 rule: the twin that
+    justifies a drop is itself provably kept, so no chain induction is needed). -/
+def pdKeep (bs : BusSemantics p) (all : List (Expression p))
+    (bis : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
+  bs.isStateful bi.busId ||
+  (match bis.findIdx? (fun b => b == bi) with
+   | none => true
+   | some i =>
+     !((bis.take i).any (fun b => !bs.isStateful b.busId && msgEqCert all b bi
+         && pdFirst bs all bis b)))
+
+/-- A first-of-class interaction is always kept — the depth-1 justification for `pdKeep`. -/
+theorem pdFirst_keep (bs : BusSemantics p) (all : List (Expression p))
+    (bis : List (BusInteraction (Expression p))) (b : BusInteraction (Expression p))
+    (h : pdFirst bs all bis b = true) : pdKeep bs all bis b = true := by
+  unfold pdKeep
+  rw [Bool.or_eq_true]
+  right
+  unfold pdFirst at h
+  cases hidx : bis.findIdx? (fun x => x == b) with
+  | none => simp
+  | some i =>
+    rw [hidx] at h
+    simp only
+    rw [Bool.not_eq_true']
+    by_contra hany
+    have hany' : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
+        && msgEqCert all b' b && pdFirst bs all bis b')) = true := by
+      by_cases hh : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
+          && msgEqCert all b' b && pdFirst bs all bis b')) = true
+      · exact hh
+      · exact absurd (by simpa using hh) hany
+    obtain ⟨b'', hb''mem, hb''⟩ := List.any_eq_true.1 hany'
+    rw [Bool.and_eq_true, Bool.and_eq_true] at hb''
+    obtain ⟨⟨hnst, hcert⟩, _⟩ := hb''
+    have hall := List.all_eq_true.mp h b'' hb''mem
+    rw [Bool.or_eq_true] at hall
+    rcases hall with hst | hnc
+    · rw [Bool.not_eq_true'] at hnst
+      rw [hnst] at hst
+      exact absurd hst (by simp)
+    · rw [Bool.not_eq_true'] at hnc
+      rw [hcert] at hnc
+      exact absurd hnc (by simp)
+
+/-- Part C as a standalone (unguarded) pass: drop stateless interactions pointwise-equal to an
+    earlier first-of-class one. -/
+def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    ⟨cs.filterBus (pdKeep bs cs.algebraicConstraints cs.busInteractions), [],
+     cs.filterBusEntailed_correct bs _
+       (by
+         intro bi _ hkf
+         unfold pdKeep at hkf
+         rw [Bool.or_eq_false_iff] at hkf
+         simpa using hkf.1)
+       (by
+         intro bi hbimem hkf env hsat hm
+         unfold pdKeep at hkf
+         rw [Bool.or_eq_false_iff] at hkf
+         obtain ⟨_hst, hmatch⟩ := hkf
+         cases hidx : cs.busInteractions.findIdx? (fun x => x == bi) with
+         | none => rw [hidx] at hmatch; simp at hmatch
+         | some i =>
+           rw [hidx] at hmatch
+           simp only [Bool.not_eq_false'] at hmatch
+           obtain ⟨b, hbmem, hb⟩ := List.any_eq_true.1 hmatch
+           rw [Bool.and_eq_true, Bool.and_eq_true] at hb
+           obtain ⟨⟨hnst, hcert⟩, hfirst⟩ := hb
+           have hbcs : b ∈ cs.busInteractions := List.mem_of_mem_take hbmem
+           have hbkeep : pdKeep bs cs.algebraicConstraints cs.busInteractions b = true :=
+             pdFirst_keep bs cs.algebraicConstraints cs.busInteractions b hfirst
+           have hbout : b ∈ (cs.filterBus
+               (pdKeep bs cs.algebraicConstraints cs.busInteractions)).busInteractions :=
+             List.mem_filter.2 ⟨hbcs, hbkeep⟩
+           have hdom : ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 := by
+             intro c hc
+             exact hsat.1 c (List.mem_of_mem_filter hc)
+           have heq : b.eval env = bi.eval env :=
+             msgEqCert_sound cs.algebraicConstraints b bi hcert env hdom
+           have hob := hsat.2 b hbout
+           rw [heq] at hob
+           exact hob hm)⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-! ## Part A: the entailed nonlinear substitution -/
+
+/-- Boolean indicator product `∏ (v or 1−v)` selecting one point of the box. Heuristic data —
+    the certificate validates its values pointwise, so the construction carries no proof. -/
+def indicatorProd (others : List Variable) (pt : List (Variable × ZMod p)) : Expression p :=
+  others.foldl (fun acc v =>
+    if envOf pt v = 1 then Expression.mul acc (Expression.var v)
+    else Expression.mul acc (Expression.add (Expression.const 1)
+      (Expression.mul (Expression.const (-1)) (Expression.var v)))) (Expression.const 1)
+
+/-- Interpolate the target's value over the survivor-side flags from the compatible points. -/
+def buildE (d : FuData p) (vy : Variable) : Expression p :=
+  let others := d.rxVars.eraseDups.filter (fun v => v != vy)
+  d.pts.foldl (fun acc ptb =>
+    if ptb.2 && (envOf ptb.1 vy == 1) then
+      Expression.add acc (indicatorProd others ptb.1)
+    else acc) (Expression.const 0)
+
+/-- Per-target certificate: `vy` is a Y-side flag, the candidate solution `E` mentions neither
+    `vy` nor anything outside the survivor's payload, and at every offset-compatible point the
+    target equals `E`. -/
+def fxCheckWith (d : FuData p) (E : Expression p) (vy : Variable) : Bool :=
+  decide (vy ∈ d.ryVars) && !(E.mentions vy) &&
+  decide (E.vars.all (fun v => v ∈ d.rxVars ∨ v ∈ d.ryVars)) &&
+  decide (E.vars.all (fun v => v ∈ d.payXVars)) &&
+  d.pts.all (fun ptb => !ptb.2 || decide (envOf ptb.1 vy = E.eval (envOf ptb.1)))
+
+/-- The full certificate, defined through the shared pair data (as `fuCheck`). -/
+def fxCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Expression p))
+    (biX biY : BusInteraction (Expression p)) (x : Variable) (E : Expression p)
+    (vy : Variable) : Bool :=
+  match fuPairData? bs facts domCs biX biY x with
+  | some d => fxCheckWith d E vy
+  | none => false
+
+theorem fxCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (biX biY : BusInteraction (Expression p))
+    (x : Variable) (E : Expression p) (vy : Variable)
+    (h : fxCheck bs facts domCs biX biY x E vy = true) :
+    ∀ v ∈ E.vars, v ∈ biX.payload.flatMap Expression.vars := by
+  intro v hv
+  unfold fxCheck at h
+  cases hd : fuPairData? bs facts domCs biX biY x with
+  | none => rw [hd] at h; simp at h
+  | some d =>
+    rw [hd] at h
+    have hpay : d.payXVars = biX.payload.flatMap Expression.vars := by
+      unfold fuPairData? at hd
+      cases hmx : biX.multiplicity.constValue? with
+      | none => rw [hmx] at hd; simp at hd
+      | some mx =>
+        cases hmy : biY.multiplicity.constValue? with
+        | none => rw [hmx, hmy] at hd; simp at hd
+        | some my =>
+          simp only [hmx, hmy] at hd
+          split_ifs at hd
+          cases hOX : biX.payload[0]? with
+          | none => simp [hOX] at hd
+          | some OX =>
+            cases hOY : biY.payload[0]? with
+            | none => simp [hOX, hOY] at hd
+            | some OY =>
+              simp only [hOX, hOY] at hd
+              cases hbX : facts.slotBound biX.busId mx
+                  (biX.payload.map Expression.constValue?) 0 with
+              | none => simp [hbX] at hd
+              | some bX =>
+                cases hbY : facts.slotBound biY.busId my
+                    (biY.payload.map Expression.constValue?) 0 with
+                | none => simp [hbX, hbY] at hd
+                | some bY =>
+                  simp only [hbX, hbY] at hd
+                  cases hsX : OX.splitAt x with
+                  | none => simp [hsX] at hd
+                  | some kRX =>
+                    obtain ⟨k, RX⟩ := kRX
+                    cases hsY : OY.splitAt x with
+                    | none => simp [hsX, hsY] at hd
+                    | some kRY =>
+                      obtain ⟨k2, RY⟩ := kRY
+                      simp only [hsX, hsY] at hd
+                      split_ifs at hd
+                      simp only [Option.some.injEq] at hd
+                      rw [← hd]
+    unfold fxCheckWith at h
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+    exact hpay ▸ of_decide_eq_true (List.all_eq_true.mp h.1.2 v hv)
+
+theorem fxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (Expression p)) (biX biY : BusInteraction (Expression p))
+    (x : Variable) (E : Expression p) (vy : Variable)
+    (h : fxCheck bs facts domCs biX biY x E vy = true)
+    (env : Variable → ZMod p)
+    (hdom : ∀ c ∈ domCs, c.eval env = 0)
+    (hobX : (biX.eval env).multiplicity ≠ 0 → bs.violatesConstraint (biX.eval env) = false)
+    (hobY : (biY.eval env).multiplicity ≠ 0 → bs.violatesConstraint (biY.eval env) = false) :
+    env vy = E.eval env := by
+  unfold fxCheck at h
+  cases hd : fuPairData? bs facts domCs biX biY x with
+  | none => rw [hd] at h; simp at h
+  | some d =>
+    rw [hd] at h
+    unfold fxCheckWith at h
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+    obtain ⟨⟨⟨⟨hvyR', _hEm⟩, hEjoint⟩, _hEpay⟩, hcw⟩ := h
+    unfold fuPairData? at hd
+    cases hmx : biX.multiplicity.constValue? with
+    | none => rw [hmx] at hd; simp at hd
+    | some mx =>
+      cases hmy : biY.multiplicity.constValue? with
+      | none => rw [hmx, hmy] at hd; simp at hd
+      | some my =>
+        simp only [hmx, hmy] at hd
+        split_ifs at hd with hmx0 hmy0
+        cases hOX : biX.payload[0]? with
+        | none => simp [hOX] at hd
+        | some OX =>
+          cases hOY : biY.payload[0]? with
+          | none => simp [hOX, hOY] at hd
+          | some OY =>
+            simp only [hOX, hOY] at hd
+            cases hbX : facts.slotBound biX.busId mx
+                (biX.payload.map Expression.constValue?) 0 with
+            | none => simp [hbX] at hd
+            | some bX =>
+              cases hbY : facts.slotBound biY.busId my
+                  (biY.payload.map Expression.constValue?) 0 with
+              | none => simp [hbX, hbY] at hd
+              | some bY =>
+                simp only [hbX, hbY] at hd
+                cases hsX : OX.splitAt x with
+                | none => simp [hsX] at hd
+                | some kRX =>
+                  obtain ⟨k, RX⟩ := kRX
+                  cases hsY : OY.splitAt x with
+                  | none => simp [hsX, hsY] at hd
+                  | some kRY =>
+                    obtain ⟨k2, RY⟩ := kRY
+                    simp only [hsX, hsY] at hd
+                    split_ifs at hd with hconds hcov hall
+                    obtain ⟨hk2, hunit, hwrapX, hwrapY⟩ := hconds
+                    obtain ⟨hcover, _hcap⟩ := hcov
+                    simp only [Option.some.injEq] at hd
+                    subst hd
+                    simp only at hvyR' hEjoint hcw
+                    -- acceptance and slot-value bounds
+                    have hmXe : (biX.eval env).multiplicity = mx :=
+                      biX.multiplicity.constValue?_sound mx hmx env
+                    have hmYe : (biY.eval env).multiplicity = my :=
+                      biY.multiplicity.constValue?_sound my hmy env
+                    have hviolX : bs.violatesConstraint (biX.eval env) = false :=
+                      hobX (by rw [hmXe]; exact hmx0)
+                    have hviolY : bs.violatesConstraint (biY.eval env) = false :=
+                      hobY (by rw [hmYe]; exact hmy0)
+                    have hgetX : (biX.eval env).payload[0]? = some (OX.eval env) := by
+                      show (biX.payload.map (fun e => e.eval env))[0]? = _
+                      rw [List.getElem?_map, hOX]; rfl
+                    have hgetY : (biY.eval env).payload[0]? = some (OY.eval env) := by
+                      show (biY.payload.map (fun e => e.eval env))[0]? = _
+                      rw [List.getElem?_map, hOY]; rfl
+                    have hbXv : (OX.eval env).val < bX :=
+                      facts.slotBound_sound (biX.eval env)
+                        (biX.payload.map Expression.constValue?) 0 bX (OX.eval env)
+                        (by rw [(rfl : (biX.eval env).busId = biX.busId), hmXe]; exact hbX)
+                        (matches_evalPattern biX.payload env) hviolX hgetX
+                    have hbYv : (OY.eval env).val < bY :=
+                      facts.slotBound_sound (biY.eval env)
+                        (biY.payload.map Expression.constValue?) 0 bY (OY.eval env)
+                        (by rw [(rfl : (biY.eval env).busId = biY.busId), hmYe]; exact hbY)
+                        (matches_evalPattern biY.payload env) hviolY hgetY
+                    -- field decomposition `x = m·u + W`, both sides
+                    set m := k⁻¹ with hm
+                    have hOXe : OX.eval env = k * env x + RX.eval env :=
+                      Expression.splitAt_eval x OX k RX hsX env
+                    have hOYe : OY.eval env = k * env x + RY.eval env := by
+                      have h0 := Expression.splitAt_eval x OY k2 RY hsY env
+                      rw [hk2] at h0; exact h0
+                    have hxX : env x = m * OX.eval env + (-m) * RX.eval env := by
+                      have h1 : m * OX.eval env = m * k * env x + m * RX.eval env := by
+                        rw [hOXe]; ring
+                      rw [mul_comm m k, hunit, one_mul] at h1
+                      linear_combination -h1
+                    have hxY : env x = m * OY.eval env + (-m) * RY.eval env := by
+                      have h1 : m * OY.eval env = m * k * env x + m * RY.eval env := by
+                        rw [hOYe]; ring
+                      rw [mul_comm m k, hunit, one_mul] at h1
+                      linear_combination -h1
+                    -- the environment restricted to the joint flag box is an enumerated point
+                    have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                        (findDomainAlg domCs v).map (fun d => (v, d))), env vd.1 ∈ vd.2 := by
+                      intro vd hvd
+                      obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
+                      cases hfd : findDomainAlg domCs v with
+                      | none => rw [hfd] at hvd'; simp at hvd'
+                      | some dm =>
+                        rw [hfd] at hvd'
+                        simp only [Option.map_some, Option.some.injEq] at hvd'
+                        obtain rfl := hvd'.symm
+                        exact findDomainAlg_sound domCs v dm hfd env hdom
+                    have hpt := mem_assignments ((RX.vars ++ RY.vars).eraseDups.filterMap
+                      (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))) env hmemdoms
+                    have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
+                        envOf (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))) v = env v := by
+                      intro v hv
+                      refine envOf_map _ env v ?_
+                      rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                        (findDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+                        = (RX.vars ++ RY.vars).eraseDups from hcover]
+                      exact hv
+                    have hRXagree : RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                        (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1)))) = RX.eval env :=
+                      Expression.eval_congr RX _ env (fun v hv =>
+                        hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
+                    have hRYagree : RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                        (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1)))) = RY.eval env :=
+                      Expression.eval_congr RY _ env (fun v hv =>
+                        hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
+                    -- pair-level point bounds, at the environment's own point
+                    have hpair := List.all_eq_true.mp hall _ hpt
+                    rw [Bool.and_eq_true] at hpair
+                    have hWXlt : ((-m) * RX.eval env).val < m.val := by
+                      rw [← hRXagree]; exact of_decide_eq_true hpair.1
+                    have hWYlt : ((-m) * RY.eval env).val < m.val := by
+                      rw [← hRYagree]; exact of_decide_eq_true hpair.2
+                    -- integer decomposition of `x.val` through both checks
+                    have hbX1 : (OX.eval env).val ≤ bX - 1 := by omega
+                    have hbY1 : (OY.eval env).val ≤ bY - 1 := by omega
+                    have hle1 : m.val * (OX.eval env).val ≤ m.val * (bX - 1) :=
+                      Nat.mul_le_mul_left _ hbX1
+                    have hle2 : m.val * (OY.eval env).val ≤ m.val * (bY - 1) :=
+                      Nat.mul_le_mul_left _ hbY1
+                    have hMuX : (m * OX.eval env).val = m.val * (OX.eval env).val :=
+                      ZMod.val_mul_of_lt (by omega)
+                    have hMuY : (m * OY.eval env).val = m.val * (OY.eval env).val :=
+                      ZMod.val_mul_of_lt (by omega)
+                    have hsumX : (m * OX.eval env).val + ((-m) * RX.eval env).val < p := by
+                      rw [hMuX]; omega
+                    have hsumY : (m * OY.eval env).val + ((-m) * RY.eval env).val < p := by
+                      rw [hMuY]; omega
+                    have hvalX : (env x).val
+                        = m.val * (OX.eval env).val + ((-m) * RX.eval env).val := by
+                      rw [hxX, ZMod.val_add_of_lt hsumX, hMuX]
+                    have hvalY : (env x).val
+                        = m.val * (OY.eval env).val + ((-m) * RY.eval env).val := by
+                      rw [hxY, ZMod.val_add_of_lt hsumY, hMuY]
+                    have hres : ((-m) * RX.eval env).val = ((-m) * RY.eval env).val :=
+                      residue_uniq m.val (OX.eval env).val (OY.eval env).val _ _
+                        (hvalX.symm.trans hvalY) hWXlt hWYlt
+                    -- the target condition at the environment's point
+                    have hmempts : (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1)),
+                        decide (((-m) * RX.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val
+                          = ((-m) * RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val))
+                        ∈ (assignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d))))).map
+                            (fun pt => (pt, decide (((-m) * RX.eval (envOf pt)).val
+                              = ((-m) * RY.eval (envOf pt)).val))) :=
+                      List.mem_map.2 ⟨_, hpt, rfl⟩
+                    have horb := List.all_eq_true.mp hcw _ hmempts
+                    have hb : decide (((-m) * RX.eval (envOf (((RX.vars
+                        ++ RY.vars).eraseDups.filterMap (fun v =>
+                          (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val
+                        = ((-m) * RY.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                          (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                            (fun vd => (vd.1, env vd.1))))).val) = true :=
+                      decide_eq_true (by rw [hRXagree, hRYagree]; exact hres)
+                    simp only [hb, Bool.not_true, Bool.false_or, decide_eq_true_eq] at horb
+                    have hEagree : E.eval (envOf (((RX.vars ++ RY.vars).eraseDups.filterMap
+                        (fun v => (findDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun vd => (vd.1, env vd.1)))) = E.eval env := by
+                      refine Expression.eval_congr E _ env (fun v hv => ?_)
+                      refine hagree v (List.mem_eraseDups.2 ?_)
+                      rcases of_decide_eq_true (List.all_eq_true.mp hEjoint v hv) with h1 | h1
+                      · exact List.mem_append_left _ h1
+                      · exact List.mem_append_right _ h1
+                    rw [← hagree vy (List.mem_eraseDups.2 (List.mem_append_right _ hvyR')),
+                        ← hEagree]
+                    exact horb
+
+/-! ## The scan loop and the composite pass -/
+
+/-- Scan for matched scaled-check pairs (reusing `fuCandidates`/`FUSeen`) and adopt every
+    certified interpolation `vy := E`. The certificate is re-checked inside the adoption
+    proof through `fxCheck`'s definition. -/
+def fxLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) :
+    (pending : List (BusInteraction (Expression p))) →
+    (∀ bi ∈ pending, bi ∈ cs.busInteractions) →
+    List (FUSeen p cs) → Solved p cs bs → Solved p cs bs
+  | [], _, _, σ => σ
+  | c :: rest, hmem, seen, σ =>
+    have hc : c ∈ cs.busInteractions := hmem c (List.mem_cons_self ..)
+    let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
+    let cands := fuCandidates c
+    match cands.findSome? (fun xk =>
+        seen.findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
+    | some ex =>
+        match hdata : fuPairData? bs facts cs.algebraicConstraints ex.1.bi c ex.2 with
+        | none =>
+            fxLoop cs bs facts rest hrest
+              (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+        | some d =>
+        let pairs := (d.ryVars.eraseDups.filter (fun v => !(v ∈ d.rxVars))).filterMap (fun vy =>
+          if fxCheckWith d (buildE d vy) vy
+          then some (vy, buildE d vy) else none)
+        have hpairs : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env := by
+          intro env hsat yt hyt
+          obtain ⟨vy, _hvy, hif⟩ := List.mem_filterMap.1 hyt
+          by_cases hck : fxCheckWith d (buildE d vy) vy = true
+          · rw [if_pos hck] at hif
+            simp only [Option.some.injEq] at hif
+            subst hif
+            show env vy = (buildE d vy).eval env
+            have hfc : fxCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2
+                (buildE d vy) vy = true := by
+              unfold fxCheck; rw [hdata]; exact hck
+            exact fxCheck_sound bs facts cs.algebraicConstraints ex.1.bi c ex.2
+              (buildE d vy) vy hfc env
+              (fun c' hc' => hsat.1 c' hc')
+              (fun hmult => hsat.2 ex.1.bi ex.1.mem hmult)
+              (fun hmult => hsat.2 c hc hmult)
+          · rw [if_neg hck] at hif
+            exact absurd hif (by simp)
+        have hpairsV : ∀ yt ∈ pairs, ∀ z ∈ yt.2.vars, z ∈ cs.vars := by
+          intro yt hyt z hz
+          obtain ⟨vy, _hvy, hif⟩ := List.mem_filterMap.1 hyt
+          by_cases hck : fxCheckWith d (buildE d vy) vy = true
+          · rw [if_pos hck] at hif
+            simp only [Option.some.injEq] at hif
+            subst hif
+            have hfc : fxCheck bs facts cs.algebraicConstraints ex.1.bi c ex.2
+                (buildE d vy) vy = true := by
+              unfold fxCheck; rw [hdata]; exact hck
+            obtain ⟨e', he', hv'⟩ := List.mem_flatMap.1
+              (fxCheck_vars bs facts cs.algebraicConstraints ex.1.bi c ex.2
+                (buildE d vy) vy hfc z hz)
+            exact ConstraintSystem.mem_vars_of_payload ex.1.mem he' hv'
+          · rw [if_neg hck] at hif
+            exact absurd hif (by simp)
+        fxLoop cs bs facts rest hrest
+          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (σ.insertAll pairs hpairs hpairsV)
+    | none =>
+        fxLoop cs bs facts rest hrest
+          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+
+/-- Part A as a standalone (unguarded) pass: substitute every certified interpolation. -/
+def fxSubstPass : VerifiedPassW p := fun cs bs facts =>
+  if hp : (decide p.Prime) = true then
+    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+    let σ := fxLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
+    if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+    else ⟨cs.substF σ.fn, [],
+      cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
+        (fun y t hyt => σ.varsIn y t hyt)⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-- The composite: substitute the XOR component, then collect the two degree overshoots the
+    substitution creates — the boxed-out booleanity (part B) and the pointwise-duplicate scaled
+    check (part C). Intermediate states exceed the degree bound by design; the composite is
+    wired under a single `guardDegree`. -/
+def flagFoldPass : VerifiedPassW p :=
+  fxSubstPass.andThen boxTautoDropPass.withFacts |>.andThen pointwiseDupDropPass.withFacts

--- a/Main.lean
+++ b/Main.lean
@@ -274,6 +274,7 @@ def cmdProfile (fileName : String) : IO Unit := do
       ("hintCollapse", hintCollapsePass.guardDegree),
       ("rootPairUnify", rootPairUnifyPass.guardDegree),
       ("flagUnify", flagUnifyPass.guardDegree),
+      ("flagFold", flagFoldPass'.guardDegree),
       ("dedup", dedupPass.withFacts.guardDegree),
       ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
       ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -135,6 +135,25 @@ are typically *received* register/memory words, which now carry proven byte boun
 (multiplicity-aware `slotBound`); `byteJustified`/`deepBoundOk` in `BusPairCancel.lean` are
 reusable justification building blocks.
 
+## Signed-comparison gadget: fold the msb flags into the comparison result (variables)
+
+Log entry 62: on slt/blt-shaped blocks (apc_003 class) we keep `{a_msb_f, b_msb_f, cmp_lt}`
+where powdr keeps a single `{cmp_result}` — +2 vars per case, and these cases are the long-tail
+losses. The msb booleans are pinned by the sign-decomposition constraints; folding them needs
+either a derived-column substitution (each msb flag becomes a `ComputationMethod` over the
+operand limbs, with the pinning constraint dropped as entailed) or a `reencode`-style
+compression of the three-variable group. Diagnose the exact gadget constraints on apc_003
+before choosing.
+
+## Read-read data sharing blocked on the last flag component (variables)
+
+Log entry 62: powdr keeps one copy of same-address read-data words across consecutive accesses
+(apc_047 class, ~+3 vars per case); our receive-equals-send chaining should entail the same but
+the addresses are not syntactically equal — the entry-59 residual (one flag component per
+unified pair relates non-componentwise). The derived-variable interpolation `b := f(a₀, a₁)`
+(see the mem-ptr residuals item) would make the addresses syntactically equal and likely
+unlock the whole cascade: flag → address → busUnify data equations → word unification.
+
 ## Reuse the deep byte justification beyond pair cancellation
 
 `deepBoundOk` (log 50) proves `x < 256` by enumerating the finite domains of a defining

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -147,15 +147,14 @@ gets a `[0,256)` domain even when no interaction carries it raw). Generalising t
 branch to `x = c₀ + Σ cᵢ·yᵢ` with a no-wrap interval bound would subsume the is-zero and
 mem-ptr-limb ideas' bound side.
 
-## Smarter witnesses for `disconnectedComponentPass`
+## Smarter witnesses for `disconnectedComponentPass` — measured empty (log 61)
 
-`disconnectedComponentPass` (entry 43) removes a disconnected component only if the **all-zero**
-witness certifies it satisfiable. This misses the common orphaned-register-read pattern (data limbs
-surviving only in a bitwise byte-check `[K − Σ 256ⁱ·limbᵢ, limb₀, 0, 0]` plus range checks), where
-the satisfying witness is the base-256 decomposition of `K`, not `0`. A witness *finder* that solves
-the component's lookups (probe `violatesConstraint`) would capture them. Only the finder changes,
-not the proof. Phrase it as a general "solve the component's lookups" search, not hard-coded
-base-256, to avoid overfitting to the OpenVM limb structure.
+**Do not build without re-measuring.** As of log 61 the optimized outputs contain **zero**
+disconnected variables on every sampled case (the entry-43 orphan pattern was consumed by the
+entry-50/51 facts and the entry-57–59 cleanup chain), and the only single-occurrence variables
+are `hintCollapse`'s reciprocal hints, which are not unconditionally solvable and hence not
+removable under powdr's `remove_free_variables` rule either. The witness-finder generalization
+only becomes relevant again if a future pass starts stranding non-zero-satisfiable components.
 
 ## Batch pair cancellation in one traversal (performance)
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -148,11 +148,10 @@ before choosing.
 ## Read-read data sharing blocked on the last flag component (variables)
 
 Log entry 62: powdr keeps one copy of same-address read-data words across consecutive accesses
-(apc_047 class, ~+3 vars per case); our receive-equals-send chaining should entail the same but
-the addresses are not syntactically equal — the entry-59 residual (one flag component per
-unified pair relates non-componentwise). The derived-variable interpolation `b := f(a₀, a₁)`
-(see the mem-ptr residuals item) would make the addresses syntactically equal and likely
-unlock the whole cascade: flag → address → busUnify data equations → word unification.
+(apc_047 class, ~+3 vars per case). **Log 63 correction:** apc_047's final output has *zero*
+scaled-check pairs, so this is *not* blocked on the flag residual there — the duplication needs
+its own diagnosis (render the accesses; the addresses presumably differ structurally). The
+flag→address→busUnify cascade may still apply on apc_005-class blocks.
 
 ## Reuse the deep byte justification beyond pair cancellation
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1963,3 +1963,50 @@ entry-53-style target for a follow-up perf pass; not intractable, and effectiven
 first. The `boxRewritePass` is general machinery: it is the "contextual polynomial reduction"
 enabler the early design surveys called for, and the sign-split comparison gadget (entry 63
 item 3) is its natural next customer.
+
+### 66. Perf: the flagFold composite from 67 s to 1.7 s on apc_005 (entry-65 follow-up)
+
+The `ImprovingRuntime.md` pass over the entry-64/65 additions. Baseline: `flagFoldPass'` cost
+66.9 s of apc_005's ~81 s run. Staged sub-pass timings (temporary `ffprof` command) plus layered
+scan decompositions localized four mechanisms, landed as three commits:
+
+1. **`findDomainAlg` gates its scan on `Expression.mentions`** (`DomainProp.lean`). `rootsIn`
+   runs `linearize` — allocation-heavy normalization — per (variable, constraint) probe, so
+   every domain lookup scanned all ~650 single-variable constraints at full price. A constraint
+   that does not mention the variable can only yield a root list through the
+   unsatisfiable-constant case (`rootsOfTerms` on an empty term list), so skipping it never
+   loses a live domain. This one gate took boxTauto from 15.4 s → 0.2 s (with the cache below)
+   and sped up every caller: flagUnify, `slotEqCert`, `brCert`.
+2. **Hoisted scan invariants** (`FlagFold.lean`, `BoxRewrite.lean`). `btCert`, `slotEqCert`/
+   `msgEqCert`, `pdFirst`/`pdKeep`, and `brRw`/`brCert` all refiltered `singleVarCs all` per
+   candidate (in `brRw`'s case per *variable* of every over-bound expression); they now take
+   the precomputed list, bound once per pass invocation. boxRewrite's fold-iteration stage:
+   4.4 s → 0.16 s. **Lean gotcha worth remembering**: precomputed values must be passed as
+   *plain arguments* — a def-local `let` in front of a trailing `fun c => …` is re-evaluated on
+   every application by arity expansion, and hoisting the partial application
+   (`let keep := btKeepCond cs`) does **not** prevent it (first attempt hung: O(n) cache
+   rebuilds per constraint).
+3. **boxTauto memoized-domain prefilter** (`btPre`): a faithful mirror of `btCert` over a
+   per-pass `HashMap` of `findDomainAlg` results gates the certificate; the certificate
+   re-checks with the real scan, so the cache carries no proof obligation (the `BusFacts`
+   philosophy applied to perf).
+4. **`slotEqCert` requires a shared carrier** (`x ∈ e'` via a ZMod-free `mentions` walk) before
+   any `splitAt`. The pointwiseDup prefix scans visit 2.5M interaction pairs on apc_005; layered
+   timing showed the skeleton (findIdx?, busId, multiplicity, payload-BEq layers) costs 0.26 s
+   and *everything else* was `splitAt`/`coeffAt` per-node ZMod ring ops — the runtime-`p`
+   instance-reconstruction tax (entry 53). The dropped arm — carrier with a fully cancelled
+   constant coefficient, absent from `e'` — cannot survive the constantFold/normalize passes
+   that run ahead of the composite every cycle. pointwiseDup: 4.1 s → 0.43 s.
+
+Dead ends, killed by measurement: a domain-`HashMap` for pointwiseDup (cache build alone cost
+9.1 s over payload vars and saved nothing — domains were never the scan's cost); iterating var
+*occurrences* instead of `eraseDups` (repeated flag variables re-ran certified arms per
+occurrence: 4.1 s → 18.7 s).
+
+Validation per the playbook: 13-case `run` outputs and the full apc_005 render **byte-identical**
+against a 9e703ed reference binary (this also empirically confirms the two "cannot fire on real
+inputs" arguments above — items 1 and 4 are conservative narrowings, sound by construction
+either way). Effectiveness unchanged by construction. apc_005: **81 s → 12.7 s**; flagFold
+**66.9 s → 1.7 s** (iter 0: 0.65 s; fold iteration: 0.44 s). The profile is now led by
+pre-existing passes — domainFold 3.3 s, reencode 1.7 s, domainBatch 1.6 s — so the composite is
+no longer the pipeline's bottleneck. `lake build` green at every commit; proof integrity clean.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1894,3 +1894,35 @@ Measurement/diagnosis only, completing entry 62 with the concrete shapes.
    (`f ∈ {a3, a3 − 256}`), so `reencode`/`domainBatch` (constant-domain machinery) cannot
    compress the group either; a folding pass would need parameterized-domain reasoning or
    derived-column substitution with the same composite-guard treatment as (1).
+
+### 64. XOR flag fold: three of five pieces built and firing; blocked on stateful-payload and selection-constraint degrees
+
+Implementation attempt on log 63's finding 1 (`FlagFold.lean`, committed **unwired**). The
+composite `flagFoldPass = fxSubstPass ∘ boxTautoDropPass ∘ pointwiseDupDropPass` under a single
+degree guard. Stage probe on apc_005's optimized output:
+
+- `fxSubstPass` **fires: 1491 → 1427 vars (−64)** — the certified interpolation `c1 := a0 ⊕ a1`
+  (built from `fuPairData?`'s own compatible-point tables, validated pointwise by `fxCheckWith`,
+  entailed by the residue argument via `fxCheck_sound`) substitutes every remaining pair flag.
+- `boxTautoDropPass` replaces the degree-4 substituted booleanities by `0` (multi-variable
+  constraints vanishing on their proven domain box; single-variable constraints are never
+  replaced, keeping the `findDomainAlg` sources — non-circular by construction).
+- `pointwiseDupDropPass` **fires: 765 → 701 bus (−64)** — stateless interactions pointwise-equal
+  on the box to an earlier *first-of-class* twin are dropped (`filterBusEntailed_correct`
+  ported from the entry-56 line with `hok` generalized to be multiplicity-conditional; the
+  depth-1 first-of-class rule avoids chain induction).
+- **But `withinDegree = false` at every stage**: the substituted flag also sits in the
+  **stateful memory address payloads** (`limbsum − F(a1, c1)`, degree 3 after substitution —
+  no pass may drop or alter stateful interactions) and in the degree-3 **data-selection
+  constraints** (degree 4 after). The guard rejects the composite, so the wired pipeline is a
+  no-op at +74 s per apc_005 run — hence unwired at this commit.
+
+**What completing it needs** (both specified, neither trivial):
+(D) a *compatible-point-entailed payload rewrite* — replace the eliminated access's address
+expression by the survivor's (already degree-legal; pointwise-equal under the pair certificate,
+i.e. `slotEqCert` refined from box-equality to compatible-point equality with both checks
+retained); sideEffects stay *equal* because the evaluated messages are. (E) a multilinear
+reduction (`b² → b` on boolean-domained variables, box-certified) for the selection
+constraints — the general contextual rewriter sketched in the design documents. (D) unlocks the
+address-side; (E) the constraint side; with both, the probe numbers above (−64 vars, −64 bus
+per apc_005-class block) become landable.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1926,3 +1926,40 @@ reduction (`b² → b` on boolean-domained variables, box-certified) for the sel
 constraints — the general contextual rewriter sketched in the design documents. (D) unlocks the
 address-side; (E) the constraint side; with both, the probe numbers above (−64 vars, −64 bus
 per apc_005-class block) become landable.
+
+### 65. Box-certified multilinear rewriting completes the XOR flag fold (`BoxRewrite.lean`)
+
+The missing piece from entry 64, and it subsumes both gaps at once: a pass that rewrites every
+**over-bound** expression of the system to its multilinear reduction (`b² → b` on
+small-domain variables), accepting each rewrite only under a decidable certificate — on every
+point of the expression's small-domain box, both forms **partially evaluate to the same affine
+form** in the remaining symbolic (e.g. data) variables (`linearize` + canonical normalized
+comparison; soundness via `eval_substF`/`envF` restriction, `linearize_eval`, and permutation
+sums). The reduction itself is heuristic monomial expansion (exponent capping on box variables,
+64-monomial cap) and carries no proof; the certificate re-verifies pointwise. Single-variable
+constraints are never rewritten (the `findDomainAlg` sources — same non-circularity as the
+entry-64 parts), and rewrites that would introduce variables are rejected by a decidable guard.
+
+The completed composite `flagFoldPass' = fxSubst ∘ boxRewrite ∘ boxTautoDrop ∘ pointwiseDupDrop`
+under one degree guard: the XOR substitution fires, the rewriter legalizes the substituted
+address payloads (degree 3 → 2) and selection constraints (degree 4 → 3), the tautology and
+duplicate collectors clean up. Stage probe on apc_005: `wd=false` after substitution,
+**`wd=true` after the rewrite**, and the guard now accepts.
+
+`lake build` green; all three `maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** apc_005-class blocks: **1491 → 1427 vars (−64), 649 → 585 constraints (−64),
+765 → 701 bus (−64)** each. 9-case sample across the other size classes byte-identical. Full
+100-case sweep (before → after, baseline = the entry-60 line):
+
+- **variables: 4.286× → 4.352× aggregate (3.655× → 3.667× geomean)** vs powdr's 4.092×/3.787×
+- **bus interactions: 3.006× → 3.077× aggregate (2.466× → 2.482× geomean)**
+- **constraints: 9.854× → 10.235× aggregate (10.214× → 10.292× geomean** — closing on powdr's
+  10.311× geomean)
+
+Runtime cost: apc_005 ~18 s → ~80 s (the composite's scans run every cycle) — a known
+entry-53-style target for a follow-up perf pass; not intractable, and effectiveness lands
+first. The `boxRewritePass` is general machinery: it is the "contextual polynomial reduction"
+enabler the early design surveys called for, and the sign-split comparison gadget (entry 63
+item 3) is its natural next customer.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1838,3 +1838,28 @@ The `docs/ideas.md` entry is updated accordingly. Together with entry 55 (degree
 inlining structurally blocked), two of the three Tier-1 variable candidates from the Rust-vs-Lean
 comparison are now measured dead on this benchmark; the live remainder of that tier is the
 constraint/limb-splitting shape (entry 36 lineage).
+
+### 62. Measurement: limb splitting is basis-neutral; the real residual gaps are the signed-comparison gadget and read-read data sharing
+
+Measurement only (entry-42 style), via a **variable-set diff** between our optimized outputs and
+powdr's exports on loss cases (apc_003: 133 vs 131; apc_047: 91 vs 87). Findings:
+
+1. **Constraint/limb splitting (the entry-36 lineage) is variable-neutral here.** Our surviving
+   `…timestamp_lt_aux__lower_decomp__1_*` high limbs pair **exactly 1:1** with powdr's surviving
+   `…prev_timestamp_*` columns (16↔16 on apc_003, 12↔12 on apc_047). powdr does not eliminate
+   the less-than witness; it solves the *high limb* away (`d1 = (now − prev − 1 − d0)·2⁻¹⁷`,
+   degree-1, substituted into its range check) and keeps `prev_timestamp`, while we solve
+   `prev_timestamp` away and keep both limbs. Different basis, same count. Do not build a
+   splitter for variables' sake; at most it trades a 12-bit range check's operand shape.
+2. **The whole apc_003-class gap (+2/case) is the signed-comparison gadget**: we keep
+   `{a_msb_f, b_msb_f, cmp_lt}` where powdr keeps `{cmp_result}` — the msb-extraction booleans
+   survive on our side. New, previously uncatalogued target (`docs/ideas.md`).
+3. **The apc_047-class gap (~+3/case) is duplicated read data**: powdr keeps one copy of the
+   same-address read words (`b__*`, `writes_aux__prev_data__*`) across consecutive accesses
+   where we keep several. Hypothesis: our receive-equals-send chaining (`busUnify`) is blocked
+   because the access addresses are still not *syntactically* equal — the entry-59 residual
+   (one flag component per access pair relates non-componentwise). Finishing that flag story
+   (the derived-variable interpolation in `docs/ideas.md`) would likely unlock this cascade.
+
+With entries 55 and 61, all three Tier-1 variable candidates from the Rust-comparison survey
+are now measured dead as scoped; the live variable work is items (2) and (3) above.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1814,3 +1814,27 @@ iterations 3–6 still pay 64 pair-datas each for zero adoptions; `rootPairUnify
 the seen-scan (measured), so likely `rpCandidates`'s per-variable `splitAt`+`LinExpr.norm`
 over every constraint every iteration; `domainFold` 3.4 s — the pre-existing
 `ImprovingRuntime.md` lead #1 (`constOnSurvs` still on per-node-instance `eval`).
+
+### 61. Measurement: free-variable removal and smarter disconnected-witnesses have no remaining targets
+
+Measurement only, no code change (in the spirit of entry 42). Two long-standing candidates — the
+`docs/ideas.md` "smarter witnesses for `disconnectedComponentPass`" item (entry 43's "dominant
+unremoved pattern": orphaned register-read byte-decompositions needing a non-zero witness) and
+powdr's `remove_free_variables` (drop a variable occurring in exactly one solvable
+constraint/stateless interaction) — were sized against the current optimizer's outputs before
+implementing. Both are **empty**:
+
+- **Disconnected variables: 0** on every sampled case (apc_001/003/008/010/014/047/056/069) —
+  the entry-43 orphan pattern has been consumed by the passes that landed since (the entry-50
+  received-byte facts, entry-51 zero-register pinning, and the entry-57–59 unification/cleanup
+  chain). The all-zero witness never fails on anything anymore because nothing disconnected
+  survives at all.
+- **Single-occurrence variables: 0–1 per case**, and the singleton is always the `hcinv#`
+  reciprocal hint from `hintCollapse` — whose defining constraint `a·inv − cmp = 0` is *not*
+  unconditionally solvable for it (`a` may be zero), so it is not removable under powdr's rule
+  either, and it is load-bearing for the is-zero gadget.
+
+The `docs/ideas.md` entry is updated accordingly. Together with entry 55 (degree-bounded
+inlining structurally blocked), two of the three Tier-1 variable candidates from the Rust-vs-Lean
+comparison are now measured dead on this benchmark; the live remainder of that tier is the
+constraint/limb-splitting shape (entry 36 lineage).

--- a/docs/log.md
+++ b/docs/log.md
@@ -1863,3 +1863,34 @@ powdr's exports on loss cases (apc_003: 133 vs 131; apc_047: 91 vs 87). Findings
 
 With entries 55 and 61, all three Tier-1 variable candidates from the Rust-comparison survey
 are now measured dead as scoped; the live variable work is items (2) and (3) above.
+
+### 63. Diagnosis: the two entry-62 gaps, pinned down (XOR flag relation; sign-split comparison gadget)
+
+Measurement/diagnosis only, completing entry 62 with the concrete shapes.
+
+1. **The entry-59 flag residual is XOR.** Probing the persisting scaled-check pairs on apc_005
+   (via `fuPairData?`'s own point tables): after entry 59 each pair's flag sets already share
+   one variable, and the compatible joint points for the remainder read off as exactly
+   `c1 = a0 ⊕ a1` — e.g. carrier `mem_ptr_limbs__0_3`, X flags `{567_0, 567_1}`, Y flags
+   `{567_1, 575_1}`, compatible points `{(0,0,0),(1,1,0),(1,0,1),(0,1,1)}`. As a field
+   polynomial `a0 + a1 − 2·a0·a1` (degree 2), so plain entailed substitution is
+   **degree-blocked twice over**: `c1`'s booleanity becomes degree 4 (> identities 3) and the
+   Y check's payload `F_Y(a1, c1 := ⊕)` becomes degree 3 (> bus 2). Eliminating the ~64
+   remaining `c1`s per apc_005-class block therefore needs a *composite, singly-guarded* pass:
+   entailed nonlinear substitution + a box-tautology constraint drop (the substituted booleanity
+   vanishes on the boolean box) + a pointwise-equal bus-payload replacement (the substituted
+   check's slot equals the survivor's on the box). All three pieces have precedents
+   (`Solved`/`substF`, the `fuCheck` box machinery, `filterBusEntailed_correct`), but composing
+   them under one `guardDegree` with intermediate over-bound states is its own project.
+2. **apc_047 has zero scaled-check pairs** in its final output — entry 62's hypothesis that its
+   duplicated read-data words are blocked on the flag residual is **wrong for that case**; its
+   read-read duplication needs a separate diagnosis (the addresses there presumably differ in
+   more than a flag component).
+3. **The sign-split comparison gadget (apc_003 class, the +2/case).** `a_msb_f` is pinned by its
+   own two-root constraint `(a__3 − f)(a__3 − f − 256) = 0` — a *definition* (limb minus sign
+   bit), not a duplicate, so `rootPairUnify` does not apply — plus the byte pair-check
+   `[a_msb_f, b_msb_f, 0, 0]` and a `diff_marker` chain deciding `cmp_lt`. powdr keeps one
+   `cmp_result` for our three `{a_msb_f, b_msb_f, cmp_lt}`. The domains are *parameterized*
+   (`f ∈ {a3, a3 − 256}`), so `reencode`/`domainBatch` (constant-domain machinery) cannot
+   compress the group either; a folding pass would need parameterized-domain reasoning or
+   derived-column substitution with the same composite-guard treatment as (1).


### PR DESCRIPTION
Stacked on #90 (`int-bounds`); only the five commits above its head are new here.

## What

The entry-63 diagnosis showed apc_005-class blocks carry a XOR flag relation the pipeline could not exploit: the bitwise-lookup flag polynomial is entailed by existing constraints, but substituting it produces nonlinear expressions that break the degree bound. This PR lands the complete composite `flagFoldPass'` (one degree guard around four sub-passes):

- **`fxSubstPass`** (`FlagFold.lean` part A): substitutes the entailed indicator-product form of the XOR output into its use sites, certified pointwise on the flags' proven boolean box.
- **`boxRewritePass`** (`BoxRewrite.lean`): rewrites every over-bound expression to its multilinear reduction (`b² → b` on small-domain variables), accepted only under a decidable certificate — on every point of the joint small-domain box, both forms partially evaluate to the same canonical affine form in the remaining symbolic variables. This legalizes the substituted stateful address payloads (degree 3 → 2) and selection constraints (degree 4 → 3). General machinery, reusable for the sign-split comparison gadget.
- **`boxTautoDropPass`** (part B): replaces constraints that vanish identically on their variables' proven domain box.
- **`pointwiseDupDropPass`** (part C): drops stateless bus interactions pointwise-equal (per-slot, box-certified) to an earlier kept one, via a depth-1 first-of-class rule.

All four are `VerifiedPass`es with their own `PassCorrect` proofs; single-variable domain-source constraints are provably never rewritten (non-circularity). No audited files touched. `lake build` green at every commit; `check-proof-integrity.sh` clean (`propext, Classical.choice, Quot.sound` only).

## Effectiveness (vs. this PR's base = #90 head)

Full 100-case `openvm-eth` sweep, `OpenVmBenchmarks/benchmark.py`:

| axis | base (#90) | this PR | powdr |
|---|---|---|---|
| **variables (aggregate)** | 4.286× | **4.352×** | 4.092× |
| variables (geomean) | 3.655× | 3.667× | 3.787× |
| **bus interactions (aggregate)** | 3.006× | **3.077×** | 3.480× |
| bus interactions (geomean) | 2.466× | 2.482× | — |
| **constraints (aggregate)** | 9.854× | **10.235×** | 5.853× |
| constraints (geomean) | 10.214× | 10.292× | 10.311× |

apc_005-class blocks: 1491 → 1427 vars (−64), 765 → 701 bus interactions (−64), 649 → 585 constraints (−64) each; other size classes byte-identical.

## Runtime

The composite initially cost ~67 s on apc_005 (~81 s total). The entry-66 perf pass (last four commits) brought it to **1.7 s (apc_005 total: 12.7 s)** via a `mentions` gate on `findDomainAlg`'s scan, hoisted scan invariants, a memoized-domain prefilter with certificate re-check, and a ZMod-free shared-carrier gate on the slot certificate — validated byte-identical against a pre-perf reference binary on 13 cases plus a full apc_005 render. One behavioral touchpoint with #90: `findDomainAlg` is also flagUnify's hot path, so it just gets faster (outputs unchanged).

Details in `docs/log.md` entries 63–66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)