### PR TITLE
Record Keccak + openvm-eth effectiveness snapshots; add keccak powdr reference manifest

### DIFF
--- a/OpenVmBenchmarks/README.md
+++ b/OpenVmBenchmarks/README.md
@@ -24,6 +24,23 @@ OpenVmBenchmarks/benchmark.py --n 20         # top 20 by cost rank
 OpenVmBenchmarks/benchmark.py --n 10 --report report.html   # + interactive HTML report
 ```
 
+## Latest results (snapshot)
+
+Effectiveness at repo commit `b8d2593` (2026-07-11); refresh this section when the numbers move.
+Full openvm-eth sweep (`OpenVmBenchmarks/benchmark.py`, 100 cases; agg = Σbefore ⁄ Σafter,
+geo = geomean):
+
+| measure | apc-optimizer (agg / geo) | powdr (agg / geo) | diff (agg) |
+| --- | --- | --- | --- |
+| variables | 4.136× / 3.706× | 4.092× / 3.787× | +0.044× |
+| bus interactions | 2.922× / 2.440× | 3.480× / 2.822× | −0.558× |
+| constraints | 9.073× / 11.190× | 5.853× / 10.311× | +3.220× |
+
+Per-case (by variables): apc-optimizer wins 17, loses 52, ties 31.
+
+For the keccak stress case (not part of the sweep), see the table in
+[keccak (standalone stress case)](#keccak-standalone-stress-case) below — same snapshot commit.
+
 ## Layout
 
 Each benchmark set is a subdirectory of `OpenVmBenchmarks/`. To add another, create a new
@@ -65,9 +82,10 @@ lake exe apc-optimizer run OpenVmBenchmarks/keccak_apc_pre_opt.json.gz
 ```
 
 Measured effectiveness (repo commit `b8d2593`, 2026-07-11). Since there is no `.powdr_opt` pair,
-powdr's numbers cannot be computed by the CLI; they are recorded here from powdr's own snapshot
-test (`autoprecompiles/tests/optimizer.rs::test_optimize`, powdr commit `b072302`), which runs the
-native Rust optimizer on the byte-identical file:
+powdr's numbers cannot be computed by the CLI; they are recorded as static reference in
+[`keccak_manifest.json`](./keccak_manifest.json) (same shape as a sweep set's `manifest.json`),
+taken from powdr's own snapshot test (`autoprecompiles/tests/optimizer.rs::test_optimize`, powdr
+commit `b072302`), which runs the native Rust optimizer on the byte-identical file:
 
 | | columns (vars) | bus interactions | constraints |
 | --- | --- | --- | --- |

--- a/OpenVmBenchmarks/README.md
+++ b/OpenVmBenchmarks/README.md
@@ -55,10 +55,22 @@ This set was built from Ethereum mainnet [block 24171377](https://etherscan.io/b
 export in the same format as the case files above, but **not** part of a sweep set: it has no
 `.powdr_opt` pair and is not walked by `benchmark.py`. It's a stress case for the optimizer.
 
-Running it takes **tens of minutes** (the cleanup loop runs to a fixpoint over a circuit this
-large), so it is not part of `benchmark.py` or CI. Run it on demand with the existing CLI — the
-same generic parse → optimize → report path used for every benchmark circuit:
+Running it takes **minutes** (the cleanup loop runs to a fixpoint over a circuit this large;
+~6.3 min at repo commit `b8d2593`, 2026-07-11), so it is not part of `benchmark.py` or CI. Run it
+on demand with the existing CLI — the same generic parse → optimize → report path used for every
+benchmark circuit:
 
 ```bash
 lake exe apc-optimizer run OpenVmBenchmarks/keccak_apc_pre_opt.json.gz
 ```
+
+Measured effectiveness (repo commit `b8d2593`, 2026-07-11). Since there is no `.powdr_opt` pair,
+powdr's numbers cannot be computed by the CLI; they are recorded here from powdr's own snapshot
+test (`autoprecompiles/tests/optimizer.rs::test_optimize`, powdr commit `b072302`), which runs the
+native Rust optimizer on the byte-identical file:
+
+| | columns (vars) | bus interactions | constraints |
+| --- | --- | --- | --- |
+| before | 27521 | 13262 | 28627 |
+| apc-optimizer | 3626 (7.59×) | 5206 (2.55×) | 492 (58.18×) |
+| powdr | 2021 (13.62×) | 1734 (7.65×) | 186 (153.91×) |

--- a/OpenVmBenchmarks/keccak_manifest.json
+++ b/OpenVmBenchmarks/keccak_manifest.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "source": {
+    "note": "keccak precompile APC (standalone stress case); byte-identical to powdr's autoprecompiles/tests/keccak_apc_pre_opt.json.gz (md5 8998aa08893f93797479ab9cee7e2008)",
+    "powdr_opt_stage": "no .powdr_opt export exists; powdr_opt_stats are the native Rust optimize() snapshot from powdr autoprecompiles/tests/optimizer.rs::test_optimize at powdr commit b07230275",
+    "date": "2026-07-11"
+  },
+  "entries": [
+    {
+      "files": {
+        "unopt": "keccak_apc_pre_opt.json.gz"
+      },
+      "stats": {
+        "before": {
+          "main_columns": 27521,
+          "constraints": 28627,
+          "bus_interactions": 13262
+        }
+      },
+      "powdr_opt_stats": {
+        "main_columns": 2021,
+        "constraints": 186,
+        "bus_interactions": 1734
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Records the measured Keccak stress-case results and a full openvm-eth sweep snapshot in `OpenVmBenchmarks/README.md`, and adds `keccak_manifest.json` as a static powdr reference for the Keccak case (which has no `.powdr_opt` export pair).

## Changes

- Keccak section: runtime note updated to the measured ~6.3 min at `b8d2593` (was "tens of minutes"), plus an effectiveness table — apc-optimizer 27521→3626 vars (7.59×), 13262→5206 bus (2.55×), 28627→492 constraints (58.18×) vs powdr 2021 (13.62×) / 1734 (7.65×) / 186 (153.91×).
- New `OpenVmBenchmarks/keccak_manifest.json`: same shape as a sweep set's `manifest.json`, holding the before stats and powdr's static reference numbers, cited from powdr's snapshot test (`autoprecompiles/tests/optimizer.rs::test_optimize`, powdr `b072302`) which runs the native optimizer on the byte-identical file (md5-verified).
- New "Latest results (snapshot)" README section: full openvm-eth sweep at `b8d2593` — variables 4.136× agg (powdr 4.092×), bus 2.922× (3.480×), constraints 9.073× (5.853×); per-case by variables wins 17 / loses 52 / ties 31.

## Testing

Keccak numbers from a fresh `timeout 600 lake exe apc-optimizer run` at `b8d2593` (exit 0, 377686 ms, degree bounds ok). openvm-eth numbers from a fresh full `OpenVmBenchmarks/benchmark.py` sweep (100 cases) at the same commit. Docs + data only, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)