### PR TITLE
Generalize the byte-check recognizer: mirror `[0,x,x,1]` drop + form-agnostic pack (idea #3)

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -154,18 +154,23 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       ∀ (x mult : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, x, 0, 1] }
             = false ↔ x.val < 256
-  /-- Byte-check *via XOR-with-zero*: the check `[x, 0, x, 1]` (`x ⊕ 0 = x`, multiplicity any) on a
-      stateless bitwise-style bus is accepted **iff** `x` is a byte. The XOR-with-zero encoding is
-      how OpenVM materializes a bare "this operand is a byte" obligation that was not packed into a
-      pair; recognising it lets the redundant-byte-check dropper reach those interactions.
+  /-- Byte-check *via XOR-with-zero*: on a stateless bitwise-style bus the checks `[x, 0, x, 1]`
+      (`x ⊕ 0 = x`) and its mirror `[0, x, x, 1]` (`0 ⊕ x = x`) — multiplicity any — are each
+      accepted **iff** `x` is a byte. The XOR-with-zero encoding is how OpenVM materializes a bare
+      "this operand is a byte" obligation that was not packed into a pair; the zero can sit in
+      *either* operand slot (`Nat.xor_zero` / `Nat.zero_xor`). Recognising both mirrors lets the
+      redundant-byte-check dropper and the byte-check packer reach every such interaction.
       `trivial` sets it `false`. -/
   xorZeroCheck : (busId : Nat) → Bool
   xorZeroCheck_sound :
     ∀ (busId : Nat), xorZeroCheck busId = true →
       bs.isStateful busId = false ∧
-      ∀ (x mult : ZMod p),
+      (∀ (x mult : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, 0, x, 1] }
-            = false ↔ x.val < 256
+            = false ↔ x.val < 256) ∧
+      (∀ (x mult : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [0, x, x, 1] }
+            = false ↔ x.val < 256)
   /-- Variable-range-checker style *stateless* bus: the 2-ary message `[x, b]` is accepted
       **iff** the requested width is supported and `x` fits (`b.val ≤ 25 ∧ x.val < 2 ^ b.val`).
       `trivial` sets it `false`; the OpenVM instance proves it for the variable range checker. -/

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -561,15 +561,15 @@ def openVmFacts (p : ℕ) [NeZero p]
       revert h; cases hb : busMap busId with
       | none => simp
       | some t => cases t <;> simp
-    refine ⟨?_, ?_⟩
+    have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+    have h1le : (1 : ZMod p).val ≤ 1 := by
+      rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_le 1 p
+    refine ⟨?_, ?_, ?_⟩
     · show (match busMap busId with | some t => t.isStateful | none => false) = false
       rw [hbus]; rfl
     · intro x mult
       -- op 1 asserts `x ⊕ 0 = x` (true) plus byte-ness of `x`; the degenerate op-0 branch
       -- (`(1 : ZMod p).val = 0`, i.e. `p = 1`) makes every value the byte `0`.
-      have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
-      have h1le : (1 : ZMod p).val ≤ 1 := by
-        rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_le 1 p
       show violates busMap { busId := busId, multiplicity := mult, payload := [x, 0, x, 1] }
           = false ↔ x.val < 256
       unfold violates; rw [hbus]
@@ -580,6 +580,18 @@ def openVmFacts (p : ℕ) [NeZero p]
         have hx0 : x.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt x)
         simp [h1, hv0, hx0, isByte]
       · simp [h1, hv0, isByte, Nat.xor_zero]
+    · intro x mult
+      -- mirror: op 1 asserts `0 ⊕ x = x` (true) plus byte-ness of `x`; degenerate branch as above.
+      show violates busMap { busId := busId, multiplicity := mult, payload := [0, x, x, 1] }
+          = false ↔ x.val < 256
+      unfold violates; rw [hbus]
+      rcases Nat.le_one_iff_eq_zero_or_eq_one.1 h1le with h1 | h1
+      · have hp1 : p = 1 := Nat.dvd_one.mp (Nat.dvd_of_mod_eq_zero (by
+          rwa [ZMod.val_one_eq_one_mod] at h1))
+        subst hp1
+        have hx0 : x.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt x)
+        simp [h1, hv0, hx0, isByte]
+      · simp [h1, hv0, isByte, Nat.zero_xor]
   zeroRangeEq busId := match busMap busId with
     | some .variableRangeChecker => true
     | _ => false

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -29,6 +29,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
+import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 
 set_option autoImplicit false
 
@@ -99,7 +100,7 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
     ("busUnify", busUnifyPass.guardDegree),
     ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint busPairCancelPass)),
     ("tupleRange", VerifiedPassW.guardDegree (iterateToFixpoint tupleRangePass)),
