### PR TITLE
Idea #5 (functional-dependence derived columns): measured dead-end, removed

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -162,8 +162,10 @@ axis to a win**. keccak: result-zero extraction removes ~50 variables (measured 
 2028 → ~1978, which would put apc *below* powdr's 2021 on keccak variables); the collapsed interaction
 becomes a `[a,a,0,1]` self-check `bytePack` then absorbs. Do **not** target the keccak genuine-XOR gap
 directly — census shows it is a variable-representation artifact (XOR chaining), not redundant
-lookups; it is addressed at the root by #5. *(The `[x,255,z,1]` complement is a different pattern,
-landed as C4b — entry 74, #109.)*
+lookups, and it is **not removable at all** (see the dead-ends list: XOR is not a field polynomial, so
+an XOR-result limb can be neither substituted away nor expressed as a `ComputationMethod`, and powdr
+keeps the same limbs). *(The `[x,255,z,1]` complement is a different pattern, landed as C4b — entry
+74, #109.)*
 
 ---
 
@@ -201,38 +203,6 @@ plus `apc_018`/`apc_037`). Top-priority axis, broadest reach; higher proof cost 
 
 ---
 
-## 5. Functional-dependence derived columns for read/write limbs  ·  *variables*  ·  medium–low confidence · high effort
-
-**Gap:** limbs that are *functionally determined* but kept free. C4a/C4b (entry 70/74) already closed
-the affine constant-operand XOR cases, so keccak is now at variable near-parity (+7); the residual
-keccak XOR gap is the **pure-XOR intermediates** — `b`/`c` limbs that appear *only* as an XOR result
-then an XOR operand, which no equality extraction can reach. The larger remaining target is the
-**runtime portion of `rd_data`** (write result `= a op b`) on openvm-eth that #1's constant fold does
-not cover.
-
-**Mechanism** — extend the `reencode` derived-column path with a functional-dependence source:
-
-```
--- z is the result slot of exactly one accepting bitwise [x,y,z,1] and not otherwise pinned:
---   BusFacts.slotFun already proves  z = x ⊕ y   (soundness half)
-register  Derivation z := ComputationMethod computing xor(x,y) from input columns
-drop z from the free-variable set          (interaction retained for byteness)
--- same device for a write-result limb pinned by  rd_data − f(inputs) = 0.
-```
-
-**Why sound.** Soundness is carried by `slotFun` (acceptance forces `z = x⊕y`). The real work is the
-completeness half: the reproduced witness must satisfy `derivesWitness` — `z` computed from input
-columns present in the input trace — which is exactly `reencode`'s `ComputationMethod` bookkeeping,
-but wiring a genuine XOR (a table lookup, not a polynomial) into `ComputationMethod` and discharging
-`derivesWitness` is nontrivial. Degree-guarded.
-
-**Expected impact.** Modest on keccak now (it is near variable-parity post-C4b; only the pure-XOR
-intermediate residual remains, part of the +7). Main value is the ~15–30 functional `rd_data` vars on
-eth that #1 does not fold, plus a small keccak tail. Top-priority axis but highest proof cost of the
-five — do it after #1 clears the constant cases.
-
----
-
 ## Smaller follow-ups (worth landing, lower ceiling)
 
 - **Width-1 range-check → booleanity constraint** (`ZeroWidthRange` width-0 → width-1). `[e,1]` on a
@@ -246,7 +216,7 @@ five — do it after #1 clears the constant cases.
   tupleRange +160 over 22 cases** (`apc_006` +76). Bus-only.
 - **Affine/product no-wrap rule for `byteJustified`.** `e = c·y` (y boolean) or `e = c₀ + Σ cᵢ·yᵢ`
   with `c₀ + Σ|cᵢ|(Bᵢ−1) < 256`, via `MemoryUnify.boundedSum_val`. A *helper*, not a headline: census
-  shows it is **not** the keccak memory blocker (idea #2a is), but it generalizes #2/#5 to affine
+  shows it is **not** the keccak memory blocker (idea #2a is), but it generalizes #2 to affine
   memory receives and rotation-carry data slots.
 
 ## Rejected / measured dead-ends (do not re-propose without re-measuring)
@@ -263,7 +233,24 @@ five — do it after #1 clears the constant cases.
 - **`disconnectedComponent` smarter witnesses:** measured **empty** (log 61) — outputs contain 0
   disconnected vars.
 - **keccak genuine-XOR bus gap (+321) as a dedup pass:** **not removable** — no duplicate/ shared-pair
-  lookups; it is a variable-representation artifact (XOR chaining), addressed by #5, not a bus pass.
+  lookups; it is a variable-representation artifact (XOR chaining), and the artifact itself is not
+  removable either (next bullet), so it is neither a bus pass nor a variable pass.
+- **Functional-dependence derived columns for read/write limbs (was idea #5):** **infeasible — measured
+  dead-end** (attempted 2026-07-13, entry below). The variable count (`ConstraintSystem.variables`,
+  Size.lean) is purely syntactic: a name is counted iff it appears in some constraint/interaction, and
+  `Derivations` are a *separate* list, so registering a `ComputationMethod` for a limb does **not**
+  drop it — only substituting the name away (Gauss/Subst) or re-encoding a group into fewer fresh vars
+  (Reencode) can. But the functional dependences that keep limbs alive are all **XOR/bitwise**
+  (`z = x⊕y`), which is **not a low-degree `ZMod p` polynomial** (no `Expression` to substitute) and
+  **not expressible as a `ComputationMethod`** (only `const`/`quotientOrZero`/`ifEqZero`); `slotFun`
+  gives only the *value-level* soundness function, not a substitutable expression. The affine
+  functional dependences (ADD/SUB carry limbs) are already eliminated by Gauss (degree-1 subst into
+  stateful memory payloads). Measured on the live renders: keccak's surviving functional limbs are 359
+  pure-XOR chain intermediates + 458 XOR-results in memory + 159 redundant range-checks on XOR results
+  — **all XOR, none affine** — and **powdr keeps the same limbs** (1 derived column total on keccak, via
+  `QuotientOrZero`), consistent with keccak's +7 variable near-parity. So there is no sound,
+  effectiveness-improving pass here. (The redundant range-checks on byte-guaranteed XOR results *are* a
+  separate bus-only opportunity — see the width-1 / redundant-byte follow-ups above.)
 - **`bit_shift_carry` elimination (+67):** keccak rho-rotation encoding — VM-specific / overfit, high
   proof risk. Excluded by the generality rule.
 - **varRange bus / range-check packing as a *variables* lever:** apc already **wins** varRange bus net

--- a/docs/log.md
+++ b/docs/log.md
@@ -2535,3 +2535,54 @@ addresses, jump targets) — the largest variable family (`rd_data`, ~93 vars/23
 (no gap), disconnected-component (empty), keccak genuine-XOR bus gap (representation artifact),
 `bit_shift_carry` (VM-specific), varRange packing (apc already wins), `b`/`c` naming artifact,
 `apc_003` now a tie, constant-operand XOR exhausted (C4a/C4b landed).
+
+## Idea #5 attempt — functional-dependence derived columns for read/write limbs — FAILED (measured dead-end, no optimizer change)
+
+**Idea (ideas.md #5).** Make a functionally-determined limb (a bitwise-XOR result `z = x⊕y`, or a
+write-result limb `rd_data = f(inputs)`) a *derived* column — register a `ComputationMethod` for it
+and "drop it from the free-variable set" — to cut the variable count. Rated medium–low confidence,
+high effort; flagged as the highest proof cost of the five.
+
+**Result: infeasible.** It cannot reduce the primary (variable) metric, for a structural reason, so
+there is nothing to prove and no pass was added. The chain, each link checked against the code and the
+live benchmark renders:
+
+1. **The variable count is purely syntactic.** `ConstraintSystem.variables` (`ApcOptimizer/Utils/Size.lean`)
+   is the dedup of every name appearing in a constraint or bus interaction. `Derivations` are a
+   *separate* output list (`Spec.lean`), not subtracted from `.variables`. So registering a
+   `ComputationMethod` for `z` does **not** drop `z` from the count — a derived column that still
+   appears in the system is still counted. The only levers that remove a name are **substitution**
+   (`Subst`/`Gauss`, replace the name by an `Expression` everywhere) and **re-encoding** a group into
+   fewer fresh vars (`Reencode`). "Drop `z` from the free-variable set (interaction retained for
+   byteness)" as written is a contradiction: if the interaction is retained, `z` is still counted.
+
+2. **XOR is not substitutable and not `ComputationMethod`-expressible.** `z = x ⊕ y` is not a
+   low-degree `ZMod p` polynomial, so there is no `Expression` to substitute for `z`; and
+   `ComputationMethod` offers only `const`/`quotientOrZero`/`ifEqZero`, none of which computes XOR
+   (encoding it bit-wise would first require bit columns the byte-level circuits don't have, adding far
+   more variables than it removes). `BusFacts.slotFun` provides only the *value-level* soundness
+   function `List (ZMod p) → ZMod p`, not a substitutable expression. `Reencode` can't reach it either:
+   it reads algebraic constraints (the XOR relation is a *bus*), and the group `{x,y,z}` has 65536
+   joint values → 16 fresh bits to replace 3 vars (a regression).
+
+3. **Every surviving functional-dependence limb is XOR-based; the affine ones are already gone.**
+   Measured on the live renders. keccak apc output: **359 pure-XOR chain intermediates** (`a=b⊕c`, then
+   `a` is an operand of another XOR), **458 XOR-results written to memory** (`rd_data`), **159 redundant
+   range-checks on XOR results** — all XOR, none affine. The affine functional dependences (ADD/SUB
+   carry limbs) are already eliminated by `Gauss` (degree-1 substitution, including into stateful memory
+   payloads; `Gauss` only *declines* to substitute raw payload slots of **stateless** buses, to
+   preserve range knowledge). eth apc-only variables (vs powdr) are dominated by idea #1 (constant
+   PC/immediate/return-address limbs), idea #4 (comparison markers), and the documented timestamp /
+   `b`,`c` naming artifacts — not a runtime-`rd_data` functional slice.
+
+4. **powdr does not beat apc here.** powdr keeps the same XOR limbs — **1** derived column total on
+   keccak, via `QuotientOrZero` — consistent with keccak's +7 variable near-parity. There is no
+   competitive gap for idea #5 to close.
+
+**Impact: none** (no code changed; `lake build` unaffected). Idea #5 removed from the active list and
+recorded under "Rejected / measured dead-ends" in `docs/ideas.md`.
+
+**Adjacent real wins surfaced while investigating** (already tracked in ideas.md, *not* idea #5): the
+159 redundant range-checks on byte-guaranteed XOR results are a bus-only drop (width-1 range-check →
+booleanity / redundant-byte follow-ups), and the `[x,y,0,0]` byte-check packing (idea #3) is a bus
+win. These reduce bus interactions, not variables.


### PR DESCRIPTION
## Summary

Attempted **idea #5** from `docs/ideas.md` — *"functional-dependence derived columns for read/write limbs"*: make a functionally-determined limb (a bitwise-XOR result `z = x⊕y`, or a write-result limb `rd_data = f(inputs)`) a **derived** column so it stops counting toward the variable metric.

**Result: infeasible.** It cannot reduce the primary (variable) metric, for a structural reason, so no pass was added. This PR records the finding and removes idea #5 from the active list. **Docs-only — no optimizer or proof change; `lake build` unaffected.**

## Why it can't work

1. **The variable count is purely syntactic.** `ConstraintSystem.variables` (`ApcOptimizer/Utils/Size.lean`) is the dedup of every name appearing in a constraint or bus interaction. `Derivations` are a *separate* output list (`Spec.lean`), not subtracted from `.variables`. Registering a `ComputationMethod` for `z` does **not** drop `z` — a derived column that still appears is still counted. The only levers that remove a name are **substitution** (`Subst`/`Gauss`) or **re-encoding** a group into fewer fresh vars (`Reencode`). "Drop `z` from the free-variable set (interaction retained for byteness)", as the idea proposed, is self-contradictory.

2. **XOR is not substitutable and not `ComputationMethod`-expressible.** `z = x ⊕ y` is not a low-degree `ZMod p` polynomial (no `Expression` to substitute), and `ComputationMethod` offers only `const`/`quotientOrZero`/`ifEqZero`. `BusFacts.slotFun` gives only the *value-level* soundness function `List (ZMod p) → ZMod p`, not a substitutable expression. `Reencode` can't reach it (it reads algebraic constraints; the XOR relation is a *bus*), and re-encoding `{x,y,z}` would need 16 fresh bits to replace 3 vars — a regression.

3. **Every surviving functional-dependence limb is XOR-based; the affine ones are already gone.** Measured on the live renders. keccak apc output: **359 pure-XOR chain intermediates** + **458 XOR-results written to memory** (`rd_data`) + **159 redundant range-checks on XOR results** — all XOR, none affine. The affine functional dependences (ADD/SUB carry limbs) are already eliminated by `Gauss`. eth apc-only variables are dominated by idea #1 (constant PC/immediate/return-address limbs), idea #4 (comparison markers), and the documented timestamp / `b`,`c` naming artifacts — not a runtime-`rd_data` slice.

4. **powdr does not beat apc here.** powdr keeps the same XOR limbs — **1** derived column total on keccak, via `QuotientOrZero` — consistent with keccak's +7 variable near-parity. No competitive gap for idea #5 to close.

## Changes

- `docs/ideas.md`: remove idea #5 from the active ranked list; record it under **"Rejected / measured dead-ends"** with the reasoning above; fix the two cross-references (idea #3 and the keccak-XOR dead-end) that pointed at #5.
- `docs/log.md`: append the full attempt/analysis entry (append-only).

## Adjacent real wins surfaced (not idea #5, already tracked in `ideas.md`)

The 159 redundant range-checks on byte-guaranteed XOR results are a **bus-only** drop (width-1 range-check → booleanity / redundant-byte follow-ups), and `[x,y,0,0]` byte-check packing (idea #3) is a bus win. These reduce bus interactions, not variables — happy to pursue one as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKLchWirH2ffvvYBagychU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKLchWirH2ffvvYBagychU)_