### PR TITLE
Bus-encoded equality extraction: width-0 range checks and 0-operand XORs → algebraic equalities

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -176,6 +176,19 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
         ∀ m ∈ msgs, m.busId = busId → m.multiplicity ≠ 0 →
           (∀ ar ∈ addrReq, m.payload[ar.1]? = some ar.2) →
           ∀ slot ∈ dataSlots, ∀ v, m.payload[slot]? = some v → v = 0
+  /-- Width-0 range equality: on a **stateless** bus, the range-check message `[x, 0]`
+      (multiplicity `1`) is accepted **iff** `x = 0`. A 0-bit range check asserts `x < 2⁰ = 1`,
+      i.e. `x = 0`; this is the "assert this linear form is zero" encoding OpenVM emits as a 0-bit
+      range check. Recognising it lets a pass convert such a stateless interaction into the
+      algebraic constraint `x = 0`, which Gaussian elimination can then consume — turning a bus
+      interaction into a variable-eliminating equality. `trivial` sets it `false`. -/
+  zeroRangeEq : (busId : Nat) → Bool
+  zeroRangeEq_sound :
+    ∀ (busId : Nat), zeroRangeEq busId = true →
+      bs.isStateful busId = false ∧
+      ∀ (x : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 0] } = false
+          ↔ x = 0
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -200,3 +213,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   xorZeroCheck_sound := by intro _ h; exact absurd h (by simp)
   zeroCell _ := none
   zeroCell_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
+  zeroRangeEq _ := false
+  zeroRangeEq_sound := by intro _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -189,6 +189,21 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       ∀ (x : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 0] } = false
           ↔ x = 0
+  /-- Bitwise XOR-with-zero equality: on a bitwise-style bus where an accepted multiplicity-1
+      message `[a, b, c, 1]` asserts `c = a ⊕ b`, a zero operand linearizes the XOR to an equality —
+      `[0, y, z, 1]` accepted ⟹ `z = y`, and `[x, 0, z, 1]` accepted ⟹ `z = x`. apc keeps these
+      equalities on the bus, so Gaussian elimination never uses them to eliminate the intermediate
+      byte the identity pins. Recognising them lets a pass add the entailed equality (keeping the
+      interaction, which still imposes byte-ness) for Gauss to consume. `trivial` sets it `false`. -/
+  xorZeroEq : (busId : Nat) → Bool
+  xorZeroEq_sound :
+    ∀ (busId : Nat), xorZeroEq busId = true →
+      (∀ (y z : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [0, y, z, 1] }
+          = false → z = y) ∧
+      (∀ (x z : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 0, z, 1] }
+          = false → z = x)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -215,3 +230,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   zeroCell_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
   zeroRangeEq _ := false
   zeroRangeEq_sound := by intro _ h; exact absurd h (by simp)
+  xorZeroEq _ := false
+  xorZeroEq_sound := by intro _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -583,6 +583,45 @@ def openVmFacts (p : ℕ) [NeZero p]
       rw [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq,
         hv0, pow_zero, Nat.lt_one_iff, ZMod.val_eq_zero]
       exact ⟨fun h => h.2, fun h => ⟨Nat.zero_le 25, h⟩⟩
+  xorZeroEq busId := match busMap busId with
+    | some .bitwiseLookup => true
+    | _ => false
+  xorZeroEq_sound := by
+    intro busId h
+    have hbus : busMap busId = some OpenVmBusType.bitwiseLookup := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    have h1le : (1 : ZMod p).val ≤ 1 := by
+      rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_le 1 p
+    -- `ZMod.val` is injective (via its right inverse `Nat.cast`).
+    have valeq : ∀ a b : ZMod p, a.val = b.val → a = b := fun a b hab =>
+      (ZMod.natCast_rightInverse a).symm.trans ((congrArg _ hab).trans (ZMod.natCast_rightInverse b))
+    -- The degenerate `p = 1` case: `ZMod 1` is a subsingleton, so any equality holds.
+    have degen : (1 : ZMod p).val = 0 → ∀ a b : ZMod p, a = b := by
+      intro h1 a b
+      have hp1 : p = 1 := Nat.dvd_one.mp (Nat.dvd_of_mod_eq_zero (by
+        rwa [ZMod.val_one_eq_one_mod] at h1))
+      subst hp1; exact Subsingleton.elim a b
+    refine ⟨?_, ?_⟩
+    · intro y z hviol
+      replace hviol : violates busMap
+          { busId := busId, multiplicity := 1, payload := [0, y, z, 1] } = false := hviol
+      unfold violates at hviol; rw [hbus] at hviol
+      rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1
+      · exact degen h1 z y
+      · simp only [h1, ZMod.val_zero, isByte, Bool.not_eq_false',
+          Bool.and_eq_true, decide_eq_true_eq] at hviol
+        exact valeq z y (hviol.2.trans (Nat.zero_xor y.val))
+    · intro x z hviol
+      replace hviol : violates busMap
+          { busId := busId, multiplicity := 1, payload := [x, 0, z, 1] } = false := hviol
+      unfold violates at hviol; rw [hbus] at hviol
+      rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1
+      · exact degen h1 z x
+      · simp only [h1, ZMod.val_zero, isByte, Bool.not_eq_false',
+          Bool.and_eq_true, decide_eq_true_eq] at hviol
+        exact valeq z x (hviol.2.trans (Nat.xor_zero x.val))
   zeroCell := zeroCellImpl busMap
   zeroCell_sound := by
     intro msgs hadm busId addrReq dataSlots hfact m hm hbusId hmne haddr slot hslot v hget

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -563,6 +563,26 @@ def openVmFacts (p : ℕ) [NeZero p]
         have hx0 : x.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt x)
         simp [h1, hv0, hx0, isByte]
       · simp [h1, hv0, isByte, Nat.xor_zero]
