### PR TITLE
Width-1 range check -> booleanity: -68 keccak / -89 eth bus, 0 regressions — eth bus agg flips to a lead over powdr (+ two measured dead-ends)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
@@ -3,97 +3,153 @@ import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
 
 set_option autoImplicit false
 
-/-! # Width-0 range-check → equality (C3)
+/-! # Width-0 / width-1 range-check → equality / booleanity (C3 + entry 80)
 
-powdr-exported blocks that compute effective addresses keep, on the variable range checker, a family
-of **width-0 range checks** `[expr, 0]` (multiplicity `1`). A 0-bit range check asserts
-`expr < 2⁰ = 1`, i.e. `expr = 0`; it is powdr/OpenVM's encoding of "this linear form is exactly
-zero" — used to pin an intermediate address/data limb to a combination of others (e.g.
-`-a__2 + b__3 = 0`, `7864320·(a__3 − b__0) = 0`). Because the optimizer's Gaussian elimination only
-consumes *algebraic* constraints, these equalities — being carried on the **bus** — are never used
-to eliminate a variable, so the intermediate limbs survive. powdr substitutes them away.
+powdr-exported blocks keep, on the variable range checker, two families of degenerate range
+checks (multiplicity `1`):
 
-This pass converts each such interaction into the algebraic constraint `expr = 0` and drops the
-interaction: the two have the *same* satisfying set (a stateless range check `[x, 0]` is accepted iff
-`x = 0`, `BusFacts.zeroRangeEq`), so the transform is a sound, side-effect-preserving refinement.
-Placed early in the cleanup cycle, it feeds the new equalities to Gauss, which then eliminates the
-intermediate variables and cascades — a variable win (and, via the dropped interaction and the
-range checks the eliminated variables no longer need, a bus win).
+* **width-0** `[expr, 0]`: asserts `expr < 2⁰ = 1`, i.e. `expr = 0` — powdr/OpenVM's encoding of
+  "this linear form is exactly zero" (e.g. `-a__2 + b__3 = 0`). Converted to the algebraic
+  equality `expr = 0`, which Gauss consumes — a variable win.
+* **width-1** `[expr, 1]`: asserts `expr < 2`, i.e. booleanity. Converted to the degree-2
+  constraint `expr·(expr − 1) = 0` — a bus win (bus ≻ constraints in the effectiveness order),
+  and the booleanity feeds the finite-domain passes. The equivalence's backward direction
+  (`x·(x−1) = 0 → x < 2`) needs an integral domain, so this arm is gated on `p` prime — decided
+  once per pass invocation, the `deep`/`hdeep` pattern of `busPairCancel`. A per-candidate
+  degree gate (`expr.degree ≤ 1`) keeps every emitted constraint within the identity bound, so
+  the arm can never trip the whole-pass `guardDegree` revert.
+
+Both conversions are *equivalences* over the accepted set (`BusFacts.zeroRangeEq` for width-0;
+the mult-generic `BusFacts.varRangeBus` iff for width-1), so the transform is a sound,
+side-effect-preserving refinement: add the constraint (entailed by the accepted interaction),
+then drop the interaction (entailed by the kept constraint).
 
 Proof shape: two `PassCorrect` steps composed by `andThen`.
-1. **Add** the equality constraints, keeping every interaction — a `PassCorrect.ofEnvEq` whose only
-   content is "each width-0 interaction, being accepted, forces its value to zero" (so the added
-   constraints hold); side effects and admissibility are literally unchanged (same interactions).
-2. **Drop** the now-entailed width-0 interactions via `filterBusEntailed_correct`: each dropped
-   interaction is stateless, and is accepted under the filtered system because the equality
-   constraint added in step 1 (which the drop keeps) forces its value to zero.
+1. **Add** the constraints, keeping every interaction — a `PassCorrect.ofEnvEq` whose only
+   content is "each recognized interaction, being accepted, forces its constraint to zero";
+   side effects and admissibility are literally unchanged (same interactions).
+2. **Drop** the now-entailed interactions via `filterBusEntailed_correct`: each dropped
+   interaction is stateless, and is accepted under the filtered system because the constraint
+   added in step 1 (which the drop keeps) forces its value.
 
