### PR TITLE
Bounded-payload digit fold: -165 eth vars / keccak variable parity, 0 regressions

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -32,6 +32,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.SubsumedRange
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 import ApcOptimizer.Implementation.OptimizerPasses.SplitBytePair
+import ApcOptimizer.Implementation.OptimizerPasses.DigitFold
 
 set_option autoImplicit false
 
@@ -90,6 +91,7 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
     ("normalize2", normalizePass.withFacts.guardDegree),
     ("constFold2", constantFoldPass.withFacts.guardDegree),
     ("zeroRegister", zeroRegisterPass.guardDegree),
+    ("digitFold", DigitFold.digitFoldPass.guardDegree),
     ("hintCollapse", hintCollapsePass.guardDegree),
     ("rootPairUnify", rootPairUnifyPass.guardDegree),
     ("flagUnify", flagUnifyPass.guardDegree),

--- a/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
@@ -1,0 +1,482 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+import ApcOptimizer.Implementation.OptimizerPasses.Subst
+import ApcOptimizer.Implementation.OptimizerPasses.Affine
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # Bounded-payload digit fold (constant limb decomposition via byte checks)
+
+Optimized blocks keep families of witness limbs that are in fact *compile-time constants*: a
+byte check (bitwise pair check, or any bus fact asserting a payload value is a byte) is applied
+to an affine expression
+
+    `E = K ± (g·v₀ + 256g·v₁ + 65536g·v₂ + …)`    (a scaled base-256 "ladder"),
+
+whose variables `vᵢ` each carry their own range check `vᵢ < Bᵢ ≤ 256`. Writing `S` for the
+ladder's ℕ-value, the byte check pins `(K ± S mod p)` to a byte `b < 256`, so over ℕ
+
+    `S = tval(b) + m·p`   for some byte `b` and wrap count `m ≤ maxM/p`.
+
+Enumerating the whole `(b, m)` grid and decoding each admissible `M` as a bounded base-256
+ladder yields the *complete* set of digit vectors any satisfying assignment can take. When that
+set is a **singleton** `[d⃗]`, every `vᵢ` is forced to the constant `dᵢ` — the pass substitutes
+`v₀ := d₀` (one variable per invocation; the cleanup fixpoint re-solves the shrunken ladder and
+converges), and the now-entailed range checks are dropped by the existing cleanup passes.
+
+The wrap analysis is essential: `p ≡ 1 (mod 256)` for BabyBear, so each wrap count `m` admits a
+digit-vector candidate — narrow range checks on the high limbs (e.g. the 6-bit top PC limb) are
+what kill the phantoms. The enumeration is exact and generic (no OpenVM specifics): it fires
+precisely when byte-check + range facts force uniqueness.
+
+Correctness: the ℕ-side `solutions_complete` theorem shows any satisfying assignment's digit
+vector appears in the enumerated set; with the singleton check this forces `env v₀ = d₀`, and
+`ConstraintSystem.subst_correct` turns that into a `PassCorrect`. -/
+
+namespace DigitFold
+
+/-! ## ℕ-side ladder arithmetic -/
+
+/-- Little-endian base-256 positional value of a digit list. -/
+def ladderVal : List ℕ → ℕ
+  | [] => 0
+  | x :: xs => x + 256 * ladderVal xs
+
+/-- Decode `T` as `Bs.length` base-256 digits (little-endian) with exclusive digit bounds `Bs`,
+    requiring the final quotient to vanish; `none` if any digit breaches its bound. -/
+def unpack? : List ℕ → ℕ → Option (List ℕ)
+  | [], T => if T = 0 then some [] else none
+  | B :: Bs, T =>
+    if T % 256 < B then (unpack? Bs (T / 256)).map (T % 256 :: ·) else none
+
+/-- Decoding is a retraction of the positional value on bounded digit lists. -/
+theorem unpack?_ladderVal : ∀ (xs Bs : List ℕ), List.Forall₂ (· < ·) xs Bs →
+    (∀ B ∈ Bs, B ≤ 256) → unpack? Bs (ladderVal xs) = some xs := by
+  intro xs Bs h
+  induction h with
+  | nil => intro _; rfl
+  | @cons x B xs Bs hxB _ ih =>
+    intro hB
+    have hx256 : x < 256 := lt_of_lt_of_le hxB (hB B (by simp))
+    have hmod : (x + 256 * ladderVal xs) % 256 = x := by
+      rw [Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hx256]
+    have hdiv : (x + 256 * ladderVal xs) / 256 = ladderVal xs := by
+      rw [Nat.add_mul_div_left _ _ (by norm_num : 0 < 256), Nat.div_eq_of_lt hx256, Nat.zero_add]
+    simp only [ladderVal, unpack?, hmod, hdiv, if_pos hxB,
+      ih (fun B hBmem => hB B (by simp [hBmem]))]
+    rfl
+
+/-- Positional value is monotone into the bound box. -/
+theorem ladderVal_le_box : ∀ (xs Bs : List ℕ), List.Forall₂ (· < ·) xs Bs →
+    ladderVal xs ≤ ladderVal (Bs.map (· - 1)) := by
+  intro xs Bs h
+  induction h with
+  | nil => exact le_refl _
+  | @cons x B xs Bs hxB _ ih =>
+    simp only [ladderVal, List.map_cons]
+    have hx : x ≤ B - 1 := Nat.le_sub_one_of_lt hxB
+    exact Nat.add_le_add hx (Nat.mul_le_mul_left _ ih)
+
+/-! ## The (byte, wrap) solution grid -/
+
+/-- All digit vectors compatible with "the checked value is a byte": for each possible byte `b`
+    and wrap count `m`, decode `tval b + m·p` as a `g`-scaled bounded ladder. `tval b` is the
+    ℕ-residue the ladder sum must have when the byte reads `b` (supplied by the caller from the
+    ZMod arithmetic). -/
+def solutions (p : ℕ) (tval : ℕ → ℕ) (g : ℕ) (Bs : List ℕ) (maxM : ℕ) : List (List ℕ) :=
+  (List.range 256).flatMap fun b =>
+    (List.range (maxM / p + 1)).filterMap fun m =>
+      let M := tval b + m * p
+      if M % g = 0 ∧ M ≤ maxM then unpack? Bs (M / g) else none
+
+/-- Completeness of the grid: the digit vector of any assignment whose ladder sum `g·ladderVal xs`
+    has residue `tval b` (for its byte value `b < 256`) and fits under `maxM` is enumerated. -/
+theorem solutions_complete (p : ℕ) (tval : ℕ → ℕ) (g : ℕ) (Bs : List ℕ) (maxM : ℕ)
+    (hp : 0 < p) (hg : 0 < g)
+    (xs : List ℕ) (hxB : List.Forall₂ (· < ·) xs Bs) (hB : ∀ B ∈ Bs, B ≤ 256)
+    (b : ℕ) (hb : b < 256)
+    (hmod : (g * ladderVal xs) % p = tval b) (hle : g * ladderVal xs ≤ maxM) :
+    xs ∈ solutions p tval g Bs maxM := by
+  set S := g * ladderVal xs with hS
+  have hSsplit : tval b + S / p * p = S := by
+    rw [← hmod, Nat.mod_add_div' S p]
+  have hm : S / p < maxM / p + 1 :=
+    Nat.lt_succ_of_le (Nat.div_le_div_right hle)
+  refine List.mem_flatMap.2 ⟨b, List.mem_range.2 hb, ?_⟩
+  refine List.mem_filterMap.2 ⟨S / p, List.mem_range.2 hm, ?_⟩
+  have hMg : S % g = 0 := by
+    rw [hS]; exact Nat.mul_mod_right g _
+  have hMdiv : S / g = ladderVal xs := by
+    rw [hS]; exact Nat.mul_div_cancel_left _ hg
+  rw [hSsplit, if_pos ⟨hMg, hle⟩, hMdiv]
+  exact unpack?_ladderVal xs Bs hxB hB
+
+/-- The payoff: a singleton grid forces the digit vector. -/
+theorem solutions_forced (p : ℕ) (tval : ℕ → ℕ) (g : ℕ) (Bs : List ℕ) (maxM : ℕ)
+    (hp : 0 < p) (hg : 0 < g) (ds : List ℕ)
+    (hsol : solutions p tval g Bs maxM = [ds])
+    (xs : List ℕ) (hxB : List.Forall₂ (· < ·) xs Bs) (hB : ∀ B ∈ Bs, B ≤ 256)
+    (b : ℕ) (hb : b < 256)
+    (hmod : (g * ladderVal xs) % p = tval b) (hle : g * ladderVal xs ≤ maxM) :
+    xs = ds := by
+  have := solutions_complete p tval g Bs maxM hp hg xs hxB hB b hb hmod hle
+  rw [hsol, List.mem_singleton] at this
+  exact this
+
+variable {p : ℕ}
+
+/-! ## Ladder recognition on linear forms -/
+
+/-- The ℕ-coefficient of a term under a sign interpretation: `c.val` when the ladder is added to
+    the constant, `(-c).val` when it is subtracted. -/
+def coeffNat (pos : Bool) (c : ZMod p) : ℕ := if pos then c.val else (-c).val
+
+/-- Check that the (sorted) terms carry the exact coefficient ladder `n, 256n, 65536n, …`. -/
+def isLadder (pos : Bool) : ℕ → List (Variable × ZMod p) → Bool
+  | _, [] => true
+  | n, (_, c) :: rest => coeffNat pos c == n && isLadder pos (256 * n) rest
+
+/-- The ladder's sign as a field element. -/
+def signum (pos : Bool) : ZMod p := if pos then 1 else -1
+
+@[simp] theorem signum_true : (signum true : ZMod p) = 1 := rfl
+@[simp] theorem signum_false : (signum false : ZMod p) = -1 := rfl
+
+/-- A ladder's ZMod sum is the cast of its ℕ positional value (up to the sign). -/
+theorem isLadder_sum [NeZero p] (pos : Bool) :
+    ∀ (g : ℕ) (l : List (Variable × ZMod p)), isLadder pos g l = true →
+    ∀ (env : Variable → ZMod p),
+    (l.map (fun t => t.2 * env t.1)).sum =
+      signum pos * ((g * ladderVal (l.map (fun t => (env t.1).val)) : ℕ) : ZMod p) := by
+  intro g l
+  induction l generalizing g with
+  | nil => intro _ env; simp [ladderVal]
+  | cons t rest ih =>
+    intro h env
+    obtain ⟨v, c⟩ := t
+    simp only [isLadder, Bool.and_eq_true, beq_iff_eq] at h
+    obtain ⟨hc, hrest⟩ := h
+    have hsum := ih (256 * g) hrest env
+    simp only [List.map_cons, List.sum_cons, hsum, ladderVal]
+    have henv : env v = (((env v).val : ℕ) : ZMod p) := (ZMod.natCast_rightInverse (env v)).symm
+    cases pos with
+    | true =>
+      have hcv : c = ((g : ℕ) : ZMod p) := by
+        rw [← hc]
+        exact (ZMod.natCast_rightInverse c).symm
+      rw [hcv, signum_true]
+      conv_lhs => rw [henv]
+      push_cast
+      ring
+    | false =>
+      have hcv : -c = ((g : ℕ) : ZMod p) := by
+        rw [← hc]
+        exact (ZMod.natCast_rightInverse (-c)).symm
+      have hcv' : c = -((g : ℕ) : ZMod p) := by rw [← hcv]; ring
+      rw [hcv', signum_false]
+      conv_lhs => rw [henv]
+      push_cast
+      ring
+
+/-- The ℕ-residue the ladder sum must have when the byte-checked value reads `b`. -/
+def tval (pos : Bool) (K : ZMod p) (b : ℕ) : ℕ :=
+  (if pos then (b : ZMod p) - K else K - (b : ZMod p)).val
+
+/-- The env-side forcing theorem: if the solution grid for a byte-checked ladder is the singleton
+    `[ds]`, any satisfying assignment's digit vector is exactly `ds`. -/
+theorem env_forced [NeZero p] (hp : 256 < p) (pos : Bool) (g : ℕ) (hg : 0 < g) (K : ZMod p)
+    (l : List (Variable × ZMod p)) (hlad : isLadder pos g l = true)
+    (Bs : List ℕ) (hB : ∀ B ∈ Bs, B ≤ 256)
+    (env : Variable → ZMod p)
+    (hbound : List.Forall₂ (fun (t : Variable × ZMod p) B => (env t.1).val < B) l Bs)
+    (hbyte : ((K + (l.map (fun t => t.2 * env t.1)).sum).val) < 256)
+    (ds : List ℕ)
+    (hsol : solutions p (tval pos K) g Bs (g * ladderVal (Bs.map (· - 1))) = [ds]) :
+    l.map (fun t => (env t.1).val) = ds := by
+  have hp0 : 0 < p := by omega
+  have hxB : List.Forall₂ (· < ·) (l.map (fun t => (env t.1).val)) Bs := by
+    rw [List.forall₂_map_left_iff]
+    exact hbound
+  have hsum := isLadder_sum pos g l hlad env
+  have hEvcast : (((K + (l.map (fun t => t.2 * env t.1)).sum).val : ℕ) : ZMod p)
+      = K + (l.map (fun t => t.2 * env t.1)).sum :=
+    ZMod.natCast_rightInverse _
+  have hmod : (g * ladderVal (l.map (fun t => (env t.1).val))) % p
+      = tval pos K ((K + (l.map (fun t => t.2 * env t.1)).sum).val) := by
+    have hvalS : (((g * ladderVal (l.map (fun t => (env t.1).val)) : ℕ)) : ZMod p).val
+        = g * ladderVal (l.map (fun t => (env t.1).val)) % p := by
+      rw [ZMod.val_natCast]
+    rw [← hvalS]
+    unfold tval
+    congr 1
+    rw [hEvcast]
+    cases pos with
+    | true =>
+      rw [hsum, signum_true, one_mul]
+      simp
+    | false =>
+      rw [hsum, signum_false]
+      simp only [Bool.false_eq_true, if_false]
+      ring
+  have hle : g * ladderVal (l.map (fun t => (env t.1).val))
+      ≤ g * ladderVal (Bs.map (· - 1)) :=
+    Nat.mul_le_mul_left g (ladderVal_le_box _ Bs hxB)
+  exact solutions_forced p (tval pos K) g Bs _ hp0 hg ds hsol _ hxB hB
+    ((K + (l.map (fun t => t.2 * env t.1)).sum).val) hbyte hmod hle
+
+/-! ## The driver: recognize byte-checked ladders and fire a substitution -/
+
+
+/-- Recognize a packed bitwise pair check `[x, y, 0, 0]` at multiplicity `1` on a bus with both
+    the pair and self-check facts: acceptance asserts both operands are bytes. -/
+def pairByteOps? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p × Expression p) :=
+  match bi.payload with
+  | [x, y, Expression.const z, Expression.const w] =>
+    if facts.bytePairBus bi.busId = true ∧ facts.byteCheck bi.busId = true
+        ∧ z = 0 ∧ w = 0 ∧ bi.multiplicity = Expression.const 1
+    then some (x, y) else none
+  | _ => none
+
+/-- Acceptance of a recognized pair check bounds both operands below 256. -/
+theorem pairByteOps?_bytes (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x y : Expression p)
+    (h : pairByteOps? bs facts bi = some (x, y))
+    (h1 : (1 : ZMod p) ≠ 0) (env : Variable → ZMod p)
+    (hacc : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
+    (x.eval env).val < 256 ∧ (y.eval env).val < 256 := by
+  unfold pairByteOps? at h
+  split at h
+  · rename_i xe ye z w hpay
+    split_ifs at h with hcond
+    obtain ⟨hpair, hbyte, hz, hw, hm⟩ := hcond
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    have heval : bi.eval env =
+        { busId := bi.busId, multiplicity := 1, payload := [xe.eval env, ye.eval env, 0, 0] } := by
+      unfold BusInteraction.eval
+      rw [hm, hpay, hz, hw]
+      simp [Expression.eval]
+    rw [heval] at hacc
+    have hviol := hacc (by simpa using h1)
+    have hpairIff := (facts.bytePairBus_sound bi.busId hpair).2.2
+      (xe.eval env) (ye.eval env) 1
+    have hself := hpairIff.1 hviol
+    have hxIff := ((facts.byteCheck_sound bi.busId hbyte).2.2 (xe.eval env) 1).1 hself.1
+    have hyIff := ((facts.byteCheck_sound bi.busId hbyte).2.2 (ye.eval env) 1).1 hself.2
+    exact ⟨hxIff, hyIff⟩
+  · exact absurd h (by simp)
+
+/-- Sort a linear form's terms by the sign-interpreted coefficient and check the ladder shape;
+    returns the leading ℕ-coefficient and the sorted terms. -/
+def tryLadder (pos : Bool) (terms : List (Variable × ZMod p)) :
+    Option (ℕ × List (Variable × ZMod p)) :=
+  match terms.mergeSort (fun a b => coeffNat pos a.2 ≤ coeffNat pos b.2) with
+  | [] => none
+  | t :: rest =>
+    if 0 < coeffNat pos t.2 ∧ isLadder pos (coeffNat pos t.2) (t :: rest) = true
+    then some (coeffNat pos t.2, t :: rest) else none
+
+theorem tryLadder_spec (pos : Bool) (terms : List (Variable × ZMod p))
+    (g : ℕ) (sorted : List (Variable × ZMod p))
+    (h : tryLadder pos terms = some (g, sorted)) :
+    terms.Perm sorted ∧ 0 < g ∧ isLadder pos g sorted = true := by
+  unfold tryLadder at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i t rest hms
+    split_ifs at h with hcond
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    have hperm : (terms.mergeSort (fun a b => coeffNat pos a.2 ≤ coeffNat pos b.2)).Perm terms :=
+      List.mergeSort_perm terms _
+    rw [hms] at hperm
+    exact ⟨hperm.symm, hcond.1, hcond.2⟩
+
+/-- Look up a fact-derived bound `≤ 256` for every ladder variable, in order. -/
+def lookupBounds (bounds : Std.HashMap Variable Nat) :
+    List (Variable × ZMod p) → Option (List ℕ)
+  | [] => some []
+  | (v, _) :: rest =>
+    match bounds[v]? with
+    | some B => if B ≤ 256 then (lookupBounds bounds rest).map (B :: ·) else none
+    | none => none
+
+theorem lookupBounds_spec (bounds : Std.HashMap Variable Nat) :
+    ∀ (l : List (Variable × ZMod p)) (Bs : List ℕ), lookupBounds bounds l = some Bs →
+    (∀ B ∈ Bs, B ≤ 256) ∧
+      List.Forall₂ (fun (t : Variable × ZMod p) B => bounds[t.1]? = some B) l Bs := by
+  intro l
+  induction l with
+  | nil =>
+    intro Bs h
+    simp only [lookupBounds, Option.some.injEq] at h
+    subst h
+    exact ⟨by simp, List.Forall₂.nil⟩
+  | cons t rest ih =>
+    intro Bs h
+    obtain ⟨v, c⟩ := t
+    simp only [lookupBounds] at h
+    split at h
+    · rename_i B hB
+      split_ifs at h with hle
+      obtain ⟨Bs', hBs', rfl⟩ := Option.map_eq_some_iff.1 h
+      obtain ⟨h256, hall⟩ := ih Bs' hBs'
+      refine ⟨?_, List.Forall₂.cons hB hall⟩
+      intro B' hB'
+      rcases List.mem_cons.1 hB' with rfl | hB'
+      · exact hle
+      · exact h256 B' hB'
+    · exact absurd h (by simp)
+
+/-- Attempt one sign interpretation on a linearized operand: ladder-match, collect bounds,
+    enumerate the grid; on a singleton return the lowest-coefficient variable and its digit. -/
+def attemptLadder (pos : Bool) (bounds : Std.HashMap Variable Nat) (l : LinExpr p) :
+    Option (Variable × ℕ) :=
+  match tryLadder pos l.terms with
+  | none => none
+  | some gs =>
+    match lookupBounds bounds gs.2 with
+    | none => none
+    | some Bs =>
+      match solutions p (tval pos l.const) gs.1 Bs (gs.1 * ladderVal (Bs.map (· - 1))) with
+      | [ds] =>
+        match gs.2, ds with
+        | t :: _, d :: _ => some (t.1, d)
+        | _, _ => none
+      | _ => none
+
+theorem attemptLadder_sound [NeZero p] (hp : 256 < p)
+    {cs : ConstraintSystem p} {bs : BusSemantics p} (bm : BoundsMap p cs bs)
+    (pos : Bool) (l : LinExpr p) (v : Variable) (d : ℕ)
+    (h : attemptLadder pos bm.map l = some (v, d))
+    (env : Variable → ZMod p)
+    (hbus : ∀ bi ∈ cs.busInteractions, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false)
+    (hbyte : (l.eval env).val < 256) :
+    env v = (d : ZMod p) := by
+  unfold attemptLadder at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i gs hladder
+    split at h
+    · exact absurd h (by simp)
+    · rename_i Bs hbounds
+      split at h
+      · rename_i hsol'
+        split at h
+        · rename_i t htail d' dtail hsorted
+          simp only [Option.some.injEq, Prod.mk.injEq] at h
+          obtain ⟨rfl, rfl⟩ := h
+          obtain ⟨hperm, hg, hlad⟩ := tryLadder_spec pos l.terms gs.1 gs.2 hladder
+          obtain ⟨h256, hbmap⟩ := lookupBounds_spec bm.map gs.2 Bs hbounds
+          -- env-level bounds from the BoundsMap
+          have hbound : List.Forall₂ (fun (t : Variable × ZMod p) B => (env t.1).val < B)
+              gs.2 Bs :=
+            hbmap.imp (fun {t} {B} hlk => bm.sound env hbus t.1 B hlk)
+          -- the linear form's value over sorted terms
+          have hsumeq : (l.terms.map (fun t => t.2 * env t.1)).sum
+              = (gs.2.map (fun t => t.2 * env t.1)).sum :=
+            (hperm.map (fun t => t.2 * env t.1)).sum_eq
+          have hbyte' : ((l.const + (gs.2.map (fun t => t.2 * env t.1)).sum).val) < 256 := by
+            have hev : l.eval env = l.const + (gs.2.map (fun t => t.2 * env t.1)).sum := by
+              rw [LinExpr.eval, hsumeq]
+            rwa [hev] at hbyte
+          have hforced := env_forced hp pos gs.1 hg l.const gs.2 hlad Bs h256 env hbound
+            hbyte' (d' :: dtail) hsol'
+          -- extract the head digit
+          rw [hsorted] at hforced
+          simp only [List.map_cons, List.cons.injEq] at hforced
+          have hv : (env t.1).val = d' := hforced.1
+          rw [← hv]
+          exact (ZMod.natCast_rightInverse (env t.1)).symm
+        · exact absurd h (by simp)
+      · exact absurd h (by simp)
+
+/-- Solve one byte-checked operand: linearize, then try both sign interpretations. -/
+def solveOperand (bounds : Std.HashMap Variable Nat) (E : Expression p) :
+    Option (Variable × ℕ) :=
+  match linearize E with
+  | none => none
+  | some l =>
+    -- the idiom needs at least two ladder digits; length-1 "ladders" are every plain
+    -- byte-checked variable, and enumerating their grids is pure overhead
+    if l.terms.length < 2 then none
+    else
+      match attemptLadder true bounds l with
+      | some r => some r
+      | none => attemptLadder false bounds l
+
+theorem solveOperand_sound [NeZero p] (hp : 256 < p)
+    {cs : ConstraintSystem p} {bs : BusSemantics p} (bm : BoundsMap p cs bs)
+    (E : Expression p) (v : Variable) (d : ℕ)
+    (h : solveOperand bm.map E = some (v, d))
+    (env : Variable → ZMod p)
+    (hbus : ∀ bi ∈ cs.busInteractions, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false)
+    (hbyte : (E.eval env).val < 256) :
+    env v = (d : ZMod p) := by
+  unfold solveOperand at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i l hlin
+    have hEl : E.eval env = l.eval env := linearize_eval E l hlin env
+    rw [hEl] at hbyte
+    split_ifs at h
+    split at h
+    · rename_i r hr
+      simp only [Option.some.injEq] at h
+      subst h
+      exact attemptLadder_sound hp bm true l v d hr env hbus hbyte
+    · exact attemptLadder_sound hp bm false l v d h env hbus hbyte
+
+/-- A forced substitution: a variable, its constant value, and the entailment proof. -/
+structure Fold (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
+  v : Variable
+  d : ℕ
+  sound : ∀ env, cs.satisfies bs env → env v = (d : ZMod p)
+
+/-- Scan the interactions for a byte-checked ladder operand with a forced digit. -/
+def findFold [NeZero p] (hp : 256 < p) {cs : ConstraintSystem p} {bs : BusSemantics p}
+    (facts : BusFacts p bs) (bm : BoundsMap p cs bs) :
+    (pending : List (BusInteraction (Expression p))) →
+    (∀ bi ∈ pending, bi ∈ cs.busInteractions) → Option (Fold p cs bs)
+  | [], _ => none
+  | bi :: rest, hmem =>
+    let hbi := hmem bi (List.mem_cons_self ..)
+    let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
+    have h1 : (1 : ZMod p) ≠ 0 := by
+      haveI : Fact (1 < p) := ⟨by omega⟩
+      exact one_ne_zero
+    match hop : pairByteOps? bs facts bi with
+    | none => findFold hp facts bm rest hrest
+    | some (x, y) =>
+      match hx : solveOperand bm.map x with
+      | some (v, d) =>
+        some ⟨v, d, fun env hsat =>
+          solveOperand_sound hp bm x v d hx env hsat.2
+            (pairByteOps?_bytes bs facts bi x y hop h1 env (hsat.2 bi hbi)).1⟩
+      | none =>
+        match hy : solveOperand bm.map y with
+        | some (v, d) =>
+          some ⟨v, d, fun env hsat =>
+            solveOperand_sound hp bm y v d hy env hsat.2
+              (pairByteOps?_bytes bs facts bi x y hop h1 env (hsat.2 bi hbi)).2⟩
+        | none => findFold hp facts bm rest hrest
+
+/-- The pass: substitute one forced digit per invocation (the cleanup fixpoint re-solves the
+    shrunken ladder on the next iteration and converges). -/
+def digitFoldPass : VerifiedPassW p := fun cs bs facts =>
+  if hp : 256 < p then
+    haveI : NeZero p := ⟨by omega⟩
+    let bm : BoundsMap p cs bs := BoundsMap.build facts
+    match findFold hp facts bm cs.busInteractions (fun _ h => h) with
+    | some f =>
+      ⟨cs.subst f.v (Expression.const (f.d : ZMod p)), [],
+        cs.subst_correct f.v (Expression.const (f.d : ZMod p)) bs
+          (fun env hsat => f.sound env hsat)
+          (fun y hy => absurd hy (by simp [Expression.vars]))⟩
+    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end DigitFold

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -9,20 +9,20 @@ this regeneration was in flight, **#117 (entry 77) and #119 (entry 78) merged**,
 on rebase from the entries' measured numbers. Older write-ups had stale or wrong gap
 attributions; re-measure before trusting anything, including this file.
 
-## Where we stand (post-#117/#119 + entry 80 = idea 4(b)+(c))
+## Where we stand (post-#117/#119 + entry 80 = idea 4(b)+(c) + entry 81 = the digit fold)
 
 Absolute output totals (identical inputs, so `agg` effectiveness follows directly):
 
 | benchmark | axis | apc | powdr | apc − powdr |
 |---|---|---|---|---|
-| openvm-eth (100) | variables | 27,967 | 30,885 | **−2,918 (lead)** |
-| | bus interactions | 16,595 | 16,722 | **−127 (lead; was +5)** |
-| | constraints | 11,303 | 20,299 | −8,996 (lead) |
-| keccak | variables | 2,025 | 2,021 | +4 |
-| | bus interactions | 1,959 | 1,734 | **+225 (was +293)** |
-| | constraints | 188 | 186 | +2 (was −66; the width-1→booleanity trade) |
+| openvm-eth (100) | variables | 27,802 | 30,885 | **−3,083 (lead)** |
+| | bus interactions | 16,454 | 16,722 | **−268 (lead; was +5)** |
+| | constraints | 11,267 | 20,299 | −9,032 (lead) |
+| keccak | variables | 2,021 | 2,021 | **exact parity** |
+| | bus interactions | 1,952 | 1,734 | **+218 (was +293)** |
+| | constraints | 186 | 186 | **exact parity** |
 
-Per-case standings on eth: variables **27 W / 29 L / 44 T** (+172 total over the losing cases).
+Per-case standings on eth: variables **30 W / 11 L / 59 T** (+56 total over the losing cases).
 Bus per-case was **7 W / 67 L / 26 T** (+588 over losing cases) at the measurement base;
 #117/#119 improved 37 case-measurements with 0 regressions (agg 3.439× → 3.479×, geo 2.723× →
 2.753×; powdr 3.480× / 2.822×) — re-measure the standings before quoting them. The reported
@@ -35,19 +35,20 @@ both benchmarks except keccak, where the identified fixes land exactly on powdr'
 Exact gap decomposition (verified on the live circuits at the measurement base; buckets marked
 LANDED are done — the remainder still adds up to the current gaps):
 
-- **eth variables +172** = M1 constant decompositions **+135** · M2 comparison gadgets residue
-  **≈ +57** (of the original +105, #114 landed −48) · M3 dead `bit_multiplier` **+14** ·
-  everything else nets in apc's favor (−114 value cluster).
-- **eth bus** (was +588 over losing cases; −191 + −132 landed) = ~~width-1 range checks 90~~
-  (**LANDED**: entry 80 −89) · ~~cancellable memory pairs 78~~ + op-0 coverage waste
-  (**LANDED**: #117 −76, #119 −115) · long same-address chains **64** (apc_010 still 247 vs 239) ·
-  constant-family checks **~126** (84 solvable directly) · tuple-slot coverage waste
+- **eth variables +56 over 11 cases** (was +172 over 29) = ~~M1 constant decompositions +135~~
+  (**LANDED**: entry 81 −165 incl. cascades; residual = full-byte-top `rd_data` ladders,
+  apc_034/066 +3 each) · M2 comparison gadgets residue (apc_037 +14, apc_018 +9 — idea 3) ·
+  M3 dead `bit_multiplier` **+14** · everything else nets in apc's favor.
+- **eth bus** (was +588 over losing cases; −191 + −132 + −141 landed) = ~~width-1 range checks
+  90~~ (**LANDED**: entry 80 −89) · ~~cancellable memory pairs 78~~ + op-0 coverage waste
+  (**LANDED**: #117 −76, #119 −115) · ~~constant-family checks ~126~~ (**LANDED**: entry 81
+  −141) · long same-address chains **64** (apc_010 still 247 vs 239) · tuple-slot coverage waste
   (**remainder of the ≥112 bucket**) · ~~subsumed range checks 22~~ (**LANDED**: entry 80 ≈ −43,
   the base also catches byte/memory-subsumed wide checks) · NOT-form byte checks **23** ·
   residual scattered.
-- **keccak bus +293** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste,
-  entry 80 −68 width-1) = NOT-form byte checks **200** · ~~width-1 checks 68~~ (**LANDED**) ·
-  ~25 misc — the bus-3 width histograms are otherwise *identical* to powdr's.
+- **keccak bus +218** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste,
+  entry 80 −68 width-1, entry 81 −7) = NOT-form byte checks **200** · ~18 misc — the bus-3
+  width histograms are otherwise *identical* to powdr's.
 
 ## In flight / recently landed — check `git log origin/main` and open PRs before picking anything up
 
@@ -55,72 +56,47 @@ LANDED are done — the remainder still adds up to the current gaps):
   parity, eth −76. Only sub-items (c) and (d) of idea 2 remain.
 - **#119 merged** (coda byte-pair splitting): the op-0 explode/dedup/drop/repack half of
   idea 4(d); keccak −45, eth −115. The tuple-slot half of 4(d) remains.