+  zeroRangeEq busId := match busMap busId with
+    | some .variableRangeChecker => true
+    | _ => false
+  zeroRangeEq_sound := by
+    intro busId h
+    have hbus : busMap busId = some OpenVmBusType.variableRangeChecker := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    refine ⟨?_, ?_⟩
+    · show (match busMap busId with | some t => t.isStateful | none => false) = false
+      rw [hbus]; rfl
+    · intro x
+      -- variableRangeChecker `[x, 0]`: `!(0 ≤ 25 ∧ x.val < 2^0) = false ↔ x.val < 1 ↔ x = 0`.
+      have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+      show violates busMap { busId := busId, multiplicity := 1, payload := [x, 0] } = false ↔ x = 0
+      unfold violates; rw [hbus]
+      rw [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq,
+        hv0, pow_zero, Nat.lt_one_iff, ZMod.val_eq_zero]
+      exact ⟨fun h => h.2, fun h => ⟨Nat.zero_le 25, h⟩⟩
   zeroCell := zeroCellImpl busMap
   zeroCell_sound := by
     intro msgs hadm busId addrReq dataSlots hfact m hm hbusId hmne haddr slot hslot v hget

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -26,6 +26,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.Dedup
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
+import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
 
 set_option autoImplicit false
 
@@ -61,7 +62,8 @@ pass's own `PassCorrect`. -/
     scale every constraint's affine factors to monic form (zero-set preserving) and re-fold.
     Extend it by composing passes with `.andThen`. -/
 def cleanupCycle : VerifiedPassW p :=
-  carryBranchPass.guardDegree
+  ZeroWidthRange.zeroWidthRangePass.guardDegree
+    |>.andThen carryBranchPass.guardDegree
     |>.andThen gaussElimPass.withFacts.guardDegree
     |>.andThen normalizePass.withFacts.guardDegree
     |>.andThen constantFoldPass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -27,6 +27,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
+import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 
 set_option autoImplicit false
 
@@ -63,6 +64,7 @@ pass's own `PassCorrect`. -/
     Extend it by composing passes with `.andThen`. -/
 def cleanupCycle : VerifiedPassW p :=
   ZeroWidthRange.zeroWidthRangePass.guardDegree
+    |>.andThen XorEqExtract.xorEqExtractPass.guardDegree
     |>.andThen carryBranchPass.guardDegree
     |>.andThen gaussElimPass.withFacts.guardDegree
     |>.andThen normalizePass.withFacts.guardDegree

