### PR TITLE
Generalize xorEqExtract to the 255-complement (C4b): −196 keccak vars, near powdr parity

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -233,6 +233,24 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       (∀ (x z : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 0, z, 1] }
           = false → z = x)
+  /-- Bitwise XOR-with-255 (byte complement): the sibling of `xorZeroEq`. On the same bitwise bus
+      where an accepted multiplicity-1 `[a, b, c, 1]` asserts `c = a ⊕ b` with byte operands, an
+      operand pinned to the all-ones byte `255` linearizes the XOR to the byte **complement** —
+      `[x, 255, z, 1]` accepted ⟹ `z = 255 − x`, and `[255, y, z, 1]` accepted ⟹ `z = 255 − y`
+      (`n ⊕ 255 = 255 − n` for a byte `n`). Together with `xorZeroEq` (operand 0 ⟹ identity) these
+      are exactly the two constant operands for which the XOR is *affine* in the other operand, so
+      Gauss can eliminate the pinned NOT-result — apc otherwise keeps these complement equalities
+      only on the bus. Sound only when `255` is a genuine byte of the field (`256 ≤ p`); a small
+      field, and `trivial`, set it `false`. -/
+  xorComplEq : (busId : Nat) → Bool
+  xorComplEq_sound :
+    ∀ (busId : Nat), xorComplEq busId = true →
+      (∀ (x z : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 255, z, 1] }
+          = false → z = 255 - x) ∧
+      (∀ (y z : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [255, y, z, 1] }
+          = false → z = 255 - y)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -265,3 +283,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   zeroRangeEq_sound := by intro _ h; exact absurd h (by simp)
   xorZeroEq _ := false
   xorZeroEq_sound := by intro _ h; exact absurd h (by simp)
+  xorComplEq _ := false
+  xorComplEq_sound := by intro _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -22,6 +22,12 @@ namespace ApcOptimizer.OpenVM
 
 variable {p : ℕ}
 
+/-- XOR-ing a byte with the all-ones byte `255` is the byte complement. Used by `xorComplEq_sound`
+    to linearize a bitwise interaction with a `255` operand into an affine equality. The 256-case
+    `decide` is a one-shot kernel check (no runtime cost). -/
+private theorem nat_xor_255 : ∀ n, n < 256 → Nat.xor n 255 = 255 - n := by
+  set_option maxRecDepth 4000 in decide
+
 private def slotBoundImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat) (mult : ZMod p)
     (pattern : List (Option (ZMod p))) (slot : Nat) : Option Nat :=
   match busMap busId, pattern, slot with
@@ -633,6 +639,49 @@ def openVmFacts (p : ℕ) [NeZero p]
       · simp only [h1, ZMod.val_zero, isByte, Bool.not_eq_false',
           Bool.and_eq_true, decide_eq_true_eq] at hviol
         exact valeq z x (hviol.2.trans (Nat.xor_zero x.val))