-- **#114 merged** (is-equal sum-of-squares collapse). **#112 open** — reworked from a duplicate into
-  a consolidation: generalizes `hintCollapse` to subsume the collapse and removes the standalone
-  `EqCollapse` pass; effectiveness-neutral vs main, ~half the combined collapse-stage runtime
-  (no separate per-cycle scan). A structural cleanup, not a new win — take it or leave it.
+- **#114 merged** (is-equal sum-of-squares collapse). **#112 merged** (entry 79) — consolidated
+  the collapse into a generalized `hintCollapse`, removing the standalone `EqCollapse` pass;
+  effectiveness-neutral, ~half the collapse-stage runtime.
+- **#122 merged** (entry 80 = idea 4(b)+(c)): width-1 → booleanity + subsumed range-check drop;
+  eth bus −132 (aggregate flips to a lead), keccak bus −68.
+- **Entry 81 (this branch): the bounded-payload digit fold** — lands the payload-ladder core of
+  idea 1 below; see the re-scoped idea 1.
 - **#116 open** (gated constant-decomposition fold): eth-neutral because its gate skips every
-  profitable case. Idea 1 below subsumes it; reuse its proven digit-uniqueness core.
+  profitable case; the digit fold (entry 81) lands the same family from the payload side, so
+  #116 is now fully subsumed — close it, but its proven digit-uniqueness core (`annDecode_forces`,
+  `annSum_val`) remains the natural starting point for the constraint-side remainder of idea 1.
 
 ---
 
