### PR TITLE
Index domain-fold covered-set scan; hash busUnify membership

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -256,12 +256,15 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
     -- keep only equalities over existing columns, so the pass introduces no new variable
     -- (the real slot equalities are built from `cs`'s payloads, so none are dropped).
-    -- `csVars` is bound once here rather than recomputed for every variable of every candidate
-    -- (`cs.vars` rebuilds the whole occurrence list); the `let` zeta-reduces in the proof below.
-    let csVars := cs.vars
+    -- The membership test `z ∈ cs.vars` is the load-bearing "no new variable" check, run for
+    -- every variable of every candidate equality. `cs.vars` is the whole occurrence list (~10⁴
+    -- entries on large blocks), so the per-`z` **linear** list scan dominated this filter. Build a
+    -- `Std.HashSet` of it once and test membership in O(1); `Std.HashSet.contains_ofList` transports
+    -- the check back to genuine list membership `z ∈ cs.vars` (all the correctness proof needs).
+    let csVarSet := Std.HashSet.ofList cs.vars
     let new := eqs.filter
       (fun c => !c.normalize.fold.isConstZero && !cs.algebraicConstraints.contains c
-        && c.vars.all (fun z => decide (z ∈ csVars)))
+        && c.vars.all (fun z => csVarSet.contains z))
     if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else
       ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
@@ -270,5 +273,7 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
          (fun c hc z hz => by
            have hp := (List.mem_filter.1 hc).2
            simp only [Bool.and_eq_true, List.all_eq_true] at hp
-           exact of_decide_eq_true (hp.2 z hz))⟩
+           have hz' : csVarSet.contains z = true := hp.2 z hz
+           rw [Std.HashSet.contains_ofList] at hz'
+           exact List.contains_iff_mem.mp hz')⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -34,15 +34,19 @@ structure CovIndex where
   buckets : Std.HashMap Variable (List Nat)
   varless : List Nat
 
+/-- One step of the index build for an item paired with its position: insert the position into
+    every bucket of the variables the item mentions (or into `varless` when it mentions none).
+    Split out of `build` so the completeness lemmas below can induct on it. -/
+def buildStep (varsOf : α → List Variable) (ai : α × Nat) (idx : CovIndex) : CovIndex :=
+  match varsOf ai.1 with
+  | [] => ⟨idx.buckets, ai.2 :: idx.varless⟩
+  | vs => ⟨vs.foldl (fun m v => m.insert v (ai.2 :: m.getD v [])) idx.buckets, idx.varless⟩
+
 /-- Build the inverted index in one pass over `items` paired with their positions. Mirrors
     `busPairCancel`'s `recvIndex`: a right fold inserting each position into every bucket of the
     variables it mentions (or into `varless` when it mentions none). -/
 def build (varsOf : α → List Variable) (items : List α) : CovIndex :=
-  items.zipIdx.foldr (fun ai idx =>
-    match varsOf ai.1 with
-    | [] => ⟨idx.buckets, ai.2 :: idx.varless⟩
-    | vs => ⟨vs.foldl (fun m v => m.insert v (ai.2 :: m.getD v [])) idx.buckets, idx.varless⟩)
-    ⟨∅, []⟩
+  items.zipIdx.foldr (buildStep varsOf) ⟨∅, []⟩
 
 /-- The candidate positions for target `xs`: every position bucketed under a variable of `xs`,
     plus the variable-less positions. -/
@@ -92,5 +96,237 @@ theorem coveredIdx_mem_of_eq (idx : CovIndex) (l : List α) (arr : Array α)
     (harr : arr = l.toArray) (Q : α → Bool) (xs : List Variable)
     {e : α} (he : e ∈ coveredIdx idx arr Q xs) : e ∈ l ∧ Q e = true := by
   subst harr; exact coveredIdx_mem_list idx l Q xs he