--- a/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
@@ -1,0 +1,116 @@
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # Bitwise-XOR equality extraction (C4a)
+
+powdr-exported memory/shift blocks keep, on the bitwise-lookup bus, a family of interactions
+`[x, y, z, 1]` (op 1: `z = x ⊕ y`, with `x`,`y` bytes) in which **one operand is the constant 0**.
+Then the XOR linearizes to an *equality*: `[0, y, z, 1] ⟹ z = y` and `[x, 0, z, 1] ⟹ z = x`. These
+equalities pin an intermediate byte (loaded-data / effective-address limb, the `b`/`a`/`c` families)
+to another variable, but — being carried on the **bus** — Gaussian elimination never uses them, so
+the intermediate limbs survive. powdr represents everything with the canonical loaded value; this
+pass closes that gap.
+
+`xorEqExtractPass` recognizes these 0-operand XOR interactions and **adds the entailed equality
+constraint** `z − y` (resp. `z − x`), keeping the interaction (which still imposes byte-ness). Placed
+in the cleanup cycle, the added equalities feed same-cycle Gauss, which eliminates the intermediate
+variables and cascades — a variable win (and, via the range/bitwise checks the eliminated variables
+no longer need, a bus win).
+
+The equality is entailed by the interaction's acceptance (`BusFacts.xorZeroEq`, proven for OpenVM's
+bitwise lookup from `Nat.zero_xor`/`Nat.xor_zero`), so the pass is a `ConstraintSystem.addConstraints_correct`
+— soundness drops the added constraints, and adding constraints touches no interaction, so side
+effects and admissibility are unchanged. Gated on `(1 : ZMod p) ≠ 0` (every prime field; identity on
+`ZMod 1`).
+
+The 255-operand XOR cases (`[x, 255, z, 1] ⟹ z = 255 − x`) are the sibling pass C4b, which needs the
+byte-complement identity and stacks on this one. -/
+
+namespace XorEqExtract
+
+variable {p : ℕ}
+
+/-- `z − e` as an expression (`z + (-1)·e`). -/
+def subE (z e : Expression p) : Expression p := .add z (.mul (.const (-1)) e)
+
+theorem subE_eval (z e : Expression p) (env : Variable → ZMod p) :
+    (subE z e).eval env = z.eval env - e.eval env := by
+  simp only [subE, Expression.eval]; ring
+
+/-- The entailed equality from a 0-operand bitwise-XOR interaction `[x, y, z, 1]` (multiplicity 1) on
+    a `xorZeroEq` bus: `some (z − y)` when `x = 0`, `some (z − x)` when `y = 0`; `none` otherwise. -/
+def xorEq? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match bi.payload with
+  | [x, y, z, op] =>
+    if facts.xorZeroEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
+        ∧ op = Expression.const 1 then
+      if x = Expression.const 0 then some (subE z y)
+      else if y = Expression.const 0 then some (subE z x)
+      else none
+    else none
+  | _ => none
+
+/-- Structure of a recognized interaction. -/
+theorem xorEq?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : xorEq? bs facts bi = some c) :
+    facts.xorZeroEq bi.busId = true ∧ bi.multiplicity = Expression.const 1 ∧
+      ∃ x y z, bi.payload = [x, y, z, Expression.const 1] ∧
+        ((x = Expression.const 0 ∧ c = subE z y) ∨ (y = Expression.const 0 ∧ c = subE z x)) := by
+  unfold xorEq? at h
+  split at h
+  · rename_i x y z op hpay
+    split_ifs at h with hcond hx hy
+    · obtain ⟨hfact, hmult, hop⟩ := hcond
+      subst hop
+      exact ⟨hfact, hmult, x, y, z, hpay, Or.inl ⟨hx, by simpa using h.symm⟩⟩
+    · obtain ⟨hfact, hmult, hop⟩ := hcond
+      subst hop
+      exact ⟨hfact, hmult, x, y, z, hpay, Or.inr ⟨hy, by simpa using h.symm⟩⟩
+  · exact absurd h (by simp)
+
+/-- Extract every 0-operand bitwise-XOR equality and add it as an algebraic constraint. -/
+def xorEqExtractPass : VerifiedPassW p := fun cs bs facts =>
+  if h1ne : (1 : ZMod p) ≠ 0 then
+    let new := cs.busInteractions.filterMap (xorEq? bs facts)
+    ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+      cs.addConstraints_correct bs new
+        (by
+          -- entailment: each added equality holds on every satisfying assignment
+          intro env _ hsat c hc
+          obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+          obtain ⟨hfact, hmult, x, y, z, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
+          have hev : bi.eval env =
+              { busId := bi.busId, multiplicity := 1,
+                payload := [x.eval env, y.eval env, z.eval env, 1] } := by
+            unfold BusInteraction.eval; rw [hmult, hpay]; simp [Expression.eval]
+          have hviol : bs.violatesConstraint (bi.eval env) = false :=
+            hsat.2 bi hbi (by rw [hev]; exact h1ne)
+          rcases hcase with ⟨hx0, rfl⟩ | ⟨hy0, rfl⟩
+          · rw [subE_eval]
+            have he0 : bi.eval env = ⟨bi.busId, 1, [0, y.eval env, z.eval env, 1]⟩ := by
+              rw [hev, hx0]; simp [Expression.eval]
+            rw [(facts.xorZeroEq_sound bi.busId hfact).1 (y.eval env) (z.eval env)
+              (he0 ▸ hviol), sub_self]
+          · rw [subE_eval]
+            have he0 : bi.eval env = ⟨bi.busId, 1, [x.eval env, 0, z.eval env, 1]⟩ := by
+              rw [hev, hy0]; simp [Expression.eval]
+            rw [(facts.xorZeroEq_sound bi.busId hfact).2 (x.eval env) (z.eval env)
+              (he0 ▸ hviol), sub_self])
+        (by
+          -- no new variables: each equality's variables come from the interaction's payload
+          intro c hc zv hz
+          obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+          obtain ⟨_, _, x, y, w, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
+          have mem_pay : ∀ e ∈ ([x, y, w] : List (Expression p)), e ∈ bi.payload := by
+            intro e he; rw [hpay]; simp only [List.mem_cons] at he ⊢; tauto
+          rcases hcase with ⟨_, rfl⟩ | ⟨_, rfl⟩ <;>
+          · rcases List.mem_append.1 (by simpa only [subE, Expression.vars, List.append_assoc,
+              List.nil_append, Expression.vars] using hz) with hzw | hze
+            · exact ConstraintSystem.mem_vars_of_payload hbi (mem_pay w (by simp)) hzw
+            · exact ConstraintSystem.mem_vars_of_payload hbi (mem_pay _ (by simp)) hze)⟩
+  else
+    ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end XorEqExtract