+  xorComplEq busId := match busMap busId with
+    | some .bitwiseLookup => decide (256 ≤ p)
+    | _ => false
+  xorComplEq_sound := by
+    intro busId h
+    have hbus : busMap busId = some OpenVmBusType.bitwiseLookup := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    have hple : 256 ≤ p := by
+      have h' : (match busMap busId with
+          | some OpenVmBusType.bitwiseLookup => decide (256 ≤ p) | _ => false) = true := h
+      rw [hbus] at h'; exact of_decide_eq_true h'
+    have hp2 : 1 < p := by omega
+    have h1val : (1 : ZMod p).val = 1 := by
+      rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_eq_of_lt hp2
+    have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
+    have h255val : (255 : ZMod p).val = 255 := by
+      rw [← hcast255, ZMod.val_natCast_of_lt (by omega : (255 : ℕ) < p)]
+    have hle_of : ∀ w : ZMod p, w.val < 256 → w.val ≤ 255 := fun w hw => Nat.le_of_lt_succ (by omega)
+    refine ⟨?_, ?_⟩
+    · intro x z hviol
+      replace hviol : violates busMap
+          { busId := busId, multiplicity := 1, payload := [x, 255, z, 1] } = false := hviol
+      unfold violates at hviol; rw [hbus] at hviol
+      simp only [h1val, isByte, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq] at hviol
+      obtain ⟨⟨hxb, _⟩, hzxor⟩ := hviol
+      rw [h255val] at hzxor
+      have hzv : z.val = 255 - x.val := by rw [hzxor]; exact nat_xor_255 x.val hxb
+      have hz : z = ((z.val : ℕ) : ZMod p) := (ZMod.natCast_rightInverse z).symm
+      rw [hz, hzv, Nat.cast_sub (hle_of x hxb), ZMod.natCast_rightInverse x, hcast255]
+    · intro y z hviol
+      replace hviol : violates busMap
+          { busId := busId, multiplicity := 1, payload := [255, y, z, 1] } = false := hviol
+      unfold violates at hviol; rw [hbus] at hviol
+      simp only [h1val, isByte, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq] at hviol
+      obtain ⟨⟨_, hyb⟩, hzxor⟩ := hviol
+      rw [h255val] at hzxor
+      have hzv : z.val = 255 - y.val := by
+        have hc : Nat.xor 255 y.val = Nat.xor y.val 255 := Nat.xor_comm 255 y.val
+        rw [hzxor, hc]; exact nat_xor_255 y.val hyb
+      have hz : z = ((z.val : ℕ) : ZMod p) := (ZMod.natCast_rightInverse z).symm
+      rw [hz, hzv, Nat.cast_sub (hle_of y hyb), ZMod.natCast_rightInverse y, hcast255]
   varRangeBus busId := match busMap busId with
     | some .variableRangeChecker => true
     | _ => false

--- a/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
@@ -2,30 +2,36 @@ import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
 
 set_option autoImplicit false
 
-/-! # Bitwise-XOR equality extraction (C4a)
+/-! # Bitwise-XOR constant-operand equality extraction (C4a + C4b)
 
-powdr-exported memory/shift blocks keep, on the bitwise-lookup bus, a family of interactions
-`[x, y, z, 1]` (op 1: `z = x ⊕ y`, with `x`,`y` bytes) in which **one operand is the constant 0**.
-Then the XOR linearizes to an *equality*: `[0, y, z, 1] ⟹ z = y` and `[x, 0, z, 1] ⟹ z = x`. These
-equalities pin an intermediate byte (loaded-data / effective-address limb, the `b`/`a`/`c` families)
-to another variable, but — being carried on the **bus** — Gaussian elimination never uses them, so
-the intermediate limbs survive. powdr represents everything with the canonical loaded value; this
-pass closes that gap.
+powdr-exported memory/shift/keccak blocks keep, on the bitwise-lookup bus, a family of interactions
+`[x, y, z, 1]` (op 1: `z = x ⊕ y`, with `x`,`y` bytes) in which **one operand is a constant byte**.
+For the two constants that make the XOR *affine* in the other operand — `0` and `255` — the
+interaction pins an intermediate byte to a linear form:
 
-`xorEqExtractPass` recognizes these 0-operand XOR interactions and **adds the entailed equality
-constraint** `z − y` (resp. `z − x`), keeping the interaction (which still imposes byte-ness). Placed
-in the cleanup cycle, the added equalities feed same-cycle Gauss, which eliminates the intermediate
-variables and cascades — a variable win (and, via the range/bitwise checks the eliminated variables
-no longer need, a bus win).
+* **zero operand** linearizes to an *equality*: `[0, y, z, 1] ⟹ z = y` and `[x, 0, z, 1] ⟹ z = x`
+  (C4a, `BusFacts.xorZeroEq`, from `Nat.zero_xor`/`Nat.xor_zero`);
+* **255 operand** linearizes to the byte *complement*: `[255, y, z, 1] ⟹ z = 255 − y` and
+  `[x, 255, z, 1] ⟹ z = 255 − x` (C4b, `BusFacts.xorComplEq`, from `n ⊕ 255 = 255 − n` for a byte
+  `n`, sound only when `255` is a genuine byte, `256 ≤ p`).
 