-## 1. Constant-decomposition folding, done right  ·  *variables (top axis) + bus*  ·  high value / medium-high effort
+## 1. Constant-decomposition folding — **CORE LANDED (entry 81, the bounded-payload digit fold)**
 
-**Gap.** The single biggest eth variable family: **+135 vars** (6 AUIPC+JALR chains ×14:
-apc_026/045/051/055/085/094; 17 `rd = pc+4` link-register writes ×3: apc_011/024/025/034/042/043/
-048/050/058/066/071/074/077/078/084/087/096) **plus ~126 bus interactions** (their range/byte
-checks, e.g. apc_042 keeps the op-0 check `(3559368 − 256·rd0 − 65536·rd1 − …, rd0)` on a JALR
-return address that is just the digits of 3559368). powdr ships literal constants — payloads like
-`[1, 4, 20, 66, 41, 0, ts+26]` and a constant exec-bridge target.
+**What landed.** `DigitFold.lean` (cleanup cycle): a bitwise pair check asserting an affine
+mixed-radix ladder `K ± (g·v₀ + 256g·v₁ + …)` is a byte, plus each ladder variable's own range
+check, force the digits — after **wrap analysis** (BabyBear `p ≡ 1 (mod 256)` admits a phantom
+digit vector per wrap count; the narrow top-limb range checks, e.g. the 6-bit PC limb, kill
+them). The pass enumerates the whole (byte, wrap) grid and substitutes constants only on a
+singleton solution set; one substitution per invocation, the cleanup fixpoint cascades (the
+pinned digits resolve the adder carry disjunctions downstream — constant seeding *does* cascade
+when the seed is the byte-check digits). Measured (entry 81): **eth −165 vars / −141 bus / −36
+constraints over 33 cases, 0 regressions; keccak −4 vars = exact powdr variable parity.** This
+covered the AUIPC+JALR ×14 chains (apc_026/045/055/085/094) and most of the `rd = pc+4`
+link-register family; no keccak pair-matching regression (unlike #116's ungated constraint-side
+attempt).
 
