### PR TITLE
Redundant byte-check removal: drop entailed bitwise byte checks

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -148,6 +148,18 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       ∀ (x mult : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, x, 0, 1] }
             = false ↔ x.val < 256
+  /-- Byte-check *via XOR-with-zero*: the check `[x, 0, x, 1]` (`x ⊕ 0 = x`, multiplicity any) on a
+      stateless bitwise-style bus is accepted **iff** `x` is a byte. The XOR-with-zero encoding is
+      how OpenVM materializes a bare "this operand is a byte" obligation that was not packed into a
+      pair; recognising it lets the redundant-byte-check dropper reach those interactions.
+      `trivial` sets it `false`. -/
+  xorZeroCheck : (busId : Nat) → Bool
+  xorZeroCheck_sound :
+    ∀ (busId : Nat), xorZeroCheck busId = true →
+      bs.isStateful busId = false ∧
+      ∀ (x mult : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, 0, x, 1] }
+            = false ↔ x.val < 256
   /-- Real-trace fixed-zero cells (e.g. the hardwired RISC-V `x0` register).
       `zeroCell busId = some (addrReq, dataSlots)` asserts that on the (stateful) bus `busId`, every
       *active* message whose payload has `payload[s] = v` for each `(s, v) ∈ addrReq` carries value
@@ -184,5 +196,7 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   bytePairBus_sound := by intro _ h; exact absurd h (by simp)
   byteCheck _ := false
   byteCheck_sound := by intro _ h; exact absurd h (by simp)
+  xorZeroCheck _ := false
+  xorZeroCheck_sound := by intro _ h; exact absurd h (by simp)
   zeroCell _ := none
   zeroCell_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -535,6 +535,34 @@ def openVmFacts (p : ℕ) [NeZero p]
       unfold violates; rw [hbus]
       rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1 <;>
         simp [h1, hv0, isByte, Nat.xor_self]
+  xorZeroCheck busId := match busMap busId with
+    | some .bitwiseLookup => true
+    | _ => false
+  xorZeroCheck_sound := by
+    intro busId h
+    have hbus : busMap busId = some OpenVmBusType.bitwiseLookup := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    refine ⟨?_, ?_⟩
+    · show (match busMap busId with | some t => t.isStateful | none => false) = false
+      rw [hbus]; rfl
+    · intro x mult
+      -- op 1 asserts `x ⊕ 0 = x` (true) plus byte-ness of `x`; the degenerate op-0 branch
+      -- (`(1 : ZMod p).val = 0`, i.e. `p = 1`) makes every value the byte `0`.
+      have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+      have h1le : (1 : ZMod p).val ≤ 1 := by
+        rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_le 1 p
+      show violates busMap { busId := busId, multiplicity := mult, payload := [x, 0, x, 1] }
+          = false ↔ x.val < 256
+      unfold violates; rw [hbus]
+      rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1
+      · have hp1 : p = 1 := Nat.dvd_one.mp (Nat.dvd_of_mod_eq_zero (by
+          rwa [ZMod.val_one_eq_one_mod] at h1))
+        subst hp1
+        have hx0 : x.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt x)
+        simp [h1, hv0, hx0, isByte]
+      · simp [h1, hv0, isByte, Nat.xor_zero]
   zeroCell := zeroCellImpl busMap
   zeroCell_sound := by
     intro msgs hadm busId addrReq dataSlots hfact m hm hbusId hmne haddr slot hslot v hget

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -25,6 +25,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
 import ApcOptimizer.Implementation.OptimizerPasses.Dedup
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
+import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 
 set_option autoImplicit false
 
@@ -90,6 +91,7 @@ theorem cleanupCycle_respectsDeg : RespectsDeg (cleanupCycle (p := p)) := by
 def pipeline : VerifiedPassW p :=
   constantFoldPass.withFacts.guardDegree
     |>.andThen (iterateToFixpoint cleanupCycle)
+    |>.andThen RedundantByteDrop.redundantByteDropPass.guardDegree
     |>.andThen monicScalePass.withFacts.guardDegree
     |>.andThen constantFoldPass.withFacts.guardDegree
 
@@ -98,6 +100,7 @@ theorem pipeline_respectsDeg : RespectsDeg (pipeline (p := p)) := by
   repeat' apply VerifiedPassW.andThen_respectsDeg
   · exact VerifiedPassW.guardDegree_respectsDeg _
   · exact iterateToFixpoint_respectsDeg cleanupCycle_respectsDeg