-The equality is entailed by the interaction's acceptance (`BusFacts.xorZeroEq`, proven for OpenVM's
-bitwise lookup from `Nat.zero_xor`/`Nat.xor_zero`), so the pass is a `ConstraintSystem.addConstraints_correct`
-— soundness drops the added constraints, and adding constraints touches no interaction, so side
-effects and admissibility are unchanged. Gated on `(1 : ZMod p) ≠ 0` (every prime field; identity on
-`ZMod 1`).
+These are the *only* two constants for which `x ⊕ c` is affine in `x`; every other constant makes
+the XOR bit-dependent. Both pin an intermediate byte (loaded-data / effective-address / NOT-result
+limb, the `b`/`a`/`c` families) to a linear form of another variable, but — being carried on the
+**bus** — Gaussian elimination never uses them, so the intermediate limbs survive. powdr represents
+everything with the canonical value; this pass closes that gap.
 
-The 255-operand XOR cases (`[x, 255, z, 1] ⟹ z = 255 − x`) are the sibling pass C4b, which needs the
-byte-complement identity and stacks on this one. -/
+`xorEqExtractPass` recognizes these constant-operand XOR interactions and **adds the entailed
+equality constraint** (`z − y`, `z − x`, `z − (255 − y)`, or `z − (255 − x)`), keeping the
+interaction (which still imposes byte-ness). Placed in the cleanup cycle, the added equalities feed
+same-cycle Gauss, which eliminates the intermediate variables and cascades — a variable win (and,
+via the range/bitwise checks the eliminated variables no longer need, a bus win).
+
+Each added equality is entailed by the interaction's acceptance (`xorZeroEq_sound` / `xorComplEq_sound`),
+so the pass is a `ConstraintSystem.addConstraints_correct` — soundness drops the added constraints,
+and adding constraints touches no interaction, so side effects and admissibility are unchanged.
+Gated on `(1 : ZMod p) ≠ 0` (every prime field; identity on `ZMod 1`); the `255` cases fire only
+where the VM's `xorComplEq` fact is available (`trivial` and small fields claim nothing). -/
 
 namespace XorEqExtract
 
@@ -38,39 +44,60 @@ theorem subE_eval (z e : Expression p) (env : Variable → ZMod p) :
     (subE z e).eval env = z.eval env - e.eval env := by
   simp only [subE, Expression.eval]; ring
 
-/-- The entailed equality from a 0-operand bitwise-XOR interaction `[x, y, z, 1]` (multiplicity 1) on
-    a `xorZeroEq` bus: `some (z − y)` when `x = 0`, `some (z − x)` when `y = 0`; `none` otherwise. -/
+/-- `255 − e` as an expression (the byte complement of `e`). -/
+def complE (e : Expression p) : Expression p := .add (.const 255) (.mul (.const (-1)) e)
+
+theorem complE_eval (e : Expression p) (env : Variable → ZMod p) :
+    (complE e).eval env = 255 - e.eval env := by
+  simp only [complE, Expression.eval]; ring
+
+/-- The entailed equality from a constant-operand bitwise-XOR interaction `[x, y, z, 1]`
+    (multiplicity 1): `z − y` / `z − x` for a `0` operand (`xorZeroEq`), and
+    `z − (255 − y)` / `z − (255 − x)` for a `255` operand (`xorComplEq`); `none` otherwise. -/
 def xorEq? (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (Expression p) :=
   match bi.payload with
   | [x, y, z, op] =>
-    if facts.xorZeroEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
-        ∧ op = Expression.const 1 then
-      if x = Expression.const 0 then some (subE z y)
-      else if y = Expression.const 0 then some (subE z x)
+    if bi.multiplicity = Expression.const 1 ∧ op = Expression.const 1 then
+      if facts.xorZeroEq bi.busId = true ∧ x = Expression.const 0 then some (subE z y)
+      else if facts.xorZeroEq bi.busId = true ∧ y = Expression.const 0 then some (subE z x)
+      else if facts.xorComplEq bi.busId = true ∧ x = Expression.const 255 then
+        some (subE z (complE y))
+      else if facts.xorComplEq bi.busId = true ∧ y = Expression.const 255 then
+        some (subE z (complE x))
       else none
     else none
   | _ => none
 
-/-- Structure of a recognized interaction. -/
+/-- Structure of a recognized interaction: multiplicity 1, payload `[x, y, z, 1]`, and one of the
+    four constant-operand cases with the matching added constraint. -/
 theorem xorEq?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) (c : Expression p) (h : xorEq? bs facts bi = some c) :