-    ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint bytePackPass)),
+    ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
     ("reencode", reencodePass.withFacts.guardDegree) ]
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ByteCheckPack.lean
@@ -1,0 +1,206 @@
+import ApcOptimizer.Implementation.OptimizerPasses.TupleRange
+
+set_option autoImplicit false
+
+/-! # Generalized single-value byte-check packing (`byteCheckPackPass`)
+
+On a bitwise-style lookup bus a single value is byte-range-checked in one of three multiplicity-1
+encodings that all impose exactly "this value is a byte":
+
+* the self-check `[x, x, 0, 1]` (`BusFacts.byteCheck`),
+* the XOR-with-zero form `[x, 0, x, 1]` and its mirror `[0, x, x, 1]` (`BusFacts.xorZeroCheck`).
+
+Two such single-value checks — in *any* combination of these forms — pack into **one** pair check
+`[eA, eB, 0, 0]` (`BusFacts.bytePairBus`), which imposes the identical obligation "both operands are
+bytes". Because these lookups are stateless, the swap leaves every stateful side effect and the
+memory discipline untouched: a pure bus-interaction win, variables and constraints unchanged. This
+generalizes `bytePackPass` (which only recognized the canonical self-check `[x, x, 0, 1]`); the extra
+mirror forms are exactly the ones OpenVM emits for keccak state limbs.
+
+The correctness of one packing step is the *general* stateless two-for-one swap
+`mergeStateless2_correct` (from `TupleRange.lean`): given that each replaced interaction's acceptance
+is equivalent to its value being a byte (`svCheck?_sound`), and the pair check's acceptance is the
+conjunction of both byte obligations (`bytePairBus` + `byteCheck`), the swap preserves the satisfying
+set. No new correctness lemma is needed. VM-agnostic: with `BusFacts.trivial` every fact is `false`,
+so `svCheck?` returns `none` and the pass is the identity. One pair is packed per invocation;
+`iterateToFixpoint` drains them (the bus length strictly drops by one each time). -/
+
+namespace ByteCheckPack
+
+variable {p : ℕ}
+
+/-! ## Recognizing a single-value byte check in any encoding -/
+
+/-- The value byte-checked by a multiplicity-1 single-value bitwise byte check: the self-check
+    `[x, x, 0, 1]` (`byteCheck`) and the two XOR-with-zero mirrors `[x, 0, x, 1]` / `[0, x, x, 1]`
+    (`xorZeroCheck`) all return `some x`; `none` otherwise. -/
+def svCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match bi.payload with
+  | [e1, e2, e3, e4] =>
+    if bi.multiplicity = Expression.const 1 ∧ e4 = Expression.const 1 then
+      if facts.byteCheck bi.busId = true ∧ e1 = e2 ∧ e3 = Expression.const 0 then some e1
+      else if facts.xorZeroCheck bi.busId = true ∧ e2 = Expression.const 0 ∧ e1 = e3 then some e1
+      else if facts.xorZeroCheck bi.busId = true ∧ e1 = Expression.const 0 ∧ e2 = e3 then some e2
+      else none
+    else none
+  | _ => none
+
+/-- A membership helper for `BusInteraction.vars`: a variable of a payload expression is a variable
+    of the interaction. -/
+theorem mem_biVars_of_payload (bi : BusInteraction (Expression p)) (e : Expression p)
+    (he : e ∈ bi.payload) {v : Variable} (hv : v ∈ e.vars) : v ∈ bi.vars := by
+  rw [BusInteraction.vars]
+  exact List.mem_append_right _ (List.mem_flatMap.2 ⟨e, he, hv⟩)
+
+/-- A recognized single-value byte check is stateless, has multiplicity 1, its value is a payload
+    entry, and its acceptance is exactly "the value is a byte". -/
+theorem svCheck?_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p) (h : svCheck? bs facts bi = some e) :
+    bs.isStateful bi.busId = false ∧ bi.multiplicity = Expression.const 1 ∧ e ∈ bi.payload ∧
+      (∀ env, bs.violatesConstraint (bi.eval env) = false ↔ (e.eval env).val < 256) := by
+  unfold svCheck? at h
+  split at h
+  case h_2 => exact absurd h (by simp)
+  case h_1 e1 e2 e3 e4 hpay =>
+    -- payload shape and multiplicity
+    have hmem : ∀ x ∈ ([e1, e2, e3, e4] : List (Expression p)), x ∈ bi.payload := by
+      intro x hx; rw [hpay]; exact hx
+    split_ifs at h with hmo hA hB hC
+    · -- self-check `[x, x, 0, 1]`
+      obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he12, he3⟩ := hA
+      obtain rfl : e1 = e := by simpa using h
+      refine ⟨(facts.byteCheck_sound bi.busId hfact).1, hm, hmem e1 (by simp), fun env => ?_⟩
+      have heq : bi.eval env
+          = { busId := bi.busId, multiplicity := 1, payload := [e1.eval env, e1.eval env, 0, 1] } := by
+        unfold BusInteraction.eval
+        rw [hm, hpay, ← he12, he3, he4]; simp [Expression.eval]
+      rw [heq]
+      exact (facts.byteCheck_sound bi.busId hfact).2.2 (e1.eval env) 1
+    · -- XOR-with-zero `[x, 0, x, 1]`
+      obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he2, he13⟩ := hB
+      obtain rfl : e1 = e := by simpa using h
+      refine ⟨(facts.xorZeroCheck_sound bi.busId hfact).1, hm, hmem e1 (by simp), fun env => ?_⟩
+      have heq : bi.eval env
+          = { busId := bi.busId, multiplicity := 1, payload := [e1.eval env, 0, e1.eval env, 1] } := by
+        unfold BusInteraction.eval
+        rw [hm, hpay, he2, ← he13, he4]; simp [Expression.eval]
+      rw [heq]
+      exact ((facts.xorZeroCheck_sound bi.busId hfact).2.1 (e1.eval env) 1)
+    · -- mirror XOR-with-zero `[0, x, x, 1]`
+      obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he1, he23⟩ := hC
+      obtain rfl : e2 = e := by simpa using h
+      refine ⟨(facts.xorZeroCheck_sound bi.busId hfact).1, hm, hmem e2 (by simp), fun env => ?_⟩
+      have heq : bi.eval env
+          = { busId := bi.busId, multiplicity := 1, payload := [0, e2.eval env, e2.eval env, 1] } := by
+        unfold BusInteraction.eval
+        rw [hm, hpay, he1, ← he23, he4]; simp [Expression.eval]
+      rw [heq]
+      exact ((facts.xorZeroCheck_sound bi.busId hfact).2.2 (e2.eval env) 1)
+
+/-! ## Acceptance of a pair check -/
+
+/-- A pair check `[x, y, 0, 0]` (multiplicity 1) on a `bytePairBus` that also carries `byteCheck` is
+    accepted exactly when both operands are bytes. -/
+theorem pairAccept (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat)
+    (hbp : facts.bytePairBus busId = true) (hbc : facts.byteCheck busId = true) (x y : ZMod p) :
+    bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, y, 0, 0] } = false
+      ↔ x.val < 256 ∧ y.val < 256 :=
+  ((facts.bytePairBus_sound busId hbp).2.2 x y 1).trans
+    (and_congr ((facts.byteCheck_sound busId hbc).2.2 x 1) ((facts.byteCheck_sound busId hbc).2.2 y 1))
+
+/-! ## The pass: find and pack one pair per invocation -/
+
+/-- Scan for the next single-value byte check on `busId`, returning the interior `mid`, the
+    interaction `b`, its checked value `eB`, and the remainder `post`. -/
+def findSecond (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat) :
+    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
+    Option (List (BusInteraction (Expression p)) × BusInteraction (Expression p) ×
+      Expression p × List (BusInteraction (Expression p)))
+  | _, [] => none
+  | revMid, b :: rest =>
+    match svCheck? bs facts b with
+    | some eB => if decide (b.busId = busId) then some (revMid.reverse, b, eB, rest)
+                 else findSecond bs facts busId (b :: revMid) rest
+    | none => findSecond bs facts busId (b :: revMid) rest
+
+/-- If `findSecond` returns `(mid, b, eB, post)` then `b` is a recognized single-value byte check
+    with value `eB`. -/
+theorem findSecond_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat) :
+    ∀ (revMid rest : List (BusInteraction (Expression p)))
+      (mid : List (BusInteraction (Expression p))) (b : BusInteraction (Expression p))
+      (eB : Expression p) (post : List (BusInteraction (Expression p))),
+      findSecond bs facts busId revMid rest = some (mid, b, eB, post) →
+      svCheck? bs facts b = some eB := by
+  intro revMid rest
+  induction rest generalizing revMid with
+  | nil => intro _ _ _ _ h; exact absurd h (by simp [findSecond])
+  | cons c cs ih =>
+    intro mid b eB post h
+    rw [findSecond] at h
+    cases hc : svCheck? bs facts c with
+    | none => rw [hc] at h; exact ih (c :: revMid) mid b eB post h
+    | some eC =>
+      rw [hc] at h
+      split_ifs at h with hbus
+      · rw [Option.some.injEq, Prod.mk.injEq, Prod.mk.injEq, Prod.mk.injEq] at h
+        obtain ⟨_, hcb, hceb, _⟩ := h
+        rw [← hcb, ← hceb]; exact hc
+      · exact ih (c :: revMid) mid b eB post h
+
+/-- Fused scan for the first packable pair; the O(n) split-equation `decide` runs only for the
+    chosen candidate (mirrors `bytePackPass`). -/
+def findGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (revPre : List (BusInteraction (Expression p))) :
+    List (BusInteraction (Expression p)) → Option (PassResult cs bs)
+  | [] => none
+  | a :: rest =>
+    match ha : svCheck? bs facts a with
+    | some eA =>
+      match hfs : findSecond bs facts a.busId [] rest with
+      | some (mid, b, eB, post) =>
+        if hbp : facts.bytePairBus a.busId = true then
+          if hbc : facts.byteCheck a.busId = true then
+            if hsplit : cs.busInteractions = revPre.reverse ++ a :: mid ++ b :: post then
+              some ⟨{ cs with busInteractions :=
+                        revPre.reverse ++ byteCheck2 a.busId eA eB :: mid ++ post }, [],
+                    by
+                      have hsb : svCheck? bs facts b = some eB :=
+                        findSecond_sound bs facts a.busId [] rest mid b eB post hfs
+                      have hsa := svCheck?_sound bs facts a eA ha
+                      have hsbd := svCheck?_sound bs facts b eB hsb
+                      refine mergeStateless2_correct cs bs hp1 a b (byteCheck2 a.busId eA eB)
+                        hsa.1 hsbd.1 hsa.1 hsa.2.1 hsbd.2.1 rfl (fun env => ?_) (fun env => ?_)
+                        (fun v hv => ?_) revPre.reverse mid post hsplit
+                      · -- obligation equivalence
+                        rw [byteCheck2_eval,
+                          pairAccept bs facts a.busId hbp hbc (eA.eval env) (eB.eval env)]
+                        exact and_congr (hsa.2.2.2 env).symm (hsbd.2.2.2 env).symm
+                      · -- the pair check breaks no invariant
+                        rw [byteCheck2_eval]
+                        exact (facts.bytePairBus_sound a.busId hbp).2.1 (eA.eval env) (eB.eval env)
+                      · -- the pair check's variables come from `a` and `b`
+                        have hvab : v ∈ eA.vars ∨ v ∈ eB.vars := by
+                          simp only [byteCheck2, BusInteraction.vars, Expression.vars,
+                            List.flatMap_cons, List.flatMap_nil, List.append_nil,
+                            List.nil_append, List.mem_append] at hv
+                          tauto
+                        rcases hvab with h | h
+                        · exact Or.inl (mem_biVars_of_payload a eA hsa.2.2.1 h)
+                        · exact Or.inr (mem_biVars_of_payload b eB hsbd.2.2.1 h)⟩
+            else findGo cs bs facts hp1 (a :: revPre) rest
+          else findGo cs bs facts hp1 (a :: revPre) rest
+        else findGo cs bs facts hp1 (a :: revPre) rest
+      | none => findGo cs bs facts hp1 (a :: revPre) rest
+    | none => findGo cs bs facts hp1 (a :: revPre) rest
+
+/-- Pack one pair of single-value byte checks (in any encoding) into a pair check.
+    `iterateToFixpoint` drains all packable pairs (the bus length strictly decreases each step). -/
+def byteCheckPackPass : VerifiedPassW p := fun cs bs facts =>
+  if hp1 : (1 : ZMod p) ≠ 0 then
+    match findGo cs bs facts hp1 [] cs.busInteractions with
+    | some r => r
+    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end ByteCheckPack

