### PR TITLE
Fold positional decompositions of a compile-time constant (C5)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -30,6 +30,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
+import ApcOptimizer.Implementation.OptimizerPasses.ConstDecomp
 
 set_option autoImplicit false
 
@@ -81,9 +82,10 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
   [ ("zeroWidthRange", ZeroWidthRange.zeroWidthRangePass.guardDegree),
     ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree),
     ("carryBranch", carryBranchPass.guardDegree),
-    ("gauss", gaussElimPass.withFacts.guardDegree),
     ("normalize1", normalizePass.withFacts.guardDegree),
     ("constFold1", constantFoldPass.withFacts.guardDegree),
+    ("constDecomp", ConstDecomp.constDecompPass.guardDegree),
+    ("gauss", gaussElimPass.withFacts.guardDegree),
     ("domainBatch", domainBatchPass.guardDegree),
     ("normalize2", normalizePass.withFacts.guardDegree),
     ("constFold2", constantFoldPass.withFacts.guardDegree),

--- a/ApcOptimizer/Implementation/OptimizerPasses/ConstDecomp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ConstDecomp.lean
@@ -1,0 +1,395 @@
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+import ApcOptimizer.Implementation.OptimizerPasses.Affine
+import Mathlib.Data.List.Sort
+
+set_option autoImplicit false
+
+/-! # Fold positional decompositions of a compile-time constant (C5)
+
+powdr-exported blocks that end in a jump (JAL/JALR) — and, more generally, any block whose result is
+a compile-time constant — carry byte/limb *decompositions of a field constant*: an affine constraint
+`Σ cᵢ·xᵢ = K` (`K` a field literal) in which the `xᵢ` are range-checked limbs and the coefficients
+`cᵢ` form a **non-overlapping positional (mixed-radix) system** — e.g. `x₀ + 256·x₁ + 65536·x₂ = K`
+with each `xᵢ < 256`. When the whole representation cannot wrap the field
+(`Σ cᵢ·(Bᵢ−1) < p`), such a constraint forces **every** limb to a specific digit of `K`
+(`xᵢ = digitᵢ(K)`, obtained by iterated `div`/`mod`), by uniqueness of a bounded mixed-radix
+representation. The optimizer's Gaussian elimination cannot crack this — the digit is a nonlinear
+function of `K` — so the limbs survive as free variables; powdr folds each to its literal.
+
+This pass adds the *entailed* per-limb equalities `xᵢ − digitᵢ(K) = 0` (keeping all interactions),
+which the downstream affine/Gauss passes then consume to eliminate the limbs — a variable win (and,
+once a limb is a literal, its range check becomes a constant lookup the tautology/byte passes drop).
+
+The mechanism is a single `ConstraintSystem.addConstraints_correct`: soundness drops the added
+constraints; the only content is that each added equality *holds* on every satisfying assignment,
+which is exactly the mixed-radix uniqueness (`annDecode_forces`). The value arithmetic uses
+`ZMod.val` with an explicit no-wrap side condition (`annSum_val`), so no primality is needed — the
+range-check bus facts (via `BoundsMap`) carry all the strength. Both sign orientations of the
+constraint are tried (the coefficients are positive-small in exactly one), so `Σ cᵢxᵢ = K` and
+`K = Σ cᵢxᵢ` are handled uniformly; terms are sorted by descending coefficient so the recognizer is
+independent of the exported term order. -/
+
+namespace ConstDecomp
+
+variable {p : ℕ}
+
+/-- An affine term annotated with a range bound: coefficient `a` on variable `v`, and a bound `B`
+    carrying the intended invariant `(env v).val < B`. -/
+structure AnnTerm (p : ℕ) where
+  v : Variable
+  a : ZMod p
+  B : Nat
+
+/-- Maximal nat value of `Σ a.val · x` over the bounds `x ≤ B − 1`. -/
+def annRestMax : List (AnnTerm p) → Nat
+  | [] => 0
+  | e :: t => e.a.val * (e.B - 1) + annRestMax t
+
+/-- The realized nat sum `Σ a.val · (env v).val`. -/
+def annNatSum (L : List (AnnTerm p)) (env : Variable → ZMod p) : Nat :=
+  (L.map (fun e => e.a.val * (env e.v).val)).sum
+
+/-- The realized field sum `Σ a · (env v)`. -/
+def annFieldSum (L : List (AnnTerm p)) (env : Variable → ZMod p) : ZMod p :=
+  (L.map (fun e => e.a * env e.v)).sum
+
+/-- Positional digit decoder: process the terms from most significant (head) to least, requiring at
+    each step that the whole *rest* cannot reach the head coefficient (`annRestMax t < e.a.val`), and
+    peeling the digit `K / e.a.val` (checked `< e.B`). Succeeds only on a genuine non-overlapping
+    positional system in descending-coefficient order. -/
+def annDecode : List (AnnTerm p) → Nat → Option (List (Variable × Nat))
+  | [], K => if K = 0 then some [] else none
+  | e :: t, K =>
+      if 1 ≤ e.a.val ∧ 1 ≤ e.B ∧ annRestMax t < e.a.val ∧ K / e.a.val < e.B then
+        (annDecode t (K % e.a.val)).map (fun ds => (e.v, K / e.a.val) :: ds)
+      else none
+
+/-- The realized nat sum is bounded by the positional maximum. -/
+theorem annNatSum_le (env : Variable → ZMod p) :
+    ∀ (L : List (AnnTerm p)), (∀ e ∈ L, (env e.v).val < e.B) →
+      annNatSum L env ≤ annRestMax L := by
+  intro L
+  induction L with
+  | nil => intro _; simp [annNatSum, annRestMax]
+  | cons e t ih =>
+    intro hb
+    have hbe := hb e (List.mem_cons_self ..)
+    have iht := ih (fun e' he' => hb e' (List.mem_cons_of_mem _ he'))
+    simp only [annNatSum, annRestMax, List.map_cons, List.sum_cons]
+    simp only [annNatSum] at iht
+    exact Nat.add_le_add (Nat.mul_le_mul (le_refl _) (by omega)) iht
+
+/-- **Mixed-radix uniqueness.** If the positional decoder accepts `L` at target `K`, then every
+    assignment whose limbs are in range and whose realized sum is `K` must hold exactly the decoded
+    digits. This is the entailment the pass relies on. -/
+theorem annDecode_forces (env : Variable → ZMod p) :
+    ∀ (L : List (AnnTerm p)) (K : Nat) (ds : List (Variable × Nat)),
+      annDecode L K = some ds → (∀ e ∈ L, (env e.v).val < e.B) → annNatSum L env = K →
+      ∀ v d, (v, d) ∈ ds → (env v).val = d := by
+  intro L
+  induction L with
+  | nil =>
+    intro K ds hdec _ _ v d hvd
+    rw [annDecode] at hdec
+    split at hdec
+    · simp only [Option.some.injEq] at hdec; subst hdec; simp at hvd
+    · exact absurd hdec (by simp)
+  | cons e t ih =>
+    intro K ds hdec hb hK
+    rw [annDecode] at hdec
+    split at hdec
+    · rename_i hcond
+      obtain ⟨hc1, hcB, hrest, hKB⟩ := hcond
+      rw [Option.map_eq_some_iff] at hdec
+      obtain ⟨ds', hdt, rfl⟩ := hdec
+      have hbt : ∀ e' ∈ t, (env e'.v).val < e'.B := fun e' he' => hb e' (List.mem_cons_of_mem _ he')
+      have htail_le : annNatSum t env ≤ annRestMax t := annNatSum_le env t hbt
+      have htaillt : annNatSum t env < e.a.val := lt_of_le_of_lt htail_le hrest
+      have hexp : annNatSum (e :: t) env = e.a.val * (env e.v).val + annNatSum t env := by
+        simp only [annNatSum, List.map_cons, List.sum_cons]
+      rw [hexp] at hK
+      have hc1' : 0 < e.a.val := hc1
+      have hdiv : K / e.a.val = (env e.v).val := by
+        rw [← hK, Nat.mul_add_div hc1', Nat.div_eq_of_lt htaillt, Nat.add_zero]
+      have hmod : K % e.a.val = annNatSum t env := by
+        rw [← hK, Nat.mul_add_mod, Nat.mod_eq_of_lt htaillt]
+      have htf := ih (K % e.a.val) ds' hdt hbt hmod.symm
+      intro v d hvd
+      rcases List.mem_cons.1 hvd with h | h
+      · injection h with hv hd; subst hv; subst hd; exact hdiv.symm
+      · exact htf v d h
+    · exact absurd hdec (by simp)
+
+/-- The variables of the decoded digits are among the term variables. -/
+theorem annDecode_vars :
+    ∀ (L : List (AnnTerm p)) (K : Nat) (ds : List (Variable × Nat)),
+      annDecode L K = some ds → ∀ v d, (v, d) ∈ ds → v ∈ L.map (fun e => e.v) := by
+  intro L
+  induction L with
+  | nil =>
+    intro K ds hdec v d hvd
+    rw [annDecode] at hdec
+    split at hdec
+    · simp only [Option.some.injEq] at hdec; subst hdec; simp at hvd
+    · exact absurd hdec (by simp)
+  | cons e t ih =>
+    intro K ds hdec v d hvd
+    rw [annDecode] at hdec
+    split at hdec
+    · rw [Option.map_eq_some_iff] at hdec
+      obtain ⟨ds', hdt, rfl⟩ := hdec
+      rcases List.mem_cons.1 hvd with h | h
+      · injection h with hv _; subst hv; simp
+      · have := ih (K % e.a.val) ds' hdt v d h
+        simp only [List.map_cons, List.mem_cons]; exact Or.inr this
+    · exact absurd hdec (by simp)
+
+/-- **Field-to-nat lifting.** With every limb in range and the positional maximum below the field
+    size, the field sum's `val` is the realized nat sum (no wrap-around). -/
+theorem annSum_val (env : Variable → ZMod p) :
+    ∀ (L : List (AnnTerm p)), (∀ e ∈ L, (env e.v).val < e.B) → annRestMax L < p →
+      (annFieldSum L env).val = annNatSum L env := by
+  intro L
+  induction L with
+  | nil =>
+    intro _ hp
+    simp only [annRestMax] at hp
+    haveI : NeZero p := ⟨(by omega : (0 : ℕ) < p).ne'⟩
+    simp [annFieldSum, annNatSum, ZMod.val_zero]
+  | cons e t ih =>
+    intro hb hp
+    have hbe := hb e (List.mem_cons_self ..)
+    have hbt : ∀ e' ∈ t, (env e'.v).val < e'.B := fun e' he' => hb e' (List.mem_cons_of_mem _ he')
+    simp only [annRestMax] at hp
+    haveI : NeZero p := ⟨(by omega : (0 : ℕ) < p).ne'⟩
+    have hpt : annRestMax t < p := by omega
+    have iht := ih hbt hpt
+    have htnat : annNatSum t env ≤ annRestMax t := annNatSum_le env t hbt
+    have hmul : (e.a * env e.v).val = e.a.val * (env e.v).val := by
+      apply ZMod.val_mul_of_lt
+      have h1 : e.a.val * (env e.v).val ≤ e.a.val * (e.B - 1) := Nat.mul_le_mul (le_refl _) (by omega)
+      omega
+    have hadd : (e.a * env e.v + annFieldSum t env).val
+              = e.a.val * (env e.v).val + annNatSum t env := by
+      have hlt : (e.a * env e.v).val + (annFieldSum t env).val < p := by
+        rw [hmul, iht]
+        have h1 : e.a.val * (env e.v).val ≤ e.a.val * (e.B - 1) := Nat.mul_le_mul (le_refl _) (by omega)
+        omega
+      rw [ZMod.val_add_of_lt hlt, hmul, iht]
+    have hfs : annFieldSum (e :: t) env = e.a * env e.v + annFieldSum t env := by
+      simp only [annFieldSum, List.map_cons, List.sum_cons]
+    have hns : annNatSum (e :: t) env = e.a.val * (env e.v).val + annNatSum t env := by
+      simp only [annNatSum, List.map_cons, List.sum_cons]
+    rw [hfs, hns, hadd]
+
+/-! ## The recognizer -/
+
+/-- Annotate each `(variable, coefficient)` term with its value bound; `none` if any is unbounded. -/
+def annotate (Bmap : Std.HashMap Variable Nat) : List (Variable × ZMod p) → Option (List (AnnTerm p))
+  | [] => some []
+  | (v, a) :: rest =>
+      match Bmap[v]?, annotate Bmap rest with
+      | some B, some anns => some (⟨v, a, B⟩ :: anns)
+      | _, _ => none
+
+theorem annotate_map (Bmap : Std.HashMap Variable Nat) :
+    ∀ (terms : List (Variable × ZMod p)) (L : List (AnnTerm p)),
+      annotate Bmap terms = some L → L.map (fun e => (e.v, e.a)) = terms := by
+  intro terms
+  induction terms with
+  | nil => intro L h; rw [annotate] at h; simp only [Option.some.injEq] at h; subst h; rfl
+  | cons t rest ih =>
+    intro L h
+    obtain ⟨v, a⟩ := t
+    rw [annotate] at h
+    split at h
+    · rename_i B anns hB hrest
+      simp only [Option.some.injEq] at h; subst h
+      simp only [List.map_cons]; rw [ih anns hrest]
+    · exact absurd h (by simp)
+
+theorem annotate_bounds (Bmap : Std.HashMap Variable Nat) :
+    ∀ (terms : List (Variable × ZMod p)) (L : List (AnnTerm p)),
+      annotate Bmap terms = some L → ∀ e ∈ L, Bmap[e.v]? = some e.B := by
+  intro terms
+  induction terms with
+  | nil => intro L h; rw [annotate] at h; simp only [Option.some.injEq] at h; subst h; simp
+  | cons t rest ih =>
+    intro L h
+    obtain ⟨v, a⟩ := t
+    rw [annotate] at h
+    split at h
+    · rename_i B anns hB hrest
+      simp only [Option.some.injEq] at h; subst h
+      intro e he
+      rcases List.mem_cons.1 he with h' | h'
+      · subst h'; exact hB
+      · exact ih anns hrest e h'
+    · exact absurd h (by simp)
+
+/-- The comparator sorting annotated terms by descending coefficient value. -/
+def cmpDesc (x y : AnnTerm p) : Bool := decide (y.a.val ≤ x.a.val)
+
+/-- Emit the entailed digit equalities from an already-sorted term list and a nat target. -/
+def foldSorted (Ls : List (AnnTerm p)) (K : Nat) : List (Expression p) :=
+  match annDecode Ls K with
+  | some ds => ds.map (fun vd => eqExpr (Expression.var vd.1) (Expression.const ((vd.2 : ℕ) : ZMod p)))
+  | none => []
+
+theorem foldSorted_sound (Ls : List (AnnTerm p)) (K : Nat) (env : Variable → ZMod p)
+    (hp0 : 0 < p) (hbLs : ∀ e ∈ Ls, (env e.v).val < e.B) (hKeq : annNatSum Ls env = K) :
+    ∀ nc ∈ foldSorted Ls K, nc.eval env = 0 := by
+  haveI : NeZero p := ⟨hp0.ne'⟩
+  intro nc hnc
+  unfold foldSorted at hnc
+  split at hnc
+  · rename_i ds hdec
+    obtain ⟨vd, hvdmem, rfl⟩ := List.mem_map.1 hnc
+    obtain ⟨v, d⟩ := vd
+    have hvval := annDecode_forces env Ls K ds hdec hbLs hKeq v d hvdmem
+    rw [eqExpr_eval]
+    simp only [Expression.eval]
+    rw [← hvval, ZMod.natCast_rightInverse (env v)]
+    ring
+  · simp at hnc
+
+theorem foldSorted_vars (Ls : List (AnnTerm p)) (K : Nat) :
+    ∀ nc ∈ foldSorted Ls K, ∀ x ∈ nc.vars, x ∈ Ls.map (fun e => e.v) := by
+  intro nc hnc x hx
+  unfold foldSorted at hnc
+  split at hnc
+  · rename_i ds hdec
+    obtain ⟨vd, hvdmem, rfl⟩ := List.mem_map.1 hnc
+    obtain ⟨v, d⟩ := vd
+    have hxv : x = v := by
+      simp only [eqExpr, Expression.vars] at hx
+      simpa using hx
+    rw [hxv]
+    exact annDecode_vars Ls K ds hdec v d hvdmem
+  · simp at hnc
+
+/-- For one orientation `m` of the affine form, try to recognize a positional constant decomposition
+    and emit the entailed digit equalities. -/
+def tryFold (Bmap : Std.HashMap Variable Nat) (m : LinExpr p) : List (Expression p) :=
+  match annotate Bmap m.terms with
+  | none => []
+  | some L =>
+      if annRestMax (L.mergeSort cmpDesc) < p then
+        foldSorted (L.mergeSort cmpDesc) ((-(m.const)).val)
+      else []
+
+theorem tryFold_sound (Bmap : Std.HashMap Variable Nat) (m : LinExpr p) (env : Variable → ZMod p)
+    (hm : m.eval env = 0) (hbnd : ∀ v b, Bmap[v]? = some b → (env v).val < b) :
+    ∀ nc ∈ tryFold Bmap m, nc.eval env = 0 := by
+  intro nc hnc
+  unfold tryFold at hnc
+  split at hnc
+  · simp at hnc
+  · rename_i L hann
+    split at hnc
+    · rename_i hp
+      set Ls := L.mergeSort (cmpDesc (p := p)) with hLs
+      have hperm : List.Perm Ls L := List.mergeSort_perm L _
+      have hbL : ∀ e ∈ L, (env e.v).val < e.B :=
+        fun e he => hbnd e.v e.B (annotate_bounds Bmap m.terms L hann e he)
+      have hbLs : ∀ e ∈ Ls, (env e.v).val < e.B :=
+        fun e he => hbL e ((List.Perm.mem_iff hperm).1 he)
+      have hp0 : 0 < p := lt_of_le_of_lt (Nat.zero_le _) hp
+      have hfsval : (annFieldSum Ls env).val = annNatSum Ls env := annSum_val env Ls hbLs hp
+      have hfs_eq : annFieldSum Ls env = -(m.const) := by
+        have h1 : annFieldSum Ls env = annFieldSum L env := by
+          unfold annFieldSum
+          exact (List.Perm.map (fun e => e.a * env e.v) hperm).sum_eq
+        have h2 : annFieldSum L env = (m.terms.map (fun t => t.2 * env t.1)).sum := by
+          unfold annFieldSum
+          conv_rhs => rw [← annotate_map Bmap m.terms L hann]
+          rw [List.map_map]; rfl
+        have h3 : m.const + (m.terms.map (fun t => t.2 * env t.1)).sum = 0 := by
+          have := hm; simp only [LinExpr.eval] at this; exact this
+        rw [h1, h2]; linear_combination h3
+      have hKeq : annNatSum Ls env = (-(m.const)).val := by rw [← hfsval, hfs_eq]
+      exact foldSorted_sound Ls ((-(m.const)).val) env hp0 hbLs hKeq nc hnc
+    · simp at hnc
+
+theorem tryFold_vars (Bmap : Std.HashMap Variable Nat) (m : LinExpr p) :
+    ∀ nc ∈ tryFold Bmap m, ∀ x ∈ nc.vars, x ∈ m.terms.map Prod.fst := by
+  intro nc hnc x hx
+  unfold tryFold at hnc
+  split at hnc
+  · simp at hnc
+  · rename_i L hann
+    split at hnc
+    · set Ls := L.mergeSort (cmpDesc (p := p)) with hLs
+      have hperm : List.Perm Ls L := List.mergeSort_perm L _
+      have hxLs : x ∈ Ls.map (fun e => e.v) := foldSorted_vars Ls _ nc hnc x hx
+      have hxL : x ∈ L.map (fun e => e.v) := (List.Perm.mem_iff (List.Perm.map _ hperm)).1 hxLs
+      have hLmap : L.map (fun e => e.v) = m.terms.map Prod.fst := by
+        rw [← annotate_map Bmap m.terms L hann, List.map_map]; rfl
+      rwa [hLmap] at hxL
+    · simp at hnc
+
+/-- Emit the entailed digit equalities for one constraint (both sign orientations tried). -/
+def foldExprConstraints (Bmap : Std.HashMap Variable Nat) (c : Expression p) : List (Expression p) :=
+  match linearize c with
+  | none => []
+  | some l => tryFold Bmap l ++ tryFold Bmap (l.scale (-1))
+
+theorem foldExprConstraints_sound (Bmap : Std.HashMap Variable Nat) (c : Expression p)
+    (env : Variable → ZMod p) (hc : c.eval env = 0)
+    (hbnd : ∀ v b, Bmap[v]? = some b → (env v).val < b) :
+    ∀ nc ∈ foldExprConstraints Bmap c, nc.eval env = 0 := by
+  intro nc hnc
+  unfold foldExprConstraints at hnc
+  split at hnc
+  · simp at hnc
+  · rename_i l hlin
+    have hlev : l.eval env = 0 := by rw [← linearize_eval c l hlin env]; exact hc
+    rcases List.mem_append.1 hnc with h | h
+    · exact tryFold_sound Bmap l env hlev hbnd nc h
+    · have hsev : (l.scale (-1)).eval env = 0 := by rw [LinExpr.scale_eval, hlev, mul_zero]
+      exact tryFold_sound Bmap (l.scale (-1)) env hsev hbnd nc h
+
+theorem foldExprConstraints_vars (Bmap : Std.HashMap Variable Nat) (c : Expression p) :
+    ∀ nc ∈ foldExprConstraints Bmap c, ∀ x ∈ nc.vars, x ∈ c.vars := by
+  intro nc hnc x hx
+  unfold foldExprConstraints at hnc
+  split at hnc
+  · simp at hnc
+  · rename_i l hlin
+    rcases List.mem_append.1 hnc with h | h
+    · exact linearize_vars c l hlin x (tryFold_vars Bmap l nc h x hx)
+    · have hx' : x ∈ (l.scale (-1)).terms.map Prod.fst := tryFold_vars Bmap (l.scale (-1)) nc h x hx
+      rw [LinExpr.scale_terms_fst] at hx'
+      exact linearize_vars c l hlin x hx'
+
+/-- Variables occurring in a **stateful** bus interaction's payload. Pinning such a limb to a
+    constant would strip the variable-shaped range check that memory send/receive pair-cancellation
+    (`busPairCancel`/`busUnify`) relies on for byte-justification, turning a cancellable pair into two
+    surviving interactions — a bus regression with no compensating variable win on that limb. We
+    therefore *skip* folding any limb that feeds a stateful payload; the field win is kept only where
+    it is genuinely free. -/
+def statefulPayloadVars (cs : ConstraintSystem p) (bs : BusSemantics p) : List Variable :=
+  (cs.busInteractions.filter (fun bi => bs.isStateful bi.busId)).flatMap
+    (fun bi => bi.payload.flatMap Expression.vars)
+
+/-- The pass: add every entailed positional-constant digit equality **whose pinned limb does not
+    feed a stateful bus payload** (see `statefulPayloadVars`), keeping all interactions. The
+    downstream affine/Gauss passes eliminate the now-pinned limbs. The gate makes `new` a *sublist*
+    of the entailed constraints, so soundness/variable-subset carry over unchanged. -/
+def constDecompPass : VerifiedPassW p := fun cs bs facts =>
+  let T : BoundsMap p cs bs := BoundsMap.build facts
+  let unsafeVars := statefulPayloadVars cs bs
+  let new := (cs.algebraicConstraints.flatMap (foldExprConstraints T.map)).filter
+    (fun nc => nc.vars.all (fun v => !unsafeVars.contains v))
+  ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+    cs.addConstraints_correct bs new
+      (fun env _hadm hsat nc hnc => by
+        obtain ⟨sc, hsc, hncsc⟩ := List.mem_flatMap.1 (List.mem_of_mem_filter hnc)
+        exact foldExprConstraints_sound T.map sc env (hsat.1 sc hsc)
+          (T.sound env hsat.2) nc hncsc)
+      (fun nc hnc z hz => by
+        obtain ⟨sc, hsc, hncsc⟩ := List.mem_flatMap.1 (List.mem_of_mem_filter hnc)
+        exact ConstraintSystem.mem_vars_of_constraint hsc
+          (foldExprConstraints_vars T.map sc nc hncsc z hz))⟩
+
+end ConstDecomp

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,7 +1,7 @@
 # Ideas for future optimization passes
 
 Ranked by **expected benefit**. Effectiveness priority is **variables > bus interactions >
-constraints**, used as the tiebreak; the cheap high-confidence bus win #2 is ranked early because it
+constraints**, used as the tiebreak; the cheap high-confidence bus win #1 is ranked early because it
 is nearly free and closes part of the *only* axis on which apc-optimizer trails powdr in aggregate,
 plus keccak's dominant gap.
 
@@ -24,47 +24,16 @@ structural families, each addressed by one idea below.
 - **eth bus** = bitwise (reduced by entry 75, but genuine-XOR / non-packable checks remain) ·
   tupleRange +160 (22 cases) · memory +144 (15 cases) · varRange **−376** (apc already *wins* — do not touch).
 - **eth vars ~+243** = `rd_data` write-result limbs ~93 (23 cases) · comparison gadget ~130 markers/flags
-  (43 cases) · `bit_shift_carry` +67 (13 cases) · `apc_071` intermediate address bytes. (Per-case
-  numbers below were measured on `c007db0`; C4b shifted only the `255`-XOR NOT cases on `apc_071`/`apc_037`,
-  otherwise per-case-neutral.)
+  (43 cases) · `bit_shift_carry` +67 (13 cases) · `apc_071` intermediate address bytes. The positional
+  constant-fold (C5, entry 76) is landed but is gated to limbs that do **not** feed a stateful payload, so it
+  leaves the eth `rd_data`/PC family untouched — those limbs are block outputs feeding memory/exec, and
+  folding them would break memory pair-cancellation; recovering them needs idea #1 (pair-cancellation on
+  constant data slots) first. (The bulk is also degree-2 disjunctions / 32-bit wrapping decompositions a
+  sound uniqueness fold cannot reach.)
 
 ---
 
-## 1. Fold byte/limb decompositions of compile-time constants  ·  *variables*  ·  high confidence · medium effort
-
-**Gap:** `rd_data`/PC-limb families are the single largest variable loss — ~93 vars over 23 cases,
-and **powdr keeps zero of them**. On JAL/JALR-terminated blocks the return address and jump target
-are compile-time constants, so powdr folds every limb to a literal; apc keeps them free because
-cracking `Σ 256ⁱ·byteᵢ = K` under byte bounds needs positional-uniqueness reasoning Gauss can't do
-(the 256³ combination space is too large for domain enumeration). Measured: `apc_045` +14 (all
-constant-PC limbs), `apc_026` +14, and the return-address part of the `+3` cluster
-(`apc_011/013/022/027/033/034/040/043`).
-
-**Mechanism** (new `VerifiedPass`; `ZeroWidthRange` is the `K=0`, single-term special case):
-
-```
-for each affine constraint  Σ cᵢ·xᵢ = K   (K a field constant):
-    require each xᵢ range-bounded 0 ≤ xᵢ < Bᵢ   (from its range-check bus fact / byteJustified)
-    sort terms by |cᵢ|; require a non-overlapping mixed-radix system:
-        cᵢ·(Bᵢ−1) < c_{i+1}   for all i,   and   Σ cᵢ·(Bᵢ−1) < p   (no wrap)
-    then the xᵢ are UNIQUELY forced:  xᵢ = digitᵢ(K)  by iterated div/mod
-    emit  Derivation xᵢ := ComputationMethod.Constant (digitᵢ K)
-    substitute the literal everywhere; drop the now-entailed range checks
-```
-
-**Why sound.** Soundness = uniqueness of a bounded mixed-radix representation (a `Nat.div`/`Nat.mod`
-digit lemma — no `native_decide`): the constraint already forces `xᵢ = digitᵢ(K)`, so substituting
-the constant preserves the satisfying set. Completeness: a real trace's column literally holds that
-constant, so the `Constant` method reproduces it (`derivesWitness` holds). Dropped range checks are
-entailed (`digitᵢ(K) < Bᵢ`).
-
-**Expected impact.** ~40–65 of the 103 extra vars across the losing cases; flips ~6–10 losses to
-ties/wins (roughly 25 W / 42 L → ~32 W / 34 L, and lifts the thin +0.031 geomean variable lead).
-Top-priority axis.
-
----
-
-## 2. Cancel interior memory send/receive pairs  ·  *bus*  ·  high confidence · low–medium effort
+## 1. Cancel interior memory send/receive pairs  ·  *bus*  ·  high confidence · low–medium effort
 
 **Gap:** the memory bus is where apc systematically trails on the memory-heavy blocks and on keccak.
 A register/heap cell accessed *N* times emits 2N memory interactions, but only the first receive and
@@ -125,7 +94,7 @@ Strictly variable-neutral.
 
 ---
 
-## 3. Collapse comparison / is-equal / is-zero gadget witnesses  ·  *variables*  ·  medium confidence · high effort
+## 2. Collapse comparison / is-equal / is-zero gadget witnesses  ·  *variables*  ·  medium confidence · high effort
 
 **Gap:** the comparison gadgets are the broadest variable family — extra markers/flags in **43 of 100
 cases**: `diff_inv_marker` +61 (16 cases), `diff_marker` +24, `c_msb_f` +27, `b_msb_f` +19. This is
@@ -172,7 +141,7 @@ plus `apc_018`/`apc_037`). Top-priority axis, broadest reach.
   tupleRange +160 over 22 cases** (`apc_006` +76). Bus-only.
 - **Affine/product no-wrap rule for `byteJustified`.** `e = c·y` (y boolean) or `e = c₀ + Σ cᵢ·yᵢ`
   with `c₀ + Σ|cᵢ|(Bᵢ−1) < 256`, via `MemoryUnify.boundedSum_val`. A *helper*, not a headline: census