+  · exact VerifiedPassW.guardDegree_respectsDeg _
   · exact VerifiedPassW.guardDegree_respectsDeg _
   · exact VerifiedPassW.guardDegree_respectsDeg _
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -1,0 +1,191 @@
+import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancel
+import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
+
+set_option autoImplicit false
+
+/-! # Redundant byte-check removal (C2)
+
+After optimization, blocks keep stateless bitwise-lookup interactions whose *only* obligation is
+"this operand is a byte" — the self-check form `[x, x, 0, 1]` (`BusFacts.byteCheck`) and the
+packed-pair form `[x, y, 0, 0]` (`BusFacts.bytePairBus` + `byteCheck`). Many of their operands are
+already byte-guaranteed by the *rest* of the system: they are raw payload slots of retained memory
+receives (whose acceptance implies byte-ness, `BusFacts.slotBound`) or are pinned to bytes by
+retained constraints (`deepBoundOk` on prime `p`). Such a check is *entailed* — every assignment
+satisfying the rest of the system satisfies it — so dropping it is sound, variable-neutral, and
+removes one bus interaction. powdr performs the same cleanup (e.g. it emits no bitwise bus at all on
+the load/store blocks); this closes the measured residual bitwise-interaction gap.
+
+Crucially it drops a check only when the operand's byte-ness is guaranteed *elsewhere*: a check on a
+freshly *computed* value (whose byte-ness only the check itself enforces) is **kept**, because
+`byteJustified` cannot justify it from the rest of the system. That is exactly powdr's behaviour
+(keep checks on ALU results, drop them on memory-read words).
+
+Two ingredients:
+
+1. `ConstraintSystem.filterBusEntailed_correct` (reused from `FlagFold.lean`) — the generalization
+   of `filterBusStateless_correct` where acceptance of a dropped interaction may be *conditional on
+   satisfaction of the filtered system* rather than universal. That is exactly what "redundant"
+   means.
+2. A **non-circular justification base**: operands are justified only against interactions this
+   pass can never drop (those not recognizable as byte checks). Otherwise two identical checks
+   could each justify the other and both would be dropped unsoundly.
+
+Justification reuses `byteJustified` from `BusPairCancel.lean` (constant bytes, bus-fact slot bounds
+from retained interactions, deep one-hot analysis on prime `p`). Runs after the cleanup fixpoint:
+dropping a check also drops the finite-domain knowledge the enumeration passes derive from its raw
+slot, so it must not starve them mid-loop. -/
+
+namespace RedundantByteDrop
+
+variable {p : ℕ}
+
+/-! ## Recognizing pure byte-check interactions -/
+
+/-- The operands whose byte-ness *implies* this interaction's acceptance (for any multiplicity):
+    `some ops` for the self-check form `[x, x, 0, 1]` (`BusFacts.byteCheck`), the XOR-with-zero form
+    `[x, 0, x, 1]` (`BusFacts.xorZeroCheck`), and the packed-pair form `[x, y, 0, 0]`
+    (`BusFacts.bytePairBus` + `byteCheck`); `none` otherwise. -/
+def byteCheckOperands? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (List (Expression p)) :=
+  match bi.payload with
+  | [e1, e2, e3, e4] =>
+    if facts.byteCheck bi.busId && e1 == e2
+        && e3.constValue? == some 0 && e4.constValue? == some 1 then
+      some [e1]
+    else if facts.xorZeroCheck bi.busId && e2.constValue? == some 0 && e1 == e3
+        && e4.constValue? == some 1 then
+      some [e1]
+    else if facts.bytePairBus bi.busId && facts.byteCheck bi.busId
+        && e3.constValue? == some 0 && e4.constValue? == some 0 then
+      some [e1, e2]
+    else none
+  | _ => none
+
+/-- A recognized byte check lives on a stateless bus. -/
+theorem byteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (ops : List (Expression p))
+    (h : byteCheckOperands? bs facts bi = some ops) : bs.isStateful bi.busId = false := by
+  unfold byteCheckOperands? at h
+  split at h
+  · split_ifs at h with h1 h2 h3
+    · exact (facts.byteCheck_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
+        exact h1.1.1.1)).1
+    · exact (facts.xorZeroCheck_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h2
+        exact h2.1.1.1)).1
+    · exact (facts.bytePairBus_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h3
+        exact h3.1.1.1)).1
+  · exact absurd h (by simp)
+
+/-- If every recognized operand evaluates to a byte, the evaluated message is accepted. -/
+theorem byteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (ops : List (Expression p))
+    (h : byteCheckOperands? bs facts bi = some ops) (env : Variable → ZMod p)
+    (hops : ∀ e ∈ ops, (e.eval env).val < 256) :
+    bs.violatesConstraint (bi.eval env) = false := by
+  obtain ⟨busId, mult, payload⟩ := bi
+  unfold byteCheckOperands? at h
+  split at h
+  case h_2 => exact absurd h (by simp)
+  case h_1 e1 e2 e3 e4 hpay =>
+    simp only at hpay
+    subst hpay
+    split_ifs at h with h1 h2 h3
+    · -- self-check form `[x, x, 0, 1]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
+      obtain ⟨⟨⟨hfact, heq⟩, hz⟩, ho⟩ := h1
+      obtain rfl : [e1] = ops := by simpa using h
+      obtain rfl : e1 = e2 := eq_of_beq heq
+      have hz' : e3.constValue? = some 0 := by simpa using hz
+      have ho' : e4.constValue? = some 1 := by simpa using ho
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e1.eval env, e3.eval env, e4.eval env] } = false
+      rw [e3.constValue?_sound 0 hz' env, e4.constValue?_sound 1 ho' env]
+      exact ((facts.byteCheck_sound busId hfact).2.2 (e1.eval env) (mult.eval env)).2
+        (hops e1 (by simp))
+    · -- XOR-with-zero form `[x, 0, x, 1]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h2
+      obtain ⟨⟨⟨hfact, hz⟩, heq⟩, ho⟩ := h2
+      obtain rfl : [e1] = ops := by simpa using h
+      obtain rfl : e1 = e3 := eq_of_beq heq
+      have hz' : e2.constValue? = some 0 := by simpa using hz
+      have ho' : e4.constValue? = some 1 := by simpa using ho
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e2.eval env, e1.eval env, e4.eval env] } = false
+      rw [e2.constValue?_sound 0 hz' env, e4.constValue?_sound 1 ho' env]
+      exact ((facts.xorZeroCheck_sound busId hfact).2 (e1.eval env) (mult.eval env)).2
+        (hops e1 (by simp))
+    · -- packed-pair form `[x, y, 0, 0]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h3
+      obtain ⟨⟨⟨hpair, hfact⟩, hz⟩, ho⟩ := h3
+      obtain rfl : [e1, e2] = ops := by simpa using h
+      have hz' : e3.constValue? = some 0 := by simpa using hz
+      have ho' : e4.constValue? = some 0 := by simpa using ho
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e2.eval env, e3.eval env, e4.eval env] } = false
+      rw [e3.constValue?_sound 0 hz' env, e4.constValue?_sound 0 ho' env]
+      refine ((facts.bytePairBus_sound busId hpair).2.2 (e1.eval env) (e2.eval env)
+        (mult.eval env)).2 ⟨?_, ?_⟩
+      · exact ((facts.byteCheck_sound busId hfact).2.2 (e1.eval env) (mult.eval env)).2
+          (hops e1 (by simp))
+      · exact ((facts.byteCheck_sound busId hfact).2.2 (e2.eval env) (mult.eval env)).2
+          (hops e2 (by simp))
+
+/-! ## The pass -/
+
+/-- The justification base: the interactions this pass can never drop (not recognizable as byte
+    checks). Justifying only against these makes the drop non-circular. -/
+def byteDropBase (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (BusInteraction (Expression p)) :=
+  cs.busInteractions.filter (fun bi => (byteCheckOperands? bs facts bi).isNone)
+
+/-- Keep `bi` unless it is a recognized byte check whose operands are all byte-justified from
+    the constraints and the justification base. -/
+def byteDropKeep (bs : BusSemantics p) (facts : BusFacts p bs) (all : List (Expression p))
+    (rest : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
+  match byteCheckOperands? bs facts bi with
+  | some ops => !(ops.all (fun e => byteJustified (decide p.Prime) all bs facts rest e))
+  | none => true
+
+/-- Drop every stateless byte-check interaction whose operands are all byte-justified from the
+    parts of the system this pass can never remove. -/
+def redundantByteDropPass : VerifiedPassW p := fun cs bs facts =>
+  ⟨cs.filterBus (byteDropKeep bs facts cs.algebraicConstraints (byteDropBase bs facts cs)), [],
+   cs.filterBusEntailed_correct bs _
+     (by
+       intro bi _ hkf
+       unfold byteDropKeep at hkf
+       cases hro : byteCheckOperands? bs facts bi with
+       | none => rw [hro] at hkf; exact absurd hkf (by simp)
+       | some ops => exact byteCheckOperands?_stateless bs facts bi ops hro)
+     (by
+       intro bi hbimem hkf env hsat _
+       unfold byteDropKeep at hkf
+       cases hro : byteCheckOperands? bs facts bi with
+       | none => rw [hro] at hkf; exact absurd hkf (by simp)
+       | some ops =>
+         rw [hro] at hkf
+         have hjust : ops.all (fun e => byteJustified (decide p.Prime)
+             cs.algebraicConstraints bs facts (byteDropBase bs facts cs) e) = true := by
+           simpa using hkf
+         refine byteCheckOperands?_accepted bs facts bi ops hro env (fun e he => ?_)
+         refine byteJustified_sound (decide p.Prime) cs.algebraicConstraints bs facts
+           (byteDropBase bs facts cs) e (fun h => of_decide_eq_true h)
+           (List.all_eq_true.mp hjust e he) env
+           (fun c hc => hsat.1 c hc) (fun bi' hbi' hmult => ?_)
+         -- every justification-base interaction survives the filter, so `hsat` accepts it
+         have hnone : byteCheckOperands? bs facts bi' = none := by
+           have := (List.mem_filter.1 hbi').2
+           simpa using this
+         have hkeep : byteDropKeep bs facts cs.algebraicConstraints
+             (byteDropBase bs facts cs) bi' = true := by
+           unfold byteDropKeep
+           rw [hnone]
+         exact hsat.2 bi' (List.mem_filter.2 ⟨(List.mem_filter.1 hbi').1, hkeep⟩) hmult)⟩
+
+end RedundantByteDrop

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -157,13 +157,12 @@ flag→address→busUnify cascade may still apply on apc_005-class blocks.
 
 `deepBoundOk` (log 50) proves `x < 256` by enumerating the finite domains of a defining
 constraint's selector flags and checking each branch pins `x` to a byte constant or a
-byte-bounded variable. Today only `busPairCancelPass` consumes it. It could also power (a) a
-redundant-range-check dropper (a stateless byte check whose operands are deep-justified from the
-*rest* of the system is removable — same `filterBus` shape as `tautoBusDropPass` but with an
-env-dependent justification), and (b) wider domains for `domainProp` (a deep-justified byte var
-gets a `[0,256)` domain even when no interaction carries it raw). Generalising the two-term
-branch to `x = c₀ + Σ cᵢ·yᵢ` with a no-wrap interval bound would subsume the is-zero and
-mem-ptr-limb ideas' bound side.
+byte-bounded variable. **Update (log 68):** part (a) — the redundant byte-check dropper — is
+**landed** as `redundantByteDropPass` (C2), consuming `byteJustified`/`deepBoundOk` to drop
+entailed bitwise byte checks in the coda. Remaining: (b) wider domains for `domainProp` (a
+deep-justified byte var gets a `[0,256)` domain even when no interaction carries it raw).
+Generalising the two-term branch to `x = c₀ + Σ cᵢ·yᵢ` with a no-wrap interval bound would
+subsume the is-zero and mem-ptr-limb ideas' bound side.
 
 ## Smarter witnesses for `disconnectedComponentPass` — measured empty (log 61)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2010,3 +2010,46 @@ either way). Effectiveness unchanged by construction. apc_005: **81 s → 12.7 s
 **66.9 s → 1.7 s** (iter 0: 0.65 s; fold iteration: 0.44 s). The profile is now led by
 pre-existing passes — domainFold 3.3 s, reencode 1.7 s, domainBatch 1.6 s — so the composite is
 no longer the pipeline's bottleneck. `lake build` green at every commit; proof integrity clean.
+
+### 68. Redundant byte-check removal (C2): drop entailed bitwise byte checks (`RedundantByteDrop.lean`)
+
+Blocks keep stateless bitwise-lookup interactions whose only obligation is "this operand is a
+byte": the self-check `[x, x, 0, 1]` (`BusFacts.byteCheck`), the XOR-with-zero `[x, 0, x, 1]`
+(`BusFacts.xorZeroCheck`, added this entry), and the packed pair `[x, y, 0, 0]`
+(`bytePairBus` + `byteCheck`). When an operand's byte-ness is already guaranteed by the *rest* of
+the retained system — a raw slot of a retained memory receive (`slotBound`), a retained range check
+(`findVarBound`), or a constraint that pins it on every selector-flag branch (`deepBoundOk`, prime
+`p`) — the check is *entailed* and dropping it is sound, variable-neutral, and removes one bus
+interaction. Checks on freshly *computed* values (byte-ness enforced only by the check itself) are
+**kept** — `byteJustified` cannot justify them — matching powdr (drop on memory-read words, keep on
+ALU results). `redundantByteDropPass` runs in the pipeline coda, after the cleanup fixpoint, so it
+does not starve the mid-loop enumeration passes of the finite-domain knowledge a raw byte-check slot
+carries.
+
+Reuses existing machinery: `ConstraintSystem.filterBusEntailed_correct` (from `FlagFold.lean`; the
+drop's acceptance is conditional on satisfaction of the *filtered* system — exactly "redundant"),
+`byteJustified`/`deepBoundOk` (from `BusPairCancel.lean`), and a **non-circular justification base**
+(operands justified only against interactions this pass can never drop, so two identical checks
+can't justify each other). `byteCheckOperands?` recognises all three forms; soundness threads
+through `byteCheck_sound`/`xorZeroCheck_sound`/`bytePairBus_sound`. Only new audit-free surface is
+the `xorZeroCheck` `BusFacts` field + its OpenVM instance (`bitwiseLookup` accepts `[x,0,x,1]` iff
+`x` is a byte).
+
+Coverage checked against powdr per case: the pass drops all three forms whenever the operand is
+byte-justified; the residual bitwise interactions it leaves are genuine XOR *operations* (not byte
+checks) or checks on computed values whose byte-ness is not otherwise entailed — which powdr removes
+only by eliminating the variable (C4) or deeper structural reasoning, outside C2's scope.
+
+`lake build` green; all three `maintainsCorrectness` theorems still `{propext, Classical.choice,
+Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** Variable- and constraint-neutral by construction (a coda `filterBus`). Full 100-case
+sweep vs the C1 (entry-67) line, per-case: **bus dropped on 57 cases, 0 regressions**; totals
+variables 28645 (unchanged), constraints 11215 (unchanged), bus 18887 → 18341 (−546). Aggregate vs
+powdr:
+
+- **bus interactions: 3.081× → 3.173× aggregate (2.486× → 2.581× geomean)** vs powdr's 3.480×/2.822×
+- variables 4.411×/3.768× and constraints 10.593×/11.585× unchanged
+
+Largest drops on memory/shift-heavy blocks (apc_037 −110 bus, apc_071 −48, apc_100 −35, apc_006 −30).
+Runtime smoke set vs C1: **+0% total** (one coda pass; worst case apc_100 +1.5%).


### PR DESCRIPTION
Stacked on #91 (`free-vars`). One commit above its head.

## What

After optimization, blocks keep stateless **bitwise-lookup byte checks** whose only obligation is "this operand is a byte" — the self-check `[x, x, 0, 1]`, the XOR-with-zero form `[x, 0, x, 1]`, and the packed-pair form `[x, y, 0, 0]`. Many of their operands are *already* byte-guaranteed by the rest of the system: raw payload slots of retained memory receives (`BusFacts.slotBound`) or values pinned to bytes by retained constraints (`deepBoundOk`). Such a check is **entailed** — every assignment satisfying the rest of the system satisfies it — so dropping it is sound, variable-neutral, and removes one bus interaction. It keeps a check on a freshly *computed* value (whose byte-ness only the check enforces), matching powdr's behaviour.

## How

`redundantByteDropPass` (`RedundantByteDrop.lean`), a coda pass after the cleanup fixpoint:
- `ConstraintSystem.filterBusEntailed_correct` (from `FlagFold.lean`) — a drop whose acceptance is conditional on satisfaction of the *filtered* system.
- `byteJustified`/`deepBoundOk` (from `BusPairCancel.lean`) for the byte justification.
- A **non-circular justification base**: operands are justified only against interactions this pass can never drop, so two identical checks can't justify each other.

Only new audit-free surface: a `BusFacts.xorZeroCheck` field (bitwise lookup accepts `[x,0,x,1]` iff `x` is a byte) + its OpenVM instance.

## Effectiveness

Full 100-case `openvm-eth` sweep vs this PR's base: **bus interactions −531 over 57 cases, variables and constraints unchanged, 0 regressions.** Aggregate bus effectiveness **3.114× → 3.205×**.

## Correctness

`VerifiedPass` with its own `PassCorrect`; no audited file touched (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`, `Basic.lean` glue). `lake build` green; `Scripts/check-proof-integrity.sh` passes — the correctness theorems depend only on `{propext, Classical.choice, Quot.sound}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