--- a/ApcOptimizer/Implementation/OptimizerPasses/BytePack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BytePack.lean
@@ -1,25 +1,20 @@
 import ApcOptimizer.Implementation.OptimizerPasses.FactPass
 
 set_option autoImplicit false
--- `simp`'s unused-argument linter mis-flags lemmas that enable a rewrite another lemma then
--- consumes (e.g. unfolding `Expression.vars` on a numeral); it is a style lint, not a soundness one.
-set_option linter.unusedSimpArgs false
 
-/-! # Byte-check packing (`bytePackPass`)
+/-! # Canonical byte-check message shapes
 
-On a bitwise-style lookup bus (OpenVM's `BitwiseLookup`), a single value is byte-range-checked by the
-self-XOR message `[e, e, 0, 1]` (op = 1: it asserts `e ⊕ e = 0`, which only forces both operands —
-here the same `e` — to be bytes). Two such single-value checks pack into **one** pair check
-`[e₁, e₂, 0, 0]` (op = 0: range-check both operands as bytes). The pair check imposes the *identical*
-obligation — "both operands are bytes" — so replacing a pair of single checks with one pair check is
-satisfaction-preserving. Because these lookups are **stateless**, the swap leaves every stateful side
-effect and the memory discipline untouched: a pure bus-interaction win (variables and constraints
-unchanged). This is exactly powdr's byte-check packing.
+On a bitwise-style lookup bus (OpenVM's `BitwiseLookup`) a single value is byte-range-checked by the
+self-XOR message `[e, e, 0, 1]` (op = 1: it asserts `e ⊕ e = 0`, forcing both operands — here the
+same `e` — to be bytes), and two such checks pack into one pair check `[e₁, e₂, 0, 0]` (op = 0:
+range-check both operands as bytes). These two message shapes are used across passes:
 
-The table equivalence is a proven `BusFacts` fact (`bytePairBus`, discharged for OpenVM in
-`ApcOptimizer/Implementation/OpenVmFacts.lean`); the pass here is VM-agnostic — with `BusFacts.trivial`
-(`bytePairBus = false`) it is a no-op. One pair is packed per invocation; `iterateToFixpoint` drains
-them (the bus length strictly drops by one each time). -/
+* `ByteCheckPack.lean` recognizes single-value byte checks (in any of their equivalent encodings)
+  and packs two into one pair check `byteCheck2` (a bus-interaction win);
+* `TupleRange.lean` reuses `byteCheck1` when repacking a byte obligation together with an
+  exact-width range check.
+
+This module just provides the two canonical constructors and their evaluation lemmas. -/
 
 variable {p : ℕ}
 
@@ -39,207 +34,3 @@ theorem byteCheck1_eval (busId : Nat) (e : Expression p) (env : Variable → ZMo
 theorem byteCheck2_eval (busId : Nat) (e₁ e₂ : Expression p) (env : Variable → ZMod p) :
     (byteCheck2 busId e₁ e₂).eval env
       = { busId := busId, multiplicity := 1, payload := [e₁.eval env, e₂.eval env, 0, 0] } := rfl
-
-/-! ## Correctness of one packing step -/
-
-/-- Replacing a pair of single-value byte checks `A = [eA,eA,0,1]`, `B = [eB,eB,0,1]` (both on a
-    `bytePairBus`) by the packed check `C = [eA,eB,0,0]` is `PassCorrect`: the fact makes `C`'s
-    obligation equivalent to `A`'s and `B`'s together (same satisfying set), and all three are
-    stateless so side effects and `admissible` are unchanged. No new variables, no derivations. -/
-theorem mergeBytePair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (busId : Nat) (hbp : facts.bytePairBus busId = true)
-    (pre mid post : List (BusInteraction (Expression p))) (eA eB : Expression p)
-    (hsplit : cs.busInteractions
-        = pre ++ byteCheck1 busId eA :: mid ++ byteCheck1 busId eB :: post) :
-    PassCorrect cs
-      { cs with busInteractions := pre ++ byteCheck2 busId eA eB :: mid ++ post } [] bs := by
-  obtain ⟨hstate, hbrk, hbicond⟩ := facts.bytePairBus_sound busId hbp
-  set out : ConstraintSystem p :=
-    { cs with busInteractions := pre ++ byteCheck2 busId eA eB :: mid ++ post } with hout
-  have houtb : out.busInteractions = pre ++ byteCheck2 busId eA eB :: mid ++ post := rfl
-  -- all three interactions are stateless
-  have hstA : bs.isStateful (byteCheck1 busId eA).busId = false := hstate
-  have hstB : bs.isStateful (byteCheck1 busId eB).busId = false := hstate
-  have hstC : bs.isStateful (byteCheck2 busId eA eB).busId = false := hstate
-  -- per-env obligation equivalence: `P C ↔ P A ∧ P B`
-  have hkey : ∀ env,
-      (bs.violatesConstraint ((byteCheck2 busId eA eB).eval env) = false ↔
-        bs.violatesConstraint ((byteCheck1 busId eA).eval env) = false ∧
-          bs.violatesConstraint ((byteCheck1 busId eB).eval env) = false) := by
-    intro env
-    rw [byteCheck1_eval, byteCheck1_eval, byteCheck2_eval]
-    exact hbicond (eA.eval env) (eB.eval env) 1
-  -- the obligation predicate that appears in `satisfies`
-  set P : (Variable → ZMod p) → BusInteraction (Expression p) → Prop :=
-    fun env bi => (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false
-    with hP
-  have hPA : ∀ env, (P env (byteCheck1 busId eA) ↔
-      bs.violatesConstraint ((byteCheck1 busId eA).eval env) = false) := by
-    intro env
-    simp only [hP, byteCheck1_eval]
-    exact ⟨fun h => h hp1, fun h _ => h⟩
-  have hPB : ∀ env, (P env (byteCheck1 busId eB) ↔
-      bs.violatesConstraint ((byteCheck1 busId eB).eval env) = false) := by
-    intro env
-    simp only [hP, byteCheck1_eval]
-    exact ⟨fun h => h hp1, fun h _ => h⟩
-  have hPC : ∀ env, (P env (byteCheck2 busId eA eB) ↔
-      bs.violatesConstraint ((byteCheck2 busId eA eB).eval env) = false) := by
-    intro env
-    simp only [hP, byteCheck2_eval]
-    exact ⟨fun h => h hp1, fun h _ => h⟩
-  -- satisfaction equivalence
-  have hsatiff : ∀ env, cs.satisfies bs env ↔ out.satisfies bs env := by
-    intro env
-    have hbus : (∀ bi ∈ cs.busInteractions, P env bi) ↔
-        (∀ bi ∈ out.busInteractions, P env bi) := by
-      rw [hsplit, houtb]
-      simp only [List.forall_mem_append, List.forall_mem_cons]
-      have hc := hPC env; have ha := hPA env; have hb := hPB env
-      have hk := hkey env
-      tauto
-    constructor
-    · rintro ⟨hcons, hb⟩
-      exact ⟨hcons, (hbus.1 (fun bi hbi => hb bi hbi))⟩
-    · rintro ⟨hcons, hb⟩
-      exact ⟨hcons, (hbus.2 (fun bi hbi => hb bi hbi))⟩
-  -- the stateful-filtered interaction lists coincide (A, B, C are stateless)
-  have hfilt : cs.busInteractions.filter (fun bi => bs.isStateful bi.busId)
-      = out.busInteractions.filter (fun bi => bs.isStateful bi.busId) := by
-    rw [hsplit, houtb]
-    simp only [List.filter_append, List.filter_cons, hstA, hstB, hstC, Bool.false_eq_true,
-      if_false]
-  have hside : ∀ env, cs.sideEffects bs env = out.sideEffects bs env := by
-    intro env
-    simp only [ConstraintSystem.sideEffects, hfilt]
-  -- the active∧stateful evaluated messages coincide too (A, B, C are stateless)
-  have hadmarg : ∀ env,
-      (cs.busInteractions.map (fun bi => bi.eval env)).filter
-        (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
-      = (out.busInteractions.map (fun bi => bi.eval env)).filter
-        (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId) := by
-    intro env
-    rw [hsplit, houtb]
-    simp only [List.map_append, List.map_cons, List.filter_append, List.filter_cons,
-      byteCheck1_eval, byteCheck2_eval, hstate, Bool.and_false, Bool.false_eq_true, if_false]
-  have hadm : ∀ env, cs.admissible bs env ↔ out.admissible bs env := by
-    intro env
-    simp only [ConstraintSystem.admissible, hadmarg]
-  -- membership: `out`'s interactions come from `cs`'s payloads (C's vars come from eA/eB)
-  have hsub : ∀ v ∈ out.vars, v ∈ cs.vars := by
-    intro v hv
-    rw [ConstraintSystem.mem_vars] at hv ⊢
-    rcases hv with ⟨c, hc, hvc⟩ | ⟨bi, hbi, hvbi⟩
-    · exact Or.inl ⟨c, hc, hvc⟩
-    · rw [houtb] at hbi
-      simp only [List.mem_append, List.mem_cons] at hbi
-      rcases hbi with (h | rfl | h) | h
-      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
-      · -- `bi = C = byteCheck2 busId eA eB`; its vars come from eA or eB
-        have hnil0 : (Expression.const (0 : ZMod p)).vars = [] := rfl
-        have hab : v ∈ eA.vars ∨ v ∈ eB.vars := by
-          rcases hvbi with hm | ⟨e, he, hve⟩
-          · -- multiplicity `1` has no variables
-            exact absurd hm (by
-              rw [show (byteCheck2 busId eA eB).multiplicity.vars = [] from rfl]
-              simp)
-          · have he' : e = eA ∨ e = eB ∨ e = Expression.const (0 : ZMod p)
-                ∨ e = Expression.const (0 : ZMod p) := by simpa [byteCheck2] using he
-            rcases he' with rfl | rfl | rfl | rfl
-            · exact Or.inl hve
-            · exact Or.inr hve
-            · exact absurd hve (by rw [hnil0]; simp)
-            · exact absurd hve (by rw [hnil0]; simp)
-        have hpayA : eA ∈ (byteCheck1 busId eA).payload := by
-          show eA ∈ [eA, eA, Expression.const 0, Expression.const 1]; exact List.mem_cons_self ..
-        have hpayB : eB ∈ (byteCheck1 busId eB).payload := by
-          show eB ∈ [eB, eB, Expression.const 0, Expression.const 1]; exact List.mem_cons_self ..
-        rcases hab with h | h
-        · exact Or.inr ⟨byteCheck1 busId eA,
-            by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto,
-            Or.inr ⟨eA, hpayA, h⟩⟩
-        · exact Or.inr ⟨byteCheck1 busId eB,
-            by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto,
-            Or.inr ⟨eB, hpayB, h⟩⟩
-      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
-      · exact Or.inr ⟨bi, by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto, hvbi⟩
-  refine PassCorrect.ofEnvEq ?_ ?_ hsub ?_
-  · intro env hsat
-    exact ⟨env, (hsatiff env).2 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
-  · intro hinv env hsat bi hbi
-    rw [houtb] at hbi
-    simp only [List.mem_append, List.mem_cons] at hbi
-    rcases hbi with (h | rfl | h) | h
-    · exact hinv env ((hsatiff env).2 hsat) bi
-        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
-    · -- `bi = C`: a multiplicity-1 packed check never breaks an invariant
-      show ((byteCheck2 busId eA eB).eval env).multiplicity ≠ 0 →
-        bs.breaksInvariant ((byteCheck2 busId eA eB).eval env) = false
-      intro _
-      rw [byteCheck2_eval]; exact hbrk (eA.eval env) (eB.eval env)
-    · exact hinv env ((hsatiff env).2 hsat) bi
-        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
-    · exact hinv env ((hsatiff env).2 hsat) bi
-        (by rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto)
-  · intro env hadmE hsat
-    exact ⟨(hsatiff env).1 hsat, (hadm env).1 hadmE, by rw [hside]; exact BusState.equiv_refl _⟩
-
-/-! ## The pass: find and pack one pair per invocation -/
-
-/-- If `bi` is a single-value byte check `[e, e, 0, 1]` (multiplicity `1`) on a `bytePairBus`,
-    return the checked value `e`. All fields are checked structurally, so a hit means
-    `bi = byteCheck1 bi.busId e`. -/
-def matchByteCheck {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
-  if facts.bytePairBus bi.busId then
-    match bi.multiplicity, bi.payload with
-    | .const c, [e, e', z, op] =>
-        if decide (c = 1) && decide (e = e') && decide (z = .const 0) && decide (op = .const 1)
-        then some e else none
-    | _, _ => none
-  else none
-
-/-- Scan for the next byte check on `busId`, returning the interior `mid`, its value `eB`, and the
-    remainder `post`. -/
-def findSecond {bs : BusSemantics p} (facts : BusFacts p bs) (busId : Nat) :
-    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
-    Option (List (BusInteraction (Expression p)) × Expression p ×
-      List (BusInteraction (Expression p)))
-  | _, [] => none
-  | revMid, b :: rest =>
-    match matchByteCheck facts b with
-    | some eB => if decide (b.busId = busId) then some (revMid.reverse, eB, rest)
-                 else findSecond facts busId (b :: revMid) rest
-    | none => findSecond facts busId (b :: revMid) rest
-
-/-- Fused scan for the first packable pair; the O(n) split-equation `decide` runs only for the
-    chosen candidate (mirrors `busPairCancel`). -/
-def findBytePackGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (revPre : List (BusInteraction (Expression p))) :
-    List (BusInteraction (Expression p)) → Option (PassResult cs bs)
-  | [] => none
-  | a :: rest =>
-    match matchByteCheck facts a with
-    | some eA =>
-      match findSecond facts a.busId [] rest with
-      | some (mid, eB, post) =>
-        if hbp : facts.bytePairBus a.busId = true then
-          if hsplit : cs.busInteractions
-              = revPre.reverse ++ byteCheck1 a.busId eA :: mid ++ byteCheck1 a.busId eB :: post then
-            some ⟨{ cs with busInteractions :=
-                      revPre.reverse ++ byteCheck2 a.busId eA eB :: mid ++ post }, [],
-                  mergeBytePair_correct cs bs facts hp1 a.busId hbp revPre.reverse mid post eA eB
-                    hsplit⟩
-          else findBytePackGo cs bs facts hp1 (a :: revPre) rest
-        else findBytePackGo cs bs facts hp1 (a :: revPre) rest
-      | none => findBytePackGo cs bs facts hp1 (a :: revPre) rest
-    | none => findBytePackGo cs bs facts hp1 (a :: revPre) rest
-
-/-- Pack one pair of single-value byte checks into a pair check. `iterateToFixpoint` drains all
-    packable pairs (the bus length strictly decreases each step). -/
-def bytePackPass : VerifiedPassW p := fun cs bs facts =>
-  if hp1 : (1 : ZMod p) ≠ 0 then
-    match findBytePackGo cs bs facts hp1 [] cs.busInteractions with
-    | some r => r
-    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
-  else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -42,9 +42,9 @@ variable {p : ℕ}
 /-! ## Recognizing pure byte-check interactions -/
 
 /-- The operands whose byte-ness *implies* this interaction's acceptance (for any multiplicity):
-    `some ops` for the self-check form `[x, x, 0, 1]` (`BusFacts.byteCheck`), the XOR-with-zero form
-    `[x, 0, x, 1]` (`BusFacts.xorZeroCheck`), and the packed-pair form `[x, y, 0, 0]`
-    (`BusFacts.bytePairBus` + `byteCheck`); `none` otherwise. -/
+    `some ops` for the self-check form `[x, x, 0, 1]` (`BusFacts.byteCheck`), the two XOR-with-zero
+    mirrors `[x, 0, x, 1]` and `[0, x, x, 1]` (`BusFacts.xorZeroCheck`), and the packed-pair form
+    `[x, y, 0, 0]` (`BusFacts.bytePairBus` + `byteCheck`); `none` otherwise. -/
 def byteCheckOperands? (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (List (Expression p)) :=
   match bi.payload with
@@ -55,6 +55,9 @@ def byteCheckOperands? (bs : BusSemantics p) (facts : BusFacts p bs)
     else if facts.xorZeroCheck bi.busId && e2.constValue? == some 0 && e1 == e3
         && e4.constValue? == some 1 then
       some [e1]
+    else if facts.xorZeroCheck bi.busId && e1.constValue? == some 0 && e2 == e3
+        && e4.constValue? == some 1 then
+      some [e2]
     else if facts.bytePairBus bi.busId && facts.byteCheck bi.busId
         && e3.constValue? == some 0 && e4.constValue? == some 0 then
       some [e1, e2]
@@ -67,16 +70,19 @@ theorem byteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p b
     (h : byteCheckOperands? bs facts bi = some ops) : bs.isStateful bi.busId = false := by
   unfold byteCheckOperands? at h
   split at h
-  · split_ifs at h with h1 h2 h3
+  · split_ifs at h with h1 h2 h3 h4
     · exact (facts.byteCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
         exact h1.1.1.1)).1
     · exact (facts.xorZeroCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h2
         exact h2.1.1.1)).1
-    · exact (facts.bytePairBus_sound bi.busId (by
+    · exact (facts.xorZeroCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h3
         exact h3.1.1.1)).1
+    · exact (facts.bytePairBus_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h4
+        exact h4.1.1.1)).1
   · exact absurd h (by simp)
 
 /-- If every recognized operand evaluates to a byte, the evaluated message is accepted. -/
@@ -92,7 +98,7 @@ theorem byteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts p bs
   case h_1 e1 e2 e3 e4 hpay =>
     simp only at hpay
     subst hpay
-    split_ifs at h with h1 h2 h3
+    split_ifs at h with h1 h2 h3 h4
     · -- self-check form `[x, x, 0, 1]`
       rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
       obtain ⟨⟨⟨hfact, heq⟩, hz⟩, ho⟩ := h1
@@ -117,11 +123,24 @@ theorem byteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts p bs
         { busId := busId, multiplicity := mult.eval env,
           payload := [e1.eval env, e2.eval env, e1.eval env, e4.eval env] } = false
       rw [e2.constValue?_sound 0 hz' env, e4.constValue?_sound 1 ho' env]
-      exact ((facts.xorZeroCheck_sound busId hfact).2 (e1.eval env) (mult.eval env)).2
+      exact ((facts.xorZeroCheck_sound busId hfact).2.1 (e1.eval env) (mult.eval env)).2
         (hops e1 (by simp))
-    · -- packed-pair form `[x, y, 0, 0]`
+    · -- mirror XOR-with-zero form `[0, x, x, 1]`
       rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h3
-      obtain ⟨⟨⟨hpair, hfact⟩, hz⟩, ho⟩ := h3
+      obtain ⟨⟨⟨hfact, hz⟩, heq⟩, ho⟩ := h3
+      obtain rfl : [e2] = ops := by simpa using h
+      obtain rfl : e2 = e3 := eq_of_beq heq
+      have hz' : e1.constValue? = some 0 := by simpa using hz
+      have ho' : e4.constValue? = some 1 := by simpa using ho
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e2.eval env, e2.eval env, e4.eval env] } = false
+      rw [e1.constValue?_sound 0 hz' env, e4.constValue?_sound 1 ho' env]
+      exact ((facts.xorZeroCheck_sound busId hfact).2.2 (e2.eval env) (mult.eval env)).2
+        (hops e2 (by simp))
+    · -- packed-pair form `[x, y, 0, 0]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h4
+      obtain ⟨⟨⟨hpair, hfact⟩, hz⟩, ho⟩ := h4
       obtain rfl : [e1, e2] = ops := by simpa using h
       have hz' : e3.constValue? = some 0 := by simpa using hz
       have ho' : e4.constValue? = some 0 := by simpa using ho

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,26 +1,28 @@
 # Ideas for future optimization passes
 
 Ranked by **expected benefit**. Effectiveness priority is **variables > bus interactions >
-constraints**, used as the tiebreak; the two cheap high-confidence bus wins (#2, #3) are ranked
-early because they are nearly free and close the *only* axis on which apc-optimizer trails powdr in
-aggregate, plus keccak's dominant gap.
+constraints**, used as the tiebreak; the cheap high-confidence bus win #2 is ranked early because it
+is nearly free and closes part of the *only* axis on which apc-optimizer trails powdr in aggregate,
+plus keccak's dominant gap.
 
-## Where we stand (measured on `c007db0`; keccak/eth figures refreshed for the merged C4b, #109)
+## Where we stand (measured on `c007db0`; keccak/eth refreshed for merged C4b #109 and the bitwise byte-check cleanup, entry 75)
 
 | benchmark | apc-optimizer | powdr | apc gap |
 |---|---|---|---|
-| **keccak** (`apc_001_pckeccak`) | 2028 v / 118 c / ~2405 bus | 2021 / 186 / 1734 | vars **+7 (near parity)**, **bus +671** (wins constraints) |
-| **openvm-eth** (100-case agg / geo) | vars 4.509× / 3.820× · bus 3.401× / 2.705× | vars 4.092× / 3.787× · bus 3.480× / 2.822× | leads vars agg (geo only +0.033); **trails bus** |
+| **keccak** (`apc_001_pckeccak`) | 2028 v / 120 c / 2348 bus | 2021 / 186 / 1734 | vars **+7 (near parity)**, **bus +614** (wins constraints) |
+| **openvm-eth** (100-case agg / geo) | vars 4.511× / 3.822× · bus 3.439× / 2.723× | vars 4.092× / 3.787× · bus 3.480× / 2.822× | leads vars agg (geo only +0.035); **trails bus by 0.040** |
 | **apc_010** (`pc0x200c18`) | 466 v / 251 c / 271 bus | 498 / 331 / 239 | wins vars+constraints, **bus +32** |
 
-C4b (#109, entry 74) closed the keccak *variable* gap to near-parity, so **keccak's dominant remaining
-loss is now bus (+671)**; on openvm-eth the story is unchanged (per-case by variables **25 W / 42 L /
-33 T**; variable losses total ~+243 over 42 cases, bus gap net +368). Both gaps decompose into a
-*small* number of structural families, each addressed by one idea below.
+C4b (#109, entry 74) closed the keccak *variable* gap to near-parity; the bitwise byte-check cleanup
+(entry 75) cut the bitwise-bus gap. **keccak's dominant remaining loss is bus (+614)**; on openvm-eth
+the story is unchanged except bus improved (per-case by variables **25 W / 42 L / 33 T**; variable
+losses total ~+243 over 42 cases, bus gap net now ≈ +300). Both gaps decompose into a *small* number of
+structural families, each addressed by one idea below.
 
-- **keccak bus +671** = memory interior pairs +276 · bitwise (bus 6) +327 · width-1 range (bus 3) +68.
-- **eth bus +368** = bitwise +440 (72 cases) · tupleRange +160 (22 cases) · memory +144 (15 cases) ·
-  varRange **−376** (apc already *wins* — do not touch).
+- **keccak bus +614** = memory interior pairs +276 · bitwise (bus 6) ≈ +257 (post entry-75 pack) ·
+  width-1 range (bus 3) +68.
+- **eth bus** = bitwise (reduced by entry 75, but genuine-XOR / non-packable checks remain) ·
+  tupleRange +160 (22 cases) · memory +144 (15 cases) · varRange **−376** (apc already *wins* — do not touch).
 - **eth vars ~+243** = `rd_data` write-result limbs ~93 (23 cases) · comparison gadget ~130 markers/flags
   (43 cases) · `bit_shift_carry` +67 (13 cases) · `apc_071` intermediate address bytes. (Per-case
   numbers below were measured on `c007db0`; C4b shifted only the `255`-XOR NOT cases on `apc_071`/`apc_037`,
@@ -123,53 +125,7 @@ Strictly variable-neutral.
 
 ---
 
-## 3. Bitwise-bus cleanup: extract result-zero equalities, then drop/pack redundant byte-checks  ·  *bus + variables*  ·  high confidence · low effort
-
-**Gap:** the bitwise bus is the **sole reason apc loses bus in aggregate** on openvm-eth (net +440
-over 72 cases) and a third of the keccak bus gap (+327). It is *not* one thing:
-- Single-operand byte checks `[0,x,x,1]`, `[x,0,x,1]`, `[x,x,0,1]` (measured 221 on eth) that powdr
-  eliminates entirely, and two-byte `[x,y,0,0]` checks (+190) it packs.
-- Result-zero XORs `[x,y,0,1]` (50 on keccak, all `aᵢ ^ aⱼ = 0` with two bare vars) that encode a
-  plain equality `x = y` powdr's Gauss removes.
-
-**Mechanism** — three additions across the existing `xorEqExtract` / `redundantByteDrop` / `bytePack`
-family (all `ConstraintSystem.addConstraints_correct` / stateless-drop shapes):
-
-```
--- (i) result-zero equality extraction (variable win, sibling of the landed C4a):
-recognize bitwise [x, y, 0, 1]  ⟹  add  x − y = 0   (fact: Nat.xor a b = 0 ↔ a = b; no byte bound)
-    keep the interaction so its byteness obligation survives; Gauss eliminates one of x,y.
-
--- (ii) one canonical byte-check recognizer shared by RedundantByteDrop and BytePack:
-byteCheckOperands? [e1,e2,e3,op] :=
-    ([x,x,0,1] | [x,0,x,1] | [0,x,x,1])  ⟹ [x]        -- add the missing [0,x,x,1] mirror arm
-  | [x,y,0,0]                            ⟹ [x,y]
--- (iii) drop a recognized byte-check whose operand(s) are byteJustified elsewhere;
---       pack the survivors two-per interaction.
-```
-
-**Why sound.** (i) is equivalence-grade (`x^y=0 ⟺ x=y` for all naturals); adding an entailed equality
-keeps the satisfying set and the interaction is retained so no byte obligation is lost. (ii)/(iii)
-reuse the proven `redundantByteDrop`/`bytePack` machinery (`byteJustified`/`deepBoundOk`, the
-`mergeStateless2_correct` swap) — a byte check whose operand's byteness is re-derivable is a redundant
-stateless lookup; dropping it changes no stateful side effect. The mirror arm needs the symmetric
-`xorZeroCheck` fact from `Nat.zero_xor` (the lemma `xorEqExtract` already uses). Variable-neutral for
-(ii)/(iii); (i) removes variables.
-
-**Expected impact.** eth bus: dropping the 221 single-operand checks takes aggregate 3.405× → ~3.45×;
-with the `[x,y,0,0]` packs (~190) → ~3.489×, **surpassing powdr's 3.480× and flipping the only losing
-axis to a win**. keccak: result-zero extraction removes ~50 variables (measured on `c007db0`:
-2028 → ~1978, which would put apc *below* powdr's 2021 on keccak variables); the collapsed interaction
-becomes a `[a,a,0,1]` self-check `bytePack` then absorbs. Do **not** target the keccak genuine-XOR gap
-directly — census shows it is a variable-representation artifact (XOR chaining), not redundant
-lookups, and it is **not removable at all** (see the dead-ends list: XOR is not a field polynomial, so
-an XOR-result limb can be neither substituted away nor expressed as a `ComputationMethod`, and powdr
-keeps the same limbs). *(The `[x,255,z,1]` complement is a different pattern, landed as C4b — entry
-74, #109.)*
-
----
-
-## 4. Collapse comparison / is-equal / is-zero gadget witnesses  ·  *variables*  ·  medium confidence · high effort
+## 3. Collapse comparison / is-equal / is-zero gadget witnesses  ·  *variables*  ·  medium confidence · high effort
 
 **Gap:** the comparison gadgets are the broadest variable family — extra markers/flags in **43 of 100
 cases**: `diff_inv_marker` +61 (16 cases), `diff_marker` +24, `c_msb_f` +27, `b_msb_f` +19. This is
@@ -199,7 +155,7 @@ Proof risk: robustly matching the marker gadget and proving the consumer needs o
 signed `<`) is delicate — flagged medium.
 
 **Expected impact.** ~60–90 recoverable variables across the 43 affected cases (the whole `+3` tail
-plus `apc_018`/`apc_037`). Top-priority axis, broadest reach; higher proof cost than #1.
+plus `apc_018`/`apc_037`). Top-priority axis, broadest reach.
 
 ---
 
@@ -217,14 +173,27 @@ plus `apc_018`/`apc_037`). Top-priority axis, broadest reach; higher proof cost 
 - **Affine/product no-wrap rule for `byteJustified`.** `e = c·y` (y boolean) or `e = c₀ + Σ cᵢ·yᵢ`
   with `c₀ + Σ|cᵢ|(Bᵢ−1) < 256`, via `MemoryUnify.boundedSum_val`. A *helper*, not a headline: census
   shows it is **not** the keccak memory blocker (idea #2a is), but it generalizes #2 to affine
-  memory receives and rotation-carry data slots.
+  memory receives and rotation-carry data slots. Would also let the entry-75 byte-check dropper drop
+  more mirror checks (currently many keccak `[0,x,x,1]` operands are only *packable*, not droppable,
+  because their byteness is not re-derivable from an affine memory receive).
 
 ## Rejected / measured dead-ends (do not re-propose without re-measuring)
 
+- **Result-zero XOR extraction (`[x,y,0,1] ⟹ x=y`):** **measured dead-end (entry 75).** The census
+  behind the old idea #3(i) was stale: the *optimized* keccak circuit contains **zero** `[x,y,0,1]`
+  interactions — every op-1 bitwise message carries a genuine XOR-result variable (XOR chaining), the
+  representation artifact recorded in the functional-dependence dead-end below, not a result-zero
+  equality. A proven `xorResultZeroEq` prototype left both benchmarks byte-identical and was dropped.
+- **Bitwise byte-check cleanup (mirror `[0,x,x,1]` drop + form-agnostic pack):** **landed** (entry 75).
+  The `[0,x,x,1]` XOR-with-zero mirror is now recognized by `RedundantByteDrop` (drop when justified)
+  and by the generalized `ByteCheckPack` packer (which packs single-value checks in *any* encoding —
+  `[x,x,0,1]`/`[x,0,x,1]`/`[0,x,x,1]` — via the existing `mergeStateless2_correct`, subsuming the old
+  `bytePackPass`). keccak bus 2418 → 2348; eth bus 3.401× → 3.439×; variable-/constraint-neutral. The
+  *non-packable* residue (genuine XORs, and pair-checks whose operands are not byte-justified) is not
+  removable — powdr keeps equivalent checks.
 - **Constant-operand XOR extraction (`⊕0` C4a, `⊕255` C4b):** **landed** (entries 70 / 74, #109);
   `{0, 255}` are the only operands making `x ⊕ c` affine, so the mechanism is **exhausted** — do not
-  re-propose a generic constant-operand XOR pass (result-zero `[x,y,0]⟹x=y` in #3 is a *different*
-  pattern and still open).
+  re-propose a generic constant-operand XOR pass.
 - **Timestamp re-encoding** (`lower_decomp__1` vs `prev_timestamp`): measured **wash** — equal free-var
   counts each side on every case.
 - **Carry-witness substitution** for genuine two-root carries: measured **wash** (log 67) — eliminating
@@ -236,7 +205,7 @@ plus `apc_018`/`apc_037`). Top-priority axis, broadest reach; higher proof cost 
   lookups; it is a variable-representation artifact (XOR chaining), and the artifact itself is not
   removable either (next bullet), so it is neither a bus pass nor a variable pass.
 - **Functional-dependence derived columns for read/write limbs (was idea #5):** **infeasible — measured
-  dead-end** (attempted 2026-07-13, entry below). The variable count (`ConstraintSystem.variables`,
+  dead-end** (attempted 2026-07-13, log entry above). The variable count (`ConstraintSystem.variables`,
   Size.lean) is purely syntactic: a name is counted iff it appears in some constraint/interaction, and
   `Derivations` are a *separate* list, so registering a `ComputationMethod` for a limb does **not**
   drop it — only substituting the name away (Gauss/Subst) or re-encoding a group into fewer fresh vars

--- a/docs/log.md
+++ b/docs/log.md
@@ -2586,3 +2586,53 @@ recorded under "Rejected / measured dead-ends" in `docs/ideas.md`.
 159 redundant range-checks on byte-guaranteed XOR results are a bus-only drop (width-1 range-check →
 booleanity / redundant-byte follow-ups), and the `[x,y,0,0]` byte-check packing (idea #3) is a bus
 win. These reduce bus interactions, not variables.
+
+## 75. Generalized single-value byte-check recognizer: `[0,x,x,1]` mirror drop + form-agnostic pack (idea #3)
+
+**Idea.** `docs/ideas.md` #3 ("bitwise-bus cleanup") had three parts: (i) result-zero equality
+extraction `[x,y,0,1] ⟹ x=y`, and (ii)/(iii) recognizing the missing XOR-with-zero mirror
+`[0,x,x,1]` so the byte-check dropper/packer reaches it. Measured on the current optimizer output:
+
+- **(i) result-zero is a measured dead-end.** Rendering the optimized keccak circuit shows **zero**
+  `[x,y,0,1]` interactions — every op-1 bitwise message carries a genuine XOR-result variable in the
+  result slot (XOR chaining), which idea #3 itself flags as *not* to target. A prototype pass
+  (`xorResultZeroEq` fact + a fifth `xorEq?` arm) built and proved clean but left both benchmarks
+  byte-identical, so it was dropped. Recorded as a dead-end.
+- **(ii)/(iii) is real.** Keccak's optimized bitwise bus has **68** `[0,x,x,1]` mirror byte-checks
+  (`0 ⊕ x = x`, i.e. "x is a byte" with the zero in the *first* operand slot). Neither
+  `RedundantByteDrop` (recognized `[x,x,0,1]`, `[x,0,x,1]`, `[x,y,0,0]`) nor `bytePackPass`
+  (recognized only `[x,x,0,1]`) could reach them.
+
+**Change.**
+- `BusFacts.xorZeroCheck` extended from `[x,0,x,1]` to *both* mirrors `[x,0,x,1]` / `[0,x,x,1]`
+  (discharged for OpenVM from `Nat.xor_zero` / `Nat.zero_xor`; the mirror is `256 ≤ p`-free, holding
+  even in the degenerate `p=1` case).
+- `RedundantByteDrop.byteCheckOperands?` gains the `[0,x,x,1]` arm (drop when the operand is
+  byte-justified elsewhere).
+- New `ByteCheckPack.lean`: one canonical single-value recognizer `svCheck?` for **all three**
+  encodings (`[x,x,0,1]`, `[x,0,x,1]`, `[0,x,x,1]`) → the checked value, and a packer that merges
+  any two into one pair check `[eA,eB,0,0]` via the *existing* general stateless two-for-one swap
+  `mergeStateless2_correct` (no new correctness lemma). This **subsumes** `bytePackPass`, which was
+  removed together with its helpers (`matchByteCheck` / `findSecond` / `findBytePackGo` /
+  `mergeBytePair_correct`); `BytePack.lean` now only exports the canonical `byteCheck1` / `byteCheck2`
+  message constructors reused by `ByteCheckPack` and `TupleRange`. The pipeline's `bytePack` slot now
+  runs the generalized packer.
+
+**Why sound.** A recognized single-value check is stateless, multiplicity-1, and accepted iff its
+value is a byte (`svCheck?_sound`, from `byteCheck` / `xorZeroCheck`); a pair check `[x,y,0,0]` is
+accepted iff both are bytes (`bytePairBus` + `byteCheck`). So the pair's obligation is exactly the
+conjunction — the hypothesis `mergeStateless2_correct` needs. All are stateless, so stateful side
+effects and `admissible` are untouched; variable-neutral (operands retained), degree-guarded.
+VM-agnostic: with `BusFacts.trivial` every fact is `false`, so `svCheck?` returns `none` and the pass
+is the identity.
+
+**Impact (variable-neutral bus win on both benchmarks; no constraint change).**
+- **keccak: bus 2418 → 2348 (−70)** — 15 mirror checks dropped (justified elsewhere), the rest packed
+  two-per; variables 2028 and constraints 120 unchanged.
+- **openvm-eth (100-case sweep): bus 3.401× → 3.439× agg (2.705× → 2.723× geo)** — closes ~half the
+  bus gap to powdr (diff −0.079× → −0.040×); variables 4.509× → 4.511× agg (non-regressing),
+  constraints ~flat, per-case standings vs powdr unchanged (25 W / 42 L / 33 T).
+
+`lake build` green; `check-proof-integrity.sh` passes (no `sorry`/`admit`/`axiom`/`native_decide`);
+the three `*_maintainsCorrectness` theorems still `{propext, Classical.choice, Quot.sound}`-only;
+keccak output within the degree bound.


### PR DESCRIPTION
## Summary

Implements the bitwise-bus cleanup from `docs/ideas.md` #3. A **variable-neutral bus-interaction win on both benchmarks**, with the correctness proof carried by the pass itself (no audited-surface change).

Measuring against the real optimizer output first showed that idea #3's part (i) — result-zero extraction `[x,y,0,1] ⟹ x=y` — is a **dead-end**: the *optimized* keccak circuit contains **zero** `[x,y,0,1]` interactions (every op-1 bitwise message carries a genuine XOR-result variable — the XOR-chaining representation artifact, which idea #3 itself flags as not to target). A proven `xorResultZeroEq` prototype left both benchmarks byte-identical and was dropped. The whole win is idea #3's part (ii)/(iii): recognizing the missing XOR-with-zero mirror and packing.

## What changed

- **`BusFacts.xorZeroCheck`** now covers *both* XOR-with-zero mirrors `[x,0,x,1]` **and** `[0,x,x,1]` (each accepted iff the value is a byte). Discharged for OpenVM from `Nat.xor_zero` / `Nat.zero_xor`; holds even in the degenerate `p=1` case.
- **`RedundantByteDrop`** gains the `[0,x,x,1]` arm — dropped when the operand's byteness is re-derivable elsewhere.
- **New `ByteCheckPack.lean`** — one canonical recognizer `svCheck?` for *all three* single-value byte-check encodings (`[x,x,0,1]`, `[x,0,x,1]`, `[0,x,x,1]`), packing any two into one pair check `[eA,eB,0,0]` via the **existing** general stateless two-for-one swap `mergeStateless2_correct` (no new correctness lemma). This subsumes the old `bytePackPass`, which is removed together with its helpers; `BytePack.lean` now only exports the canonical `byteCheck1`/`byteCheck2` message constructors reused by `ByteCheckPack` and `TupleRange`.

## Why it's sound

A recognized single-value check is stateless, multiplicity-1, and accepted iff its value is a byte (`svCheck?_sound`, from `byteCheck`/`xorZeroCheck`); a pair check `[x,y,0,0]` is accepted iff both are bytes (`bytePairBus` + `byteCheck`). So the pair's obligation is exactly the conjunction — the hypothesis `mergeStateless2_correct` needs. All interactions are stateless, so stateful side effects and `admissible` are untouched; operands are retained, so it is variable-neutral; degree-guarded. VM-agnostic: with `BusFacts.trivial` every fact is `false`, so `svCheck?` returns `none` and the pass is the identity.

## Effectiveness (priority: variables > bus > constraints)

| | baseline | this PR | Δ |
|---|---|---|---|
| **keccak** bus | 2418 | **2348** | **−70** |
| keccak vars / constraints | 2028 / 120 | 2028 / 120 | neutral |
| **openvm-eth** bus (agg / geo) | 3.401× / 2.705× | **3.439× / 2.723×** | **+0.038× / +0.018×** |
| openvm-eth vars (agg / geo) | 4.509× / 3.820× | 4.511× / 3.822× | non-regressing |
| openvm-eth constraints (agg) | 10.590× | 10.595× | ~flat |

- keccak: 15 mirror checks dropped (justified elsewhere), the rest packed two-per.
- openvm-eth: closes ~half the aggregate bus gap to powdr (diff −0.079× → −0.040×); per-case standings vs powdr unchanged (25 W / 42 L / 33 T), no variable regression.

## Verification

- `lake build` green.
- `Scripts/check-proof-integrity.sh` passes — no `sorry`/`admit`/`axiom`/`native_decide`; the three `*_maintainsCorrectness` theorems remain `{propext, Classical.choice, Quot.sound}`-only.
- keccak output within the degree bound.
- `docs/log.md` (entry 75) and `docs/ideas.md` updated (idea #3 resolved: mirror cleanup landed, result-zero recorded as a measured dead-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaSFKgvuquB7zRACUstMJd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaSFKgvuquB7zRACUstMJd)_