-  shows it is **not** the keccak memory blocker (idea #2a is), but it generalizes #2 to affine
+  shows it is **not** the keccak memory blocker (idea #1a is), but it generalizes #1 to affine
   memory receives and rotation-carry data slots. Would also let the entry-75 byte-check dropper drop
   more mirror checks (currently many keccak `[0,x,x,1]` operands are only *packable*, not droppable,
   because their byteness is not re-derivable from an affine memory receive).
@@ -191,6 +160,16 @@ plus `apc_018`/`apc_037`). Top-priority axis, broadest reach.
   `bytePackPass`). keccak bus 2418 → 2348; eth bus 3.401× → 3.439×; variable-/constraint-neutral. The
   *non-packable* residue (genuine XORs, and pair-checks whose operands are not byte-justified) is not
   removable — powdr keeps equivalent checks.
+- **Fold positional decompositions of a compile-time constant (C5, `ConstDecomp`):** **landed**
+  (entry 76). For an affine `Σ cᵢ·xᵢ = K` whose range-checked limbs form a non-overlapping positional
+  system that cannot wrap the field, it adds the entailed `xᵢ = digitᵢ(K)` digit equalities (mixed-radix
+  uniqueness, `annDecode_forces`; no `native_decide`, 3-axiom clean) for Gauss to eliminate. **Gated** to
+  limbs that do not feed a stateful (memory/exec) payload: pinning such a limb to a constant strips the
+  variable range-check that memory pair-cancellation needs for byte-justification (an ungated prototype
+  cost keccak **+187 bus** and eth −0.021× bus, and doubled runtime). Gated, it is a **clean win on keccak**
+  (2028→2024 vars, 2348→2339 bus, 120→118 constraints — all three axes) and **neutral on openvm-eth**
+  (eth’s positional constants are all stateful-connected, so the gate skips them). The residual eth family
+  is idea #1 (memory pair-cancellation on constant data slots).
 - **Constant-operand XOR extraction (`⊕0` C4a, `⊕255` C4b):** **landed** (entries 70 / 74, #109);
   `{0, 255}` are the only operands making `x ⊕ c` affine, so the mechanism is **exhausted** — do not
   re-propose a generic constant-operand XOR pass.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2636,3 +2636,47 @@ is the identity.
 `lake build` green; `check-proof-integrity.sh` passes (no `sorry`/`admit`/`axiom`/`native_decide`);
 the three `*_maintainsCorrectness` theorems still `{propext, Classical.choice, Quot.sound}`-only;
 keccak output within the degree bound.
+
+## 76. Fold positional decompositions of a compile-time constant, gated to safe limbs (C5, idea #1)
+
+New `ApcOptimizer/Implementation/OptimizerPasses/ConstDecomp.lean` (`constDecompPass`, a `VerifiedPassW`).
+For an affine constraint `Σ cᵢ·xᵢ = K` (K a field literal) whose range-checked limbs form a
+**non-overlapping positional (mixed-radix) system** and whose total range cannot wrap the field
+(`Σ cᵢ·(Bᵢ−1) < p`), the limbs are uniquely the digits of `K`. The pass adds the entailed per-limb
+equalities `xᵢ = digitᵢ(K)` (iterated `div`/`mod`), which the affine/Gauss passes then eliminate — the
+nonlinear fact Gauss can't crack, that powdr folds to literals.
+
+**Gate (the key to making it a clean win).** Only fold a limb that does **not** feed a *stateful*
+(memory/exec) bus payload (`statefulPayloadVars`). Pinning such a limb to a constant strips the
+variable-shaped range check that memory send/receive **pair-cancellation** (`busPairCancel`/`busUnify`)
+relies on for byte-justification, so folding a block-output limb *breaks* cancellations. An ungated
+prototype cost **keccak +187 bus** (2348 → 2535) and eth −0.021× bus, and doubled runtime; the gate keeps
+the fold only where it is genuinely free (the limb's range check becomes a constant lookup the tautology
+pass drops). The gate makes `new` a *sublist* of the entailed constraints, so soundness/variable-subset
+carry over unchanged.
+
+**Proof.** One `ConstraintSystem.addConstraints_correct`; content is that each added equality holds on
+every satisfying assignment — mixed-radix uniqueness (`annDecode_forces`), lifted from ℕ to the field by
+the no-wrap `ZMod.val` lemma `annSum_val`. Bounds from the range-check facts via `MemoryUnify.BoundsMap`.
+Terms `mergeSort`ed by descending coefficient; both sign orientations tried. No primality, no
+`native_decide`; `check-proof-integrity.sh` passes and the three `*_maintainsCorrectness` theorems remain
+`{propext, Classical.choice, Quot.sound}`-only.
+
+**Pipeline.** `constDecomp` runs after `constFold1`, immediately before `gauss` — it must precede `gauss`
+(with `gauss` earlier it transforms the positional constraint before the pass sees it, making the pass a
+no-op, measured). `gauss` still runs before `domainBatch`, so there is no runtime regression (the failed
+ungated version had moved `gauss` fully late, which blew up `domainBatch` 4.7 s → 11.6 s).
+
+**Impact.**
+- **keccak (`apc_001_pckeccak`): 2028 → 2024 variables, 120 → 118 constraints, 2348 → 2339 bus — a clean
+  win on all three axes** (variables move toward powdr's 2021; bus and constraints both drop).
+- **openvm-eth (100-case sweep): neutral** — variables 4.511× / 3.822×, bus 3.439× / 2.723×, all unchanged.
+  eth's positional constants are block-output limbs (`rd_data`/PC) feeding memory/exec, which the gate
+  skips; that family remains, reachable only via idea #1 (memory pair-cancellation on constant data slots).
+- Per-case standings vs powdr unchanged (25 W / 42 L / 33 T); no case regresses.
+
+**Assessment.** A general, sound pass (fires on any safe positional-constant decomposition, not
+keccak-specific) that lands a strict keccak improvement and never regresses eth. The originally-targeted
+eth `rd_data`/PC families are out of reach: their limbs are stateful-connected (gated out to avoid the
+pair-cancellation regression), and the bulk surface as degree-2 disjunctions or 32-bit (wrapping)
+decompositions a sound uniqueness fold cannot reach. Recovering them is a follow-up on idea #1.


### PR DESCRIPTION
## What

Implements idea #1 from `docs/ideas.md`: **fold byte/limb decompositions of a compile-time constant**. New verified pass `ApcOptimizer/Implementation/OptimizerPasses/ConstDecomp.lean` (`constDecompPass`).

For an affine constraint `Σ cᵢ·xᵢ = K` (K a field literal) whose range-checked limbs form a **non-overlapping positional (mixed-radix) system** and whose total range cannot wrap the field (`Σ cᵢ·(Bᵢ−1) < p`), the limbs are uniquely the digits of `K`. The pass adds the entailed per-limb equalities `xᵢ = digitᵢ(K)` (iterated `div`/`mod`), which the affine/Gauss passes then eliminate — the nonlinear fact Gauss can't crack, that powdr folds to literals.

## The gate (what makes it a clean win)

An **ungated** fold regresses the bus: pinning a *block-output* limb (return address, jump target, write data) to a constant strips the variable range-check that memory send/receive **pair-cancellation** (`busPairCancel`/`busUnify`) relies on for byte-justification, breaking cancellations. An ungated prototype cost **keccak +187 bus interactions** and doubled runtime.

So the pass **only folds limbs that do not feed a stateful (memory/exec) bus payload** (`statefulPayloadVars`) — keeping the fold where it is genuinely free (the limb's range check becomes a constant lookup the tautology pass drops). The gate makes the added-constraint set a *sublist*, so the soundness/variable-subset proofs carry over unchanged.

## Effectiveness (this branch vs main; main = post-#113)

| benchmark | measure | main | this PR | Δ |
|---|---|---|---|---|
| **keccak** | variables | 2028 | **2024** | **−4** |
| | bus interactions | 2348 | **2339** | **−9** |
| | constraints | 120 | **118** | **−2** |
| **openvm-eth** (100-case) | variables (agg/geo) | 4.511× / 3.822× | 4.511× / 3.822× | — |
| | bus (agg/geo) | 3.439× / 2.723× | 3.439× / 2.723× | — |

**keccak improves on all three axes** (variables move toward powdr's 2021); **openvm-eth is exactly neutral** — no case regresses. eth's positional constants are all block-output limbs feeding memory/exec, which the gate skips, so the eth `rd_data`/PC family is left for a follow-up (idea #1: memory pair-cancellation on constant data slots). The pass is general — it fires on any *safe* positional-constant decomposition, not keccak-specific logic.

## Proof

A single `ConstraintSystem.addConstraints_correct`; the only content is that each added equality holds on every satisfying assignment — mixed-radix uniqueness (`annDecode_forces`), lifted from ℕ to the field by a no-wrap `ZMod.val` sum lemma (`annSum_val`). Bounds come from the range-check bus facts via `MemoryUnify.BoundsMap`. Terms are `mergeSort`ed by descending coefficient (order-independent recognition); both sign orientations are tried.

- No `sorry`/`admit`/`axiom`/`native_decide`; `Scripts/check-proof-integrity.sh` passes.
- `optimizerWithBusFacts_maintainsCorrectness` / `simpleOptimizer_maintainsCorrectness` / `openVmOptimizer_maintainsCorrectness` still depend only on `{propext, Classical.choice, Quot.sound}`.
- `lake build` green; output within the degree bound.
- Audited surface (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`, `Basic.lean`) untouched.

## Pipeline

`constDecomp` runs after `constFold1`, immediately before `gauss` (it must precede `gauss`, else `gauss` transforms the positional constraint before the pass sees it and the pass is a no-op). `gauss` still runs before `domainBatch`, so there is no runtime regression.

`docs/ideas.md`: the now-implemented idea removed from the ranked list (rest renumbered); `docs/log.md` entry 76 records the design, the gate rationale, and the measured impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABaBxL8fvUCXLwMnHrajQr