### PR TITLE
Symbolic-timestamp forwarding: two-root address disequality

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -1,0 +1,262 @@
+import ApcOptimizer.Implementation.OptimizerPasses.RootPairUnify
+import ApcOptimizer.MemoryBus
+
+set_option autoImplicit false
+
+/-! # Two-root address disequality (symbolic-timestamp forwarding enabler)
+
+`addrConstsNeq` (`BusUnify.lean`) can only refute an in-window memory message as a
+*different-address* one when both address slots are literal constants. On keccak's heap the
+address slot is a pointer *expression* `mem_ptr_limbs__0 + 2¹⁶·mem_ptr_limbs__1`, so no two
+distinct heap pointers are ever refuted, and `busUnifyPass`'s consumer scan aborts on the first
+interleaved other-pointer access — the whole "forward the read/`prev_data` limbs across the
+symbolic-timestamp access, pin the decomp" chain never fires.
+
+This module provides the missing certificate. Each pointer limb is pinned by a **two-root**
+decomposition constraint `(A + k·x)(A + δ + k·x) = 0` (the address-wraparound branch, recognised
+by `twoRootOf?`). Substituting the high limb's two roots into the address expression
+`limb₀ + 2¹⁶·limb₁` **cancels the low limb algebraically** — over BabyBear `1 + 2¹⁶·30720 ≡ 0`,
+so the `limb₀` coefficient vanishes — leaving an affine form in the base register plus a constant,
+in each of the two branches. For two accesses off the *same* base register the branch forms differ
+only in their constant (the immediate), so every one of the four branch-pair differences is a
+nonzero field constant and the addresses provably differ — with **no bounds reasoning at all**,
+purely the two-root disjunction and linear arithmetic.
+
+Everything is a decidable, re-checkable certificate consumed by `busUnifyPass` / `busPairCancel`
+via `addrTwoRootNeq`; the field-membership step (`twoRootOf?_sound`) needs an integral domain, so
+the top-level certificate self-gates on `decide (Nat.Prime p)` and needs no change to the passes'
+own primality handling. -/
+
+variable {p : ℕ}
+
+/-! ## Substituting a two-root branch into a linear form -/
+
+/-- The two affine forms obtained by replacing the variable with coefficient `cx` in `rest + cx·x`
+    by the two roots `x = -(k⁻¹·A)` and `x = -(k⁻¹·A) - k⁻¹·δ` of a `twoRootOf?` decomposition
+    `(k, A, δ)`. Returned normalized (so a cancelled limb drops out). -/
+def ptrBranchesOf (k : ZMod p) (A : LinExpr p) (δ cx : ZMod p) (rest : LinExpr p) :
+    LinExpr p × LinExpr p :=
+  let r1 := A.scale (-(k⁻¹))
+  let r2 := r1.add ⟨-(k⁻¹ * δ), []⟩
+  ((rest.add (r1.scale cx)).norm, (rest.add (r2.scale cx)).norm)
+
+theorem ptrBranchesOf_eval (k : ZMod p) (A : LinExpr p) (δ cx : ZMod p) (rest : LinExpr p)
+    (env : Variable → ZMod p) :
+    ((ptrBranchesOf k A δ cx rest).1).eval env = rest.eval env + cx * (-(k⁻¹) * A.eval env) ∧
+    ((ptrBranchesOf k A δ cx rest).2).eval env
+      = rest.eval env + cx * (-(k⁻¹) * A.eval env - k⁻¹ * δ) := by
+  have hc0 : (⟨-(k⁻¹ * δ), []⟩ : LinExpr p).eval env = -(k⁻¹ * δ) := by simp [LinExpr.eval]
+  refine ⟨?_, ?_⟩
+  · simp only [ptrBranchesOf, LinExpr.norm_eval, LinExpr.add_eval, LinExpr.scale_eval]
+  · simp only [ptrBranchesOf, LinExpr.norm_eval, LinExpr.add_eval, LinExpr.scale_eval, hc0]
+    ring
+
+/-! ## Reducing a pointer expression through its limb decompositions -/
+
+/-! ### A proof-carrying two-root map (memoized `twoRootOf?`)
+
+Scanning every constraint per variable per candidate pair is quadratic on
+keccak's interleaved window. The two-root data `(k, A, δ)` for each variable is instead precomputed
+once per pass into a hash map bundled with its soundness. Each entry also carries `Nat.Prime p`
+(needed for the field-membership step) — the map is built empty on composite `p` — so the
+downstream certificate needs no per-call primality `decide`. -/
+
+variable {constraints : List (Expression p)}
+
+/-- Per-variable two-root decomposition data, each entry sound and witnessed by an actual
+    constraint (and `p` prime, needed for the root-membership step). -/
+structure TwoRootMap (p : ℕ) (constraints : List (Expression p)) where
+  map : Std.HashMap Variable (ZMod p × LinExpr p × ZMod p)
+  sound : ∀ v k A δ, map[v]? = some (k, A, δ) →
+    Nat.Prime p ∧ k * k⁻¹ = 1 ∧ ∃ c ∈ constraints, twoRootOf? c v = some (k, A, δ)
+
+namespace TwoRootMap
+
+def empty : TwoRootMap p constraints where
+  map := ∅
+  sound := by
+    intro v k A δ h
+    rw [Std.HashMap.getElem?_empty] at h
+    exact absurd h (by simp)
+
+/-- Insert a sound entry (last write wins). -/
+def insertEntry (T : TwoRootMap p constraints) (v : Variable) (k : ZMod p) (A : LinExpr p)
+    (δ : ZMod p) (h : Nat.Prime p ∧ k * k⁻¹ = 1 ∧ ∃ c ∈ constraints, twoRootOf? c v = some (k, A, δ)) :
+    TwoRootMap p constraints where
+  map := T.map.insert v (k, A, δ)
+  sound := by
+    intro w k' A' δ' hw
+    rw [Std.HashMap.getElem?_insert] at hw
+    by_cases hvw : (v == w) = true
+    · rw [if_pos hvw] at hw
+      have hvw' : v = w := by simpa using hvw
+      have heq : (k, A, δ) = (k', A', δ') := by simpa using hw
+      simp only [Prod.mk.injEq] at heq
+      obtain ⟨rfl, rfl, rfl⟩ := heq
+      subst hvw'
+      exact h
+    · rw [if_neg hvw] at hw
+      exact T.sound w k' A' δ' hw
+
+/-- Insert the two-root entry (if any, with a unit coefficient) for each of `c`'s variables. -/
+def addVars (hp : Nat.Prime p) (c : Expression p) (hc : c ∈ constraints) :
+    TwoRootMap p constraints → List Variable → TwoRootMap p constraints
+  | T, [] => T
+  | T, v :: vs =>
+    match htr : twoRootOf? c v with
+    | some (k, A, δ) =>
+      if hu : k * k⁻¹ = 1 then
+        addVars hp c hc (T.insertEntry v k A δ ⟨hp, hu, c, hc, htr⟩) vs
+      else addVars hp c hc T vs
+    | none => addVars hp c hc T vs
+
+/-- Fold `addVars` over a constraint list. -/
+def addAll (hp : Nat.Prime p) :
+    TwoRootMap p constraints → (pending : List (Expression p)) →
+    (∀ c ∈ pending, c ∈ constraints) → TwoRootMap p constraints
+  | T, [], _ => T
+  | T, c :: rest, hmem =>
+    addAll hp (addVars hp c (hmem c (List.mem_cons_self ..)) T c.vars.eraseDups) rest
+      (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
+
+/-- Build the map for a constraint list (empty on composite `p`). -/
+def build (constraints : List (Expression p)) : TwoRootMap p constraints :=
+  if hp : Nat.Prime p then addAll hp empty constraints (fun _ h => h)
+  else empty
+
+end TwoRootMap
+
+/-- All affine two-root reductions of an expression `E`: for each variable of the linearized form
+    that carries a two-root entry, the pair of branch forms `ptrBranchesOf`. Every returned pair
+    `(b₁, b₂)` satisfies `E.eval ∈ {b₁.eval, b₂.eval}` under the constraints
+    (`ptrReductions_sound`). -/
+def ptrReductions (T : TwoRootMap p constraints) (E : Expression p) :
+    List (LinExpr p × LinExpr p) :=
+  match linearize E with
+  | none => []
+  | some L =>
+    (L.terms.map Prod.fst).eraseDups.filterMap (fun v =>
+      match T.map[v]? with
+      | some (k, A, δ) => some (ptrBranchesOf k A δ (L.coeff v) (L.others v))
+      | none => none)
+
+theorem ptrReductions_sound (T : TwoRootMap p constraints) (E : Expression p)
+    (b1 b2 : LinExpr p) (hmem : (b1, b2) ∈ ptrReductions T E)
+    (env : Variable → ZMod p) (hcon : ∀ c ∈ constraints, c.eval env = 0) :
+    E.eval env = b1.eval env ∨ E.eval env = b2.eval env := by
+  unfold ptrReductions at hmem
+  cases hL : linearize E with
+  | none => rw [hL] at hmem; simp at hmem
+  | some L =>
+    rw [hL] at hmem
+    rw [List.mem_filterMap] at hmem
+    obtain ⟨v, _hv, hmatch⟩ := hmem
+    cases htm : T.map[v]? with
+    | none => rw [htm] at hmatch; simp at hmatch
+    | some kAδ =>
+      obtain ⟨k, A, δ⟩ := kAδ
+      rw [htm] at hmatch
+      dsimp only at hmatch
+      simp only [Option.some.injEq] at hmatch
+      obtain ⟨hp, hunit, c, hc, htr⟩ := T.sound v k A δ htm
+      haveI : Fact p.Prime := ⟨hp⟩
+      have hroot := twoRootOf?_sound c v k A δ htr hunit env (hcon c hc)
+      have hEL : E.eval env = L.eval env := linearize_eval E L hL env
+      have hsplit : L.eval env = L.coeff v * env v + (L.others v).eval env := L.eval_split v env
+      obtain ⟨he1, he2⟩ := ptrBranchesOf_eval k A δ (L.coeff v) (L.others v) env
+      have hb1 : b1 = (ptrBranchesOf k A δ (L.coeff v) (L.others v)).1 :=
+        (congrArg Prod.fst hmatch).symm
+      have hb2 : b2 = (ptrBranchesOf k A δ (L.coeff v) (L.others v)).2 :=
+        (congrArg Prod.snd hmatch).symm
+      rcases hroot with hr | hr
+      · left; rw [hEL, hsplit, hr, hb1, he1]; ring
+      · right; rw [hEL, hsplit, hr, hb2, he2]; ring
+
+/-! ## Nonzero-constant differences -/
+
+/-- The two forms differ by a nonzero field constant (checked structurally after normalization). -/
+def constDiffNZ (a b : LinExpr p) : Bool :=
+  let d := (a.add (b.scale (-1))).norm
+  d.terms.isEmpty && decide (d.const ≠ 0)
+
+theorem constDiffNZ_sound (a b : LinExpr p) (h : constDiffNZ a b = true)
+    (env : Variable → ZMod p) : a.eval env ≠ b.eval env := by
+  unfold constDiffNZ at h
+  simp only [Bool.and_eq_true] at h
+  obtain ⟨hterms, hconst⟩ := h
+  have hd : ((a.add (b.scale (-1))).norm).eval env = a.eval env - b.eval env := by
+    rw [LinExpr.norm_eval, LinExpr.add_eval, LinExpr.scale_eval]; ring
+  have hd2 : ((a.add (b.scale (-1))).norm).eval env = ((a.add (b.scale (-1))).norm).const := by
+    simp only [LinExpr.eval, List.isEmpty_iff.1 hterms, List.map_nil, List.sum_nil, add_zero]
+  intro heq
+  have hz : ((a.add (b.scale (-1))).norm).const = 0 := by rw [← hd2, hd, heq, sub_self]
+  exact (of_decide_eq_true hconst) hz
+
+/-! ## The expression- and address-level certificates -/
+
+/-- Two expressions provably evaluate differently: some two-root reduction of each yields four
+    branch-pair differences that are all nonzero field constants. -/
+def exprTwoRootNeq (T : TwoRootMap p constraints) (e e' : Expression p) : Bool :=
+  (ptrReductions T e).any (fun red =>
+    (ptrReductions T e').any (fun red' =>
+      constDiffNZ red.1 red'.1 && constDiffNZ red.1 red'.2 &&
+      constDiffNZ red.2 red'.1 && constDiffNZ red.2 red'.2))
+
+theorem exprTwoRootNeq_sound (T : TwoRootMap p constraints)
+    (e e' : Expression p) (h : exprTwoRootNeq T e e' = true) (env : Variable → ZMod p)
+    (hcon : ∀ c ∈ constraints, c.eval env = 0) : e.eval env ≠ e'.eval env := by
+  unfold exprTwoRootNeq at h
+  rw [List.any_eq_true] at h
+  obtain ⟨⟨a1, a2⟩, hred, hinner⟩ := h
+  rw [List.any_eq_true] at hinner
+  obtain ⟨⟨b1, b2⟩, hred', hchk⟩ := hinner
+  simp only [Bool.and_eq_true] at hchk
+  obtain ⟨⟨⟨h11, h12⟩, h21⟩, h22⟩ := hchk
+  have he := ptrReductions_sound T e a1 a2 hred env hcon
+  have he' := ptrReductions_sound T e' b1 b2 hred' env hcon
+  rcases he with ha | ha <;> rcases he' with hb | hb <;> rw [ha, hb]
+  · exact constDiffNZ_sound a1 b1 h11 env
+  · exact constDiffNZ_sound a1 b2 h12 env
+  · exact constDiffNZ_sound a2 b1 h21 env
+  · exact constDiffNZ_sound a2 b2 h22 env
+
+/-- Some address slot of `S` and `bi` provably evaluates differently: the two interactions have
+    different addresses. Primality (needed for the two-root membership) is carried by the map's
+    entries, so this is a total `Bool` predicate composable with `addrConstsNeq`. -/
+def addrTwoRootNeq (shape : MemoryBusShape) (T : TwoRootMap p constraints)
+    (S bi : BusInteraction (Expression p)) : Bool :=
+  shape.addressFields.any (fun slot =>
+    match S.payload[slot]?, bi.payload[slot]? with
+    | some e, some e' => exprTwoRootNeq T e e'
+    | _, _ => false)
+
+theorem addrTwoRootNeq_sound (shape : MemoryBusShape) (T : TwoRootMap p constraints)
+    (S bi : BusInteraction (Expression p))
+    (h : addrTwoRootNeq shape T S bi = true) (env : Variable → ZMod p)
+    (hcon : ∀ c ∈ constraints, c.eval env = 0) :
+    shape.address (S.eval env) ≠ shape.address (bi.eval env) := by
+  unfold addrTwoRootNeq at h
+  obtain ⟨slot, hslot, hcond⟩ := List.any_eq_true.1 h
+  intro heq
+  obtain ⟨j, hj⟩ : ∃ j, shape.addressFields[j]? = some slot := List.getElem?_of_mem hslot
+  -- the address projections agree at `slot`'s position
+  have key : (S.eval env).payload[slot]? = (bi.eval env).payload[slot]? := by
+    have e1 : (shape.address (S.eval env))[j]? = some ((S.eval env).payload[slot]?) := by
+      simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+    have e2 : (shape.address (bi.eval env))[j]? = some ((bi.eval env).payload[slot]?) := by
+      simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+    rw [heq, e2] at e1; exact (Option.some.inj e1).symm
+  have keyS : (S.eval env).payload[slot]? = (S.payload[slot]?).map (fun e => e.eval env) := by
+    show (S.payload.map (fun e => e.eval env))[slot]? = _; rw [List.getElem?_map]
+  have keyB : (bi.eval env).payload[slot]? = (bi.payload[slot]?).map (fun e => e.eval env) := by
+    show (bi.payload.map (fun e => e.eval env))[slot]? = _; rw [List.getElem?_map]
+  rw [keyS, keyB] at key
+  cases hSp : S.payload[slot]? with
+  | none => rw [hSp] at hcond; simp at hcond
+  | some e =>
+    cases hbp : bi.payload[slot]? with
+    | none => rw [hSp, hbp] at hcond; simp at hcond
+    | some e' =>
+      rw [hSp, hbp] at hcond key
+      simp only [Option.map_some, Option.some.injEq] at key
+      exact exprTwoRootNeq_sound T e e' hcond env hcon key

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+import ApcOptimizer.Implementation.OptimizerPasses.AddrDiseq
 import ApcOptimizer.MemoryBus
 
 set_option autoImplicit false
@@ -119,14 +120,17 @@ theorem consecutivePayloadEq (cs : ConstraintSystem p) (bs : BusSemantics p)
 /-- A checked consecutive send→receive pair on bus `busId`: `L` splits as `pre ++ S :: mid ++ R
     :: post`, `S` a constant send, `R` a constant receive, same constant address, and every `mid`
     message is provably inactive or of a different address. -/
-def checkPair (shape : MemoryBusShape) (L : List (BusInteraction (Expression p)))
+def checkPair (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : TwoRootMap p constraints)
+    (L : List (BusInteraction (Expression p)))
     (pre : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
     (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (post : List (BusInteraction (Expression p))) : Bool :=
   decide (L = pre ++ S :: mid ++ R :: post) &&
   decide (multConst S = some 1) && decide (multConst R = some (-1)) &&
   addrConstsEq shape S R &&
-  mid.all (fun m => addrConstsNeq shape S m || decide (multConst m = some 0))
+  mid.all (fun m => addrConstsNeq shape S m || addrTwoRootNeq shape T S m
+    || decide (multConst m = some 0))
 
 theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0)
@@ -134,9 +138,11 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (pre : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
     (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (post : List (BusInteraction (Expression p)))
-    (hchk : checkPair shape (cs.busInteractions.filter (fun bi => bi.busId = busId))
+    (T : TwoRootMap p cs.algebraicConstraints)
+    (hchk : checkPair shape T
+      (cs.busInteractions.filter (fun bi => bi.busId = busId))
       pre S mid R post = true)
-    (env : Variable → ZMod p) (hadm : cs.admissible bs env) :
+    (env : Variable → ZMod p) (hadm : cs.admissible bs env) (hsat : cs.satisfies bs env) :
     ∀ c ∈ memEqConstraints shape S R, c.eval env = 0 := by
   unfold checkPair at hchk
   simp only [Bool.and_eq_true] at hchk
@@ -151,11 +157,14 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     show R.multiplicity.eval env = -1; exact R.multiplicity.constValue?_sound (-1) hRm env
   have haddr : shape.address (S.eval env) = shape.address (R.eval env) :=
     addrConstsEq_sound shape S R haddrEq env
+  have hcon : ∀ c ∈ cs.algebraicConstraints, c.eval env = 0 := hsat.1
   have hmid : ∀ m ∈ mid, (m.eval env).multiplicity ≠ 0 →
       shape.address (m.eval env) = shape.address (S.eval env) → False := by
     intro m hm hmne hmaddr
-    rcases (Bool.or_eq_true _ _).mp (List.all_eq_true.mp hmidall m hm) with hneq | hz
-    · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
+    rcases (Bool.or_eq_true _ _).mp (List.all_eq_true.mp hmidall m hm) with hcond | hz
+    · rcases (Bool.or_eq_true _ _).mp hcond with hneq | h2r
+      · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
+      · exact addrTwoRootNeq_sound shape T S m h2r env hcon (hmaddr.symm)
     · have : (m.eval env).multiplicity = 0 := by
         show m.multiplicity.eval env = 0
         exact m.multiplicity.constValue?_sound 0 (of_decide_eq_true hz) env
@@ -178,7 +187,8 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
 /-- Scan forward from a send `S` for its consumer: the first same-address receive, with every
     message before it excludable (different address, or inactive). Returns `(mid, R, post)` on
     success; `none` if a possibly-same-address active non-receive blocks the window. -/
-def findConsumer (shape : MemoryBusShape) (S : BusInteraction (Expression p)) :
+def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : TwoRootMap p constraints) (S : BusInteraction (Expression p)) :
     List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
     Option (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
       × List (BusInteraction (Expression p)))
@@ -186,14 +196,16 @@ def findConsumer (shape : MemoryBusShape) (S : BusInteraction (Expression p)) :
   | revMid, r :: rest =>
       if decide (multConst r = some (-1)) && addrConstsEq shape S r then
         some (revMid.reverse, r, rest)
-      else if addrConstsNeq shape S r || decide (multConst r = some 0) then
-        findConsumer shape S (r :: revMid) rest
+      else if addrConstsNeq shape S r || addrTwoRootNeq shape T S r
+          || decide (multConst r = some 0) then
+        findConsumer shape T S (r :: revMid) rest
       else none
 
 /-- One candidate `(pre, S, mid, R, post)` per active send `S`, pairing it with its consumer
     receive (`findConsumer`). Linear in the number of sends × scan length, so no O(n²) blow-up
     on large buses. `checkPair` re-verifies each candidate. -/
-def candidateSplits (shape : MemoryBusShape) :
+def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : TwoRootMap p constraints) :
     List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
     List (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
       × List (BusInteraction (Expression p)) × BusInteraction (Expression p)
@@ -201,14 +213,15 @@ def candidateSplits (shape : MemoryBusShape) :
   | _, [] => []
   | revPre, S :: rest =>
       (if decide (multConst S = some 1) then
-        match findConsumer shape S [] rest with
+        match findConsumer shape T S [] rest with
         | some (mid, R, post) => [(revPre.reverse, S, mid, R, post)]
         | none => []
-       else []) ++ candidateSplits shape (S :: revPre) rest
+       else []) ++ candidateSplits shape T (S :: revPre) rest
 
 /-- Collect the entailed equalities for one bus, with proof. -/
 def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (shape : MemoryBusShape)
+    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
+    (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape) :
     List (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
       × List (BusInteraction (Expression p)) × BusInteraction (Expression p)
@@ -217,29 +230,31 @@ def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
   | (pre, S, mid, R, post) :: rest =>
-    let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 busId shape hshape rest
-    if hchk : checkPair shape (cs.busInteractions.filter (fun bi => bi.busId = busId))
+    let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T busId shape hshape rest
+    if hchk : checkPair shape T
+        (cs.busInteractions.filter (fun bi => bi.busId = busId))
         pre S mid R post = true then
       ⟨memEqConstraints shape S R ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
-        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post hchk env hadm c h
+        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T hchk env hadm hsat c h
         · exact hacc env hadm hsat c h⟩
     else ⟨acc, hacc⟩
 
 /-- Collect over every declared bus, with proof. -/
 def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) :
+    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints) :
     List Nat →
     { out : List (Expression p) //
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
   | busId :: rest =>
-    let ⟨acc, hacc⟩ := collectAllBuses cs bs facts hp1 rest
+    let ⟨acc, hacc⟩ := collectAllBuses cs bs facts hp1 T rest
     match hshape : facts.memShape busId with
     | some shape =>
-      let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 busId shape hshape
-        (candidateSplits shape [] (cs.busInteractions.filter (fun bi => bi.busId = busId)))
+      let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 T busId shape hshape
+        (candidateSplits shape T []
+          (cs.busInteractions.filter (fun bi => bi.busId = busId)))
       ⟨eqs ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
@@ -252,7 +267,10 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     trivially zero). Replaces `memoryUnifyBatchPass`, `execChainPass`, and `chainUnifyPass`. -/
 def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
-    let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1
+    -- precompute the per-variable two-root data once (memoized `twoRootOf?`), so the
+    -- address-disequality certificate is a constant-time hash lookup per candidate pair
+    let T := TwoRootMap.build cs.algebraicConstraints
+    let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1 T
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
     -- keep only equalities over existing columns, so the pass introduces no new variable
     -- (the real slot equalities are built from `cs`'s payloads, so none are dropped).

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -2,24 +2,12 @@
 
 ## keccak: unify read-data limbs to close the variable gap (variables — top priority)
 
-On the keccak stress case, after the bitwise-result byte bound (log entry 58) cancelled the memory
-send/receive chains (bus 5206 → 3904), the **variable** gap is now the story: apc-optimizer 3622
-vs powdr 2021. The bulk is ~1200 read-data limbs (`b__*`, `c__*` classes — powdr has *none* of
-them) that survive because, although their memory interactions cancelled, the same limbs still
-occur as **operands/results of the XOR (bitwise) interactions**. powdr eliminates them by
-substituting each read limb by the value written to that cell (memory last-write-wins: a read
-returns the send's payload, so `read_limb = written_limb`) and/or by the XOR functional dependence
-(`slotFun` already proves `z = x ⊕ y` for the bitwise result). Two concrete angles:
-- **Read-value substitution.** When `busUnify` pairs a constant-address send `S` (writing value
-  `V`) with the next receive `R` (reading `W`), it already adds `W = V`; Gauss should then
-  substitute `W := V` and drop `W`. Check why this is not eliminating the keccak `b`/`c` limbs —
-  likely the chain's *first* receive reads a genuine pre-block value (no earlier send), so only
-  the initial limb is irreducible and the rest should collapse. If `busUnify`'s constant-address
-  gate or `findConsumer`'s mid-refutation is missing these, widening it is the win.
-- **XOR-result derivation.** A bitwise interaction `[x, y, z, 1]` functionally determines `z`
-  (`slotFun`, entry-for the XOR). A pass that turns `z` into a derived column
-  (`ComputationMethod`, like `reencode`) reading `x, y` would remove `z` as a free variable. Needs
-  the completeness `derivesWitness` bookkeeping, but `slotFun` already carries the soundness half.
+**Read-value substitution: LANDED (entry 71, symbolic-ts forwarding).** The "widen `findConsumer`'s
+mid-refutation" angle is done: `AddrDiseq.lean`'s two-root address-disequality (`addrTwoRootNeq`) lets
+`busUnify` step over interleaved other-pointer heap accesses (their addresses are `mem_ptr_limbs`
+expressions, not constants), so the send↔consumer slot equalities now fire on the heap. keccak
+**3056 → 2224 vars (−832), 2862 → 2411 bus**; `lower_decomp` 534→164, `prev_data` 448→148, width-12/17
+range checks → 129/129 (= powdr). Gap to powdr now +203 (was +1035).
 
 The bitwise-**result** byte bound itself is now landed (`openVmFacts.slotBound` slot 2, entry 58) —
 do not re-propose it.
@@ -31,6 +19,23 @@ do not re-propose it.
 `a + b − (a⊕b) = 2·(a∧b)` and `a∧b < 256`). Not a clean finite-domain shape; a dedicated
 AND-result recogniser would justify it, but it is one case and low priority — do the earliest-send
 relaxation first.
+
+**Remaining variable gap (≈203, the residual `b`/`c` read-data limbs).** powdr additionally eliminates
+each read limb via the **XOR functional dependence** (`slotFun` proves `z = x ⊕ y`): a bitwise
+`[x, y, z, 1]` determines `z`. A pass turning `z` into a derived column (`ComputationMethod`, like
+`reencode`) reading `x, y` removes `z` as a free variable. Needs the completeness `derivesWitness`
+bookkeeping, but `slotFun` already carries the soundness half. This is the reencode-class residual.
+
+**Two cheap bus follow-ups unlocked by entry 71:**
+- **1.2 identical-tuple cancellation (−≈282 bus).** The forwarding created 282 memory interactions in
+  syntactically-identical ±1 pairs (was 178) that `busPairCancel` cannot cancel: the dropped receive's
+  data slots are rotation *expressions* (`128·a__1 + bit_shift_carry__…`) and `byteJustified` has no
+  affine rule. Add a no-wrap affine byte rule: for `e = c₀ + Σ cᵢ·yᵢ` with every `yᵢ` bounded and
+  `c₀ + Σ cᵢ·(Bᵢ−1) < 256`, conclude `e < 256`. Shares the bound machinery with the shift-carry work.
+- **2.2 AS2 middle-pair telescoping (below powdr's 200 floor).** Wire `addrTwoRootNeq` into
+  `busPairCancel`'s `midRefuted` (same predicate) so the heap middle pairs telescope — AS2 count
+  (still 482 here) could drop toward / below powdr's 200.
+
 ## Genuine two-root carries: carry-witness substitution — MEASURED WASH, do not build
 
 **Measured a wash (faithful census what-if, 2026-07).** `carryCollapsePass` (log 67) collapses only

--- a/docs/log.md
+++ b/docs/log.md
@@ -2382,3 +2382,58 @@ case**; only the covered-set lookup differs. No audited surface; proof integrity
 (`{propext, Classical.choice, Quot.sound}`-only). Expected effect: keccak keeps its −13 % `domainFold`
 win; openvm-eth `domainFold` returns to baseline (no 1.24× regression); `busUnify`'s −66/−72 % win is
 unaffected.
+## Entry 71: symbolic-timestamp forwarding — two-root address disequality
+
+**Idea.** `busUnifyPass` (`BusUnify.lean`) forwards read/`prev_data` limbs across a
+symbolic-timestamp memory access by pairing an active send `S` with its consumer receive `R` (same
+address, none active-same-address between) and adding the slot equalities `memEqConstraints`
+(timestamp included) — Gauss then pins the timestamp `lower_decomp` and substitutes the read/
+`prev_data` limbs by the written value. On keccak's heap this never fired: `findConsumer`'s scan
+must step over interleaved *other-pointer* accesses, and `addrConstsNeq` only refutes a
+different-address message when **both** address slots are literal constants — but a heap address is
+the pointer *expression* `mem_ptr_limbs__0 + 2¹⁶·mem_ptr_limbs__1`, so no candidate ever formed
+(AS2 stuck at 482, `lower_decomp`/`prev_data` families uncollapsed — the concrete blocker behind the
+top ideas.md item "unify read-data limbs").
+
+**Mechanism (bound-free, simpler than a bounded-interval approach).** Each pointer limb is
+pinned by a two-root constraint `(A + k·x)(A + δ + k·x) = 0` (recognized by `twoRootOf?`,
+`RootPairUnify.lean`). The high limb's constraint reads `(F − limb₁)(F − 2¹⁶ − limb₁) = 0` with
+`F = C_hi + 30720·limb₀`. Over BabyBear `1 + 2¹⁶·30720 ≡ 0 (mod p)`, so substituting either root of
+`limb₁` into `addr = limb₀ + 2¹⁶·limb₁` **cancels `limb₀` algebraically**, leaving an affine form in
+the base register `rs1_data` only, in each of the two branches: `addr ∈ {2¹⁶·C_hi, 2¹⁶·C_hi − 2³²}`.
+For two same-base pointers every one of the four branch-pair differences is a nonzero field constant
+(the immediate diff, ±2³²) ⇒ the addresses provably differ — **no range bounds needed**, purely the
+two-root disjunction and linear arithmetic.
+
+**How.** New audit-free `AddrDiseq.lean`: `ptrBranchesOf` (substitute a two-root branch into a
+`LinExpr`), `ptrReductions` (the ≤2 branch forms per limb of an address expression), `constDiffNZ`
+(a nonzero-constant difference), `exprTwoRootNeq` (four branch-pair diffs all nonzero constants),
+`addrTwoRootNeq` (some address slot provably differs). Wired into `BusUnify.lean`: the new disjunct
+`addrTwoRootNeq` is OR-ed into `findConsumer`'s step-over test and `checkPair`'s `mid`-refutation;
+`checkPair_sound` gained an `hsat` hypothesis (the two-root soundness needs the constraints to hold).
+The same predicate is also usable by `busPairCancel`'s `midRefuted` (not wired yet). Zero audit
+surface, no new `BusFacts`. Proof: `twoRootOf?_sound` gives the root disjunction, `LinExpr`
+arithmetic gives the branch reduction, and the four nonzero-constant checks contradict any address
+equality.
+
+**Perf.** The naive per-pair certificate (re-scan every constraint per `(send, mid)`
+pair, plus a per-call `decide (Nat.Prime p)`) made keccak **~5× slower** (30+ min vs ~6). Fixed with
+a proof-carrying `TwoRootMap` (per-variable `(k, A, δ)` data, mirroring `BoundsMap`) built **once per
+pass** — constant-time hash lookup per pair; each entry also carries `Nat.Prime p`, dropping the
+per-call primality `decide`. Keccak runtime is **back to ~baseline (~6 min)**; output byte-identical
+to the naive version on the quick case.
+
+**Impact.** **keccak: 3056 → 2224 variables (−832, −27%), 2862 → 2411 bus interactions (−451),
+120 → 118 constraints.** The variable gap to powdr shrank **+1035 → +203** (80% closed, now 2224 vs
+2021). The cascade landed as predicted: `read_data_aux…lower_decomp` 534→164, `prev_data` 448→148,
+width-12/17 range checks 267/267 → **129/129 (= powdr)**; register-chain (AS1) cancellation cascaded
+free (230 → **58 = powdr**). AS2 count itself stays 482 (the ±1 identical-tuple residue rose 178→282 —
+those need the item-1.2 affine `byteJustified` rule to cancel; future work). **openvm-eth 100-case
+sweep: variables 4.490× → 4.507× agg (3.810 → 3.818 geo), bus 3.290× → 3.331× agg (2.629 → 2.641
+geo), constraints ~flat, 0 regressions** — the pass also fires on the main benchmark's heap accesses.
+Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
+
+**Follow-up.** (1) The 282 identical ±1 memory tuples my forwarding created are cancellable by
+`busPairCancel` once `byteJustified` gets an affine no-wrap rule (ideas.md 1.2) — another ~−282 bus.
+(2) Wiring `addrTwoRootNeq` into `busPairCancel.midRefuted` could telescope the AS2 middle pairs
+(below powdr's 200 floor; ideas.md 2.2).


### PR DESCRIPTION
## Symbolic-timestamp forwarding: two-root address disequality

Unblocks `busUnify`'s read-value / `prev_data` forwarding across symbolic-timestamp memory
accesses on the **heap**, where addresses are pointer *expressions*
(`mem_ptr_limbs__0 + 2¹⁶·mem_ptr_limbs__1`) rather than literal constants.

### Mechanism

Each pointer limb is pinned by a two-root constraint `(A + k·x)(A + δ + k·x) = 0`. New audit-free
`AddrDiseq.lean` (`addrTwoRootNeq`) substitutes either root into `addr = limb₀ + 2¹⁶·limb₁`; over
BabyBear `1 + 2¹⁶·30720 ≡ 0`, so the low limb cancels algebraically and each address reduces to one
of two affine branches. For two same-base pointers, all four branch-pair differences are nonzero
field constants ⇒ the addresses **provably differ — no range bounds needed**. This is OR-ed into
`findConsumer`'s step-over test and `checkPair`'s mid-refutation, so the send↔consumer slot
equalities finally fire on the heap and Gauss pins the read/`prev_data` limbs.

A proof-carrying `TwoRootMap` (mirroring `BoundsMap`) memoizes the per-variable two-root data once
per pass, keeping runtime at baseline (the naive per-pair certificate was ~5× slower).

### Impact (as measured when authored, vs the then-current main)

- **keccak: 3056 → 2224 variables (−832, −27%), 2862 → 2411 bus interactions (−451)**; variable gap
  to powdr shrank **+1035 → +203**. `lower_decomp` 534→164, `prev_data` 448→148, width-12/17 range
  checks → 129/129 (= powdr).
- **openvm-eth 100-case: variables 4.490× → 4.507× agg, bus 3.290× → 3.331× agg, 0 regressions.**

(CI's benchmark on this PR will report the authoritative effectiveness delta against the current
`main`.)

### Correctness

Audit-free — all changes are under `ApcOptimizer/Implementation/`; no new `BusFacts`, no change to
the audited surface. Correctness follows from the pass's own `PassCorrect`. Proof integrity
(`{propext, Classical.choice, Quot.sound}`-only) green; `lake build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