-The pass gates on `(1 : ZMod p) ≠ 0` (true for every prime field, in particular OpenVM's BabyBear);
-on the degenerate `ZMod 1` it degrades to the identity. -/
+The pass gates on `(1 : ZMod p) ≠ 0` (true for every prime field, in particular OpenVM's
+BabyBear); on the degenerate `ZMod 1` it degrades to the identity. -/
 
 namespace ZeroWidthRange
 
 variable {p : ℕ}
 
-/-- Recognize a width-0 range check `[value, 0]` (multiplicity `1`) on a `zeroRangeEq` bus, returning
-    the value expression whose zeroness it asserts; `none` otherwise. -/
-def zeroRangeValue? (bs : BusSemantics p) (facts : BusFacts p bs)
+/-- `v·(v − 1)` as an expression — the booleanity constraint of `v`. -/
+def boolC (v : Expression p) : Expression p := .mul v (.add v (.const (-1)))
+
+theorem boolC_eval (v : Expression p) (env : Variable → ZMod p) :
+    (boolC v).eval env = v.eval env * (v.eval env - 1) := by
+  simp only [boolC, Expression.eval]; ring
+
+theorem boolC_vars (v : Expression p) : ∀ x ∈ (boolC v).vars, x ∈ v.vars := by
+  intro x hx
+  simp only [boolC, Expression.vars, List.mem_append, List.not_mem_nil, or_false] at hx
+  tauto
+
+/-- On a prime field, `x < 2` (as a value) is exactly booleanity. -/
+theorem val_lt_two_iff (hp : Nat.Prime p) (x : ZMod p) :
+    x.val < 2 ↔ x * (x - 1) = 0 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  constructor
+  · intro hlt
+    have : x.val = 0 ∨ x.val = 1 := by omega
+    rcases this with h0 | h1
+    · rw [ZMod.val_eq_zero] at h0; rw [h0]; ring
+    · have hx1 : x = 1 := by
+        have := (ZMod.natCast_rightInverse x).symm
+        rw [this, h1]; norm_cast
+      rw [hx1]; ring
+  · intro hprod
+    rcases mul_eq_zero.1 hprod with h0 | h1
+    · rw [h0, ZMod.val_zero]; omega
+    · have hx1 : x = 1 := by linear_combination h1
+      rw [hx1, ZMod.val_one_eq_one_mod, Nat.mod_eq_of_lt hp.one_lt]; omega
+
+/-- Recognize a degenerate range check (multiplicity `1`) and return the equivalent algebraic
+    constraint: the value itself for width-0 (`zeroRangeEq` bus), its booleanity `boolC` for
+    width-1 (`varRangeBus` bus, degree-gated, only when `one = true` — i.e. `p` prime). -/
+def rangeEq? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (Expression p) :=
   match bi.payload with
   | [v, c] =>
-    if facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
-        ∧ c = Expression.const 0 then some v else none
+    if bi.multiplicity = Expression.const 1 then
+      if facts.zeroRangeEq bi.busId = true ∧ c = Expression.const 0 then some v
+      else if one = true ∧ facts.varRangeBus bi.busId = true ∧ c = Expression.const 1
+          ∧ v.degree ≤ 1 then some (boolC v)
+      else none
+    else none
   | _ => none
 
-/-- Structure of a recognized interaction: the bus admits the equality fact, the multiplicity is the
-    constant `1`, and the payload is `[value, 0]`. -/
-theorem zeroRangeValue?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
-      ∧ bi.payload = [v, Expression.const 0] := by
-  unfold zeroRangeValue? at h
+/-- Structure of a recognized interaction: multiplicity `1`, payload `[v, width]`, and either
+    the width-0 or the width-1 case with the matching constraint. -/
+theorem rangeEq?_spec (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p)
+    (h : rangeEq? one bs facts bi = some e) :
+    bi.multiplicity = Expression.const 1 ∧
+      ∃ v, ((facts.zeroRangeEq bi.busId = true ∧ bi.payload = [v, Expression.const 0] ∧ e = v)
+        ∨ (one = true ∧ facts.varRangeBus bi.busId = true
+            ∧ bi.payload = [v, Expression.const 1] ∧ e = boolC v)) := by
+  unfold rangeEq? at h
   split at h
   · rename_i v' c hpay
-    split_ifs at h with hcond
-    obtain ⟨hz, hm, hc⟩ := hcond
-    simp only [Option.some.injEq] at h
-    subst h
-    exact ⟨hz, hm, by rw [hpay, hc]⟩
+    split_ifs at h with hm hA hB
+    · obtain ⟨hz, hc⟩ := hA
+      simp only [Option.some.injEq] at h
+      exact ⟨hm, e, Or.inl ⟨hz, by rw [hpay, hc, h], rfl⟩⟩
+    · obtain ⟨hone, hv, hc, _⟩ := hB
+      simp only [Option.some.injEq] at h
+      exact ⟨hm, v', Or.inr ⟨hone, hv, by rw [hpay, hc], h.symm⟩⟩
   · exact absurd h (by simp)
 
-/-- A recognized interaction evaluates to the message `[value.eval, 0]` with multiplicity `1`. -/
-theorem zeroRangeValue?_eval (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [v.eval env, 0] } := by
-  obtain ⟨_, hm, hp⟩ := zeroRangeValue?_spec bs facts bi v h
-  unfold BusInteraction.eval
-  rw [hm, hp]
-  simp [Expression.eval]
-
 /-- A recognized interaction lives on a stateless bus. -/
-theorem zeroRangeValue?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p)
-    (h : zeroRangeValue? bs facts bi = some v) : bs.isStateful bi.busId = false :=
-  (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).1
+theorem rangeEq?_stateless (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p)
+    (h : rangeEq? one bs facts bi = some e) : bs.isStateful bi.busId = false := by
+  obtain ⟨_, v, hcase⟩ := rangeEq?_spec one bs facts bi e h
+  rcases hcase with ⟨hz, _, _⟩ | ⟨_, hv, _, _⟩
+  · exact (facts.zeroRangeEq_sound bi.busId hz).1
+  · exact (facts.varRangeBus_sound bi.busId hv).1
 