--- a/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
@@ -1,0 +1,151 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
+
+set_option autoImplicit false
+
+/-! # Width-0 range-check → equality (C3)
+
+powdr-exported blocks that compute effective addresses keep, on the variable range checker, a family
+of **width-0 range checks** `[expr, 0]` (multiplicity `1`). A 0-bit range check asserts
+`expr < 2⁰ = 1`, i.e. `expr = 0`; it is powdr/OpenVM's encoding of "this linear form is exactly
+zero" — used to pin an intermediate address/data limb to a combination of others (e.g.
+`-a__2 + b__3 = 0`, `7864320·(a__3 − b__0) = 0`). Because the optimizer's Gaussian elimination only
+consumes *algebraic* constraints, these equalities — being carried on the **bus** — are never used
+to eliminate a variable, so the intermediate limbs survive. powdr substitutes them away.
+
+This pass converts each such interaction into the algebraic constraint `expr = 0` and drops the
+interaction: the two have the *same* satisfying set (a stateless range check `[x, 0]` is accepted iff
+`x = 0`, `BusFacts.zeroRangeEq`), so the transform is a sound, side-effect-preserving refinement.
+Placed early in the cleanup cycle, it feeds the new equalities to Gauss, which then eliminates the
+intermediate variables and cascades — a variable win (and, via the dropped interaction and the
+range checks the eliminated variables no longer need, a bus win).
+
+Proof shape: two `PassCorrect` steps composed by `andThen`.
+1. **Add** the equality constraints, keeping every interaction — a `PassCorrect.ofEnvEq` whose only
+   content is "each width-0 interaction, being accepted, forces its value to zero" (so the added
+   constraints hold); side effects and admissibility are literally unchanged (same interactions).
+2. **Drop** the now-entailed width-0 interactions via `filterBusEntailed_correct`: each dropped
+   interaction is stateless, and is accepted under the filtered system because the equality
+   constraint added in step 1 (which the drop keeps) forces its value to zero.
+
+The pass gates on `(1 : ZMod p) ≠ 0` (true for every prime field, in particular OpenVM's BabyBear);
+on the degenerate `ZMod 1` it degrades to the identity. -/
+
+namespace ZeroWidthRange
+
+variable {p : ℕ}
+
+/-- Recognize a width-0 range check `[value, 0]` (multiplicity `1`) on a `zeroRangeEq` bus, returning
+    the value expression whose zeroness it asserts; `none` otherwise. -/
+def zeroRangeValue? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match bi.payload with
+  | [v, c] =>
+    if facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
+        ∧ c = Expression.const 0 then some v else none
+  | _ => none
+
+/-- Structure of a recognized interaction: the bus admits the equality fact, the multiplicity is the
+    constant `1`, and the payload is `[value, 0]`. -/
+theorem zeroRangeValue?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (v : Expression p)
+    (h : zeroRangeValue? bs facts bi = some v) :
+    facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
+      ∧ bi.payload = [v, Expression.const 0] := by
+  unfold zeroRangeValue? at h
+  split at h
+  · rename_i v' c hpay
+    split_ifs at h with hcond
+    obtain ⟨hz, hm, hc⟩ := hcond
+    simp only [Option.some.injEq] at h
+    subst h
+    exact ⟨hz, hm, by rw [hpay, hc]⟩
+  · exact absurd h (by simp)
+
+/-- A recognized interaction evaluates to the message `[value.eval, 0]` with multiplicity `1`. -/
+theorem zeroRangeValue?_eval (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
+    (h : zeroRangeValue? bs facts bi = some v) :
+    bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [v.eval env, 0] } := by
+  obtain ⟨_, hm, hp⟩ := zeroRangeValue?_spec bs facts bi v h
+  unfold BusInteraction.eval
+  rw [hm, hp]
+  simp [Expression.eval]
+
+/-- A recognized interaction lives on a stateless bus. -/
+theorem zeroRangeValue?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (v : Expression p)
+    (h : zeroRangeValue? bs facts bi = some v) : bs.isStateful bi.busId = false :=
+  (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).1
+
+/-- The evaluated message is accepted iff the value evaluates to zero. -/
+theorem zeroRangeValue?_violates_iff (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
+    (h : zeroRangeValue? bs facts bi = some v) :
+    bs.violatesConstraint (bi.eval env) = false ↔ v.eval env = 0 := by
+  rw [zeroRangeValue?_eval bs facts bi v env h]
+  exact (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).2 (v.eval env)
+
+/-- Convert every width-0 range check into the equality `value = 0` and drop the interaction. -/
+def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
+  if h1ne : (1 : ZMod p) ≠ 0 then
+    let newC := cs.busInteractions.filterMap (zeroRangeValue? bs facts)
+    let out1 : ConstraintSystem p :=
+      { cs with algebraicConstraints := cs.algebraicConstraints ++ newC }
+    let keep := fun bi => (zeroRangeValue? bs facts bi).isNone
+    -- Step 1: add the equality constraints; interactions (hence side effects, admissibility) unchanged.
+    have hstep1 : PassCorrect cs out1 [] bs := by
+      refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+      · -- soundness: out1 has extra constraints, same interactions
+        intro env hsat
+        exact ⟨env, ⟨fun c hc => hsat.1 c (List.mem_append_left _ hc), hsat.2⟩,
+          BusState.equiv_refl _⟩
+      · -- invariant preservation
+        intro hcs env hsat
+        exact hcs env ⟨fun c hc => hsat.1 c (List.mem_append_left _ hc), hsat.2⟩
+      · -- no new variables
+        intro x hx
+        rw [ConstraintSystem.mem_vars] at hx ⊢
+        rcases hx with ⟨c, hc, hxc⟩ | ⟨bi, hbi, hbrest⟩
+        · rcases List.mem_append.1 hc with hc | hc
+          · exact Or.inl ⟨c, hc, hxc⟩
+          · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
+            obtain ⟨_, _, hp⟩ := zeroRangeValue?_spec bs facts bi c hval
+            exact Or.inr ⟨bi, hbi, Or.inr ⟨c, by rw [hp]; simp, hxc⟩⟩
+        · exact Or.inr ⟨bi, hbi, hbrest⟩
+      · -- completeness: same env; the added equalities hold because the interactions are accepted
+        intro env hadm hsat
+        refine ⟨⟨fun c hc => ?_, hsat.2⟩, hadm, BusState.equiv_refl _⟩
+        rcases List.mem_append.1 hc with hc | hc
+        · exact hsat.1 c hc
+        · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
+          have hmult : (bi.eval env).multiplicity = 1 := by
+            rw [zeroRangeValue?_eval bs facts bi c env hval]
+          have hviol : bs.violatesConstraint (bi.eval env) = false :=
+            hsat.2 bi hbi (by rw [hmult]; exact h1ne)
+          exact (zeroRangeValue?_violates_iff bs facts bi c env hval).1 hviol
+    -- Step 2: drop the now-entailed width-0 interactions.
+    have hstep2 : PassCorrect out1 (out1.filterBus keep) [] bs := by
+      refine out1.filterBusEntailed_correct bs keep ?_ ?_
+      · intro bi _ hkf
+        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
+          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
+          cases hopt : zeroRangeValue? bs facts bi with
+          | none => rw [hopt] at hkf'; simp at hkf'
+          | some v => exact ⟨v, rfl⟩
+        exact zeroRangeValue?_stateless bs facts bi v hv
+      · intro bi hbi hkf env hsatf _
+        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
+          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
+          cases hopt : zeroRangeValue? bs facts bi with
+          | none => rw [hopt] at hkf'; simp at hkf'
+          | some v => exact ⟨v, rfl⟩
+        have hvmem : v ∈ (out1.filterBus keep).algebraicConstraints :=
+          List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, hv⟩)
+        rw [zeroRangeValue?_violates_iff bs facts bi v env hv]
+        exact hsatf.1 v hvmem
+    ⟨out1.filterBus keep, [], hstep1.andThen hstep2⟩
+  else
+    ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end ZeroWidthRange

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -36,7 +36,17 @@ eliminating `a` as a derived column adds `carry`, a pure swap with no cascade. p
 these blocks (e.g. apc_061/003 var-identical). The ceiling was entirely unsound one-root collapse.
 Do not build a carry-witness pass; the residual C1 gap is not a real variable opportunity.
 
-## Intermediate effective-address elimination (the residual after C3 / entry 69)
+## Bitwise-XOR equality extraction (C4a landed, entry 70; C4b = 255-operand follow-up)
+
+**Update (log 70):** the dominant residual mechanism turned out to be **bitwise XOR interactions
+with a constant operand** encoding equalities Gauss can't see. `[0,y,z,1] ⟹ z=y`, `[x,0,z,1] ⟹ z=x`
+(0-operand, `Nat.zero_xor`/`Nat.xor_zero`) landed as `xorEqExtractPass` (C4a) — adds the entailed
+equality, Gauss eliminates the `b`/`a`/`c` limbs. −449 vars / −554 bus over 16 cases, 0 regressions,
+runtime −3.9%. **Remaining C4b:** the 255-operand cases `[x,255,z,1] ⟹ z=255−x` (needs the
+byte-complement identity `Nat.xor n 255 = 255−n` for `n<256`, plus `x` byte from acceptance);
++16 vars on apc_071, +3 on apc_037. Stacks directly on C4a via a second `xorZeroEq`-style fact.
+
+## Intermediate effective-address elimination (deeper residual, after C4a/C4b)
 
 `zeroWidthRangePass` (log 69, C3) converts the width-0 range checks `[expr, 0]` into equalities
 `expr = 0`, letting Gauss eliminate the pinned limbs — closing ~40 of apc_071's 123-variable gap to

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -23,6 +23,35 @@ returns the send's payload, so `read_limb = written_limb`) and/or by the XOR fun
 
 The bitwise-**result** byte bound itself is now landed (`openVmFacts.slotBound` slot 2, entry 58) —
 do not re-propose it.
+## Genuine two-root carries: carry-witness substitution — MEASURED WASH, do not build
+
+**Measured a wash (faithful census what-if, 2026-07).** `carryCollapsePass` (log 67) collapses only
+*pure copies* `(L)·(L±256)=0` where a byte bound rules out one root, correctly leaving **genuine**
+two-root carries intact (both roots reachable): the 3-operand ADD limb carry `(b+c−a)·(b+c−a−256)=0`
+and the `mem_ptr` page-boundary carry (gap 65536). It looked like a large win — an *optimistic* what-if
+(zero one root, ignore whether the bound holds, re-optimize) claimed up to **−249 vars** on apc_037,
+−52 on apc_071. But the **faithful** transform (introduce the boolean carry witness it actually needs,
+`a = b+c − 256·carry`, plus booleanity, then re-optimize) nets **exactly 0 variables** on every case:
+eliminating `a` as a derived column adds `carry`, a pure swap with no cascade. powdr matches apc on
+these blocks (e.g. apc_061/003 var-identical). The ceiling was entirely unsound one-root collapse.
+Do not build a carry-witness pass; the residual C1 gap is not a real variable opportunity.
+
+## Intermediate effective-address elimination (the residual after C3 / entry 69)
+
+`zeroWidthRangePass` (log 69, C3) converts the width-0 range checks `[expr, 0]` into equalities
+`expr = 0`, letting Gauss eliminate the pinned limbs — closing ~40 of apc_071's 123-variable gap to
+powdr (and 11 on apc_020, 3 on apc_037). The **residual** gap on apc_071 is the `a` (48) and `c`
+(16) families: intermediate effective-address bytes. For each access at `base + offsetᵢ`, apc
+materializes the effective address as a fresh 4-byte decomposition via a two-root carry chain and
+then decomposes again into `mem_ptr_limbs`; powdr derives `mem_ptr_limbs` **directly** from
+`rs1_data + offsetᵢ`, skipping the intermediate byte layer entirely. Eliminating it needs a
+derived-column pass (reencode-class): recognise `addr = base + offset` carry chains feeding only a
+memory address / byte-decomposed write, and express the `mem_ptr` limbs affinely in `base + offset`
+with carry witnesses, without materializing the intermediate bytes. Higher proof cost; the true
+"highest cost" item of the old C4 cluster. Note the naive per-limb carry-witnessing is net-neutral
+(swap 4 address bytes for 4 carries — same wash as the carry-witness follow-up below); the win comes
+only from *not materializing the intermediate layer at all* while still satisfying the memory bus's
+byte requirement.
 
 ## Consider dropping `reencode` in favour of `domainFoldPass` alone (entry-47 option B)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2106,3 +2106,42 @@ genuine-two-root carry-witness follow-up (add a boolean carry ⇒ net 0 vars —
 ceiling was unsound one-root collapse), the N2 signed-compare msb fold (basis rename; apc/powdr both
 keep 2 gadget vars), and the C4c timestamp split (`2×lower_decomp` ↔ `lower_decomp + prev_timestamp`,
 equal counts).
