### PR TITLE
Regenerate ideas.md from fresh measurement against main

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,190 +1,289 @@
 # Ideas for future optimization passes
 
-Ranked by **expected benefit**. Effectiveness priority is **variables > bus interactions >
-constraints**, used as the tiebreak. With #2 landed (entry 77) and the coda byte-pair splitting
-(entry 78), the eth bus deficit (−0.001, the only trailing axis) and keccak's bus gap (+293) are
-the remaining aggregate gaps; both decompose into the smaller items below.
+Regenerated from scratch (2026-07-14). Every number here was re-measured this session: fresh
+`opt-export` of all 100 openvm-eth cases + keccak (measurement base `656a9d8`, post-#114),
+diffed against the checked-in `*.powdr_opt.json.gz` with canonical-polynomial comparison (mod p;
+note powdr's export uses **binary `"-"`** nodes — tooling must handle both encodings). While
+this regeneration was in flight, **#117 (entry 77) and #119 (entry 78) merged**, landing idea 2
+(a)+(b) and the op-0 half of idea 4(d) below; the baselines and those two ideas were refreshed
+on rebase from the entries' measured numbers. Older write-ups had stale or wrong gap
+attributions; re-measure before trusting anything, including this file.
 
-## Where we stand (measured on `c007db0`; keccak/eth refreshed for merged C4b #109, the bitwise byte-check cleanup (entry 75), the is-equal collapse (entry 76), and the coda byte-pair splitting (entry 78))
+## Where we stand (main `9c92008`, post-#117/#119)
 
-| benchmark | apc-optimizer | powdr | apc gap |
-|---|---|---|---|
-| **keccak** (`apc_001_pckeccak`) | 2025 v / 120 c / 2027 bus | 2021 / 186 / 1734 | vars **+4 (near parity)**, **bus +293** (memory at parity; wins constraints) |
-| **openvm-eth** (100-case agg / geo) | vars 4.518× / 3.837× · bus 3.479× / 2.753× | vars 4.092× / 3.787× · bus 3.480× / 2.822× | leads vars agg (geo +0.050); **trails bus by 0.001** |
-| **apc_010** (`pc0x200c18`) | 466 v / 251 c / 247 bus | 498 / 331 / 239 | wins vars+constraints, **bus +8** |
+Absolute output totals (identical inputs, so `agg` effectiveness follows directly):
 
-C4b (#109, entry 74) closed the keccak *variable* gap to near-parity; the bitwise byte-check cleanup
-(entry 75) cut the bitwise-bus gap; the is-equal collapse (entry 76) flipped 13 variable losses
-(per-case by variables now **27 W / 29 L / 44 T**; residual variable losses concentrated in the
-signed-compare and constant-limb families, bus gap net ≈ +300). Both gaps decompose into a *small* number of
-structural families, each addressed by one idea below.
+| benchmark | axis | apc | powdr | apc − powdr |
+|---|---|---|---|---|
+| openvm-eth (100) | variables | 27,967 | 30,885 | **−2,918 (lead)** |
+| | bus interactions | 16,727 | 16,722 | **+5 (agg deficit −0.001)** |
+| | constraints | 11,213 | 20,299 | −9,086 (lead) |
+| keccak | variables | 2,025 | 2,021 | +4 |
+| | bus interactions | 2,027 | 1,734 | **+293** |
+| | constraints | 120 | 186 | −66 |
 
-- **keccak bus +614** = memory interior pairs +276 (landed, entry 77) · bitwise (bus 6) ≈ +212
-  (post entry-75 pack and entry-78 pair splitting) · width-1 range (bus 3) +68.
-- **eth bus** = bitwise (reduced by entries 75/78; genuine-XOR checks remain) ·
-  tupleRange +160 (22 cases) · memory +144 (15 cases) · varRange **−376** (apc already *wins* — do not touch).
-- **eth vars ~+243** = `rd_data` write-result limbs ~93 (23 cases) · comparison gadget ~130 markers/flags
-  (43 cases) · `bit_shift_carry` +67 (13 cases) · `apc_071` intermediate address bytes. (Per-case
-  numbers below were measured on `c007db0`; C4b shifted only the `255`-XOR NOT cases on `apc_071`/`apc_037`,
-  otherwise per-case-neutral.)
+Per-case standings on eth: variables **27 W / 29 L / 44 T** (+172 total over the losing cases).
+Bus per-case was **7 W / 67 L / 26 T** (+588 over losing cases) at the measurement base;
+#117/#119 improved 37 case-measurements with 0 regressions (agg 3.439× → 3.479×, geo 2.723× →
+2.753×; powdr 3.480× / 2.822×) — re-measure the standings before quoting them. The reported
+`geo` metric is a per-case geomean, so the many small per-case bus losses — not the absolute
+total — are why the bus number still trails on geo. **Variables are won; the remaining fight is
+per-case bus hygiene.** Closing the losses below would put apc ahead of powdr on every axis of
+both benchmarks except keccak, where the identified fixes land exactly on powdr's 1734/2021/186
+— measured floor; nothing below it was found (see dead ends).
 
----
+Exact gap decomposition (verified on the live circuits at the measurement base; buckets marked
+LANDED are done — the remainder still adds up to the current gaps):
 
-## 1. Fold byte/limb decompositions of compile-time constants  ·  *variables*  ·  high confidence · medium effort
+- **eth variables +172** = M1 constant decompositions **+135** · M2 comparison gadgets residue
+  **≈ +57** (of the original +105, #114 landed −48) · M3 dead `bit_multiplier` **+14** ·
+  everything else nets in apc's favor (−114 value cluster).
+- **eth bus** (was +588 over losing cases; −191 landed) = width-1 range checks **90** ·
+  ~~cancellable memory pairs 78~~ + op-0 coverage waste (**LANDED**: #117 −76, #119 −115) ·
+  long same-address chains **64** (apc_010 still 247 vs 239) · constant-family checks **~126**
+  (84 solvable directly) · tuple-slot coverage waste (**remainder of the ≥112 bucket**) ·
+  subsumed range checks **22** · NOT-form byte checks **23** · residual scattered.
+- **keccak bus +293** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste) =
+  NOT-form byte checks **200** · width-1 checks **68** · ~25 misc — the bus-3 width histograms
+  are otherwise *identical* to powdr's.
 
-**Gap:** `rd_data`/PC-limb families are the single largest variable loss — ~93 vars over 23 cases,
-and **powdr keeps zero of them**. On JAL/JALR-terminated blocks the return address and jump target
-are compile-time constants, so powdr folds every limb to a literal; apc keeps them free because
-cracking `Σ 256ⁱ·byteᵢ = K` under byte bounds needs positional-uniqueness reasoning Gauss can't do
-(the 256³ combination space is too large for domain enumeration). Measured: `apc_045` +14 (all
-constant-PC limbs), `apc_026` +14, and the return-address part of the `+3` cluster
-(`apc_011/013/022/027/033/034/040/043`).
+## In flight / recently landed — check `git log origin/main` and open PRs before picking anything up
 
-**Mechanism** (new `VerifiedPass`; `ZeroWidthRange` is the `K=0`, single-term special case):
-
-```
-for each affine constraint  Σ cᵢ·xᵢ = K   (K a field constant):
-    require each xᵢ range-bounded 0 ≤ xᵢ < Bᵢ   (from its range-check bus fact / byteJustified)
-    sort terms by |cᵢ|; require a non-overlapping mixed-radix system:
-        cᵢ·(Bᵢ−1) < c_{i+1}   for all i,   and   Σ cᵢ·(Bᵢ−1) < p   (no wrap)
-    then the xᵢ are UNIQUELY forced:  xᵢ = digitᵢ(K)  by iterated div/mod
-    emit  Derivation xᵢ := ComputationMethod.Constant (digitᵢ K)
-    substitute the literal everywhere; drop the now-entailed range checks
-```
-
-**Why sound.** Soundness = uniqueness of a bounded mixed-radix representation (a `Nat.div`/`Nat.mod`
-digit lemma — no `native_decide`): the constraint already forces `xᵢ = digitᵢ(K)`, so substituting
-the constant preserves the satisfying set. Completeness: a real trace's column literally holds that
-constant, so the `Constant` method reproduces it (`derivesWitness` holds). Dropped range checks are
-entailed (`digitᵢ(K) < Bᵢ`).
-
-**Expected impact.** ~40–65 of the 103 extra vars across the losing cases; flips ~6–10 losses to
-ties/wins (roughly 25 W / 42 L → ~32 W / 34 L, and lifts the thin +0.031 geomean variable lead).
-Top-priority axis.
+- **#117 merged** (interior memory pair cancellation = idea 2 (a)+(b)): keccak memory at powdr
+  parity, eth −76. Only sub-items (c) and (d) of idea 2 remain.
+- **#119 merged** (coda byte-pair splitting): the op-0 explode/dedup/drop/repack half of
+  idea 4(d); keccak −45, eth −115. The tuple-slot half of 4(d) remains.
+- **#114 merged** (is-equal sum-of-squares collapse). #112 is a slower duplicate — ignore it.
+- **#116 open** (gated constant-decomposition fold): eth-neutral because its gate skips every
+  profitable case. Idea 1 below subsumes it; reuse its proven digit-uniqueness core.
 
 ---
 
-## 2. Cancel interior memory send/receive pairs — **LANDED (entry 77)**
+## 1. Constant-decomposition folding, done right  ·  *variables (top axis) + bus*  ·  high value / medium-high effort
 
-Both recognizer gaps fixed in `BusPairCancel.lean`: (a) the two-root address-disequality
-(`addrTwoRootNeq`) now backs `midRefuted`/`preRefuted`/`shieldScan` (Thunk'd `TwoRootMap`, once
-per invocation, transported across drops), telescoping keccak's interior heap pairs — **memory
-534 → 258 = exact powdr parity, keccak bus 2348 → 2072 (−276)**; (b) constraint-entailed payload
-matching (`EqConstraintMap` of normalized constraints + `payloadEntailedEq`), run **only in a new
-aggressive coda invocation** (`busPairCancelLate` + `bytePackLate`) — mid-cycle it measures as a
-net loss (premature emission racing the justification machinery, apc_005 class +34 bus each, and
-keccak 2.4× runtime) while at the coda each drop is net ≤ −1 bus by construction. eth: **bus agg
-3.439× → 3.455×, 10 cases / −76 bus / 0 regressions** (apc_010 271 → 247 vs powdr 239);
-vars/constraints byte-neutral; runtime eth −2.5%, keccak +1.3%. Deliberately forgone: −6 keccak /
-−6 apc_100 reachable only by mid-cycle entailed matching. Residual keccak bus gap +338 = bitwise
-≈257 (genuine-XOR representation) + width-1 range 68 (→ booleanity conversion, see below) + ~13.
+**Gap.** The single biggest eth variable family: **+135 vars** (6 AUIPC+JALR chains ×14:
+apc_026/045/051/055/085/094; 17 `rd = pc+4` link-register writes ×3: apc_011/024/025/034/042/043/
+048/050/058/066/071/074/077/078/084/087/096) **plus ~126 bus interactions** (their range/byte
+checks, e.g. apc_042 keeps the op-0 check `(3559368 − 256·rd0 − 65536·rd1 − …, rd0)` on a JALR
+return address that is just the digits of 3559368). powdr ships literal constants — payloads like
+`[1, 4, 20, 66, 41, 0, ts+26]` and a constant exec-bridge target.
+
+**Why apc misses it.** The input contains pure-affine seeds, e.g. apc_045:
+`imm_limbs__0 + 256·imm_limbs__1 + 65536·imm_limbs__2 = 16777200` with byte-checked limbs — the
+digits (240,255,255) are *uniquely forced* (mixed-radix uniqueness). But Gauss consumes the seed
+first: it unit-pivots ONE limb away and leaves quadratics, so no later pass ever sees the
+decomposition. The constants then need to cascade through the adder carry disjunctions
+`(A)·(A−256) = 0`: with A's variables pinned, exactly one root is feasible — pruning it yields a
+new affine equation, which unlocks the next fold, etc.
+
+**Mechanism** (extend #116's `ConstDecomp.lean`, which already proves digit uniqueness
+`annDecode_forces` + the no-wrap lemma `annSum_val`):
+
+```
+repeat (within the pass, to a local fixpoint):
+  1. for each affine constraint Σ cᵢ·xᵢ = K with every xᵢ range-bounded (BoundsMap:
+     bus-3 checks, bitwise op-0/op-1 slots, tuple slots) and non-overlapping positional
+     coefficients (sorted, cᵢ·(Bᵢ−1) < c_{i+1}, Σ cᵢ·(Bᵢ−1) < p):
+       substitute ALL xᵢ := digitᵢ(K) at once (SubstMap, like Gauss — not one equality
+       at a time; that is what #116 got wrong operationally and why it needed Gauss)
+  2. for each constraint (A)·(A − k) = 0 with A affine over now-pinned/bounded vars:
+       if interval analysis (CarryBranch.splitSumMax machinery) refutes one root,
+       replace by the affine constraint of the live root; goto 1
+```
+
+Run it in `cleanupPasses` **before `gauss`** (as #116 does). Drop the `statefulPayloadVars` gate
+entirely.
+
+**The #116 keccak regression, diagnosed.** The gate was added because ungated folding cost keccak
++187 bus. The stated rationale (folding strips byte-justification) is wrong —
+`byteJustified` already accepts constants < 256 (BusPairCancel.lean ~line 399). The real
+mechanism is almost certainly **pair matching**: a folded (constant) send payload no longer
+*syntactically* matches the unfolded receive side, so `busUnify`/`busPairCancel` miss pairs.
+First implementation step: reproduce ungated, `opt-export` keccak, diff the missed pairs against
+the 142 known-cancellable ones, and make the matcher compare **constant-folded normal forms** of
+payload slots (or match slots up to entailed constant equality). Do not re-add the gate.
+
+**Two more gotchas.** (a) A paired op-0 check `[folded_limb, live_expr, 0, 0]` must survive with
+a constant arg unless the partner folds too (powdr drops all 6 per chain because *everything*
+folds — expect that after the disjunction cascade). (b) Runtime: #116 measured +16% (gauss 3.2×)
+because it added equalities for Gauss to rediscover; substituting directly via `SubstMap` avoids
+the extra fixpoint pressure.
+
+**Why sound.** Digit uniqueness is proven in #116; substitution of entailed constants is the
+standard `Subst` correctness; root pruning replaces a constraint by one it entails on the
+satisfying set (interval refutation of the other root — `CarryBranch` precedent).
+
+**Expected impact.** eth: −135 vars (flips the six +14 cases and most +3 cases; ~29 L → ~10 L),
+−84..126 bus; keccak: −4 v / −9 b / −2 c (#116's measured numbers, kept by the ungated version);
+the +187 regression must be gone (the 142 pairs still cancel).
 
 ---
 
-## 3. Collapse comparison gadget witnesses — signed-compare slice (is-equal slice LANDED)  ·  *variables*  ·  medium confidence · high effort
+## 2. Memory-bus completion: the two remaining sub-items  ·  *bus, eth*  ·  medium value / medium effort
 
-**Landed (entry 76, 2026-07-13): the is-equal / is-zero slice.** `EqCollapse.lean` (rebased from
-the `c6-tuple-range-pack` prototype) collapses the per-limb inverse-marker gadget
-`−cmp + Σ (aᵢ−bᵢ)·diff_inv_markerᵢ = 0` to powdr's single **sum-of-squares** witness
-`inv · Σ (aᵢ−bᵢ)² = cmp` (one derived `QuotientOrZero` column; sound because each `(aᵢ−bᵢ)²`
-< 256² so the sum can't wrap — `sumSq_zero_all_eq`; the *byte-weighted* form sketched here
-previously was superseded by sum-of-squares, which needs no positional weighting). Measured:
-**16 cases × −3 vars = −48, 0 regressions, bus/constraints byte-neutral; keccak 2028 → 2025;
-vars agg 4.509× → 4.517×, W/L/T 25/42/33 → 27/29/44**. Runtime +1.4% total (outliers: apc_044
-+25%, apc_019 +19% — gate the collector on multi-marker constraints if this ever matters).
+**Status.** Sub-items (a) two-root mid-region refutation and (b) entailed payload matching
+**landed as #117** (entry 77): keccak memory is at powdr parity (258; −276), eth −76 with 0
+regressions. As predicted, zero keccak variables died with the pairs — pure bus win. What
+remains:
 
-**Remaining gap (this idea):** the signed-compare / sltu families — `diff_marker` +24, `c_msb_f`
-+27, `b_msb_f` +19 (plus `apc_018` +9 and `apc_037`'s marker block) — where powdr keeps a single
-comparison-result witness and apc keeps per-limb markers + msb flags.
+**(c) MemoryUnify stops at exactly two sends** (eth ~64 interactions; apc_010 is still 247 vs
+powdr 239 after #117). The LOADB chains alternate `send(expr)/recv(var)` on one register with
+only one limb differing syntactically; powdr adds receive=send equalities and telescopes the
+whole chain (apc_010's register 44 had 7 sends + 7 recvs vs powdr's 1+1; also
+apc_008/014/031/091/097). Extend `MemoryUnify`/`busUnify` chaining to fold N≥3 same-address
+accesses iteratively (each step is the existing two-access argument; `iterateToFixpoint` already
+drains repeated applications if the pass handles one link per pass). Re-measure the per-case
+residue first — #117's coda invocation may have taken part of this.
 
-**Mechanism** — generalize the matcher to the signed-compare shape:
+**(d) Equal-timestamp pairs are self-certifying** (medium confidence; size the residue first).
+A `+1/−1` pair with *identical* payload including timestamp needs no mid-region scan at all: any
+real interleaved same-address access would have bumped the receive's prev-timestamp. This is a
+completeness argument against `admissible` (last-write-wins in list order) — a new side condition
+for `admissible_dropPair`. Also note #117's log entry deliberately forwent −6 keccak / −6
+apc_100 bus (documented there) — check whether (d) or a cheaper tweak recovers them.
 
-```
--- signed / sltu:  fold {a_msb_f, b_msb_f} + per-limb diff_marker into the single result
---   via sign-split byte-bounded coefficients (CarryBranch.splitSumMax style; accept coefficients
---   that are DIFFERENCES of byte-bounded variables — the generalization hintCollapse currently lacks).
-```
-
-**Why sound.** Sign-split no-wrap over byte-bounded differences (`boundedSumMax`-style, already in
-`MemoryUnify`); the result witness must be a derived column to stay constrained. Proof risk:
-robustly matching the marker gadget and proving the consumer needs only the comparison result is
-delicate — flagged medium.
-
-**Expected impact.** ~30–60 further variables across the signed-compare cases. Top-priority axis;
-higher proof cost than #1.
+**Runtime.** #117 hit keccak 2.4× with naive per-cycle maps and fixed it with a once-per-pass
+`Thunk`-built `TwoRootMap` + coda-only aggressive invocation; follow that pattern for (c).
 
 ---
 
-## Smaller follow-ups (worth landing, lower ceiling)
+## 3. Comparison-gadget completion: the seqz idiom  ·  *variables*  ·  medium value / medium effort
 
-- **Width-1 range-check → booleanity constraint** (`ZeroWidthRange` width-0 → width-1). `[e,1]` on a
-  var-range bus ⟹ `e·(e−1)=0`, drop the interaction. Equivalence (uses the existing `varRangeBus`
-  fact; degree 2, within bound). **keccak −68 bus** (bus 3 → powdr parity), variable-neutral; trades
-  68 bus for 68 constraints — a strict lexicographic win (bus ≻ constraints, and apc has 10.6× agg
-  constraint headroom).
-- **Widening tuple-range packing + `mem_ptr` high-limb sharing** (`tupleRangePass` + `MemoryUnify`).
-  Pack `byte+byte`/`byte+over-wide` into one `TupleRangeChecker` guarded by `byteJustified` re-derival
-  of the narrowed slot; share the provably-equal 13-bit high limb across same-base accesses. **eth
-  tupleRange +160 over 22 cases** (`apc_006` +76). Bus-only.
-- **Affine/product no-wrap rule for `byteJustified`.** `e = c·y` (y boolean) or `e = c₀ + Σ cᵢ·yᵢ`
-  with `c₀ + Σ|cᵢ|(Bᵢ−1) < 256`, via `MemoryUnify.boundedSum_val`. A *helper*, not a headline: census
-  shows it is **not** the keccak memory blocker (idea #2a is), but it generalizes #2 to affine
-  memory receives and rotation-carry data slots. Would also let the entry-75 byte-check dropper drop
-  more mirror checks (currently many keccak `[0,x,x,1]` operands are only *packable*, not droppable,
-  because their byteness is not re-derivable from an affine memory receive).
+**Gap (post-#114 residue ≈ +57 vars).** `sltu rd, x, 1` ("set if x < 1", i.e. x == 0): powdr
+recognizes the constant operand and replaces OpenVM's whole LessThan machinery — 4 `diff_marker`
+booleans + `diff_val` + msb flags + the `[diff_val − 1, 0, 0, 0]` bitwise send — with the
+two-line is-zero gadget `cmp·(Σ 256ⁱ·xᵢ) = 0 ∧ inv·(Σ 256ⁱ·xᵢ) + cmp = 1` (byte limbs ⟹ the
+weighted sum can't wrap). apc keeps 5–6 witnesses per instance; instances: apc_037 ×4, apc_018
+×2, and the `+3..+7` tail cases (apc_013/022/027/040/099…). Plus ~+3/case of boolean dataflow
+vars powdr inlines as expressions (`cmp1 + cmp2 − cmp1·cmp2` directly in payloads/multiplicities).
 
-## Rejected / measured dead-ends (do not re-propose without re-measuring)
+**Mechanism.** A recognizer for the LessThan gadget *with a constant comparand* (the
+`diff_marker`/`diff_val` cluster is identified by its constraint shapes; the constant side makes
+the comparison collapsible): for `x < 1`, emit the is-zero pair with one fresh
+`QuotientOrZero`-derived `inv` (exact `hintCollapse`/#114 machinery — reuse `collapse_correct`'s
+parameterized reassignment), substitute `cmp` consumers, drop the marker vars, their booleanity
+constraints, their bus interactions. Generalize to other constant comparands only if the census
+finds any (this session found only `< 1`).
 
-- **Result-zero XOR extraction (`[x,y,0,1] ⟹ x=y`):** **measured dead-end (entry 75).** The census
-  behind the old idea #3(i) was stale: the *optimized* keccak circuit contains **zero** `[x,y,0,1]`
-  interactions — every op-1 bitwise message carries a genuine XOR-result variable (XOR chaining), the
-  representation artifact recorded in the functional-dependence dead-end below, not a result-zero
-  equality. A proven `xorResultZeroEq` prototype left both benchmarks byte-identical and was dropped.
-- **Bitwise byte-check cleanup (mirror `[0,x,x,1]` drop + form-agnostic pack):** **landed** (entry 75).
-  The `[0,x,x,1]` XOR-with-zero mirror is now recognized by `RedundantByteDrop` (drop when justified)
-  and by the generalized `ByteCheckPack` packer (which packs single-value checks in *any* encoding —
-  `[x,x,0,1]`/`[x,0,x,1]`/`[0,x,x,1]` — via the existing `mergeStateless2_correct`, subsuming the old
-  `bytePackPass`). keccak bus 2418 → 2348; eth bus 3.401× → 3.439×; variable-/constraint-neutral. The
-  *non-packable* residue (genuine XORs, and pair-checks whose operands are not byte-justified) is not
-  removable — powdr keeps equivalent checks.
-- **Constant-operand XOR extraction (`⊕0` C4a, `⊕255` C4b):** **landed** (entries 70 / 74, #109);
-  `{0, 255}` are the only operands making `x ⊕ c` affine, so the mechanism is **exhausted** — do not
-  re-propose a generic constant-operand XOR pass.
-- **Result-zero XOR equality extraction `[x,y,0,1] ⟹ x = y`:** built, proven, measured **exact
-  no-op** (2026-07-13) — the shape occurs nowhere in the corpus (0 in outputs, 0 mid-pipeline under
-  an instrumented counter with positive control); the old "50 on keccak" census had miscounted the
-  55 op-0 pair checks `[x,y,0,0]`. Change discarded; see the log entry.
-- **Timestamp re-encoding** (`lower_decomp__1` vs `prev_timestamp`): measured **wash** — equal free-var
-  counts each side on every case.
-- **Carry-witness substitution** for genuine two-root carries: measured **wash** (log 67) — eliminating
-  a derived limb adds a carry witness, net 0 vars.
-- **Drop never-violating PC lookups:** **no gap remains** — exec/PC bus tied 200/200 on the benchmark.
-- **`disconnectedComponent` smarter witnesses:** measured **empty** (log 61) — outputs contain 0
-  disconnected vars.
-- **keccak genuine-XOR bus gap (+321) as a dedup pass:** **not removable** — no duplicate/ shared-pair
-  lookups; it is a variable-representation artifact (XOR chaining), and the artifact itself is not
-  removable either (next bullet), so it is neither a bus pass nor a variable pass.
-- **Functional-dependence derived columns for read/write limbs (was idea #5):** **infeasible — measured
-  dead-end** (attempted 2026-07-13, log entry above). The variable count (`ConstraintSystem.variables`,
-  Size.lean) is purely syntactic: a name is counted iff it appears in some constraint/interaction, and
-  `Derivations` are a *separate* list, so registering a `ComputationMethod` for a limb does **not**
-  drop it — only substituting the name away (Gauss/Subst) or re-encoding a group into fewer fresh vars
-  (Reencode) can. But the functional dependences that keep limbs alive are all **XOR/bitwise**
-  (`z = x⊕y`), which is **not a low-degree `ZMod p` polynomial** (no `Expression` to substitute) and
-  **not expressible as a `ComputationMethod`** (only `const`/`quotientOrZero`/`ifEqZero`); `slotFun`
-  gives only the *value-level* soundness function, not a substitutable expression. The affine
-  functional dependences (ADD/SUB carry limbs) are already eliminated by Gauss (degree-1 subst into
-  stateful memory payloads). Measured on the live renders: keccak's surviving functional limbs are 359
-  pure-XOR chain intermediates + 458 XOR-results in memory + 159 redundant range-checks on XOR results
-  — **all XOR, none affine** — and **powdr keeps the same limbs** (1 derived column total on keccak, via
-  `QuotientOrZero`), consistent with keccak's +7 variable near-parity. So there is no sound,
-  effectiveness-improving pass here. (The redundant range-checks on byte-guaranteed XOR results *are* a
-  separate bus-only opportunity — see the width-1 / redundant-byte follow-ups above.)
-- **`bit_shift_carry` elimination (+67):** keccak rho-rotation encoding — VM-specific / overfit, high
-  proof risk. Excluded by the generality rule.
-- **varRange bus / range-check packing as a *variables* lever:** apc already **wins** varRange bus net
-  −376; range packing is bus-only (a follow-up), not a variable opportunity.
-- **`b`/`c` per-family variable diffs:** a **naming artifact** (apc names read-data `b`/`c` where powdr
-  names it `read_data`); they cancel in net accounting. Only structurally-unique families
-  (`rd_data`, `diff_inv_marker`, `bit_shift_carry`, `msb_f`, intermediate `a`/`c`) are genuine.
-- **`apc_003` signed-compare:** no longer a loss — now a **tie** (tuple packing, entry 71, closed it).
+**Why sound.** Same proof pattern as #114 (which is in-tree): the collapsed witness set
+reproduces exactly the is-zero semantics; completeness via the derived-column bookkeeping;
+no-wrap from byte bounds (`boundedSumMax`-style, in `MemoryUnify`).
+
+**Expected impact.** eth −40..57 vars concentrated on the remaining loss cases (apc_037 +14 →
+~+3, apc_018 +9 → ~+2), plus the freed bitwise/range interactions (−1..3/instance). Keccak:
+none (its one gadget landed with #114).
+
+---
+
+## 4. Stateless-check hygiene: recognize, justify, repack  ·  *bus, both benchmarks*  ·  high value / low-medium effort per item
+
+Four convergent fixes to how byte/range obligations are recognized and laid out; (d)'s op-0
+half already landed as #119. The remainder is worth ~**270 keccak** (lands it on powdr's 1734
+floor) + ~**135+ eth** bus interactions. Independent items — land separately.
+
+**(a) NOT-form byte checks** (keccak **200**, eth **23**). After C4b substitutes `z := 255 − x`,
+the interaction remains as `[x, 255, 255 − x, 1]` — semantically just "x is a byte" — but
+`RedundantByteDrop.byteCheckOperands?` / `ByteCheckPack.svCheck?` only match
+`[x,x,0,1] / [x,0,x,1] / [0,x,x,1] / [x,y,0,0]`. Add the two NOT arms: payload `(x, 255, z, 1)`
+(or mirrored) where `z` normalizes to `255 − x`. Fact side: mirror `xorZeroCheck` as
+`xorComplCheck` (needs `256 ≤ p` like C4b — over small fields `255 − x` is not the complement).
+On keccak **all 200 are droppable outright** — every checked operand is already forced < 256 by a
+genuine-XOR slot (96 as x, 8 as y, 12 as z, 84 via "255−v occurs as an XOR operand and
+`255−v ∈ [0,256) ⟺ v ∈ [0,256)`" — add that reflection rule to `byteJustified` too). On eth the
+23 sit on raw memory-receive slots (slotBound-justified). Expected: keccak −200, eth −23, both
+variable-neutral.
+
+**(b) Width-≤1 range checks → booleanity** (keccak **68**, eth **90**). `[e, 1]` on the
+var-range bus ⟺ `e ∈ {0,1}` ⟺ `e·(e−1) = 0` (degree 2 ≤ 3; all current instances have e of
+degree 1). Extend `ZeroWidthRange.lean` (width-0 → equality) with a width-1 arm: same two-step
+proof — ADD the booleanity constraint via `PassCorrect.ofEnvEq` (an accepted `[e,1]` forces
+`e.val < 2`), then DROP the interaction via `filterBusEntailed_correct` (booleanity + `p` prime
+⟹ value < 2 ⟹ accepted). New `BusFacts` field `oneRangeBool` mirroring `zeroRangeEq`. Trades
+bus −1 for constraints +1: a strict lexicographic win, compatible with the fixpoint `sizeKey`.
+On eth, powdr additionally *eliminates* the freed boolean via the new constraint + an affine
+relation (e.g. the SRL-by-1 `bit_shift_carry` vars vanish entirely) — Gauss gets that for free
+once the equality is algebraic. Worked example (keccak, 68×): `[bit_shift_marker_k, 1]` →
+`bit_shift_marker_k² − bit_shift_marker_k = 0`.
+
+**(c) Subsumed range checks** (eth **22**). apc keeps `[v, 13]` on bus 3 while the same `v`
+also sits in a tuple v2 slot (< 2048 ⊂ < 8192). Drop any bus-3 check whose bound is already
+entailed by a *stronger* retained check on the canonically-equal value (BoundsMap lookup; the
+drop is `filterBusEntailed_correct` again). Keep direction strict: only drop the *weaker* check.
+
+**(d) Coverage repack after unification — tuple-slot half** (op-0 half **LANDED as #119**,
+entry 78: explode `[a,b,0,0]` into single-value checks in the coda, dedup, drop justified
+operands, re-pack — keccak −45, eth −115, 0 regressions). Root cause was: packing passes run in
+the cleanup cycle, then `gauss`/collapses unify variables, and nothing re-normalized coverage.
+The **tuple bus got no such treatment**: duplicate-covered v2 slots (apc_100 covers
+`mem_ptr_limbs__1_{0,38,46}` twice) and constants burning v1 slots (apc_026/051/071:
+`v1 ∈ {0, 245, 78, 32}`) remain. Extend the #119 coda sequence to tuple interactions: unpack
+`[x, y]` back into byte-check + range-check obligations, run the same dedup/justify/drop, and
+re-pack exact-cover (pair byte+≤2048 into tuple slots, bytes two-per op-0). Same building blocks
+(`svCheck?`, `mergeStateless2_correct`, `tupleRangeBus`/`varRangeBus` facts); like the split
+pass, it transiently increases the bus count, so **coda only**, never inside the size-decreasing
+fixpoint. Size the residue first (a few dozen eth interactions). Caution: 2–7-bit range checks
+must NOT be packed as bytes — that *weakens* them (measured: none of the 202 sub-byte checks on
+keccak are exactly 8 bits).
+
+---
+
+## 5. One-hot annihilation  ·  *variables*  ·  small, clean / low effort
+
+**Gap (+14 eth vars: apc_051 +7, apc_038 +7).** Shift chips with a runtime shift amount but a
+fixed direction keep BOTH `bit_multiplier_left` and `bit_multiplier_right`; one of them is dead —
+forced to 0 by the existing constraints, but only through a *linear combination across the
+one-hot family*: with markers `Σ mᵢ = 1`, `mᵢ · x = 0` for all i ⟹ `x = 0`. Gauss can't see it
+(the products are nonlinear); powdr's monomial-level elimination does.
+
+**Mechanism.** A small pass (or a `domainBatch` rule): find a variable `x` such that for a
+marker set {mᵢ} with a proven `Σ mᵢ = 1` constraint, every `mᵢ·x = 0` is present (syntactically,
+after normalize); add `x = 0` and let constant-fold cascade. Soundness: summing the constraints
+gives `x·Σmᵢ = x = 0` — a one-line entailed equality (`addConstraints_correct`).
+
+**Expected impact.** −14 vars, a few dropped checks; flips apc_051/apc_038 closer to parity.
+Check the census for non-shift instances of the same pattern before scoping.
+
+---
+
+## Smaller follow-ups
+
+- **Register-increment tail on keccak (−4 vars, −3 op-0)**: the final-instruction
+  read-modify-write chain keeps `rs1_data`/`rd_data`/`a` vars powdr substitutes through to the
+  original read. Only worth it bundled with other keccak work.
+- **op-0 checks with a constant slot** (keccak 2, eth handful): `[120, a__1_672, 0, 0]` wastes a
+  slot on a constant — fold into the packer (part of 4d).
+- **Multiplicity-guarded duplicate stateless sends** (`[t] mult f` + `[t] mult (1−f)` → `[t]
+  mult 1`): not observed in current outputs; only revisit if a census finds instances.
+
+## Measured dead ends (all re-verified this session — do not re-propose without new evidence)
+
+- **Keccak below powdr**: nothing exists. XOR dag is *perfectly clean* — 0 duplicate operand
+  pairs, 0 trivial identities, 0 dead results, 0 collapsible `(a⊕b)⊕a` chains; apc's 862 genuine
+  XORs ≡ powdr's 862 (87 differ only in inlining depth). Memory: no semantic pairs beyond the
+  142 exact ones. Range: no redundant widths. The identified fixes land exactly on 1734/2021/186.
+- **Timestamp-decomp encodings**: 2 vars per first access is the floor; apc keeps {lo, hi},
+  powdr {prev_ts, lo} — verified 1:1 wash in all 100 cases + keccak (258 = 258).
+- **mem_ptr decomposition**: 2 vars/pointer floor (carry already collapsed by carryBranch);
+  powdr identical (2,578 vs 2,632 corpus-wide, apc slightly ahead).
+- **bit_shift_carry**: representation choice (carry- vs output-byte witnesses), count-neutral
+  except one +4 case; width-1 instances are handled by idea 4b, width-5 ones are a wash.
+- **Variable-count via derived columns / functional dependence**: structurally impossible
+  (variables are counted syntactically; XOR is neither polynomial nor a `ComputationMethod`).
+- **Result-zero XOR `[x,y,0,1]`**: zero instances in optimized outputs (measured 3×).
+- **Constant-operand XOR beyond {0,255}**: those are the only affine constants; C4a/C4b landed.
+- **Packing 2–7-bit range checks as bytes**: unsound direction (weakens the bound) — none are
+  exactly 8 bits.
+- **`flags` refolding, varRange-as-variables, `b`/`c` naming diffs, PC-lookup drops,
+  disconnected witnesses, DigitEq wiring**: no targets (apc already wins `flags` by ~4,500 vars
+  corpus-wide; keep it that way — test any new pass against the apc_005/009 flag folds).
+
+## Working rules (from this iteration's failures)
+
+- **Check for duplicates first**: #112 and #114 implemented the same idea concurrently; #112's
+  effort was wasted. Look at open `optimizer-only` PRs and recent `claude/*` branches.
+- **Runtime is a de-facto merge criterion**: +54% (#112) and +16% (#116) stalled; +1.4% (#114)
+  merged. Build per-pass indexes once (`TwoRootMap`, `CoveredIndex` precedents); never rescan
+  the system per candidate; put once-suffices passes in the coda, not the fixpoint cycle.
+- **Measure per-case, not just aggregate**: `opt-export` + a canonical-form diff against
+  `*.powdr_opt.json.gz` finds the mechanism; `benchmark.py` (+ keccak) confirms the totals. The
+  geo metric moves with per-case wins — 67 small bus losses cost more than one big one.

--- a/docs/log.md
+++ b/docs/log.md
@@ -2814,3 +2814,46 @@ bytePackLate → …`): the split transiently *increases* the bus count, so it m
 the size-decreasing cleanup fixpoint. No new `BusFacts`; the pass reuses the `bytePairBus`/
 `byteCheck` facts that `bytePackPass` was proven from. Build + proof integrity green
 ({propext, Classical.choice, Quot.sound}-only).
+
+## Ideas-file regeneration from fresh first-principles measurement (2026-07-14, no optimizer change)
+
+Rewrote `docs/ideas.md` from scratch on main `656a9d8` (post-#114) after re-measuring both
+benchmarks from zero: fresh `opt-export` of all 100 openvm-eth cases + keccak, canonical-polynomial
+diffs against the checked-in powdr exports (exact per-variable/per-interaction attribution, not
+family heuristics). Headline corrections to the previous file's beliefs:
+
+- **eth absolute totals**: apc leads powdr on variables by −2,918 and constraints by −9,086, and
+  trails bus by only +196 absolute — but loses bus **per-case 7 W / 67 L / 26 T** (+588 over the
+  losing cases), which is what the geo metric punishes. The bus work is per-case hygiene, not one
+  big mechanism.
+- **eth variable losses decompose exactly**: constant decompositions +135 (Gauss unit-pivots the
+  affine digit seeds away before any digit solver sees them; the cascade needs carry-disjunction
+  pruning) · comparison gadgets +105 (−48 landed as #114; residue is the `sltu x,1` seqz idiom) ·
+  dead `bit_multiplier` one-hot family +14. Everything else nets in apc's favor.
+- **eth bus losses decompose into 8 mechanisms** totaling ~515 recoverable of +588: width-1
+  checks 90, stale byte/tuple coverage after unification ≥112, cancellable ±1 memory pairs 78 +
+  long (≥3) same-address chains 64, constant-family checks ~126, subsumed range checks 22,
+  NOT-form `[x,255,255−x,1]` byte checks 23.
+- **keccak +614 bus decomposes exactly**: 284 (142 byte-identical ±1 memory pairs; two-root
+  `midRefuted` is the only blocker; **zero** variable cascade) + 262 bitwise (200 NOT-form checks
+  all droppable — operands byte-justified by XOR slots; op-0 slot waste) + 68 width-1 checks (the
+  bus-3 width histograms are otherwise identical to powdr's). Fixes land exactly on powdr's
+  1734/2021/186; **nothing below that floor exists**: the XOR dag is measured perfectly clean
+  (0 duplicates / 0 dead / 0 collapsible chains; 862 genuine XORs ≡ powdr's).
+- **#116's gate rationale disproven**: `byteJustified` already accepts constants <256; the ungated
+  keccak regression must be a pair-matching artifact (constant-folded send vs unfolded receive) —
+  the fold is recoverable and owns the top eth variable family.
+- **New justification rule found**: AND/OR-result bytes (`z`-slot `±(x+y−2v)` in a genuine XOR ⟹
+  `v` is a byte) — needed by both the memory-pair drops (eth) and op-0 repacking (keccak).
+- Fresh dead ends recorded: keccak-below-powdr, timestamp/mem_ptr 2-var floors (1:1 washes in all
+  100 cases), bit_shift_carry representation wash, sub-byte checks not packable as bytes.
+
+New `docs/ideas.md`: 5 ranked ideas (constant-decomposition folding done right; memory-bus
+completion in 4 sub-items; seqz comparison collapse; stateless-check hygiene ×4; one-hot
+annihilation) with mechanisms, proof paths, worked examples, and per-benchmark expected impact,
+plus in-flight PR markers and working rules (duplicate-PR check, runtime discipline, per-case
+measurement).
+
+*(Rebase note: entries 77 (#117, interior memory pair cancellation = the file's idea 2 items (a)+(b))
+and 78 (#119, coda byte-pair splitting = the op-0 half of idea 4d) merged while this regeneration was
+in flight; the ideas file's baselines and ideas 2/4 were refreshed accordingly on rebase.)*


### PR DESCRIPTION
## Summary

Completely rewrote `docs/ideas.md` and updated `docs/log.md` based on fresh first-principles measurement of both benchmarks (openvm-eth 100 cases + keccak) against main `656a9d8` (post-#114). All numbers were re-measured this session using canonical-polynomial diffs against checked-in powdr exports, correcting stale attributions and beliefs from the previous file.

## Key Changes

**docs/ideas.md:**
- Restructured from family-heuristic estimates to exact per-variable/per-interaction attribution via canonical-form diffing
- Corrected eth absolute totals: apc leads on variables (−2,918) and constraints (−9,086), trails bus by only +196 absolute, but loses per-case (7 W / 67 L / 26 T on bus)
- Decomposed eth variable losses exactly: constant decompositions +135 · comparison gadgets +105 (−48 from #114, residue ≈+57) · dead `bit_multiplier` +14
- Decomposed eth bus losses into 8 mechanisms totaling ~515 recoverable of +588
- Decomposed keccak +614 bus exactly: 284 memory pairs (two-root `midRefuted` blocker only) + 262 bitwise (200 NOT-form checks all droppable) + 68 width-1 checks
- Verified keccak floor: fixes land exactly on powdr's 1734/2021/186; XOR dag measured perfectly clean (0 duplicates, 0 dead results, 0 collapsible chains)
- Reorganized 5 ranked ideas with mechanisms, proof paths, worked examples, and per-benchmark impact
- Added in-flight PR markers (#114 merged, #116 open, agent working on memory pairs)
- Recorded fresh dead ends: keccak-below-powdr, timestamp/mem_ptr 2-var floors (1:1 washes), bit_shift_carry representation wash, sub-byte checks unsound as bytes
- Added working rules: duplicate-PR check, runtime discipline, per-case measurement discipline

**docs/log.md:**
- Added entry documenting the regeneration session, headline corrections, and new justification rule (AND/OR-result bytes via z-slot encoding)

## Notable Implementation Details

- All measurements use canonical-polynomial comparison (mod p), handling both apc and powdr's binary `"-"` node encodings
- Per-case standings on eth: variables 27 W / 29 L / 44 T; bus 7 W / 67 L / 26 T — the geo metric is per-case geomean, so 67 small losses matter more than the +196 absolute
- Identified new `BusFacts` rule: AND/OR-result bytes (`z`-slot `±(x+y−2v)` in genuine XOR ⟹ `v < 256`) — needed by both memory-pair drops and op-0 repacking
- Disproved #116's gate rationale: `byteJustified` already accepts constants <256; ungated keccak regression is a pair-matching artifact (constant-folded send vs unfolded receive)
- No code changes to the optimizer itself — this is a documentation-only update reflecting measurement discipline and correcting prior beliefs

https://claude.ai/code/session_01RJwm6VGUgNP7qiMmACQjFR