+
+/-! ## Completeness: `coveredIdx` equals the plain filter (for the exact-covered-set passes)
+
+`domainBatch` / `reencode` consume only `coveredIdx_mem` (each returned item genuinely satisfies
+`Q`) — index *completeness* only affects their effectiveness and is checked empirically. The
+domain-**fold** pass, however, threads the covered set into `groupDoms` / `foldOut_correct`, whose
+statements pin it to `cs.algebraicConstraints.filter (coveredBy xs)` *exactly*; substituting the
+index there needs a genuine `coveredIdx … = items.filter Q` equality. It holds whenever every
+`Q`-item shares a variable with the target `xs` (so the index gathers it) — the case for
+`coveredBy`, whose `hasVar` guarantees at least one variable and whose `varsInF` puts every one in
+`xs`. The proof is generic over the item type. -/
+
+/-- Membership in the fold of a list into a `Std.HashSet` (used for the candidate-position dedup). -/
+theorem mem_foldl_insert (l : List Nat) (s : Std.HashSet Nat) (i : Nat) :
+    i ∈ l.foldl (·.insert ·) s ↔ i ∈ s ∨ i ∈ l := by
+  induction l generalizing s with
+  | nil => simp
+  | cons a rest ih =>
+    rw [List.foldl_cons, ih (s.insert a), Std.HashSet.mem_insert, List.mem_cons]
+    simp only [beq_iff_eq]
+    constructor
+    · rintro ((rfl | h) | h)
+      · exact Or.inr (Or.inl rfl)
+      · exact Or.inl h
+      · exact Or.inr (Or.inr h)
+    · rintro (h | rfl | h)
+      · exact Or.inl (Or.inr h)
+      · exact (Or.inl (Or.inl rfl))
+      · exact Or.inr h
+
+/-- Inserting a position into buckets never removes an existing membership. -/
+theorem inner_getD_mono (i : Nat) (vs : List Variable) (w : Variable) (j : Nat) :
+    ∀ (m : Std.HashMap Variable (List Nat)), j ∈ m.getD w [] →
+    j ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD w [] := by
+  induction vs with
+  | nil => intro m hj; simpa using hj
+  | cons v0 rest ih =>
+    intro m hj
+    simp only [List.foldl_cons]
+    apply ih
+    rw [Std.HashMap.getD_insert]
+    by_cases h : (v0 == w) = true
+    · rw [if_pos h]
+      have hvw : v0 = w := eq_of_beq h
+      subst hvw
+      exact List.mem_cons_of_mem _ hj
+    · rw [if_neg h]; exact hj
+
+/-- After inserting `i` into every bucket of `vs`, `i` is in the bucket of each `v ∈ vs`. -/
+theorem inner_getD_self (i : Nat) (vs : List Variable) (v : Variable) :
+    ∀ (m : Std.HashMap Variable (List Nat)), v ∈ vs →
+    i ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD v [] := by
+  induction vs with
+  | nil => intro m hv; simp at hv
+  | cons v0 rest ih =>
+    intro m hv
+    simp only [List.foldl_cons]
+    rcases List.mem_cons.1 hv with rfl | hv
+    · apply inner_getD_mono
+      rw [Std.HashMap.getD_insert, if_pos (by simp)]
+      exact List.mem_cons_self
+    · exact ih _ hv
+
+/-- The `.buckets` of one `buildStep` when the item has no variables (unchanged). -/
+theorem buildStep_buckets_nil (varsOf : α → List Variable) (ai : α × Nat) (idx : CovIndex)
+    (h : varsOf ai.1 = []) : (buildStep varsOf ai idx).buckets = idx.buckets := by
+  simp only [buildStep, h]
+
+/-- The `.buckets` of one `buildStep` when the item has variables (the inner insert fold). -/
+theorem buildStep_buckets_cons (varsOf : α → List Variable) (ai : α × Nat) (idx : CovIndex)
+    (w0 : Variable) (ws : List Variable) (h : varsOf ai.1 = w0 :: ws) :
+    (buildStep varsOf ai idx).buckets
+      = (w0 :: ws).foldl (fun m v => m.insert v (ai.2 :: m.getD v [])) idx.buckets := by
+  simp only [buildStep, h]
+
+/-- **Index completeness (buckets).** Every item at position `i` with variable `v` bucketed under
+    `v`: the fold inserts `i` into `v`'s bucket and later steps never remove it. -/
+theorem buildStep_bucket_complete (varsOf : α → List Variable) :
+    ∀ (l : List (α × Nat)) (a : α) (i : Nat), (a, i) ∈ l → ∀ (v : Variable), v ∈ varsOf a →
+      i ∈ (l.foldr (buildStep varsOf) ⟨∅, []⟩).buckets.getD v [] := by
+  intro l
+  induction l with
+  | nil => intro a i hai; simp at hai
+  | cons ai0 rest ih =>
+    intro a i hai v hv
+    rw [List.foldr_cons]
+    rcases List.mem_cons.1 hai with heq | hmem
+    · rw [← heq]
+      cases hvs : varsOf a with
+      | nil => rw [hvs] at hv; simp at hv
+      | cons w0 ws =>
+        rw [buildStep_buckets_cons varsOf (a, i) _ w0 ws hvs]
+        exact inner_getD_self i (w0 :: ws) v _ (by rw [← hvs]; exact hv)
+    · have hrec : i ∈ (rest.foldr (buildStep varsOf) ⟨∅, []⟩).buckets.getD v [] := ih a i hmem v hv
+      cases hvs : varsOf ai0.1 with
+      | nil => rw [buildStep_buckets_nil varsOf ai0 _ hvs]; exact hrec
+      | cons w0 ws =>
+        rw [buildStep_buckets_cons varsOf ai0 _ w0 ws hvs]
+        exact inner_getD_mono ai0.2 (w0 :: ws) v i _ hrec
+
+/-- A position bucketed under a variable of `xs` is a candidate. -/
+theorem mem_candidates (idx : CovIndex) (xs : List Variable) (v : Variable) (i : Nat)
+    (hv : v ∈ xs) (hi : i ∈ idx.buckets.getD v []) : i ∈ candidates idx xs :=
+  List.mem_append_left _ (List.mem_flatMap.2 ⟨v, hv, hi⟩)
+
+/-- `filterMap` of a guarded `some` is the plain filter-then-map. -/
+theorem filterMap_if_some {β γ : Type _} (P : β → Bool) (f : β → γ) (l : List β) :
+    l.filterMap (fun x => if P x then some (f x) else none) = (l.filter P).map f := by
+  induction l with
+  | nil => rfl
+  | cons a rest ih =>
+    by_cases h : P a
+    · rw [List.filterMap_cons_some (by rw [if_pos h]), List.filter_cons_of_pos h, List.map_cons, ih]
+    · rw [List.filterMap_cons_none (by rw [if_neg h]), List.filter_cons_of_neg (by simpa using h), ih]
+
+/-- `filterMap` respects pointwise equality of its function on the list. -/
+theorem filterMap_congr' {β γ : Type _} {f g : β → Option γ} (l : List β)
+    (h : ∀ x ∈ l, f x = g x) : l.filterMap f = l.filterMap g := by
+  induction l with
+  | nil => rfl
+  | cons a rest ih =>
+    have ha := h a (List.mem_cons_self)
+    have hr := ih (fun x hx => h x (List.mem_cons_of_mem _ hx))
+    cases hfa : f a with
+    | none => rw [List.filterMap_cons_none hfa, List.filterMap_cons_none (ha ▸ hfa), hr]
+    | some b => rw [List.filterMap_cons_some hfa, List.filterMap_cons_some (ha ▸ hfa), hr]
+
+/-- **`coveredIdx` equals the plain filter** whenever every `Q`-item shares a variable with `xs`.
+    All the fold/sort machinery collapses: the index gathers every `Q`-position (completeness), the
+    `HashSet` dedup and `mergeSort` reorder them into ascending (i.e. original list) order, and the
+    per-position `Q` re-check reproduces `items.filter Q` exactly. -/
+theorem coveredIdx_eq_filter (varsOf : α → List Variable) (items : List α)
+    (Q : α → Bool) (xs : List Variable)
+    (hcomplete : ∀ (i : Nat) (hi : i < items.length),
+      Q items[i] = true → ∃ v ∈ varsOf items[i], v ∈ xs) :
+    coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q := by
+  rw [coveredIdx]
+  simp only [List.size_toArray, List.getElem_toArray]
+  set cand := candidates (build varsOf items) xs with hcand
+  set gI : Nat → Option α :=
+    (fun i => if h : i < items.length then (if Q items[i] then some items[i] else none) else none)
+    with hgI
+  set sortedL := ((cand.foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList).mergeSort (· ≤ ·)
+    with hsortedL
+  -- (F1) membership in the sorted candidate list is membership in `cand`
+  have F1 : ∀ i, i ∈ sortedL ↔ i ∈ cand := by
+    intro i
+    rw [hsortedL, List.mem_mergeSort, Std.HashSet.mem_toList, mem_foldl_insert]
+    simp [Std.HashSet.not_mem_empty]
+  -- (F2) the sorted list is duplicate-free
+  have hnodupUniq : ((cand.foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList).Nodup :=
+    Std.HashSet.distinct_toList.imp (fun {a b} h => by simpa using h)
+  have F2 : sortedL.Nodup := by
+    rw [hsortedL]; exact (List.mergeSort_perm _ _).nodup_iff.mpr hnodupUniq
+  -- (F3) the sorted list is `≤`-sorted
+  have F3 : sortedL.Pairwise (· ≤ ·) := by
+    rw [hsortedL]; exact List.sortedLE_mergeSort.pairwise
+  -- (F4) completeness: every in-range `Q`-position is a candidate
+  have F4 : ∀ (i : Nat) (hi : i < items.length), Q items[i] = true → i ∈ cand := by
+    intro i hi hQ
+    obtain ⟨v, hvvars, hvxs⟩ := hcomplete i hi hQ
+    have hz : (items.zipIdx)[i]? = some (items[i], i) := by
+      rw [List.getElem?_zipIdx, List.getElem?_eq_getElem hi]; simp
+    have hmem : (items[i], i) ∈ items.zipIdx := List.mem_of_getElem? hz
+    have hbucket := buildStep_bucket_complete varsOf items.zipIdx items[i] i hmem v hvvars
+    rw [hcand]
+    exact mem_candidates (build varsOf items) xs v i hvxs hbucket
+  -- the keep-predicate coincides with `gI`'s definedness
+  set keepB : Nat → Bool := (fun i => (gI i).isSome) with hkeepB
+  have hkeep_lt : ∀ i, keepB i = true → i < items.length := by
+    intro i hk
+    by_contra hcon
+    simp only [hkeepB, hgI, dif_neg hcon, Option.isSome_none, Bool.false_eq_true] at hk
+  have hkeep_Q : ∀ i, keepB i = true → ∃ (_ : i < items.length), Q items[i] = true := by
+    intro i hk
+    have hlt := hkeep_lt i hk
+    refine ⟨hlt, ?_⟩
+    by_contra hQc
+    simp only [hkeepB, hgI, dif_pos hlt, if_neg hQc, Option.isSome_none, Bool.false_eq_true] at hk
+  -- (L1) dropping the `none`-mapping positions before `filterMap` changes nothing
+  have L1 : ∀ (l : List Nat), l.filterMap gI = (l.filter keepB).filterMap gI := by
+    intro l
+    induction l with
+    | nil => rfl
+    | cons a rest ih =>
+      by_cases hk : keepB a = true
+      · rw [List.filter_cons_of_pos hk]
+        cases hga : gI a with
+        | none => rw [hkeepB] at hk; simp [hga] at hk
+        | some b => rw [List.filterMap_cons_some hga, List.filterMap_cons_some hga, ih]
+      · rw [List.filter_cons_of_neg hk]
+        have hga : gI a = none := by
+          by_contra hne
+          obtain ⟨b, hb⟩ := Option.ne_none_iff_exists'.1 hne
+          exact hk (by simp [hkeepB, hb])
+        rw [List.filterMap_cons_none hga, ih]
+  -- (Claim1) the filter equals the filterMap over `[0, n)`
+  have claim1 : (List.range items.length).filterMap gI = items.filter Q := by
+    have hrange : List.range items.length = items.zipIdx.map Prod.snd := by
+      rw [List.zipIdx_map_snd, List.range_eq_range']
+    rw [hrange, List.filterMap_map]
+    rw [filterMap_congr' items.zipIdx
+      (f := gI ∘ Prod.snd) (g := fun p => if Q p.1 then some p.1 else none)
+      (by
+        rintro ⟨a, j⟩ hp
+        obtain ⟨_, hlt, heq⟩ := List.mem_zipIdx (k := 0) hp
+        have hlt' : j < items.length := by simpa using hlt
+        have heq' : items[j]'hlt' = a := by simpa using heq.symm
+        simp only [Function.comp_apply, hgI, dif_pos hlt', heq'])]
+    rw [filterMap_if_some]
+    show ((items.zipIdx.filter (Q ∘ Prod.fst)).map Prod.fst) = items.filter Q
+    rw [← List.filter_map, List.zipIdx_map_fst]
+  -- (L2) the kept positions of the sorted list coincide with those of `[0, n)`
+  have L2 : sortedL.filter keepB = (List.range items.length).filter keepB := by
+    refine List.Perm.eq_of_sortedLE
+      (List.Pairwise.sublist List.filter_sublist F3).sortedLE
+      (List.Pairwise.sublist List.filter_sublist List.pairwise_le_range).sortedLE
+      ((List.perm_ext_iff_of_nodup
+        (List.Nodup.sublist List.filter_sublist F2)
+        (List.Nodup.sublist List.filter_sublist List.nodup_range)).mpr ?_)
+    intro i
+    rw [List.mem_filter, List.mem_filter, F1 i, List.mem_range]
+    constructor
+    · rintro ⟨hcandi, hk⟩; exact ⟨hkeep_lt i hk, hk⟩
+    · rintro ⟨_, hk⟩
+      obtain ⟨hlt', hQ⟩ := hkeep_Q i hk
+      exact ⟨F4 i hlt' hQ, hk⟩
+  calc sortedL.filterMap gI
+      = (sortedL.filter keepB).filterMap gI := L1 sortedL
+    _ = ((List.range items.length).filter keepB).filterMap gI := by rw [L2]
+    _ = (List.range items.length).filterMap gI := (L1 _).symm
+    _ = items.filter Q := claim1
 
 end CoveredIndex

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -483,6 +483,49 @@ def foldLoop [Fact p.Prime] (bs : BusSemantics p) :
     let r2 := foldLoop bs rest r1.1.out r1.2
     ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
 
+/-! ### Direct (unindexed) path for small systems
+
+The inverted index amortizes a full covered-set scan across many targets, but it pays a fixed
+per-invocation build (and a rebuild on each accepted fold) plus a per-target `HashSet`/`mergeSort`.
+On the *small* circuits (openvm-eth blocks, ≤ ~4.6k constraints) that overhead exceeds the saved
+scan — the plain `coveredCsOf` filter is cheaper — even though it wins decisively on the keccak
+stress case (~28.6k constraints). `domainFoldPass` therefore gates on system size: the direct loop
+below (recomputing `coveredCsOf` per target, as before this file's index change) runs on small
+systems, the indexed `foldLoop` on large ones. Both call the same `foldStepWith` core, so the fold
+semantics — hence effectiveness — are identical on every case; only the covered-set *lookup* differs. -/
+
+/-- One checked fold for a candidate group, given the covered set `es` (required to equal
+    `coveredCsOf cs xs`, so `foldOut_correct`'s `hdoms` transports). Used by the direct path with
+    `es := coveredCsOf cs xs`, `hes := rfl`; the indexed `foldStep` mirrors this same logic inline
+    (it additionally threads and rebuilds the covered-set index on each accepted fold, which the
+    dependent `Σ' r, FoldIdx r.out` return forces it to do branch-by-branch rather than delegate). -/
+def foldStepWith [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (xs : List Variable)
+    (es : List (Expression p)) (hes : es = coveredCsOf cs xs) : PassResult cs bs :=
+  match hdoms : groupDoms es xs with
+  | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  | some doms =>
+    if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
+      let survs := groupSurvivors cs xs doms
+      if 1 ≤ survs.length && systemHasFoldable cs xs survs then
+        ⟨foldOut cs xs survs, [], foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩
+      else ⟨cs, [], PassCorrect.refl cs bs⟩
+    else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-- Direct-path fold loop: recompute `coveredCsOf cs xs` per target (no index). -/
+def foldLoopDirect [Fact p.Prime] (bs : BusSemantics p) :
+    List (List Variable) → (cs : ConstraintSystem p) → PassResult cs bs
+  | [], cs => ⟨cs, [], PassCorrect.refl cs bs⟩
+  | xs :: rest, cs =>
+    let r1 := foldStepWith bs cs xs (coveredCsOf cs xs) rfl
+    let r2 := foldLoopDirect bs rest r1.out
+    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
+
+/-- Systems at least this many algebraic constraints use the inverted index; smaller ones use the
+    direct per-target `coveredCsOf` scan. openvm-eth's largest block is ~4.6k constraints (index is
+    net-slower there); the keccak stress case is ~28.6k (index wins ~13 %). Purely a runtime gate —
+    both paths compute the identical fold. -/
+def domainFoldIndexThreshold : Nat := 8192
+
 /-- The domain-constant folding pass: for every constraint's (small) variable group, fold each
     subexpression that is constant on the group's surviving joint values to that constant — keeping
     the group's variables. Recovers the address-constant folding that unblocks memory chaining
@@ -495,5 +538,10 @@ def domainFoldPass : VerifiedPass p := fun cs bsem =>
       let vs := c.vars.dedup
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    foldLoop bsem targets cs (FoldIdx.mk' cs)
+    -- Runtime gate (effectiveness-identical): amortize the covered-set scan through the inverted
+    -- index only on large systems, where it wins; small systems use the cheaper direct filter.
+    if domainFoldIndexThreshold ≤ cs.algebraicConstraints.length then
+      foldLoop bsem targets cs (FoldIdx.mk' cs)
+    else
+      foldLoopDirect bsem targets cs
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -388,28 +388,100 @@ def systemHasFoldable (cs : ConstraintSystem p) (xs : List Variable)
     cs.busInteractions.any (fun bi =>
       bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
 
+/-! ### Indexing the per-target covered-constraint scan
+
+`foldStep` gates every target on `groupDoms (coveredCsOf cs xs) xs`, whose `coveredCsOf` is a full
+`cs.algebraicConstraints.filter (coveredBy xs)` scan run **once per target** — an
+O(#targets × #system) cost that dominates this pass on large circuits (the keccak stress case).
+`domainBatch`/`reencode` (log 72) cut the same term with a variable→positions inverted index, but
+consumed only the soundness-only `coveredIdx_mem`. Here the covered set is threaded into
+`foldOut_correct`, whose statement pins it to `coveredCsOf cs xs` **exactly**, so we need the
+genuine equality `coveredIdx … = coveredCsOf cs xs` (`CoveredIndex.coveredIdx_eq_filter`, valid
+because a `coveredBy`-item always shares a variable with `xs`). The index is built once per pass
+and rebuilt only on an accepted fold (`cs` changes), carrying the proofs tying it to the current
+`cs` via `FoldIdx`. Effectiveness is bit-identical (the covered set is unchanged); only the scan is
+faster. -/
+
+/-- The prebuilt covered-constraint index for the current `cs`, with the proofs tying it to `cs` so
+    the covered set it yields is provably `coveredCsOf cs xs` (`coveredCsIdx_eq`). -/
+structure FoldIdx (cs : ConstraintSystem p) where
+  idx : CoveredIndex.CovIndex
+  hidx : idx = CoveredIndex.build Expression.vars cs.algebraicConstraints
+  arr : Array (Expression p)
+  harr : arr = cs.algebraicConstraints.toArray
+
+/-- Build the index for a system (by construction the equalities hold `rfl`). -/
+def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
+  idx := CoveredIndex.build Expression.vars cs.algebraicConstraints
+  hidx := rfl
+  arr := cs.algebraicConstraints.toArray
+  harr := rfl
+
+/-- An expression with any variable has a nonempty variable list. -/
+theorem hasVar_vars_ne_nil (c : Expression p) (h : c.hasVar = true) : c.vars ≠ [] := by
+  induction c with
+  | const n => simp [Expression.hasVar] at h
+  | var y => simp [Expression.vars]
+  | add a b iha ihb =>
+    intro hnil
+    rw [Expression.vars, List.append_eq_nil_iff] at hnil
+    simp only [Expression.hasVar, Bool.or_eq_true] at h
+    rcases h with h | h
+    · exact iha h hnil.1
+    · exact ihb h hnil.2
+  | mul a b iha ihb =>
+    intro hnil
+    rw [Expression.vars, List.append_eq_nil_iff] at hnil
+    simp only [Expression.hasVar, Bool.or_eq_true] at h
+    rcases h with h | h
+    · exact iha h hnil.1
+    · exact ihb h hnil.2
+
+/-- A `coveredBy`-item shares a variable with the target `xs` (`hasVar` gives one variable;
+    `varsInF` puts every one in `xs`) — the completeness hypothesis `coveredIdx_eq_filter` needs. -/
+theorem coveredBy_shares_var (xs : List Variable) (c : Expression p) (h : coveredBy xs c = true) :
+    ∃ v ∈ c.vars, v ∈ xs := by
+  rw [coveredBy, Bool.and_eq_true] at h
+  obtain ⟨hhv, hvin⟩ := h
+  obtain ⟨v, hmem⟩ := List.exists_mem_of_ne_nil c.vars (hasVar_vars_ne_nil c hhv)
+  exact ⟨v, hmem, Expression.varsIn_sound xs c (Expression.varsInF_eq xs c ▸ hvin) v hmem⟩
+
+/-- The index yields exactly `coveredCsOf cs xs` for every target — an equality (not just
+    soundness), so the domains it feeds and the `foldOut_correct` proof transport unchanged. -/
+theorem coveredCsIdx_eq (cs : ConstraintSystem p) (xs : List Variable) (fidx : FoldIdx cs) :
+    CoveredIndex.coveredIdx fidx.idx fidx.arr (coveredBy xs) xs = coveredCsOf cs xs := by
+  rw [fidx.hidx, fidx.harr, coveredCsOf]
+  exact CoveredIndex.coveredIdx_eq_filter Expression.vars cs.algebraicConstraints (coveredBy xs) xs
+    (fun i _hi hQ => coveredBy_shares_var xs cs.algebraicConstraints[i] hQ)
+
 /-- One checked fold for a candidate group (identity unless the group has a bounded domain, at least
-    one survivor, and some foldable subexpression). Prime `p`; the caller supplies `Fact p.Prime`. -/
-def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (xs : List Variable) :
-    PassResult cs bs :=
-  match hdoms : groupDoms (coveredCsOf cs xs) xs with
-  | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+    one survivor, and some foldable subexpression). The per-target covered scan is served from the
+    prebuilt index (`coveredCsIdx_eq`), rebuilt only when a fold rewrites `cs`. Prime `p`; the
+    caller supplies `Fact p.Prime`. -/
+def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fidx : FoldIdx cs)
+    (xs : List Variable) : Σ' (r : PassResult cs bs), FoldIdx r.out :=
+  let es := CoveredIndex.coveredIdx fidx.idx fidx.arr (coveredBy xs) xs
+  have hes : es = coveredCsOf cs xs := coveredCsIdx_eq cs xs fidx
+  match hdoms : groupDoms es xs with
+  | none => ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
   | some doms =>
     if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
       let survs := groupSurvivors cs xs doms
       if 1 ≤ survs.length && systemHasFoldable cs xs survs then
-        ⟨foldOut cs xs survs, [], foldOut_correct cs bs xs doms hdoms⟩
-      else ⟨cs, [], PassCorrect.refl cs bs⟩
-    else ⟨cs, [], PassCorrect.refl cs bs⟩
+        ⟨⟨foldOut cs xs survs, [], foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩,
+         FoldIdx.mk' (foldOut cs xs survs)⟩
+      else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
 
-/-- Process the candidate groups sequentially (correctness composes; no derivations). -/
+/-- Process the candidate groups sequentially (correctness composes; no derivations). The index is
+    threaded and rebuilt by `foldStep` on each accepted fold. -/
 def foldLoop [Fact p.Prime] (bs : BusSemantics p) :
-    List (List Variable) → (cs : ConstraintSystem p) → PassResult cs bs
-  | [], cs => ⟨cs, [], PassCorrect.refl cs bs⟩
-  | xs :: rest, cs =>
-    let r1 := foldStep bs cs xs
-    let r2 := foldLoop bs rest r1.out
-    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
+    List (List Variable) → (cs : ConstraintSystem p) → FoldIdx cs → PassResult cs bs
+  | [], cs, _ => ⟨cs, [], PassCorrect.refl cs bs⟩
+  | xs :: rest, cs, fidx =>
+    let r1 := foldStep bs cs fidx xs
+    let r2 := foldLoop bs rest r1.1.out r1.2
+    ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
 
 /-- The domain-constant folding pass: for every constraint's (small) variable group, fold each
     subexpression that is constant on the group's surviving joint values to that constant — keeping
@@ -423,5 +495,5 @@ def domainFoldPass : VerifiedPass p := fun cs bsem =>
       let vs := c.vars.dedup
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    foldLoop bsem targets cs
+    foldLoop bsem targets cs (FoldIdx.mk' cs)
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -230,26 +230,23 @@ it **is** a measured bottleneck: with the `hintCollapse`/`reencode` rescans fixe
 is ~24 s of apc_005's 65 s optimizer time (second only to `domainBatch`, whose fix is sketched in
 entry 45's remaining-bottleneck note).
 
-## Runtime: extend the covered-set inverted index (entry 72 follow-ups)
+## Runtime: extend the covered-set inverted index (entry 72 / 73 follow-ups)
 
 Entry 72 added `CoveredIndex.lean` (a variable→positions index + `coveredIdx`) and wired it into
-`domainBatch` and `reencode`, killing their per-target O(#system) covered-set `filter`s. Remaining
-keccak-profile hot spots, in rough priority:
+`domainBatch` and `reencode`; entry 73 added `coveredIdx_eq_filter` (the completeness/equality
+lemma — `build` bucket completeness + `HashSet`/`mergeSort` collapse) and wired it into `domainFold`,
+and hashed `busUnify`'s `z ∈ cs.vars` membership (−72 % on that pass). Remaining keccak-profile hot
+spots, in rough priority:
 
-- **`domainFold` (~65 s).** Its `foldStep` feeds the covered set to `groupDoms` and then to
-  `foldOut_correct`, which is stated against `coveredCsOf cs xs`. Indexing the scrutinee therefore
-  needs a proven `coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q` equality
-  (so `hdoms` transports), rather than the soundness-only `coveredIdx_mem` used elsewhere. The
-  equality needs `build`'s bucket/varless completeness (a `foldr`/`HashMap.getD_insert` invariant)
-  plus a sorted-nodup-perm argument that the deduped-sorted candidate indices equal
-  `(range n).filter …`.
-- **`flagFold` (~50 s), `busUnify` (~48 s).** Different pattern: per-candidate `z ∈ cs.vars`
-  (list membership over ~10⁴ occurrences) and `cs.algebraicConstraints.contains c`
-  (O(#constraints) structural compare). A once-built `Std.HashSet Variable` for `cs.vars`
-  membership (load-bearing: proves no new variable — needs a `mem` lemma) and a structHash-keyed
-  index for `contains` (heuristic; collision-safe re-verify) would cut both. No `Hashable
-  (Expression p)` instance exists yet — deriving one (+`LawfulHashable` via `structHash`) would
-  unblock HashSet-based dedup here and in the `dedup` pass.
+- **`busUnify`'s `cs.algebraicConstraints.contains c` (residual, after entry 73).** The variable
+  membership is now O(1); the other per-equality scan is a structural `List.contains` over all
+  constraints. It is **not** load-bearing for correctness (only the kept-set effectiveness), so a
+  structHash-keyed `Std.HashSet` (heuristic; collision-safe re-verify to keep the output identical)
+  would cut it. Needs a `Hashable (Expression p)` instance (+ `LawfulHashable` via `structHash`) —
+  which would also unblock the `dedup` pass and `flagFold` below.
+- **`flagFold` (~51 s).** Same pattern as the old `busUnify`: per-candidate `z ∈ cs.vars` and
+  structural `contains`/dedup scans. A once-built `Std.HashSet Variable` for `cs.vars` membership
+  (as in entry 73) plus the `Hashable (Expression p)` index above would cut it.
 - **Finite-domain enumeration residual.** After indexing, `domainBatch`/`domainFold`'s remaining
   cost is the box scan (`scanInit`/`scanForced`) and `constraintRedundant`; the `envOf` linear
   lookup (log entry 45's note, `docs/log.md:1030`) — substitute pinned domain-1 constants and

--- a/docs/log.md
+++ b/docs/log.md
@@ -2363,3 +2363,22 @@ this machine, so the per-pass profile deltas are the reliable signal.
 `cs.algebraicConstraints.contains c`, needs a `Hashable (Expression p)` instance to index; the next
 runtime tiers are `flagFold` (~51 s) and the finite-domain box enumeration inside
 `domainBatch` / `domainFold`.
+
+### 73a. Follow-up: size-gate the domain-fold index (avoid the small-circuit regression)
+
+The entry-73 `domainFold` index amortizes the covered-set scan across targets but pays a fixed
+per-invocation build (+ a rebuild per accepted fold) and a per-target `HashSet`/`mergeSort`. The #103
+CI bench (openvm-eth 100 cases + keccak) showed this is **net-slower on small circuits**: per-pass
+`domainFold` 5344 → 6639 ms (**1.24×**) on openvm-eth (largest block ~4.6k constraints), even though
+it wins on keccak (~28.6k constraints, −13 %). End-to-end the openvm-eth total was still flat (busUnify
+offsets it: 1870 → 644 ms, 0.34×), and keccak was −10 % overall — but the pass-level regression is
+avoidable.
+
+`domainFoldPass` now gates on `cs.algebraicConstraints.length`: ≥ `domainFoldIndexThreshold` (8192,
+comfortably above openvm-eth's ~4.6k and below keccak's ~28.6k) uses the indexed `foldLoop`; smaller
+systems use the new `foldLoopDirect` (recomputing `coveredCsOf` per target, as before the index).
+Both call the shared `foldStepWith` core, so the fold — hence effectiveness — is **identical on every
+case**; only the covered-set lookup differs. No audited surface; proof integrity unchanged
+(`{propext, Classical.choice, Quot.sound}`-only). Expected effect: keccak keeps its −13 % `domainFold`
+win; openvm-eth `domainFold` returns to baseline (no 1.24× regression); `busUnify`'s −66/−72 % win is
+unaffected.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2319,3 +2319,47 @@ reliable signal; a solo `run` A/B measured 529 → 378 s.
 `coveredCsOf`), so indexing it needs a `coveredIdx = items.filter Q` equality lemma; the residual
 per-pass time is the finite-domain enumeration itself (box scanning); the next tier is `flagFold`
 and `busUnify` (per-target `cs.vars` / `List.contains` membership).
+
+### 73. Runtime: index the domain-fold covered-set scan; hash the busUnify variable-membership check
+
+**Context / profiling.** Building on the entry-72 inverted index (#104), the post-#104 keccak
+profile (`apc-optimizer profile`, 7 cleanup iterations, ~383 s total) leaves these finite-domain / bus
+hot spots: `domainBatch` 75.2 s, `domainFold` 54.6 s, `flagFold` 50.9 s, `reencode` 45.3 s,
+`busPairCancel` 45.2 s, `busUnify` 40.8 s. This entry attacks two of them, with **no effectiveness
+change**.
+
+**(a) `domainFold` covered-set index (`CoveredIndex.coveredIdx_eq_filter`).** `foldStep` gated every
+target on `groupDoms (coveredCsOf cs xs) xs`, whose `coveredCsOf` is a full
+`cs.algebraicConstraints.filter (coveredBy xs)` scan **per target** — the same O(#targets × #system)
+term #104 removed from `domainBatch` / `reencode`. Those passes consumed only the soundness-only
+`coveredIdx_mem`, but `domainFold` threads the covered set into `foldOut_correct`, whose statement
+pins it to `coveredCsOf cs xs` **exactly**, so soundness is not enough. New
+`CoveredIndex.coveredIdx_eq_filter`: `coveredIdx (build varsOf items) items.toArray Q xs =
+items.filter Q` whenever every `Q`-item shares a variable with `xs` (index *completeness* — the
+`build` buckets, `HashSet` dedup and `mergeSort` all collapse back to the plain filter). The
+hypothesis holds for `coveredBy` (`hasVar` yields a variable, `varsInF` puts every one in `xs`).
+Wired into `foldStep` via a `FoldIdx` structure carrying the index plus the `= build …` /
+`= …toArray` proofs, built once per pass and rebuilt only on an accepted fold; the step re-derives
+`foldOut_correct`'s `hdoms` by rewriting the equality.
+
+**(b) `busUnify` membership (`Std.HashSet`).** The pass's load-bearing "introduces no new variable"
+filter tests `z ∈ cs.vars` for every variable of every collected slot-equality; `cs.vars` is the
+whole ~27.5k-entry occurrence list, so each `z` paid a **linear** list scan. Replace it with a
+`Std.HashSet.ofList cs.vars` membership test (O(1)); `Std.HashSet.contains_ofList` transports the
+result back to genuine `z ∈ cs.vars` (all the correctness proof consumes). Output is bit-identical
+(the kept set `new` is unchanged).
+
+**Impact.** No audited surface touched; the three `*_maintainsCorrectness` theorems stay
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes. **Effectiveness
+unchanged** — keccak output bit-identical (3056 vars / 120 constraints / 2690 bus interactions), and
+the full openvm-eth sweep matches the entry-72 baseline exactly (variables 4.491× / 3.810× agg/geo,
+bus 3.398× / 2.705×, constraints 10.595× / 11.585×; per-case 25 W / 43 L / 32 T). **Runtime (keccak
+profile, per-pass):** `busUnify` 40.8 → 11.3 s (**−72 %**, −29.6 s) — the variable-membership scan was
+the dominant term; `domainFold` 54.6 → ~46–48 s (−~13 %). Every other pass is flat within the ~3 %
+cross-pass measurement noise; profiled total 383 → 356 s. As in #104 the `run` wall-clock is noisy on
+this machine, so the per-pass profile deltas are the reliable signal.
+
+**Remaining (see `docs/ideas.md`).** `busUnify`'s other per-equality scan,
+`cs.algebraicConstraints.contains c`, needs a `Hashable (Expression p)` instance to index; the next
+runtime tiers are `flagFold` (~51 s) and the finite-domain box enumeration inside
+`domainBatch` / `domainFold`.


### PR DESCRIPTION
## Summary

Extends the inverted-index optimization from entry 72 to eliminate two more O(n) bottlenecks:
1. **`domainFold` covered-set scan** — adds `CoveredIndex.coveredIdx_eq_filter` (completeness lemma proving the index equals the plain filter when items share variables with the target), wires it into `foldStep` via a `FoldIdx` structure, and rebuilds the index only on accepted folds.
2. **`busUnify` variable-membership test** — replaces linear list scans of `cs.vars` with O(1) `Std.HashSet` lookups via `Std.HashSet.contains_ofList`.

No effectiveness change; output is bit-identical.

## Key Changes

**CoveredIndex.lean:**
- Extracted `buildStep` helper to enable inductive completeness proofs
- Added `mem_foldl_insert`, `inner_getD_mono`, `inner_getD_self` lemmas for bucket invariants
- Added `buildStep_bucket_complete` — proves every `Q`-item with a variable in `xs` is bucketed
- Added `filterMap_if_some`, `filterMap_congr'` — utility lemmas for filter/map reasoning
- **Added `coveredIdx_eq_filter`** — the main completeness theorem: `coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q` whenever every `Q`-item shares a variable with `xs`. Proof: bucket completeness + `HashSet` dedup + `mergeSort` collapse back to the plain filter.

**DomainFold.lean:**
- Added `FoldIdx` structure carrying the prebuilt index plus `= build …` and `= …toArray` proofs
- Added `FoldIdx.mk'` constructor
- Added `hasVar_vars_ne_nil` — if an expression has a variable, its variable list is nonempty
- Added `coveredBy_shares_var` — a `coveredBy`-item always shares a variable with the target (the completeness hypothesis for `coveredIdx_eq_filter`)
- Added `coveredCsIdx_eq` — applies `coveredIdx_eq_filter` to prove the index yields exactly `coveredCsOf cs xs`
- Modified `foldStep` to accept and thread a `FoldIdx`, use the indexed covered set, and rebuild the index on accepted folds
- Modified `foldLoop` to thread the `FoldIdx` through the target sequence
- Modified `domainFoldPass` to initialize the index once at the start

**BusUnify.lean:**
- Replaced `let csVars := cs.vars` with `let csVarSet := Std.HashSet.ofList cs.vars`
- Changed membership test from `decide (z ∈ csVars)` to `csVarSet.contains z`
- Added `Std.HashSet.contains_ofList` lemma to transport the hash-set membership back to list membership in the correctness proof

**docs/log.md:**
- Added entry 73 documenting the runtime improvements and remaining bottlenecks

**docs/ideas.md:**
- Updated to reflect entry 73 completions and revised priority list for remaining optimizations

## Implementation Details

- The `coveredIdx_eq_filter` proof is generic over the item type and predicate, making it reusable beyond `domainFold`.
- The `FoldIdx` structure decouples index construction from its use, allowing the index to be rebuilt only when `cs` changes (on accepted folds), not on every target.
- The `busUnify` change is purely a performance optimization with no semantic impact — the `Std.HashSet.contains_ofList` lemma ensures the hash-set membership test is equivalent to the original list membership.
- All three `*_maintainsCorrectness` theorems remain unchanged; no new axioms introduced.

https://claude.ai/code/session_01DhwSyyjPjAAJCtvtpWFcio