-    facts.xorZeroEq bi.busId = true ∧ bi.multiplicity = Expression.const 1 ∧
+    bi.multiplicity = Expression.const 1 ∧
       ∃ x y z, bi.payload = [x, y, z, Expression.const 1] ∧
-        ((x = Expression.const 0 ∧ c = subE z y) ∨ (y = Expression.const 0 ∧ c = subE z x)) := by
+        ((facts.xorZeroEq bi.busId = true ∧ x = Expression.const 0 ∧ c = subE z y)
+          ∨ (facts.xorZeroEq bi.busId = true ∧ y = Expression.const 0 ∧ c = subE z x)
+          ∨ (facts.xorComplEq bi.busId = true ∧ x = Expression.const 255 ∧ c = subE z (complE y))
+          ∨ (facts.xorComplEq bi.busId = true ∧ y = Expression.const 255 ∧ c = subE z (complE x))) := by
   unfold xorEq? at h
   split at h
   · rename_i x y z op hpay
-    split_ifs at h with hcond hx hy
-    · obtain ⟨hfact, hmult, hop⟩ := hcond
-      subst hop
-      exact ⟨hfact, hmult, x, y, z, hpay, Or.inl ⟨hx, by simpa using h.symm⟩⟩
-    · obtain ⟨hfact, hmult, hop⟩ := hcond
-      subst hop
-      exact ⟨hfact, hmult, x, y, z, hpay, Or.inr ⟨hy, by simpa using h.symm⟩⟩
+    split_ifs at h with hmo hA hB hC hD
+    · obtain ⟨hm, hop⟩ := hmo; obtain ⟨hfact, hx0⟩ := hA
+      rw [hop] at hpay
+      exact ⟨hm, x, y, z, hpay, Or.inl ⟨hfact, hx0, by simpa using h.symm⟩⟩
+    · obtain ⟨hm, hop⟩ := hmo; obtain ⟨hfact, hy0⟩ := hB
+      rw [hop] at hpay
+      exact ⟨hm, x, y, z, hpay, Or.inr (Or.inl ⟨hfact, hy0, by simpa using h.symm⟩)⟩
+    · obtain ⟨hm, hop⟩ := hmo; obtain ⟨hfact, hx255⟩ := hC
+      rw [hop] at hpay
+      exact ⟨hm, x, y, z, hpay, Or.inr (Or.inr (Or.inl ⟨hfact, hx255, by simpa using h.symm⟩))⟩
+    · obtain ⟨hm, hop⟩ := hmo; obtain ⟨hfact, hy255⟩ := hD
+      rw [hop] at hpay
+      exact ⟨hm, x, y, z, hpay, Or.inr (Or.inr (Or.inr ⟨hfact, hy255, by simpa using h.symm⟩))⟩
   · exact absurd h (by simp)
 
-/-- Extract every 0-operand bitwise-XOR equality and add it as an algebraic constraint. -/
+/-- Extract every constant-operand bitwise-XOR equality and add it as an algebraic constraint. -/
 def xorEqExtractPass : VerifiedPassW p := fun cs bs facts =>
   if h1ne : (1 : ZMod p) ≠ 0 then
     let new := cs.busInteractions.filterMap (xorEq? bs facts)
@@ -80,14 +107,15 @@ def xorEqExtractPass : VerifiedPassW p := fun cs bs facts =>
           -- entailment: each added equality holds on every satisfying assignment
           intro env _ hsat c hc
           obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-          obtain ⟨hfact, hmult, x, y, z, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
+          obtain ⟨hmult, x, y, z, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
           have hev : bi.eval env =
               { busId := bi.busId, multiplicity := 1,
                 payload := [x.eval env, y.eval env, z.eval env, 1] } := by
             unfold BusInteraction.eval; rw [hmult, hpay]; simp [Expression.eval]
           have hviol : bs.violatesConstraint (bi.eval env) = false :=
             hsat.2 bi hbi (by rw [hev]; exact h1ne)
