### PR TITLE
Runtime: inverted index for domainBatch/reencode covered-set scans

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -1,0 +1,96 @@
+import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+
+set_option autoImplicit false
+
+/-! # Inverted index for covered-set scans
+
+The finite-domain passes (`domainBatch`, `domainFold`, `reencode`) repeatedly ask, for a *target*
+variable set `xs`, which items (algebraic constraints / bus interactions) have **all** their
+variables in `xs` — the "covered" items, filtered by a boolean predicate `Q` (e.g.
+`Expression.varsInF xs`, or `coveredBy xs`). Done naively (`items.filter Q`) this is a full-system
+scan **per target**, and the passes run one target per constraint and per interaction, so the cost
+is O(#targets × #system) — the dominant runtime term on large circuits.
+
+This module builds, once per pass invocation, a variable→positions inverted index. A target's
+covered items are then found by gathering only the items that share a variable with `xs` (plus the
+variable-less items, covered by every `xs`) and re-checking `Q` on those few candidates — turning
+the per-target cost from O(#system) into O(local). Correctness of the passes never depends on the
+index being *complete*: `coveredIdx` re-applies the exact predicate `Q`, so every returned item
+genuinely satisfies `Q` (`coveredIdx_mem`), which is all the enumeration soundness proofs consume.
+This mirrors the candidate-then-reverify pattern already used by `busPairCancel`'s `recvIndex`.
+
+Purely `List`/`Nat`/`Std.HashMap` combinatorics — no field theory, generic over the item type. -/
+
+namespace CoveredIndex
+
+universe u
+
+variable {α : Type u}
+
+/-- Inverted index over a list of items: `buckets v` is the positions (indices into the item list)
+    of the items whose variable set contains `v`; `varless` is the positions of the items with no
+    variables (covered by every target `xs`). -/
+structure CovIndex where
+  buckets : Std.HashMap Variable (List Nat)
+  varless : List Nat
+
+/-- Build the inverted index in one pass over `items` paired with their positions. Mirrors
+    `busPairCancel`'s `recvIndex`: a right fold inserting each position into every bucket of the
+    variables it mentions (or into `varless` when it mentions none). -/
+def build (varsOf : α → List Variable) (items : List α) : CovIndex :=
+  items.zipIdx.foldr (fun ai idx =>
+    match varsOf ai.1 with
+    | [] => ⟨idx.buckets, ai.2 :: idx.varless⟩
+    | vs => ⟨vs.foldl (fun m v => m.insert v (ai.2 :: m.getD v [])) idx.buckets, idx.varless⟩)
+    ⟨∅, []⟩
+
+/-- The candidate positions for target `xs`: every position bucketed under a variable of `xs`,
+    plus the variable-less positions. -/
+def candidates (idx : CovIndex) (xs : List Variable) : List Nat :=
+  (xs.flatMap (fun v => idx.buckets.getD v [])) ++ idx.varless
+
+/-- The covered items for target `xs`: gather the candidate positions, deduplicate them in **linear
+    time** through a `HashSet` (a position appears once per variable of `xs` it carries; the naive
+    `List.dedup` is quadratic and blows up on widely-shared variables), sort ascending (so the
+    result keeps the items' original relative order), then keep the in-range ones whose item passes
+    `Q`. `arr` is the item list as an `Array` (O(1) positional access). -/
+def coveredIdx (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : List Variable) : List α :=
+  let uniq := ((candidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+  (uniq.mergeSort (· ≤ ·)).filterMap (fun i =>
+    if h : i < arr.size then (if Q arr[i] then some arr[i] else none) else none)
+
+/-- **Soundness.** Every item `coveredIdx` returns is a genuine item of `arr` (hence of the
+    underlying list) that satisfies `Q`. This is all the enumeration proofs need; the index need
+    not be complete for correctness (completeness only affects effectiveness, checked empirically). -/
+theorem coveredIdx_mem (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : List Variable)
+    {e : α} (he : e ∈ coveredIdx idx arr Q xs) :
+    ∃ i, ∃ _h : i < arr.size, arr[i] = e ∧ Q e = true := by
+  rw [coveredIdx, List.mem_filterMap] at he
+  obtain ⟨i, _hi, hfe⟩ := he
+  by_cases h : i < arr.size
+  · rw [dif_pos h] at hfe
+    by_cases hq : Q arr[i]
+    · rw [if_pos hq] at hfe
+      have hei : arr[i] = e := Option.some.inj hfe
+      exact ⟨i, h, hei, by rw [← hei]; exact hq⟩
+    · rw [if_neg hq] at hfe; exact absurd hfe (by simp)
+  · rw [dif_neg h] at hfe; exact absurd hfe (by simp)
+
+/-- Soundness, specialized to the array being a list's `toArray` (what the passes pass in): every
+    returned item is a genuine member of the list and satisfies `Q`. -/
+theorem coveredIdx_mem_list (idx : CovIndex) (l : List α) (Q : α → Bool) (xs : List Variable)
+    {e : α} (he : e ∈ coveredIdx idx l.toArray Q xs) : e ∈ l ∧ Q e = true := by
+  obtain ⟨i, hi, hei, hq⟩ := coveredIdx_mem idx l.toArray Q xs he
+  subst hei
+  have hi' : i < l.length := by simpa using hi
+  have hmem : l.toArray[i] ∈ l := by simp [l.getElem_mem hi']
+  exact ⟨hmem, hq⟩
+
+/-- Soundness for an array threaded as a value together with the proof it is `l.toArray` (what the
+    passes carry, so the array is built once rather than per target): the same conclusion. -/
+theorem coveredIdx_mem_of_eq (idx : CovIndex) (l : List α) (arr : Array α)
+    (harr : arr = l.toArray) (Q : α → Bool) (xs : List Variable)
+    {e : α} (he : e ∈ coveredIdx idx arr Q xs) : e ∈ l ∧ Q e = true := by
+  subst harr; exact coveredIdx_mem_list idx l Q xs he
+
+end CoveredIndex

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
 import ApcOptimizer.Implementation.OptimizerPasses.Gauss
+import ApcOptimizer.Implementation.OptimizerPasses.CoveredIndex
 
 set_option autoImplicit false
 
@@ -953,6 +954,23 @@ theorem scanNone_unsat {cs : ConstraintSystem p} {bs : BusSemantics p}
   rw [hsurv] at hdead
   exact absurd hdead (by simp)
 
+/-- Prebuilt inverted indices for `forcedOver`'s per-target covered-set scans, built **once** per
+    `domainBatch` invocation and threaded through the target loop (`cs`/`activeCs` are fixed across
+    it). Each item array is carried with the proof it is the corresponding list's `.toArray`, so the
+    scans get O(1) positional access while `forcedOver` still recovers list membership for its
+    soundness witnesses. Replaces the per-target full-system `filter`s (`coveredCs` / `coveredBis` /
+    `activeCs.filter`) — the dominant runtime cost on large circuits — with an O(local) lookup. -/
+structure ForcedIdx (cs : ConstraintSystem p) (activeCs : List (Expression p)) where
+  csIdx : CoveredIndex.CovIndex
+  arrCs : Array (Expression p)
+  harrCs : arrCs = cs.algebraicConstraints.toArray
+  bisIdx : CoveredIndex.CovIndex
+  arrBis : Array (BusInteraction (Expression p))
+  harrBis : arrBis = cs.busInteractions.toArray
+  activeIdx : CoveredIndex.CovIndex
+  arrActive : Array (Expression p)
+  harrActive : arrActive = activeCs.toArray
+
 /-- All checked forced constants over the variable set `xs` (the vars of one target
     constraint or interaction): scan the domain box once against everything the set
     covers (`scanInit`/`scanWith`), aborting early when nothing can be forced. Skips
@@ -969,6 +987,7 @@ theorem scanNone_unsat {cs : ConstraintSystem p} {bs : BusSemantics p}
 def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
     (T : DomainTable p cs bs)
     (activeCs : List (Expression p)) (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints)
+    (fidx : ForcedIdx cs activeCs)
     (xs : List Variable) : List ((x : Variable) × { c : ZMod p //
       ∀ env, cs.satisfies bs env → env x = c }) :=
   match hdoms : T.doms xs with
@@ -984,20 +1003,24 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts
       -- analogous drop for *obligations* is not worthwhile: an interaction's sub-box is large and
       -- its payload evaluation costly, and it is covered by few targets, so verifying its
       -- redundancy costs about what it would save.)
-      let esFull := coveredCs cs xs
-      let bis := coveredBis bs cs xs
-      let es := activeCs.filter (fun c => c.varsInF xs)
+      let esFull := CoveredIndex.coveredIdx fidx.csIdx fidx.arrCs (fun c => c.varsInF xs) xs
+      let bis := CoveredIndex.coveredIdx fidx.bisIdx fidx.arrBis
+        (fun bi => bi.varsInF xs && !bs.isStateful bi.busId) xs
+      let es := CoveredIndex.coveredIdx fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs
       let informative := !esFull.isEmpty || bis.any (biInformative bs facts)
       if informative && boxSize * (esFull.length + bis.length) ≤ maxEnumWork then
-        have hes : ∀ e ∈ es, e ∈ cs.algebraicConstraints ∧ e.varsIn xs = true :=
-          fun e he => ⟨hactiveCs e (List.mem_filter.1 he).1,
-            Expression.varsInF_eq xs e ▸ (List.mem_filter.1 he).2⟩
+        have hes : ∀ e ∈ es, e ∈ cs.algebraicConstraints ∧ e.varsIn xs = true := by
+          intro e he
+          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdx_mem_of_eq fidx.activeIdx activeCs
+            fidx.arrActive fidx.harrActive (fun c => c.varsInF xs) xs he
+          refine ⟨hactiveCs e hMem, ?_⟩
+          rw [← Expression.varsInF_eq]; exact hQ
         have hbis : ∀ bi ∈ bis, bi ∈ cs.busInteractions ∧ bi.varsIn xs = true := by
           intro bi hbi
-          have hm := List.mem_filter.1 hbi
-          have h2 := hm.2
-          rw [Bool.and_eq_true] at h2
-          exact ⟨hm.1, BusInteraction.varsInF_eq xs bi ▸ h2.1⟩
+          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdx_mem_of_eq fidx.bisIdx cs.busInteractions
+            fidx.arrBis fidx.harrBis (fun bi => bi.varsInF xs && !bs.isStateful bi.busId) xs hbi
+          simp only [Bool.and_eq_true] at hQ
+          exact ⟨hMem, by rw [← BusInteraction.varsInF_eq]; exact hQ.1⟩
         let survC := compiledSurv bs es bis (doms.map Prod.fst)
         match hscan : scanInit survC.val (doms.map Prod.fst) (assignments doms) with
         | none =>
@@ -1023,15 +1046,15 @@ def varSetKey (xs : List Variable) : String :=
     membership witness are threaded to `forcedOver`. -/
 def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
     (T : DomainTable p cs bs) (activeCs : List (Expression p))
-    (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints) :
+    (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints) (fidx : ForcedIdx cs activeCs) :
     List (List Variable) → Std.HashSet String → Solved p cs bs → Solved p cs bs
   | [], _, σ => σ
   | xs :: rest, seen, σ =>
     let key := varSetKey xs
-    if seen.contains key then collectForced facts T activeCs hactiveCs rest seen σ
+    if seen.contains key then collectForced facts T activeCs hactiveCs fidx rest seen σ
     else
-      let found := forcedOver facts T activeCs hactiveCs xs
-      collectForced facts T activeCs hactiveCs rest (seen.insert key)
+      let found := forcedOver facts T activeCs hactiveCs fidx xs
+      collectForced facts T activeCs hactiveCs fidx rest (seen.insert key)
         (σ.insertAll (found.map (fun f => (f.1, .const f.2.val)))
           (by
             intro env hsat yt hyt
@@ -1057,7 +1080,14 @@ def domainBatchPass : VerifiedPassW p := fun cs bs facts =>
     let targets := cs.algebraicConstraints.map (fun e => e.vars.dedup) ++
       cs.busInteractions.map (fun bi => bi.vars.dedup)
     let activeCs := cs.algebraicConstraints.filter (fun c => !constraintRedundant T c)
-    let σ := collectForced facts T activeCs (fun _ h => (List.mem_filter.1 h).1) targets ∅
+    let fidx : ForcedIdx cs activeCs :=
+      { csIdx := CoveredIndex.build Expression.vars cs.algebraicConstraints,
+        arrCs := cs.algebraicConstraints.toArray, harrCs := rfl,
+        bisIdx := CoveredIndex.build BusInteraction.vars cs.busInteractions,
+        arrBis := cs.busInteractions.toArray, harrBis := rfl,
+        activeIdx := CoveredIndex.build Expression.vars activeCs,
+        arrActive := activeCs.toArray, harrActive := rfl }
+    let σ := collectForced facts T activeCs (fun _ h => (List.mem_filter.1 h).1) fidx targets ∅
       Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1426,10 +1426,13 @@ def interpPoly (pz : List (List (Variable × ZMod p) × List (Variable × ZMod p
     (.const 0)
 
 /-- Construct the bits and the substitution map for a candidate group (proof-free — the
-    checked certificate re-verifies everything). -/
-def buildReencode (cs : ConstraintSystem p) (xs : List Variable) (freshBase : String) :
+    checked certificate re-verifies everything). The covered constraints come from a prebuilt
+    inverted index (`csIdx`/`arrCs`, built once per pass and rebuilt on each accepted rewrite)
+    instead of a full-system `filter` per candidate group — the dominant cost of this pass. -/
+def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
+    (xs : List Variable) (freshBase : String) :
     Option (List Variable × Std.HashMap Variable (Expression p)) :=
-  let es := coveredCsOf cs xs
+  let es := CoveredIndex.coveredIdx csIdx arrCs (coveredBy xs) xs
   match groupDoms es xs with
   | none => none
   | some doms =>
@@ -1452,11 +1455,13 @@ def buildReencode (cs : ConstraintSystem p) (xs : List Variable) (freshBase : St
     is all input columns and disjoint from the fresh bits, the bits carry no powdr ID) are only
     checked for the few groups that are actually re-encodable. The output-variable frame is proven
     by construction (`reencodeOut_vars_subset`), so no per-variable scan is needed. -/
-def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p)
-    (xs : List Variable) (freshBase : String) : PassResult cs bsem :=
+def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
+    (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p)) (cs : ConstraintSystem p)
+    (xs : List Variable) (freshBase : String) :
+    PassResult cs bsem × CoveredIndex.CovIndex × Array (Expression p) :=
   if hxs : xs.all (fun x => x.powdrId?.isSome) = true then
-  match hb : buildReencode cs xs freshBase with
-  | none => ⟨cs, [], PassCorrect.refl cs bsem⟩
+  match hb : buildReencode csIdx arrCs xs freshBase with
+  | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
   | some (bits, hm) =>
     -- The group-membership scan is checked only for the few groups `buildReencode` accepts, and
     -- against a `cs.vars` bound once — the occurrence list is ~10⁴ entries, so materializing it
@@ -1468,30 +1473,35 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (cs : ConstraintSystem p
     if hchk : checkReencode cs xs bits hm = true then
       let ro := reencodeOut cs xs bits hm
       if ro.withinDegreeB bsem.degreeBound then
-        ⟨ro,
+        -- `cs` changed: rebuild the index for `ro` (accepts are rare, so this is cheap overall).
+        ⟨⟨ro,
          bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)),
          checkReencode_sound_D cs bsem xs bits hm
            (fun x hx => by simpa using List.all_eq_true.mp hxs x hx)
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsCs x hx))
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
-           hchk⟩
-      else ⟨cs, [], PassCorrect.refl cs bsem⟩
-    else ⟨cs, [], PassCorrect.refl cs bsem⟩
-    else ⟨cs, [], PassCorrect.refl cs bsem⟩
-    else ⟨cs, [], PassCorrect.refl cs bsem⟩
-    else ⟨cs, [], PassCorrect.refl cs bsem⟩
-  else ⟨cs, [], PassCorrect.refl cs bsem⟩
+           hchk⟩,
+         CoveredIndex.build Expression.vars ro.algebraicConstraints, ro.algebraicConstraints.toArray⟩
+      else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+  else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
 
-/-- Process the candidate groups sequentially (correctness composes; derivations concatenate). -/
+/-- Process the candidate groups sequentially (correctness composes; derivations concatenate). The
+    inverted index (`csIdx`/`arrCs`, valid for the current `cs`) is threaded through and rebuilt by
+    `reencodeStep` whenever it rewrites `cs`. -/
 def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
-    List (List Variable) → Nat → (cs : ConstraintSystem p) → PassResult cs bsem
-  | [], _, cs => ⟨cs, [], PassCorrect.refl cs bsem⟩
-  | xs :: rest, idx, cs =>
-    let r1 := reencodeStep bsem cs xs
+    List (List Variable) → Nat → (cs : ConstraintSystem p) →
+    CoveredIndex.CovIndex → Array (Expression p) → PassResult cs bsem
+  | [], _, cs, _, _ => ⟨cs, [], PassCorrect.refl cs bsem⟩
+  | xs :: rest, idx, cs, csIdx, arrCs =>
+    let r1 := reencodeStep bsem csIdx arrCs cs xs
       (s!"rnc{cs.algebraicConstraints.length}_{cs.busInteractions.length}_{idx}")
-    let r2 := reencodeLoop bsem rest (idx + 1) r1.out
-    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
+    let r2 := reencodeLoop bsem rest (idx + 1) r1.1.out r1.2.1 r1.2.2
+    ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
 
 /-- `List.dedup` computed in linear time via a hash set, with the **identical** result: an element
     is kept at its last-occurrence position (exactly `List.dedup`'s order), so swapping this in is a
@@ -1514,4 +1524,5 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
       let vs := c.vars.dedup
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none))
     reencodeLoop bsem targets 0 cs
+      (CoveredIndex.build Expression.vars cs.algebraicConstraints) cs.algebraicConstraints.toArray
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -229,3 +229,33 @@ single-traversal multi-drop would be O(n) but needs a multi-drop discipline lemm
 it **is** a measured bottleneck: with the `hintCollapse`/`reencode` rescans fixed, `busPairCancel`
 is ~24 s of apc_005's 65 s optimizer time (second only to `domainBatch`, whose fix is sketched in
 entry 45's remaining-bottleneck note).
+
+## Runtime: extend the covered-set inverted index (entry 72 follow-ups)
+
+Entry 72 added `CoveredIndex.lean` (a variable→positions index + `coveredIdx`) and wired it into
+`domainBatch` and `reencode`, killing their per-target O(#system) covered-set `filter`s. Remaining
+keccak-profile hot spots, in rough priority:
+
+- **`domainFold` (~65 s).** Its `foldStep` feeds the covered set to `groupDoms` and then to
+  `foldOut_correct`, which is stated against `coveredCsOf cs xs`. Indexing the scrutinee therefore
+  needs a proven `coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q` equality
+  (so `hdoms` transports), rather than the soundness-only `coveredIdx_mem` used elsewhere. The
+  equality needs `build`'s bucket/varless completeness (a `foldr`/`HashMap.getD_insert` invariant)
+  plus a sorted-nodup-perm argument that the deduped-sorted candidate indices equal
+  `(range n).filter …`.
+- **`flagFold` (~50 s), `busUnify` (~48 s).** Different pattern: per-candidate `z ∈ cs.vars`
+  (list membership over ~10⁴ occurrences) and `cs.algebraicConstraints.contains c`
+  (O(#constraints) structural compare). A once-built `Std.HashSet Variable` for `cs.vars`
+  membership (load-bearing: proves no new variable — needs a `mem` lemma) and a structHash-keyed
+  index for `contains` (heuristic; collision-safe re-verify) would cut both. No `Hashable
+  (Expression p)` instance exists yet — deriving one (+`LawfulHashable` via `structHash`) would
+  unblock HashSet-based dedup here and in the `dedup` pass.
+- **Finite-domain enumeration residual.** After indexing, `domainBatch`/`domainFold`'s remaining
+  cost is the box scan (`scanInit`/`scanForced`) and `constraintRedundant`; the `envOf` linear
+  lookup (log entry 45's note, `docs/log.md:1030`) — substitute pinned domain-1 constants and
+  enumerate only free vars — is the algorithmic follow-up (needs `forcedOver` soundness reproven
+  over the reduced box).
+- **`coveredIdx` on hub variables.** A variable shared across many constraints yields a large
+  candidate bucket; most candidates fail the `Q` (⊆xs) re-check. Cost is O(bucket) per target.
+  Acceptable while partitioned, but a conjunctive (smallest-bucket-first) gather could help if a
+  future circuit has heavy hubs.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2281,3 +2281,41 @@ bus); apc_005 701 → 702 (+1 — a packed tuple survives where the interplay wi
 byte-check dropper would otherwise have removed a single; aggregate-invisible). The remaining
 tuple gap is the byte+byte *widening* pack (second slot only needs `< s2`), which needs a
 justification argument — see `docs/ideas.md`.
+
+### 72. Runtime: inverted index for the domain-trio covered-set scans (`CoveredIndex.lean`)
+
+**Context / profiling.** On the keccak stress case (~28.6k constraints, 13.3k bus interactions,
+27.5k variables) the optimizer runs 7 cleanup-cycle iterations; `apc-optimizer profile` (accurate
+since the shared pass list of #102) attributes the bulk of the time to the three finite-domain
+passes, each doing an
+**O(#targets × #system)** covered-set rescan — for every target variable set `xs` (one per
+constraint and per bus interaction, ~42k on keccak) it `filter`s the *entire* system for the items
+whose variables all lie in `xs`: baseline `domainBatch` 127.0 s, `reencode` 88.7 s,
+`domainFold` 64.7 s (of a 494 s profiled total).
+
+**Change.** New audit-free `ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean`: a
+variable→positions inverted index (`CovIndex`, built once per pass invocation) plus
+`coveredIdx idx arr Q xs`, which gathers only the items sharing a variable with `xs` (plus the
+variable-less items), deduplicates the candidate positions through a `HashSet` (linear — a naive
+`List.dedup` is quadratic and blows up on widely-shared variables), sorts them ascending to keep the
+items' original order, and re-checks the exact predicate `Q`. Correctness needs only `coveredIdx_mem`
+(every returned item is a genuine system item satisfying `Q`); index *completeness* is not required
+for the proof, so the enumeration soundness lemmas are unchanged and completeness (hence
+effectiveness) is verified empirically. Wired into `domainBatch` (`forcedOver`; `cs` is immutable
+across the target loop, one build per invocation) and `reencode` (`buildReencode`, proof-free; the
+index is threaded through `reencodeLoop` and rebuilt only on the rare accepted rewrite).
+
+**Impact.** No audited surface touched; the three `*_maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes. **Effectiveness
+unchanged** — full openvm-eth sweep bit-identical to `main` (variables 4.491× / 3.810× agg/geo,
+constraints 10.595× / 11.585×, per-case 25 W / 43 L / 32 T), keccak output identical
+(3056 vars / 120 constraints / 2690 bus). **Runtime (profile, per-pass):** `domainBatch`
+127.0 → 85.2 s, `reencode` 88.7 → 53.8 s (−77 s combined; every other pass flat, confirming no
+collateral change); profiled total 494 → 431 s. The `run` wall-clock timer is noisy on this machine
+(baseline solo 529 s vs concurrent 449 s — ~18 % variance), so the per-pass profile deltas are the
+reliable signal; a solo `run` A/B measured 529 → 378 s.
+
+**Remaining (see `docs/ideas.md`).** `domainFold`'s covered scan feeds `foldOut_correct` (tied to
+`coveredCsOf`), so indexing it needs a `coveredIdx = items.filter Q` equality lemma; the residual
+per-pass time is the finite-domain enumeration itself (box scanning); the next tier is `flagFold`
+and `busUnify` (per-target `cs.vars` / `List.contains` membership).


### PR DESCRIPTION
## What

Speeds up the optimizer's dominant runtime cost on the Keccak stress case by replacing per-target full-system covered-set scans with a variable→positions inverted index. **Effectiveness is unchanged; no audited surface is touched.**

## Why

Profiling Keccak (`apc-optimizer profile`, accurate since the shared pass list of #102) shows the three finite-domain passes each doing an **O(#targets × #system)** covered-set rescan: for every target variable set (one per constraint and per bus interaction, ~42k on Keccak) they `filter` the *entire* system for items whose variables all lie in the target. Baseline per-pass: `domainBatch` 127 s, `reencode` 89 s, `domainFold` 65 s (of ~494 s profiled total).

## Change

New audit-free `ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean`:

- `CovIndex` — a variable→positions inverted index, built once per pass invocation.
- `coveredIdx idx arr Q xs` — gathers only the items sharing a variable with `xs` (plus variable-less items), deduplicates candidate positions through a `HashSet` (linear; a naive `List.dedup` is quadratic and blows up on widely-shared variables), sorts ascending to keep original order, and re-checks the exact predicate `Q`.

Correctness needs only `coveredIdx_mem` — every returned item is a genuine system item satisfying `Q` — so the enumeration soundness proofs are unchanged. Index *completeness* is not required for the proof (completeness, hence effectiveness, is verified empirically). This mirrors the candidate-then-reverify pattern already used by `busPairCancel`'s `recvIndex`.

Wired into:
- `domainBatch` (`forcedOver`; `cs` is immutable across the target loop, so one build per invocation);
- `reencode` (`buildReencode`, proof-free; the index is threaded through `reencodeLoop` and rebuilt only on the rare accepted rewrite).

`domainFold` is left for a follow-up: its covered scan feeds `foldOut_correct` (stated against `coveredCsOf`), so indexing it needs a `coveredIdx = items.filter Q` equality lemma rather than soundness alone (scoped in `docs/ideas.md`).

## Verification

- `lake build` green; `Scripts/check-proof-integrity.sh` passes — the three `*_maintainsCorrectness` theorems still depend on exactly `{propext, Classical.choice, Quot.sound}`; no `sorry`/`admit`/`axiom`/`native_decide`.
- **Effectiveness unchanged** — full openvm-eth sweep bit-identical to `main` (variables 4.491× / 3.810× agg/geo, constraints 10.595× / 11.585×, per-case 25 W / 43 L / 32 T); Keccak output identical (3056 vars / 120 constraints / 2690 bus).
- **Runtime (profile, per-pass — the reliable signal):** `domainBatch` 127 → 85 s, `reencode` 89 → 54 s (−77 s combined; every other pass flat, confirming no collateral change); profiled total 494 → 431 s. The wall-clock `run` timer is noisy on the bench machine (~18 % run-to-run variance for identical code), so the per-pass profile deltas are cited over any single run.

## Scope

This is a partial win (removes the covered-scan; the passes' residual is the inherent finite-domain enumeration). The path to further gains — indexing `domainFold`, `flagFold`/`busUnify` membership, and the enumeration residual — is recorded in `docs/ideas.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zUonvH782fiH9Gqdxaaoz)_