-**Why apc misses it.** The input contains pure-affine seeds, e.g. apc_045:
-`imm_limbs__0 + 256·imm_limbs__1 + 65536·imm_limbs__2 = 16777200` with byte-checked limbs — the
-digits (240,255,255) are *uniquely forced* (mixed-radix uniqueness). But Gauss consumes the seed
-first: it unit-pivots ONE limb away and leaves quadratics, so no later pass ever sees the
-decomposition. The constants then need to cascade through the adder carry disjunctions
-`(A)·(A−256) = 0`: with A's variables pinned, exactly one root is feasible — pruning it yields a
-new affine equation, which unlocks the next fold, etc.
-
-**Mechanism** (extend #116's `ConstDecomp.lean`, which already proves digit uniqueness
-`annDecode_forces` + the no-wrap lemma `annSum_val`):
-
-```
-repeat (within the pass, to a local fixpoint):
-  1. for each affine constraint Σ cᵢ·xᵢ = K with every xᵢ range-bounded (BoundsMap:
-     bus-3 checks, bitwise op-0/op-1 slots, tuple slots) and non-overlapping positional
-     coefficients (sorted, cᵢ·(Bᵢ−1) < c_{i+1}, Σ cᵢ·(Bᵢ−1) < p):
-       substitute ALL xᵢ := digitᵢ(K) at once (SubstMap, like Gauss — not one equality
-       at a time; that is what #116 got wrong operationally and why it needed Gauss)
-  2. for each constraint (A)·(A − k) = 0 with A affine over now-pinned/bounded vars:
-       if interval analysis (CarryBranch.splitSumMax machinery) refutes one root,
-       replace by the affine constraint of the live root; goto 1
-```
-
-Run it in `cleanupPasses` **before `gauss`** (as #116 does). Drop the `statefulPayloadVars` gate
-entirely.
-
-**The #116 keccak regression, diagnosed.** The gate was added because ungated folding cost keccak
-+187 bus. The stated rationale (folding strips byte-justification) is wrong —
-`byteJustified` already accepts constants < 256 (BusPairCancel.lean ~line 399). The real
-mechanism is almost certainly **pair matching**: a folded (constant) send payload no longer
-*syntactically* matches the unfolded receive side, so `busUnify`/`busPairCancel` miss pairs.
-First implementation step: reproduce ungated, `opt-export` keccak, diff the missed pairs against
-the 142 known-cancellable ones, and make the matcher compare **constant-folded normal forms** of
-payload slots (or match slots up to entailed constant equality). Do not re-add the gate.
-
-**Two more gotchas.** (a) A paired op-0 check `[folded_limb, live_expr, 0, 0]` must survive with
-a constant arg unless the partner folds too (powdr drops all 6 per chain because *everything*
-folds — expect that after the disjunction cascade). (b) Runtime: #116 measured +16% (gauss 3.2×)
-because it added equalities for Gauss to rediscover; substituting directly via `SubstMap` avoids
-the extra fixpoint pressure.
-
-**Why sound.** Digit uniqueness is proven in #116; substitution of entailed constants is the
-standard `Subst` correctness; root pruning replaces a constraint by one it entails on the
-satisfying set (interval refutation of the other root — `CarryBranch` precedent).
-
-**Expected impact.** eth: −135 vars (flips the six +14 cases and most +3 cases; ~29 L → ~10 L),
-−84..126 bus; keccak: −4 v / −9 b / −2 c (#116's measured numbers, kept by the ungated version);
-the +187 regression must be gone (the 142 pairs still cancel).
+**Remaining slices of this idea:**
+- **Shifted `rd_data__{1,2,3}` ladders whose top limb is a full byte** (apc_034/066 +3 each,
+  parts of apc_038/042/064): all-byte bounds genuinely admit wrap phantoms; needs a tighter
+  top-limb bound from another constraint, if one exists. Low ceiling (~6–15 vars).
+- **Constraint-side affine seeds** (`Σ cᵢ·xᵢ = K` as an algebraic constraint rather than a
+  payload ladder), which Gauss unit-pivots away before any digit solver sees them. #116's
+  `ConstDecomp.lean` proves the digit-uniqueness core (`annDecode_forces`, `annSum_val`); if
+  built, substitute all digits at once via `SubstMap` *before* `gauss`, and heed #116's measured
+  traps: the ungated version cost keccak +187 bus (folded constant send payloads stop matching
+  unfolded receives in `busUnify`/`busPairCancel` — fix the matcher, don't re-add the gate) and
+  +16% runtime (don't emit equalities for Gauss to rediscover). Unclear residual value now that
+  the payload side landed — re-census first.
 
 ---
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -2946,3 +2946,72 @@ Build green; `Scripts/check-proof-integrity.sh` passes — the correctness theor
 (`optimizerWithBusFacts_maintainsCorrectness`, `simpleOptimizer_maintainsCorrectness`,
 `openVmOptimizer_maintainsCorrectness`) depend only on `{propext, Classical.choice, Quot.sound}`.
 Worked: yes.
+### 81. Bounded-payload digit fold: byte-checked mixed-radix ladders force constant limbs (−165 eth vars, keccak variable parity)
+
+**Idea (the bounded-payload slice of ideas.md idea 1, constant-decomposition folding).** A bitwise pair check asserts an
+affine operand `E = K ± (g·v₀ + 256g·v₁ + 65536g·v₂ + …)` is a byte, and each ladder variable
+carries its own range check `vᵢ < Bᵢ ≤ 256` — together these can force every `vᵢ` to a
+compile-time constant (the digits of the byte-checked value). The census on current output
+(renders, all 100 cases): **42 such checks over 35 cases**, two shapes — the `rd_data` return
+address `K − 256·rd₀ − 65536·rd₁ − 16777216·rd₂`, and a scaled `K + 480·rd₀ + 122880·pc₀ +
+31457280·pc₁` PC-limb form — 2–3 pinnable vars each, far above the recorded "~3 vars over ~20
+cases" estimate.
+
+**The wrap analysis is the crux.** BabyBear `p ≡ 1 (mod 256)`, so `S = tval(b) + m·p` admits a
+phantom digit vector for every wrap count `m ≤ maxΣ/p` (≈ 2 for the rd_data shape): the digits
+are *not* forced by byte bounds alone. What kills the phantoms is the **narrow top-limb range
+check** (e.g. the 6-bit top PC limb: phantom tops 120/240 ≥ 64) — a first solver assuming
+all-byte bounds found unique solutions on only 6/35 cases; with the true per-variable widths,
+33/35. The what-if (solve digits offline, pin via a scratch `whatif-pin` subcommand, re-run the
+full pipeline): **−165 vars / −141 bus / −36 constraints over 33 cases, 0 regressions** —
+including a −14-var cascade on the apc_045/026/051/055/085/094 family where pinned digits enable
+folds an earlier affine-seed what-if had measured as non-cascading (that experiment seeded only
+the `imm_limbs` constraint slice; seeding the byte-check digits is what cascades).
+
+**Pass (`DigitFold.lean`, cleanup cycle).** Recognize `[x, y, 0, 0]` pair checks (mult 1,
+`bytePairBus` + `byteCheck` facts), `linearize` each operand, sort terms into a `g·256^i`
+coefficient ladder (both sign interpretations), read per-variable bounds from the proof-carrying
+`BoundsMap` (`varRangeBus`/bitwise slot facts), then **enumerate the whole (byte, wrap) grid**
+(`solutions`, ≤ 256·(maxΣ/p+1) points) and decode each admissible value as a bounded ladder.
+Fires only on a **singleton** solution set: `solutions_complete` proves any satisfying
+assignment's digit vector is enumerated (mixed-radix uniqueness `unpack?_ladderVal` + the
+ZMod→ℕ residue bridge), so the singleton forces `env v₀ = d₀`, discharged into
+`ConstraintSystem.subst_correct`. One substitution per invocation; the cleanup fixpoint
+re-solves the shrunken ladder. The enumeration is generic — no OpenVM constants, no
+`native_decide`; it fires exactly when the facts force uniqueness.
+
+**Perf lesson (measured, then fixed).** A first cut hit **+174% eth runtime**: a length-1
+"ladder" is every plain byte-checked variable, and each paid the 256-point grid with
+runtime-`p` ZMod ops (profile: digitFold 19.0s of 28s on apc_019). A `terms.length ≥ 2` guard
+(the idiom is multi-digit by nature) dropped it to **36 ms** on the same case; full-corpus
+runtime is now **−1% eth / −2% keccak** vs main.
+
+**Measured (per-case JSON A/B, exactly matching the what-if; first measured vs `9c92008` = #119,
+re-measured with identical deltas after rebasing onto `71330d5` = #122 — the fold is independent
+of the width-1/subsumed-range and hintCollapse-consolidation landings):**
+- openvm-eth (vs `71330d5`): vars agg **4.518× → 4.545×** (geo 3.837× → 3.878×), bus
+  **3.506× → 3.536×** (geo 2.762× → 2.796×), constraints 10.511× → 10.544×; 33 cases improved,
+  **−165 vars / −141 bus / −36 constraints / 0 regressions** (totals 27967 → 27802 vars,
+  16595 → 16454 bus, 11303 → 11267 constraints). Per-case variable W/L/T vs powdr
+  **27/29/44 → 30/11/59** — 18 losses flip (apc_045/055/094/026/085 −14 each to parity or win);
+  the aggregate bus lead over powdr widens (16454 vs 16722).
+- keccak (vs `71330d5`): vars **2025 → 2021 = exact powdr variable parity** (13.618× both), bus
+  1959 → 1952 (gap +218), constraints 188 → 186 = **exact powdr constraint parity**, runtime flat
+  (273.3s vs 275.8s solo) — the same fold fires on a keccak address ladder and cascades.
+- Residual eth variable losses: **11 cases / +56 vars** (was 29 / ~150): apc_037 +14,
+  apc_051/018 +9, apc_038 +7, apc_064/042 +4, apc_066/034 +3 (shifted `rd_data__{1,2,3}`
+  ladders whose top limb is a full byte — genuinely not forced by the present facts), 3× +1.
+
+**Also measured this iteration (what-if only, no pass): the signed-compare collapse re-scoped.**
+The ideas.md #3 remaining slice assumed powdr keeps "a single comparison-result witness" —
+render diffs show **powdr has no generic signed-compare collapse either** (it keeps the marker
+gadgets on apc_037/100/027; the apparent msb-flag gap is a var-neutral naming difference, flag
+vs top limb). Its real lever is **compare-against-constant → is-zero-of-limb-sum** (per-case
+renders: `cmp·Σlimbs = 0` + inv witness replacing 4 markers + diff_val). Census on our output:
+118 surviving marker-gadget instances, **11 unsigned-vs-constant → est −44 vars / −11 bus over
+8 cases** (plus a few signed-vs-constant, e.g. apc_018's second gadget). Smaller than the digit
+fold, so deferred — recorded in ideas.md #3 with the corrected mechanism.
+
+Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
+**Worked: yes.**
+


### PR DESCRIPTION
## What

New cleanup pass `DigitFold` (`OptimizerPasses/DigitFold.lean`): when a bitwise pair check asserts an affine mixed-radix ladder `K ± (g·v₀ + 256g·v₁ + 65536g·v₂ + …)` is a byte, and each ladder variable carries its own range check `vᵢ < Bᵢ ≤ 256`, the digits can be **forced to compile-time constants** — the `rd_data` return-address / PC-limb idiom that survived on 35 cases (JAL/JALR blocks, where powdr folds every limb to a literal).

**The wrap analysis is the crux.** BabyBear `p ≡ 1 (mod 256)`, so `S = t(b) + m·p` admits a phantom digit vector for every wrap count `m` — byte bounds alone do *not* force the digits. What kills the phantoms is the narrow top-limb range check (e.g. the 6-bit top PC limb). The pass therefore **enumerates the entire (byte, wrap) grid** (`solutions`, ≤ 256·(maxΣ/p+1) points, plain ℕ arithmetic) and fires only on a **singleton** solution set: `solutions_complete` proves any satisfying assignment's digit vector is enumerated (mixed-radix uniqueness + a ZMod→ℕ residue bridge), so the singleton forces `env v₀ = d₀`, discharged into the existing `ConstraintSystem.subst_correct`. One substitution per invocation; the cleanup fixpoint re-solves the shrunken ladder. Generic — no OpenVM constants, no `native_decide`; fires exactly when the facts force uniqueness.

## Effectiveness (rebased onto `71330d5` = #122; per-case JSON A/B vs that main — deltas identical to the pre-rebase measurement on `9c92008`, i.e. fully independent of #112/#122)

- **openvm-eth: vars agg 4.518× → 4.545×** (geo 3.837× → 3.878×), bus 3.506× → **3.536×** (geo 2.762× → 2.796×), constraints 10.511× → 10.544×; 33 cases improved, **−165 vars / −141 bus / −36 constraints / 0 regressions** (totals 27967 → 27802 vars, 16595 → 16454 bus). Per-case variable W/L/T vs powdr **27/29/44 → 30/11/59** (18 losses flip; apc_045/055/094/026/085 −14 each to parity/win). The aggregate bus lead over powdr widens (16454 vs 16722).
- **keccak: vars 2025 → 2021 = exact powdr variable parity** (13.618× both); bus 1959 → 1952; constraints 188 → 186 = **exact powdr constraint parity**; runtime flat (273.3s vs 275.8s solo).
- **Runtime: −1% eth / −2% keccak.** A first cut cost +174%: a length-1 "ladder" is every plain byte-checked variable, each paying the 256-point grid (profile: 19.0s of 28s on apc_019). The `terms.length ≥ 2` guard (the idiom is multi-digit by nature) dropped it to 36 ms on the same case.

Build green; `check-proof-integrity.sh` passes ({propext, Classical.choice, Quot.sound}-only).

## Also measured (what-if only, recorded in ideas.md idea 3): signed-compare collapse re-scoped

Render diffs show powdr has **no generic signed-compare collapse** (it keeps the marker gadgets on apc_037/100/027; the apparent `msb_f` gap is a var-neutral naming difference). Its real lever is **compare-against-constant → is-zero-of-limb-sum**: census 118 surviving marker gadgets, 11 unsigned-vs-constant → est **−44 vars / −11 bus over 8 cases**. Smaller than this PR's fold, so deferred; ideas.md idea 3 carries the corrected mechanism.

Notes: log entry is now **81** (79/80 were taken by #112/#122 on main). This lands the payload-ladder core of ideas.md idea 1; idea 1 is re-scoped accordingly, and **#116 is now fully subsumed** (its gate skips every profitable case; this pass lands the same family from the payload side). #118 remains superseded by the merged #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