-          rcases hcase with ⟨hx0, rfl⟩ | ⟨hy0, rfl⟩
+          rcases hcase with ⟨hfact, hx0, rfl⟩ | ⟨hfact, hy0, rfl⟩ | ⟨hfact, hx255, rfl⟩
+            | ⟨hfact, hy255, rfl⟩
           · rw [subE_eval]
             have he0 : bi.eval env = ⟨bi.busId, 1, [0, y.eval env, z.eval env, 1]⟩ := by
               rw [hev, hx0]; simp [Expression.eval]
@@ -97,17 +125,27 @@ def xorEqExtractPass : VerifiedPassW p := fun cs bs facts =>
             have he0 : bi.eval env = ⟨bi.busId, 1, [x.eval env, 0, z.eval env, 1]⟩ := by
               rw [hev, hy0]; simp [Expression.eval]
             rw [(facts.xorZeroEq_sound bi.busId hfact).2 (x.eval env) (z.eval env)
+              (he0 ▸ hviol), sub_self]
+          · rw [subE_eval, complE_eval]
+            have he0 : bi.eval env = ⟨bi.busId, 1, [255, y.eval env, z.eval env, 1]⟩ := by
+              rw [hev, hx255]; simp [Expression.eval]
+            rw [(facts.xorComplEq_sound bi.busId hfact).2 (y.eval env) (z.eval env)
+              (he0 ▸ hviol), sub_self]
+          · rw [subE_eval, complE_eval]
+            have he0 : bi.eval env = ⟨bi.busId, 1, [x.eval env, 255, z.eval env, 1]⟩ := by
+              rw [hev, hy255]; simp [Expression.eval]
+            rw [(facts.xorComplEq_sound bi.busId hfact).1 (x.eval env) (z.eval env)
               (he0 ▸ hviol), sub_self])
         (by
           -- no new variables: each equality's variables come from the interaction's payload
           intro c hc zv hz
           obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-          obtain ⟨_, _, x, y, w, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
+          obtain ⟨_, x, y, w, hpay, hcase⟩ := xorEq?_spec bs facts bi c hbc
           have mem_pay : ∀ e ∈ ([x, y, w] : List (Expression p)), e ∈ bi.payload := by
             intro e he; rw [hpay]; simp only [List.mem_cons] at he ⊢; tauto
-          rcases hcase with ⟨_, rfl⟩ | ⟨_, rfl⟩ <;>
-          · rcases List.mem_append.1 (by simpa only [subE, Expression.vars, List.append_assoc,
-              List.nil_append, Expression.vars] using hz) with hzw | hze
+          rcases hcase with ⟨_, _, rfl⟩ | ⟨_, _, rfl⟩ | ⟨_, _, rfl⟩ | ⟨_, _, rfl⟩ <;>
+          · rcases List.mem_append.1 (by simpa only [subE, complE, Expression.vars,
+              List.append_assoc, List.nil_append] using hz) with hzw | hze
             · exact ConstraintSystem.mem_vars_of_payload hbi (mem_pay w (by simp)) hzw
             · exact ConstraintSystem.mem_vars_of_payload hbi (mem_pay _ (by simp)) hze)⟩
   else

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -9,6 +9,11 @@ expressions, not constants), so the send↔consumer slot equalities now fire on 
 **3056 → 2224 vars (−832), 2862 → 2411 bus**; `lower_decomp` 534→164, `prev_data` 448→148, width-12/17
 range checks → 129/129 (= powdr). Gap to powdr now +203 (was +1035).
 
+**Constant-operand XOR extraction: LANDED (C4a entry 70, C4b entry 74).** The affine constant-operand
+XORs (`⊕0`, `⊕255`) are done — see the dedicated section below. Stacked on the entry-71 forwarding
+baseline, C4b (`[x,255,z,1] ⟹ z=255−x`) eliminated the residual `c`-family NOT-results: keccak
+**2224 → 2028 vars (−196)**, so the gap to powdr collapsed to **+7** (2028 vs 2021 — near parity).
+
 The bitwise-**result** byte bound itself is now landed (`openVmFacts.slotBound` slot 2, entry 58) —
 do not re-propose it.
 
@@ -49,15 +54,19 @@ eliminating `a` as a derived column adds `carry`, a pure swap with no cascade. p
 these blocks (e.g. apc_061/003 var-identical). The ceiling was entirely unsound one-root collapse.
 Do not build a carry-witness pass; the residual C1 gap is not a real variable opportunity.
 