-/-- The evaluated message is accepted iff the value evaluates to zero. -/
-theorem zeroRangeValue?_violates_iff (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    bs.violatesConstraint (bi.eval env) = false ↔ v.eval env = 0 := by
-  rw [zeroRangeValue?_eval bs facts bi v env h]
-  exact (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).2 (v.eval env)
+/-- The evaluated message is accepted iff the returned constraint evaluates to zero. -/
+theorem rangeEq?_violates_iff (one : Bool) (hone : one = true → Nat.Prime p)
+    (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p) (env : Variable → ZMod p)
+    (h : rangeEq? one bs facts bi = some e) :
+    bs.violatesConstraint (bi.eval env) = false ↔ e.eval env = 0 := by
+  obtain ⟨hm, v, hcase⟩ := rangeEq?_spec one bs facts bi e h
+  rcases hcase with ⟨hz, hp', rfl⟩ | ⟨hone', hv, hp', rfl⟩
+  · have hev : bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [e.eval env, 0] } := by
+      unfold BusInteraction.eval; rw [hm, hp']; simp [Expression.eval]
+    rw [hev]
+    exact (facts.zeroRangeEq_sound bi.busId hz).2 (e.eval env)
+  · have hev : bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [v.eval env, 1] } := by
+      unfold BusInteraction.eval; rw [hm, hp']; simp [Expression.eval]
+    have hprime := hone hone'
+    rw [hev, boolC_eval, ← val_lt_two_iff hprime]
+    have h1val : (1 : ZMod p).val = 1 := by
+      rw [ZMod.val_one_eq_one_mod, Nat.mod_eq_of_lt hprime.one_lt]
+    rw [(facts.varRangeBus_sound bi.busId hv).2 (v.eval env) 1 1, h1val]
+    constructor
+    · exact fun ⟨_, hlt⟩ => by rwa [pow_one] at hlt
+    · exact fun hlt => ⟨by omega, by rwa [pow_one]⟩
 
-/-- Convert every width-0 range check into the equality `value = 0` and drop the interaction. -/
+/-- Convert every width-0 range check into the equality `value = 0`, and — on a prime field —
+    every width-1 range check into the booleanity `value·(value−1) = 0`, dropping the
+    interactions. -/
 def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
   if h1ne : (1 : ZMod p) ≠ 0 then
-    let newC := cs.busInteractions.filterMap (zeroRangeValue? bs facts)
+    let one : Bool := decide (Nat.Prime p)
+    have hone : one = true → Nat.Prime p := fun h => of_decide_eq_true h
+    let newC := cs.busInteractions.filterMap (rangeEq? one bs facts)
     let out1 : ConstraintSystem p :=
       { cs with algebraicConstraints := cs.algebraicConstraints ++ newC }
-    let keep := fun bi => (zeroRangeValue? bs facts bi).isNone
-    -- Step 1: add the equality constraints; interactions (hence side effects, admissibility) unchanged.
+    let keep := fun bi => (rangeEq? one bs facts bi).isNone
+    -- Step 1: add the constraints; interactions (hence side effects, admissibility) unchanged.
     have hstep1 : PassCorrect cs out1 [] bs := by
       refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
       · -- soundness: out1 has extra constraints, same interactions
@@ -110,40 +166,44 @@ def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
         · rcases List.mem_append.1 hc with hc | hc
           · exact Or.inl ⟨c, hc, hxc⟩
           · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
-            obtain ⟨_, _, hp⟩ := zeroRangeValue?_spec bs facts bi c hval
-            exact Or.inr ⟨bi, hbi, Or.inr ⟨c, by rw [hp]; simp, hxc⟩⟩
+            obtain ⟨_, v, hcase⟩ := rangeEq?_spec one bs facts bi c hval
+            rcases hcase with ⟨_, hp', rfl⟩ | ⟨_, _, hp', rfl⟩
+            · exact Or.inr ⟨bi, hbi, Or.inr ⟨c, by rw [hp']; simp, hxc⟩⟩
+            · exact Or.inr ⟨bi, hbi, Or.inr ⟨v, by rw [hp']; simp, boolC_vars v x hxc⟩⟩
         · exact Or.inr ⟨bi, hbi, hbrest⟩
-      · -- completeness: same env; the added equalities hold because the interactions are accepted
+      · -- completeness: same env; the added constraints hold because the interactions are accepted
         intro env hadm hsat
         refine ⟨⟨fun c hc => ?_, hsat.2⟩, hadm, BusState.equiv_refl _⟩
         rcases List.mem_append.1 hc with hc | hc
         · exact hsat.1 c hc
         · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
           have hmult : (bi.eval env).multiplicity = 1 := by
-            rw [zeroRangeValue?_eval bs facts bi c env hval]
+            obtain ⟨hm, _, _⟩ := rangeEq?_spec one bs facts bi c hval
+            unfold BusInteraction.eval
+            rw [hm]; simp [Expression.eval]
           have hviol : bs.violatesConstraint (bi.eval env) = false :=
             hsat.2 bi hbi (by rw [hmult]; exact h1ne)
-          exact (zeroRangeValue?_violates_iff bs facts bi c env hval).1 hviol
-    -- Step 2: drop the now-entailed width-0 interactions.
+          exact (rangeEq?_violates_iff one hone bs facts bi c env hval).1 hviol
+    -- Step 2: drop the now-entailed interactions.
     have hstep2 : PassCorrect out1 (out1.filterBus keep) [] bs := by
       refine out1.filterBusEntailed_correct bs keep ?_ ?_
       · intro bi _ hkf
-        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
-          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
-          cases hopt : zeroRangeValue? bs facts bi with
+        obtain ⟨e, he⟩ : ∃ e, rangeEq? one bs facts bi = some e := by
+          have hkf' : (rangeEq? one bs facts bi).isNone = false := hkf
+          cases hopt : rangeEq? one bs facts bi with
           | none => rw [hopt] at hkf'; simp at hkf'
-          | some v => exact ⟨v, rfl⟩
-        exact zeroRangeValue?_stateless bs facts bi v hv
+          | some e => exact ⟨e, rfl⟩
+        exact rangeEq?_stateless one bs facts bi e he
       · intro bi hbi hkf env hsatf _
-        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
-          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
-          cases hopt : zeroRangeValue? bs facts bi with
+        obtain ⟨e, he⟩ : ∃ e, rangeEq? one bs facts bi = some e := by
+          have hkf' : (rangeEq? one bs facts bi).isNone = false := hkf
+          cases hopt : rangeEq? one bs facts bi with
           | none => rw [hopt] at hkf'; simp at hkf'
-          | some v => exact ⟨v, rfl⟩
-        have hvmem : v ∈ (out1.filterBus keep).algebraicConstraints :=
-          List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, hv⟩)
-        rw [zeroRangeValue?_violates_iff bs facts bi v env hv]
-        exact hsatf.1 v hvmem
+          | some e => exact ⟨e, rfl⟩
+        have hemem : e ∈ (out1.filterBus keep).algebraicConstraints :=
+          List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, he⟩)
+        rw [rangeEq?_violates_iff one hone bs facts bi e env he]
+        exact hsatf.1 e hemem
     ⟨out1.filterBus keep, [], hstep1.andThen hstep2⟩
   else
     ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -30,37 +30,28 @@ structural families, each addressed by one idea below.
 
 ---
 
-## 1. Fold byte/limb decompositions of compile-time constants  ·  *variables*  ·  high confidence · medium effort
+## 1. Fold constant limb decompositions — **RE-SCOPED (entry 78): needs chain reasoning, not a digit lemma**  ·  *variables*  ·  high effort
 
-**Gap:** `rd_data`/PC-limb families are the single largest variable loss — ~93 vars over 23 cases,
-and **powdr keeps zero of them**. On JAL/JALR-terminated blocks the return address and jump target
-are compile-time constants, so powdr folds every limb to a literal; apc keeps them free because
-cracking `Σ 256ⁱ·byteᵢ = K` under byte bounds needs positional-uniqueness reasoning Gauss can't do
-(the 256³ combination space is too large for domain enumeration). Measured: `apc_045` +14 (all
-constant-PC limbs), `apc_026` +14, and the return-address part of the `+3` cluster
-(`apc_011/013/022/027/033/034/040/043`).
+**Mechanism correction (measured, entry 78).** The sketched pass — fold affine
+`Σ cᵢ·xᵢ = K` under range bounds — measures **−2 / −3 / 0 vars** on apc_045/apc_026/apc_013
+(faithful pin-and-reoptimize what-if): the clean equations exist only in the raw input, cover
+only the `imm_limbs` slice, and constant-seeding does **not** cascade. (An optimistic what-if
+claiming −54/−141/−154 was traced to unsoundly pinning `Σ flagᵢ = 1` one-hot selector sums —
+excluded.) Do not build the affine-only pass.
 
-**Mechanism** (new `VerifiedPass`; `ZeroWidthRange` is the `K=0`, single-term special case):
+**Where the (still-real) gap lives** — apc_045/apc_026 remain +14 vars each vs powdr, which
+folds every one of these limbs to literals:
+- **Bounded-payload idiom** (~3 vars/case): memory payload `K − Σ 256ⁱ⁺¹·rdᵢ` asserted a byte by
+  a bitwise pair check; with the limbs' range checks the digits are forced (hand-verified =
+  powdr's values). Recognizer needs payload linearization + bus-side byte facts; a contained
+  sub-pass, worth building if the census over the ~20 affected cases justifies it.
+- **Guarded two-root carry chains** (~11 vars/case): `(L−r₁)(L−r₂) = 0` with both roots inside
+  the operands' interval per-constraint — only the joint chain + range facts disambiguate.
+  Requires multi-constraint interval/relational reasoning (idea #6-class saturation), not a
+  mixed-radix lemma. carryBranch cannot be unblocked by constant seeding (measured).
 
-```
-for each affine constraint  Σ cᵢ·xᵢ = K   (K a field constant):
-    require each xᵢ range-bounded 0 ≤ xᵢ < Bᵢ   (from its range-check bus fact / byteJustified)
-    sort terms by |cᵢ|; require a non-overlapping mixed-radix system:
-        cᵢ·(Bᵢ−1) < c_{i+1}   for all i,   and   Σ cᵢ·(Bᵢ−1) < p   (no wrap)
-    then the xᵢ are UNIQUELY forced:  xᵢ = digitᵢ(K)  by iterated div/mod
-    emit  Derivation xᵢ := ComputationMethod.Constant (digitᵢ K)
-    substitute the literal everywhere; drop the now-entailed range checks
-```
-
-**Why sound.** Soundness = uniqueness of a bounded mixed-radix representation (a `Nat.div`/`Nat.mod`
-digit lemma — no `native_decide`): the constraint already forces `xᵢ = digitᵢ(K)`, so substituting
-the constant preserves the satisfying set. Completeness: a real trace's column literally holds that
-constant, so the `Constant` method reproduces it (`derivesWitness` holds). Dropped range checks are
-entailed (`digitᵢ(K) < Bᵢ`).
-
-**Expected impact.** ~40–65 of the 103 extra vars across the losing cases; flips ~6–10 losses to
-ties/wins (roughly 25 W / 42 L → ~32 W / 34 L, and lifts the thin +0.031 geomean variable lead).
-Top-priority axis.
+Census refresh needed before any build: the "+93 vars / 23 cases" figure predates #114/#117
+(apc_013 is now a variable tie).
 
 ---
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -126,6 +126,13 @@ higher proof cost than #1.
 
 ## Rejected / measured dead-ends (do not re-propose without re-measuring)
 
+- **Degree-bounded witness inlining + per-candidate degree planning (roadmap 4.7/4.10):** measured
+  **zero** corpus-wide (entry 79, alternation what-if through the real optimizer, cascade-capable).
+  Constant-coefficient nonlinear pivots barely exist post-optimization (4 on apc_051, 1 on keccak)
+  and all are blocked by the **bus payload bound** — the inlined variable is the bus-facing value,
+  beyond any booleanity legalization. The audit's deg-4 "near-misses" are conditional pivots
+  (already measured dead). Do not build; 4.10 only ever with a measured consumer.
+
 - **Result-zero XOR extraction (`[x,y,0,1] ⟹ x=y`):** **measured dead-end (entry 75).** The census
   behind the old idea #3(i) was stale: the *optimized* keccak circuit contains **zero** `[x,y,0,1]`
   interactions — every op-1 bitwise message carries a genuine XOR-result variable (XOR chaining), the

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,16 +1,17 @@
 # Ideas for future optimization passes
 
 Ranked by **expected benefit**. Effectiveness priority is **variables > bus interactions >
-constraints**, used as the tiebreak. With #2 landed (entry 77) and the coda byte-pair splitting
-(entry 78), the eth bus deficit (−0.001, the only trailing axis) and keccak's bus gap (+293) are
-the remaining aggregate gaps; both decompose into the smaller items below.
+constraints**, used as the tiebreak. With #2 landed (entry 77), the coda byte-pair splitting
+(entry 78), and the width-1→booleanity conversion (entry 81, which flipped the eth bus axis to a
+lead), keccak's bus gap (+225) is the remaining aggregate gap; it decomposes into the smaller
+items below.
 
-## Where we stand (measured on `c007db0`; keccak/eth refreshed for merged C4b #109, the bitwise byte-check cleanup (entry 75), the is-equal collapse (entry 76), and the coda byte-pair splitting (entry 78))
+## Where we stand (measured on `c007db0`; keccak/eth refreshed for merged C4b #109, the bitwise byte-check cleanup (entry 75), the is-equal collapse (entry 76), the coda byte-pair splitting (entry 78), and the width-1→booleanity conversion (entry 81))
 
 | benchmark | apc-optimizer | powdr | apc gap |
 |---|---|---|---|
-| **keccak** (`apc_001_pckeccak`) | 2025 v / 120 c / 2027 bus | 2021 / 186 / 1734 | vars **+4 (near parity)**, **bus +293** (memory at parity; wins constraints) |
-| **openvm-eth** (100-case agg / geo) | vars 4.518× / 3.837× · bus 3.479× / 2.753× | vars 4.092× / 3.787× · bus 3.480× / 2.822× | leads vars agg (geo +0.050); **trails bus by 0.001** |
+| **keccak** (`apc_001_pckeccak`) | 2025 v / 188 c / 1959 bus | 2021 / 186 / 1734 | vars **+4 (near parity)**, **bus +225** (memory at parity; constraints ~tied) |
+| **openvm-eth** (100-case agg / geo) | vars 4.518× / 3.837× · bus 3.497× / 2.759× | vars 4.092× / 3.787× · bus 3.480× / 2.822× | leads vars agg (geo +0.050); **leads bus agg by 0.018** |
 | **apc_010** (`pc0x200c18`) | 466 v / 251 c / 247 bus | 498 / 331 / 239 | wins vars+constraints, **bus +8** |
 
 C4b (#109, entry 74) closed the keccak *variable* gap to near-parity; the bitwise byte-check cleanup
@@ -20,7 +21,8 @@ signed-compare and constant-limb families, bus gap net ≈ +300). Both gaps deco
 structural families, each addressed by one idea below.
 
 - **keccak bus +614** = memory interior pairs +276 (landed, entry 77) · bitwise (bus 6) ≈ +212
-  (post entry-75 pack and entry-78 pair splitting) · width-1 range (bus 3) +68.
+  (post entry-75 pack and entry-78 pair splitting) · width-1 range **CONVERTED to booleanity
+  constraints (entry 81: −68 keccak / −89 eth bus)**.
 - **eth bus** = bitwise (reduced by entries 75/78; genuine-XOR checks remain) ·
   tupleRange +160 (22 cases) · memory +144 (15 cases) · varRange **−376** (apc already *wins* — do not touch).
 - **eth vars ~+243** = `rd_data` write-result limbs ~93 (23 cases) · comparison gadget ~130 markers/flags
@@ -67,8 +69,9 @@ net loss (premature emission racing the justification machinery, apc_005 class +
 keccak 2.4× runtime) while at the coda each drop is net ≤ −1 bus by construction. eth: **bus agg
 3.439× → 3.455×, 10 cases / −76 bus / 0 regressions** (apc_010 271 → 247 vs powdr 239);
 vars/constraints byte-neutral; runtime eth −2.5%, keccak +1.3%. Deliberately forgone: −6 keccak /
-−6 apc_100 reachable only by mid-cycle entailed matching. Residual keccak bus gap +338 = bitwise
-≈257 (genuine-XOR representation) + width-1 range 68 (→ booleanity conversion, see below) + ~13.
+−6 apc_100 reachable only by mid-cycle entailed matching. Residual keccak bus gap +225 (post
+entry-78 pair splitting and entry 81's width-1→booleanity conversion) = bitwise ≈212
+(genuine-XOR representation) + ~13.
 
 ---
 
@@ -108,11 +111,10 @@ higher proof cost than #1.
 
 ## Smaller follow-ups (worth landing, lower ceiling)
 
-- **Width-1 range-check → booleanity constraint** (`ZeroWidthRange` width-0 → width-1). `[e,1]` on a
-  var-range bus ⟹ `e·(e−1)=0`, drop the interaction. Equivalence (uses the existing `varRangeBus`
-  fact; degree 2, within bound). **keccak −68 bus** (bus 3 → powdr parity), variable-neutral; trades
-  68 bus for 68 constraints — a strict lexicographic win (bus ≻ constraints, and apc has 10.6× agg
-  constraint headroom).
+- **Width-1 range-check → booleanity constraint** — **LANDED (entry 81)**: `ZeroWidthRange`
+  width-0 → width-1, `[e,1]` on a var-range bus ⟹ `e·(e−1)=0`, drop the interaction.
+  **keccak −68 bus** (bus 3 → powdr parity) / **eth −89 bus**, variable-neutral; a strict
+  lexicographic win (bus ≻ constraints, and apc has ~2× agg constraint headroom).
 - **Widening tuple-range packing + `mem_ptr` high-limb sharing** (`tupleRangePass` + `MemoryUnify`).
   Pack `byte+byte`/`byte+over-wide` into one `TupleRangeChecker` guarded by `byteJustified` re-derival
   of the narrowed slot; share the provably-equal 13-bit high limb across same-base accesses. **eth
@@ -127,7 +129,7 @@ higher proof cost than #1.
 ## Rejected / measured dead-ends (do not re-propose without re-measuring)
 
 - **Degree-bounded witness inlining + per-candidate degree planning (roadmap 4.7/4.10):** measured
-  **zero** corpus-wide (entry 79, alternation what-if through the real optimizer, cascade-capable).
+  **zero** corpus-wide (entry 80, alternation what-if through the real optimizer, cascade-capable).
   Constant-coefficient nonlinear pivots barely exist post-optimization (4 on apc_051, 1 on keccak)
   and all are blocked by the **bus payload bound** — the inlined variable is the bus-facing value,
   beyond any booleanity legalization. The audit's deg-4 "near-misses" are conditional pivots

--- a/docs/log.md
+++ b/docs/log.md
@@ -2814,3 +2814,46 @@ bytePackLate → …`): the split transiently *increases* the bus count, so it m
 the size-decreasing cleanup fixpoint. No new `BusFacts`; the pass reuses the `bytePairBus`/
 `byteCheck` facts that `bytePackPass` was proven from. Build + proof integrity green
 ({propext, Classical.choice, Quot.sound}-only).
+### 79. Constant limb-decomposition folding (ideas.md #1): mechanism refuted by what-if — re-scoped, no pass built
+
+**Idea (ideas.md #1, the ranked-top variable lever).** Fold `rd_data`/PC-limb decompositions of
+compile-time constants: for an affine `Σ cᵢ·xᵢ = K` with range-bounded `xᵢ` and non-overlapping
+mixed-radix coefficients, the `xᵢ` are uniquely `K`'s digits — substitute and drop the range
+checks. Predicted ~40–65 vars over 23 cases.
+
+**Premise check (renders + a scratch `whatif41` pin-and-reoptimize command, since reverted).**
+The clean affine shape exists **only in the raw input** (e.g. apc_045's
+`imm_limbs__0 + 256·imm__1 + 65536·imm__2 = 16777200`) — Gauss consumes it in the first cycle,
+so a cycle-placed pass never sees it and a prelude-placed pass sees *only* that slice. The
+faithful what-if (pin the strictly-decreasing-coefficient digit solutions, re-run the full
+pipeline): **apc_045 −2 vars, apc_026 −3, apc_013 0** — against powdr gaps of +14/+14/0 on those
+cases. An optimistic first cut had claimed −54/−141/−154, which decomposed into exactly 8
+equations × 5 pins of `Σ flagᵢ = 1` **one-hot selector sums** (all-(−1) coefficients — not
+uniquely forced; pinning them is unsound and collapses the selector logic). Filter those and the
+mechanism is nearly empty.
+
+**Where the +14-per-case really lives** (apc_045 anatomy, confirmed against powdr's render,
+which folds every one of these limbs to literals — write payload `[…, 20, 66, 41, 0, …]`, jump
+target `2701288`):
+- ~3 vars: a *bounded-payload* idiom — the memory write carries
+  `2703892 − 256·rd₀ − 65536·rd₁ − 16777216·rd₂` and a bitwise pair check asserts it is a byte;
+  with the limbs' range checks this forces the digits (verified by hand: exactly powdr's values).
+  A recognizer needs bus-side byte facts + payload linearization, not constraint matching.
+- ~11 vars: **guarded two-root carry chains** (`is_valid·(L)·(c·L − 1) = 0` in the input,
+  normalized mid-pipeline to `(L − r₁)(L − r₂) = 0` with **both roots inside the operands'
+  interval** — e.g. roots −200/+56 for `b − a ∈ (−256, 256)`). No single constraint
+  disambiguates; only the joint chain plus the range facts does. Measured: seeding the constants
+  from the affine slice does **not** cascade (pinned apc_045 stays at 93 vars — `carryBranch`
+  cannot use the tighter constants because per-constraint both roots stay feasible). This is
+  multi-constraint interval/relational reasoning — ideas.md #6-class (finite-domain relational
+  saturation), not a digit lemma.
+
+**Outcome: no pass built; idea re-scoped in ideas.md** (the affine slice is not worth a pass at
+−2/−3/0; the real lever is re-classified as high-effort chain reasoning). The census total
+(~93 vars / 23 cases) also needs a refresh — apc_013 is a variable *tie* with powdr post-#114.
+Worked: the premise check did — mechanism refuted for the cost of a render + a ~40-line scratch
+command, before any proof work. Second instance of the pattern from the result-zero entry:
+**recorded mechanisms go stale or were never render-verified; check the shape on current output
+first.**
+
+**Impact: none (no code landed).**

--- a/docs/log.md
+++ b/docs/log.md
@@ -2857,3 +2857,46 @@ command, before any proof work. Second instance of the pattern from the result-z
 first.**
 
 **Impact: none (no code landed).**
+
+### 79. Degree-bounded witness inlining + per-candidate degree planning: measured zero — dead-end
+
+**Idea (roadmap 4.7 + 4.10; Dead-ends §9's re-measure caveat).** Inline a variable with a
+constant-coefficient linear pivot whose solved RHS is nonlinear (`c := a·b`), per-candidate
+degree-gated, with `BoxRewrite` legalization (`b² → b`) re-opening previously degree-blocked
+substitutions. Historically "the biggest sound variable gap", parked pending re-measurement on
+top of the legalizer.
+
+**Instrument: an alternation what-if, not a static census** (a survivor count would be blind to
+mid-pipeline shapes and cascades). Scratch `whatif47` (since reverted): find constant-coefficient
+pivots with RHS degree ≥ 2 (affine RHS is Gauss's territory; where Gauss declines it is
+deliberate range-knowledge policy), substitute system-wide, legalize with the *proven*
+`ConstraintSystem.boxRewrite`, accept iff `withinDegreeB` — then alternate with the full real
+optimizer to a joint fixpoint, so any accepted inlining seeds another optimization round.
+
+**Result: zero accepted inlinings on all 100 openvm-eth cases and keccak.** The candidate
+population is itself nearly empty:
+- apc_051 (flagship degree-blocked case): **4 candidates** — `write_data` limbs with deg-3 mux
+  RHS — all rejected because the substitution lands in a **memory-bus payload (bound 2)**, a
+  structural wall no booleanity rewrite can cross: the variable being inlined *is* the
+  bus-facing value. (This family's bus-side cost was already addressed by #117's entailed
+  matching; the variable itself is not eliminable.)
+- keccak: **1 candidate** (the is-equal `cmp_result`, deg-3 sum-of-squares RHS) — same rejection.
+- The audit's 98 deg-4-vs-3 "near-misses" never appear as candidates: their pivot coefficients
+  are *expressions* (the conditional/mux class), excluded from 4.7 by definition and measured
+  unexploitable by the entry-75 cond sweep (all deg-4-blocked, powdr keeps them all).
+
+**Blind spots, stated:** (a) conditional/expression-coefficient pivots — covered by the prior
+cond-exploitability sweep (mux/inv/nzk = 0); (b) multi-constraint pivot synthesis beyond mux —
+uncharted, no positive signal anywhere; (c) mid-cycle-transient definitions — small by
+construction here, since nonlinear definitions are precisely what no cycle pass consumes.
+(A first instinct — counting legalizable pivots on final outputs — was rejected during design
+review as false-negative-prone; the alternation harness closes the survivor-bias and cascade
+gaps.)
+
+**Conclusion: do not build 4.7; do not build 4.10 without a consumer** (its standalone value —
+rescuing other passes' whole-pass `guardDegree` reverts — remains unmeasured, but framework
+without a beneficiary is not effectiveness work). The degree-blocked survivor band is
+payload-bound and conditional-pivot mass, not legalizable witness definitions.
+
+**Impact: none (no code landed).** Worked: the measurement did — a corpus-wide refutation with
+explicit blind-spot accounting, for the cost of a ~100-line scratch harness.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2858,7 +2858,7 @@ first.**
 
 **Impact: none (no code landed).**
 
-### 79. Degree-bounded witness inlining + per-candidate degree planning: measured zero — dead-end
+### 80. Degree-bounded witness inlining + per-candidate degree planning: measured zero — dead-end
 
 **Idea (roadmap 4.7 + 4.10; Dead-ends §9's re-measure caveat).** Inline a variable with a
 constant-coefficient linear pivot whose solved RHS is nonlinear (`c := a·b`), per-candidate
@@ -2900,3 +2900,34 @@ payload-bound and conditional-pivot mass, not legalizable witness definitions.
 
 **Impact: none (no code landed).** Worked: the measurement did — a corpus-wide refutation with
 explicit blind-spot accounting, for the cost of a ~100-line scratch harness.
+
+### 81. Width-1 range check → booleanity constraint
+
+**Idea (the first slice of lookup→constraint conversion; ideas.md follow-up of entry 77).** A
+width-1 range check `[e, 1]` on the variable range checker asserts `e < 2` — booleanity. Convert
+it to the degree-2 algebraic constraint `e·(e−1) = 0` and drop the interaction: a strict
+lexicographic win (bus ≻ constraints, and constraint headroom is ~2× powdr), and the booleanity
+feeds the finite-domain passes.
+
+**Change (extend `zeroWidthRangePass`; no new pass, no new facts).** `ZeroWidthRange.lean`'s
+recognizer generalizes to `rangeEq?` with a width-1 arm built on the *existing* mult-generic
+`BusFacts.varRangeBus` iff. The equivalence's backward direction (`x·(x−1) = 0 → x.val < 2`,
+`val_lt_two_iff`) needs an integral domain, so the arm is gated on `decide (Nat.Prime p)` per
+invocation (the `deep`/`hdeep` pattern), and a **per-candidate degree gate** (`e.degree ≤ 1`, so
+the emitted constraint is degree ≤ 2) ensures the arm can never trip the whole-pass
+`guardDegree` revert — the transactional-degree lesson from entry 80 applied preemptively.
+
+**Measured vs `main` = #119 (`9c92008`, per-case JSON A/B; re-measured after rebase over the
+entry-78 byte-pair splitting — per-case deltas identical to the pre-rebase measurement vs #117,
+the two are fully independent):**
+- keccak: bus **2027 → 1959 (−68)**, constraints 120 → 188 (+68), vars 2025 unchanged — bus
+  effectiveness 6.543× → **6.770×**; bus gap to powdr now **+225** (memory at parity since entry
+  77; the residual is genuine-XOR bitwise ≈212 + ~13 misc). Runtime flat (−0%).
+- openvm-eth: bus agg **3.479× → 3.497×** (geo 2.753× → 2.759×) — powdr bus gap
+  **−0.001 → +0.018: the last trailing aggregate axis flips to a lead** (apc 16638 vs powdr
+  16722 total bus); 4 cases improved (apc_100 −40, apc_037 −25, apc_038/051 −12), −89 bus /
+  +90 constraints / **0 regressions**; variables byte-neutral (4.518×, W/L/T 27/29/44
+  unchanged); constraints agg 10.595× → 10.511× (powdr 5.853×).
+
+Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
+**Worked: yes.**


### PR DESCRIPTION
## What

Extends `zeroWidthRangePass` with a **width-1 arm**: a range check `[e, 1]` on the variable range checker is accepted iff `e < 2` — booleanity — so it converts to the degree-2 algebraic constraint `e·(e−1) = 0` and the interaction is dropped. A strict lexicographic win (bus ≻ constraints, and constraint headroom vs powdr is large); the booleanity also feeds the finite-domain passes. No new pass, no new `BusFacts` — the width-1 iff comes from the existing mult-generic `varRangeBus` fact.

Two guards worth noting:
- the equivalence's backward direction (`x·(x−1) = 0 → x < 2`) needs an integral domain, so the arm gates on `decide (Nat.Prime p)` per invocation (the `deep`/`hdeep` pattern);
- a **per-candidate degree gate** (`e.degree ≤ 1`) keeps every emitted constraint at degree ≤ 2, so the arm can never trip the whole-pass `guardDegree` revert.

## Effectiveness (per-case JSON A/B vs main = #119 `9c92008`, re-measured after rebase)

Per-case deltas are identical to the pre-rebase measurement vs #117 — the win is fully independent of the entry-78 byte-pair splitting.

- **keccak: bus 2027 → 1959 (−68)** — bus effectiveness 6.543× → **6.770×**; gap to powdr now +225 (memory already at parity via #117; the residual is the genuine-XOR representation ≈212 + ~13 misc). Constraints 120 → 188; vars 2025 unchanged; runtime flat.
- **openvm-eth: bus agg 3.479× → 3.497×** (geo 2.753× → 2.759×) — the powdr bus gap goes **−0.001 → +0.018: the last trailing aggregate axis flips to a lead** (apc 16638 vs powdr 16722 total bus); 4 cases improved (apc_100 −40, apc_037 −25, apc_038/051 −12), −89 bus / +90 constraints / **0 regressions**; variables byte-neutral (4.518×, W/L/T 27/29/44 unchanged).

Build green; `check-proof-integrity.sh` passes ({propext, Classical.choice, Quot.sound}-only).

## Also included: two docs-only negative results (log entries 79–80)

- **Constant limb-decomposition folding (ideas.md #1, the ranked-top variable idea): mechanism refuted by a faithful what-if.** The clean affine `Σ cᵢ·xᵢ = K` equations exist only in the raw input and net −2/−3/0 vars on the flagship cases; the real +14/case gap vs powdr lives in a bounded-payload digit idiom (~3 vars/case) and guarded two-root carry chains needing joint multi-constraint interval reasoning (an optimistic what-if claiming −54/−141/−154 traced to unsoundly pinning one-hot selector sums). ideas.md #1 re-scoped accordingly.
- **Degree-bounded witness inlining + per-candidate degree planning: measured zero corpus-wide.** A cascade-capable alternation what-if (inline + certified `boxRewrite` legalization, alternated with the full optimizer to a joint fixpoint) accepted **0 inlinings on all 100 eth cases and keccak** — the few constant-coefficient nonlinear pivots that exist are blocked by the bus *payload* bound (the variable is the bus-facing value), beyond any booleanity legalization. Recorded as a dead-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
