### PR TITLE
Clean up simp lemma arguments in proof tactics

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -210,9 +210,9 @@ theorem brRw_sound [Fact p.Prime] (singles : List (Expression p)) (bound : Nat)
         match findDomainAlg (singles) v with
         | some d => d.length ≤ 2
         | none => false)) e with
-    | none => simp only [hr]
+    | none => simp only []
     | some e' =>
-      simp only [hr]
+      simp only []
       split_ifs with hok
       · rw [Bool.and_eq_true, Bool.and_eq_true] at hok
         exact (brCert_sound singles e e' hok.2 env hdom).symm
@@ -247,9 +247,9 @@ theorem brRw_singleVar (singles : List (Expression p)) (bound : Nat) (c : Expres
         match findDomainAlg (singles) v with
         | some d => d.length ≤ 2
         | none => false)) c with
-    | none => simp only [hr]
+    | none => simp only []
     | some e' =>
-      simp only [hr]
+      simp only []
       have hcert : brCert singles c e' = false := by
         unfold brCert
         have h2 : (2 ≤ c.vars.eraseDups.length : Bool) = false := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -378,7 +378,7 @@ theorem domainByteJustified_sound [Fact p.Prime] (domCs : List (Expression p)) (
             intro y t hy
             by_cases hk : y = x
             · subst y
-              simp only [if_pos rfl] at hy
+              simp only [] at hy
               injection hy with hy'
               subst hy'
               rfl

--- a/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
@@ -40,7 +40,7 @@ theorem dedupStateless_subset (bs : BusSemantics p) :
       ∀ bi ∈ dedupStateless bs seen l, bi ∈ l := by
   intro seen l
   induction l generalizing seen with
-  | nil => intro bi h; simpa [dedupStateless] using h
+  | nil => intro bi h; simp [dedupStateless] at h
   | cons b rest ih =>
     intro bi h
     rw [dedupStateless] at h


### PR DESCRIPTION
## Summary
Remove unnecessary lemma arguments from `simp only` tactics across multiple optimizer passes. These changes simplify the proof code without affecting correctness.

## Key Changes
- **BoxRewrite.lean**: Removed `hr` argument from four `simp only` calls in `brRw_sound` and `brRw_singleVar` theorems
- **BusPairCancel.lean**: Removed `if_pos rfl` argument from `simp only` in `domainByteJustified_sound` theorem
- **Dedup.lean**: Changed `simpa [dedupStateless]` to `simp [dedupStateless] at h` in `dedupStateless_subset` theorem for consistency

## Implementation Details
These are minor proof hygiene improvements where the simp tactic can discharge the goals without explicit lemma hints. The changes maintain the same proof structure and correctness while making the code more maintainable.

https://claude.ai/code/session_01ASsgvGUWUaSMMW6C3Lt3a2