-## Bitwise-XOR equality extraction (C4a landed, entry 70; C4b = 255-operand follow-up)
+## Bitwise-XOR constant-operand equality extraction — COMPLETE (C4a entry 70, C4b entry 74)
 
-**Update (log 70):** the dominant residual mechanism turned out to be **bitwise XOR interactions
-with a constant operand** encoding equalities Gauss can't see. `[0,y,z,1] ⟹ z=y`, `[x,0,z,1] ⟹ z=x`
-(0-operand, `Nat.zero_xor`/`Nat.xor_zero`) landed as `xorEqExtractPass` (C4a) — adds the entailed
-equality, Gauss eliminates the `b`/`a`/`c` limbs. −449 vars / −554 bus over 16 cases, 0 regressions,
-runtime −3.9%. **Remaining C4b:** the 255-operand cases `[x,255,z,1] ⟹ z=255−x` (needs the
-byte-complement identity `Nat.xor n 255 = 255−n` for `n<256`, plus `x` byte from acceptance);
-+16 vars on apc_071, +3 on apc_037. Stacks directly on C4a via a second `xorZeroEq`-style fact.
+Both **affine** constant operands are now landed in `xorEqExtractPass`: the 0-operand
+(`[0,y,z,1] ⟹ z=y`, `[x,0,z,1] ⟹ z=x`, C4a entry 70, `Nat.zero_xor`/`Nat.xor_zero`) and the
+255-operand byte complement (`[x,255,z,1] ⟹ z=255−x`, `[255,y,z,1] ⟹ z=255−y`, C4b entry 74,
+`n ⊕ 255 = 255−n` for a byte `n`, `xorComplEq` fact gated on `256 ≤ p`). `{0, 255}` are the **only**
+constants for which `x ⊕ c` is affine in `x` (every other makes the XOR bit-dependent), so this
+mechanism is **exhausted — do not re-propose a generic constant-operand XOR pass.** C4b removed 196
+keccak variables on the post-#105 base (2224 → 2028, +7 from powdr parity), openvm-eth
+variable-positive / per-case-neutral. The remaining XOR-computation gap to powdr is the **pure-XOR
+intermediates** — `b`/`c` limbs that appear *only* as an XOR result then an XOR operand — which no
+affine extraction can reach: eliminating them needs turning the XOR result into a **derived column**
+(the XOR-result-derivation angle in the keccak idea below), not another equality.
 
 ## Intermediate effective-address elimination (deeper residual, after C4a/C4b)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2382,6 +2382,7 @@ case**; only the covered-set lookup differs. No audited surface; proof integrity
 (`{propext, Classical.choice, Quot.sound}`-only). Expected effect: keccak keeps its −13 % `domainFold`
 win; openvm-eth `domainFold` returns to baseline (no 1.24× regression); `busUnify`'s −66/−72 % win is
 unaffected.
+
 ## Entry 71: symbolic-timestamp forwarding — two-root address disequality
 
 **Idea.** `busUnifyPass` (`BusUnify.lean`) forwards read/`prev_data` limbs across a