+
+## Entry 70: bitwise-XOR equality extraction, 0-operand (C4a)
+
+**Idea.** powdr-exported memory/shift blocks keep, on the bitwise-lookup bus, interactions
+`[x, y, z, 1]` (op 1: `z = x ⊕ y`, `x`,`y` bytes) with **one operand the constant 0**. The XOR then
+linearizes to an equality: `[0, y, z, 1] ⟹ z = y`, `[x, 0, z, 1] ⟹ z = x`. These pin an intermediate
+loaded-data / effective-address byte (the `b`/`a`/`c` families — essentially the whole residual
+variable gap to powdr) to another variable, but Gaussian elimination — consuming only *algebraic*
+constraints — never uses them, so the intermediate limbs survive. powdr represents everything with
+the canonical loaded value.
+
+`xorEqExtractPass` recognizes each 0-operand XOR interaction and **adds the entailed equality**
+`z − y` (resp. `z − x`) as an algebraic constraint, keeping the interaction (still imposes byte-ness).
+Placed early in the cleanup cycle, the equalities feed same-cycle Gauss, which eliminates the
+intermediate variables and cascades — a variable win plus a bus win (the range/bitwise checks the
+eliminated variables no longer need).
+
+**How.** New audit-free `BusFacts` field `xorZeroEq busId` — "an accepted mult-1 `[0,y,z,1]` forces
+`z = y`, `[x,0,z,1]` forces `z = x`" — proven for OpenVM's `bitwiseLookup` from `Nat.zero_xor` /
+`Nat.xor_zero`. The pass is a `ConstraintSystem.addConstraints_correct`: the equalities are entailed
+by the interactions' acceptance (completeness), soundness drops the added constraints, and adding
+constraints touches no interaction so side effects/admissibility are unchanged. Gated on
+`(1 : ZMod p) ≠ 0` (identity on `ZMod 1`).
+
+`lake build` green; all three `maintainsCorrectness` theorems still `{propext, Classical.choice,
+Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** Faithful census what-if (#XE0) predicted the realized numbers. Broad: **38 of 100 cases**
+carry const-operand XOR interactions. Full 100-case sweep vs the C3 (entry-69) line: **16 cases
+changed, 0 regressions**; totals **−449 variables, −554 bus interactions, 0 constraints**. Biggest:
+apc_071 413→349 vars / 335→279 bus (now 349 vs powdr 330), apc_006 −64 vars, apc_019/012/049 −64 vars
+each, apc_089 −40, apc_037 −16 vars / −148 bus, apc_100 −24. Aggregate vs powdr: **variables
+4.420× → 4.490× agg (3.772× → 3.810× geo)** — well ahead of powdr's 4.092×/3.787×; **bus 3.190× →
+3.290× agg (2.588× → 2.629× geo)** vs powdr 3.480×/2.822×; constraints unchanged. Runtime smoke set
+vs C3: **−3.9% total** (the pass pays for itself — eliminating variables early shrinks the circuit
+for later passes; apc_056/069/092 −80%, apc_008 −21%, apc_014 −19%).
+
+**Follow-up (C4b).** The 255-operand XOR cases (`[x, 255, z, 1] ⟹ z = 255 − x`) stack on this pass —
+they need the byte-complement identity `Nat.xor n 255 = 255 − n` (n < 256); +16 vars on apc_071.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2053,3 +2053,56 @@ powdr:
 
 Largest drops on memory/shift-heavy blocks (apc_037 −110 bus, apc_071 −48, apc_100 −35, apc_006 −30).
 Runtime smoke set vs C1: **+0% total** (one coda pass; worst case apc_100 +1.5%).
+
+## Entry 69: width-0 range-check → equality (C3)
+
+**Idea.** powdr-exported address-computation blocks keep, on the variable range checker, a family of
+**width-0 range checks** `[expr, 0]` (multiplicity 1). A 0-bit range check asserts `expr < 2⁰ = 1`,
+i.e. `expr = 0` — it is powdr/OpenVM's encoding of "this linear form is exactly zero", pinning an
+intermediate address/data limb to a combination of others (e.g. `-a__2 + b__3 = 0`,
+`7864320·(a__3 − b__0) = 0`). Because the optimizer's Gaussian elimination consumes only *algebraic*
+constraints, these equalities — carried on the **bus** — are never used to eliminate a variable, so
+the intermediate limbs (the `a`/`b`/`c` families) survive. powdr substitutes them away.
+
+`zeroWidthRangePass` converts each such interaction into the algebraic constraint `expr = 0` and
+drops the interaction — they have the *same* satisfying set (a stateless range check `[x, 0]` is
+accepted iff `x = 0`, new fact `BusFacts.zeroRangeEq`). Placed first in the cleanup cycle, it feeds
+the equalities to same-cycle Gauss, which eliminates the intermediate variables and cascades: a
+variable win, plus a bus win (the dropped interaction and the range checks the eliminated variables
+no longer need).
+
+**How.** New audit-free `BusFacts` field `zeroRangeEq busId` — "on a stateless bus, `[x,0]` mult-1 is
+accepted iff `x = 0`" — proven for the OpenVM `variableRangeChecker` (`violates [x,0] = false ↔ x.val
+< 2⁰ = 1 ↔ x = 0`). The pass is two `PassCorrect` steps via `andThen`: (1) *add* the equality
+constraints, keeping every interaction — `PassCorrect.ofEnvEq`, side effects/admissibility literally
+unchanged (same interactions), completeness from "an accepted width-0 interaction forces its value to
+zero"; (2) *drop* the now-entailed interactions via `ConstraintSystem.filterBusEntailed_correct`
+(each dropped check is stateless and accepted under the filtered system, which retains the step-1
+equality). Gated on `(1 : ZMod p) ≠ 0` (every prime field; identity on `ZMod 1`).
+
+`lake build` green; all three `maintainsCorrectness` theorems still `{propext, Classical.choice,
+Quot.sound}`-only; `check-proof-integrity.sh` passes.
+
+**Impact.** A faithful census what-if (apply the sound transform to apc's own output, re-optimize)
+predicted the exact realized numbers. The pattern occurs on 3 of the 100 cases (address-computation
+loads/stores); the pass is a provable no-op on the other 97. Full 100-case sweep vs the C2 (entry-68)
+line — **circuit sizes changed on exactly 3 cases, 0 regressions**:
+
+- **apc_071: 453 → 413 vars (−40), 407 → 335 bus (−72)**, constraints unchanged (53)
+- **apc_020: 800 → 789 vars (−11), 457 → 435 bus (−22)** — already ahead of powdr (800 < 850), lead extended
+- **apc_037: 733 → 730 vars (−3), 793 → 789 bus (−4)**
+- totals across the 3: **−54 variables, −98 bus interactions, 0 constraints**
+
+Aggregate vs powdr: **variables 4.411× → 4.420× agg (3.768× → 3.772× geo)**, ahead of powdr's
+4.092×/3.787×; **bus 3.173× → 3.190× agg (2.581× → 2.588× geo)** vs powdr 3.480×/2.822×; constraints
+unchanged (10.593×/11.585×). Runtime smoke set (13 cases, none width-0-bearing) vs C2: **−0.9% total**
+(within noise; the only cost is one filter/filterMap scan per cleanup iteration).
+
+**Follow-up.** #EQ closes ~40 of apc_071's 123-variable gap to powdr; the residual `a`/`c` families
+(~64 vars on apc_071) are the intermediate effective-address bytes powdr derives directly from
+`base + offset` — a derived-column (reencode-class) elimination (see docs/ideas.md), higher proof
+cost. The same faithful-what-if pass also confirmed three **washes** (do not build): the
+genuine-two-root carry-witness follow-up (add a boolean carry ⇒ net 0 vars — the −249-on-apc_037
+ceiling was unsound one-root collapse), the N2 signed-compare msb fold (basis rename; apc/powdr both
+keep 2 gadget vars), and the C4c timestamp split (`2×lower_decomp` ↔ `lower_decomp + prev_timestamp`,
+equal counts).


### PR DESCRIPTION
Stacked on #96 (redundant byte-check removal). Two commits above its head.

## What

Two sibling passes exploiting the same principle: **a stateless bus interaction that provably encodes a linear equality can be emitted as an algebraic constraint**, so Gaussian elimination consumes it and eliminates the intermediate variable it pins. powdr-exported memory/address blocks carry many such equalities *on the bus*, where Gauss (which only consumes algebraic constraints) never sees them — leaving intermediate loaded-data / effective-address byte limbs alive.

- **C3 — width-0 range check → equality** (`ZeroWidthRange.lean`): a `variableRangeChecker` message `[expr, 0]` asserts `expr < 2⁰ = 1`, i.e. `expr = 0`. Convert it to the constraint `expr = 0` and drop the interaction (same satisfying set).
- **C4a — 0-operand bitwise-XOR → equality** (`XorEqExtract.lean`): a bitwise-lookup `[x, y, z, 1]` (op 1: `z = x⊕y`, bytes) with a constant-0 operand linearizes: `[0,y,z,1] ⟹ z=y`, `[x,0,z,1] ⟹ z=x`. Add the entailed equality (keeping the interaction, which still imposes byte-ness).

Both are placed early in `cleanupCycle` so the new equalities feed **same-cycle Gauss**, which eliminates the intermediate limbs and cascades.

## How

New audit-free `BusFacts` fields, each proven against the concrete OpenVM `violates`:
- `zeroRangeEq` — `[x,0]` on the range checker is accepted iff `x = 0`.
- `xorZeroEq` — `[0,y,z,1]` forces `z=y`, `[x,0,z,1]` forces `z=x` (from `Nat.zero_xor`/`Nat.xor_zero`).

C3 composes `PassCorrect.ofEnvEq` (add the equality) with `filterBusEntailed_correct` (drop the now-entailed interaction); C4a uses `ConstraintSystem.addConstraints_correct`. Both gated on `(1 : ZMod p) ≠ 0` (identity on `ZMod 1`).

## Depends on carry-collapse upstream

These passes only pay off once the degree-2 adder carry products are collapsed to linear form (else Gauss can't pivot the added equalities and the fixpoint bloats). That carry-collapse is provided by **#89 (`carryBranch`) already in main** — verified equivalent to the earlier standalone approach: the carry-heavy cases (apc_006, apc_071, apc_005, …) are eliminated identically.

## Effectiveness

Full 100-case sweep vs this PR's base (#96): **variables −503, bus interactions −653 over 17 cases, constraints unchanged, 0 regressions.** Aggregate: **variables 4.412× → 4.491×** (ahead of powdr's 4.092×), **bus 3.205× → 3.324×**. Largest: apc_071 vars 413→349 / bus 335→279, apc_006/019/012/049 −64 vars each, apc_037 −16 vars / −148 bus. Runtime is net-neutral (the early variable elimination shrinks the circuit for later passes, paying for the extra scan).

## Correctness

Both are `VerifiedPass`es with their own `PassCorrect`; no audited file touched. `lake build` green; `Scripts/check-proof-integrity.sh` passes — correctness theorems depend only on `{propext, Classical.choice, Quot.sound}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