@@ -2437,3 +2438,63 @@ Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound
 `busPairCancel` once `byteJustified` gets an affine no-wrap rule (ideas.md 1.2) — another ~−282 bus.
 (2) Wiring `addrTwoRootNeq` into `busPairCancel.midRefuted` could telescope the AS2 middle pairs
 (below powdr's 200 floor; ideas.md 2.2).
+
+### 74. Generalize `xorEqExtract` to the 255-complement (C4b) — keccak variable effectiveness
+
+**Idea.** `xorEqExtractPass` (entry 70, C4a) already recognizes the *zero*-operand bitwise-XOR
+interactions `[0, y, z, 1] ⟹ z = y` / `[x, 0, z, 1] ⟹ z = x` and adds the entailed equality so
+Gauss can eliminate the pinned intermediate byte. The other constant that makes `x ⊕ c` **affine**
+in `x` is `255`: XOR-ing a byte with the all-ones byte is the byte complement,
+`[x, 255, z, 1] ⟹ z = 255 − x` and `[255, y, z, 1] ⟹ z = 255 − y` (`n ⊕ 255 = 255 − n` for a byte
+`n`). `{0, 255}` are the *only* two affine constants, so this **completes** the constant-operand
+generalization rather than adding a new mechanism. Diagnosed on the keccak stress case: ~200 of its
+bitwise interactions have the form `[x, 255, z, 1]` with `z` a fresh NOT-result variable (the `c__*`
+family) that powdr does not materialize — apc kept the complement equality only on the bus, so Gauss
+never used it (196 of them are eliminable on the post-#105 base; see below).
+
+**Change (generalize the existing pass, no new pass, no pipeline edit).**
+- New proven `BusFacts` field `xorComplEq` (sibling of `xorZeroEq`): on the bitwise bus an accepted
+  `[x, 255, z, 1]` / `[255, y, z, 1]` gives `z = 255 − x` / `z = 255 − y`. Discharged for OpenVM
+  from the concrete `violates` (byte bound on the free operand + `z.val = x.val ⊕ 255`) via the nat
+  lemma `n ⊕ 255 = 255 − n` for `n < 256` (a one-shot 256-case `decide`, no runtime cost). Sound
+  only when `255` is a genuine byte of the field, so the OpenVM instance **gates the fact on
+  `256 ≤ p`** (true for BabyBear; a small field, and `trivial`, claim nothing — the pass stays a
+  no-op and VM-agnostic). Counterexample without the gate: `(255 : ZMod 3) = 0`, where the identity
+  is `z = x`, not `z = 255 − x`.
+- `xorEq?` extended from 2 to 4 constant-operand cases; the pass proof adds the two 255 branches via
+  `xorComplEq_sound`. Same shape as C4a — `addConstraints_correct` (soundness drops the added
+  equality; adding a constraint touches no interaction, so side effects / admissibility are
+  unchanged; the added equality's variables all come from the interaction's payload, so no new
+  variable is introduced).
+
+`lake build` green; the three `*_maintainsCorrectness` theorems still
+`{propext, Classical.choice, Quot.sound}`-only; `check-proof-integrity.sh` passes (no
+`sorry`/`admit`/`axiom`/`native_decide`); keccak output within the degree bound.
+
+All numbers below are measured on the **post-#105 (entry-71 forwarding) base**, on which this pass
+stacks — C4b is orthogonal to the memory forwarding, so the two compose (a baseline vs. C4b A/B on
+one build; the two changes touch disjoint families).
+
+**Impact — keccak (post-#105 baseline → C4b, same build).**
+- **variables 2224 → 2028 (−196; 12.375× → 13.571×)** — the `[x, 255, z, 1]` NOT-results eliminated
+  by same-cycle Gauss (substituted `z := 255 − x`). This puts keccak at **2028 vs powdr 2021 — a +7
+  variable gap (near parity)**, closing the residual +203 gap that #105 left down to +7.
+- bus interactions 2405 → 2418 (+13), constraints 118 → 120 (+2) — small, and dominated by the −196
+  variables under the priority order (the 255-XOR interactions stay put, still byte-checking their
+  free operand; a few send/receive cancellations shift under the changed variable structure).
+- **Runtime not increased — FASTER: solo `run` 674.6 s → 633.5 s (−6 %)** — eliminating 196 variables
+  in the prelude of the cleanup cycle shrinks the system every downstream pass rescans (wall-clock is
+  noisy on this machine, but the direction is not increase).
+
+**Impact — openvm-eth (full 100-case benchmark.py sweep; post-#105 baseline → C4b, same build).**
+Variable-positive and per-case-neutral: variables 4.507× → **4.509×** agg (3.818× → 3.820× geo), bus
+interactions 3.405× → 3.401× agg (2.707× → 2.705× geo), constraints 10.595× → 10.590× agg
+(11.585× → 11.578× geo); the per-case standings vs powdr are **unchanged at 25 W / 42 L / 33 T**. The
+variable gain lands on the register/shift blocks carrying `255`-complement (NOT) results (the
+apc_071 / apc_037 cases `docs/ideas.md` flagged for C4b); the sub-0.01× bus/constraint movement is the
+255-XOR interactions staying put as a few downstream cancellations shift (aggregate-invisible).
+
+Together with #105 (entry 71), the keccak variable gap to powdr collapses from +1035 (pre-both) to
+**+7** (post-both). The residual keccak variable families are the memory read/write-aux witnesses and
+`bit_shift_carry` (rotation-gadget carries) — separate mechanisms, not constant-operand XOR; see
+`docs/ideas.md`.


### PR DESCRIPTION
## What

Generalizes the existing `xorEqExtractPass` to complete its constant-operand bitwise-XOR handling. It already extracted the **zero**-operand equalities (`[0,y,z,1] ⟹ z=y`, `[x,0,z,1] ⟹ z=x`, C4a). This adds the other constant that makes `x ⊕ c` **affine** in `x`: the all-ones byte `255`, the byte **complement** (`[x,255,z,1] ⟹ z=255−x`, `[255,y,z,1] ⟹ z=255−y`).

`{0, 255}` are the *only* two constant operands for which the XOR is affine (every other makes it bit-dependent), so this **completes** the pattern rather than adding a mechanism — **no new pass, no pipeline edit**, just a generalized recognizer plus a proven bus fact. It is orthogonal to (and stacks cleanly on) #105's symbolic-timestamp forwarding: #105 eliminated the memory read/`prev_data` limbs, this eliminates the XOR NOT-result limbs.

## Why it's sound (no audited-surface change)

- New proven `BusFacts.xorComplEq` field (sibling of `xorZeroEq`), discharged for OpenVM against the concrete `violates` from `n ⊕ 255 = 255 − n` for a byte `n` (a one-shot 256-case `decide`).
- **Gated on `256 ≤ p`**: the identity is unsound for small primes (e.g. `(255 : ZMod 3) = 0`, where `z = x`, not `z = 255 − x`), so the OpenVM instance only claims the fact when `255` is a genuine byte. `trivial` and small fields claim nothing, so the pass stays a no-op and VM-agnostic.
- The pass remains a `ConstraintSystem.addConstraints_correct`: it adds a *true* equality Gauss then consumes, introduces no new variable (every variable of the added equality comes from the interaction's payload), and touches no bus interaction — so side effects and admissibility are unchanged.

All changes live under the audit-free `ApcOptimizer/Implementation/` surface; `Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, and the audited `ApcOptimizer/Optimizer.lean` are untouched.

## Effectiveness

All numbers are a **same-build A/B on the post-#105 base** (this branch rebased onto #105; baseline = these three files reverted to #105, rebuilt).

**Keccak** (`apc_001_pckeccak`):

| axis | baseline (post-#105) | with C4b | Δ |
|---|---|---|---|
| **variables** | 2224 | **2028** | **−196** (12.375× → 13.571×) |
| bus interactions | 2405 | 2418 | +13 |
| constraints | 118 | 120 | +2 |
| solo `run` time | 674.6 s | **633.5 s** | **~6% faster** |

The `[x, 255, z, 1]` NOT-results are eliminated by same-cycle Gauss (`z := 255 − x`). This puts keccak at **2028 variables vs powdr's 2021 — a +7 gap (near parity)**; combined with #105 the keccak variable gap to powdr collapses from +1035 to +7. Runtime does not increase — it drops, since eliminating 196 variables early shrinks the system every downstream pass rescans.

**openvm-eth** (full 100-case `benchmark.py` sweep, same-build A/B): variable-positive and per-case-neutral — variables 4.507× → **4.509×** agg (3.818× → 3.820× geo), bus 3.405× → 3.401× agg, constraints 10.595× → 10.590× agg; per-case standings vs powdr **unchanged at 25 W / 42 L / 33 T**. Under the effectiveness priority (variables ≫ bus ≫ constraints), the variable gain is the deciding axis; the sub-0.01× bus/constraint movement is the 255-XOR interactions staying put while a few downstream cancellations shift.

## Proof integrity

- `lake build` green (rebased onto #105).
- All three `*_maintainsCorrectness` theorems remain `{propext, Classical.choice, Quot.sound}`-only.
- `Scripts/check-proof-integrity.sh` passes — no `sorry` / `admit` / `axiom` / `native_decide`.
- Output stays within the degree bound.

Logged as entry 74 in `docs/log.md`; `docs/ideas.md` updated (constant-operand XOR mechanism now exhausted; residual keccak gap is the pure-XOR intermediates and `bit_shift_carry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZks5PC6xXrWWx3bj1rtCe