### PR TITLE
Width-1 range check → booleanity + subsumed range-check drop (idea 4(b)+(c)): −132 eth / −68 keccak bus, 0 variable regressions

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -28,6 +28,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
+import ApcOptimizer.Implementation.OptimizerPasses.SubsumedRange
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 import ApcOptimizer.Implementation.OptimizerPasses.SplitBytePair
@@ -116,6 +117,7 @@ def codaPasses : List (String × VerifiedPassW p) :=
     ("splitBytePair", SplitBytePair.splitBytePairPass.guardDegree),
     ("dedupLate", dedupPass.withFacts.guardDegree),
     ("redundantByteDrop", RedundantByteDrop.redundantByteDropPass.guardDegree),
+    ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
     ("bytePackLate", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("monicScale", monicScalePass.withFacts.guardDegree),
     ("constFoldEnd", constantFoldPass.withFacts.guardDegree) ]

--- a/ApcOptimizer/Implementation/OptimizerPasses/SubsumedRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SubsumedRange.lean
@@ -1,0 +1,156 @@
+import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
+
+set_option autoImplicit false
+
+/-! # Subsumed range-check removal (idea 4(c))
+
+After unification and packing, blocks keep a variable range check `[x, w]` on the variable range
+checker whose bound `2^w` is *already implied* by a **stronger or equal** stateless check retained
+elsewhere in the system: most commonly the same `x` also sits in a tuple-range slot (e.g.
+`mem_ptr_limbs__1` is checked `< 8192` by a `[x, 13]` range check *and* carried in a
+`TupleRangeChecker[256, 8192]` slot 1), or is a byte-guaranteed memory-receive limb. Such a
+range check is *entailed* — every assignment satisfying the rest of the system already forces
+`x` into range — so dropping it is sound, variable-neutral, and removes one bus interaction.
+
+The drop reuses two proven ingredients, exactly as `RedundantByteDrop`:
+
+1. `ConstraintSystem.filterBusEntailed_correct` — a stateless interaction may be dropped when it
+   is accepted under *every assignment satisfying the filtered system*.
+2. A **non-circular justification base**: the checked variable's bound is looked up only among the
+   interactions this pass can never drop (those *not* recognized as single-variable range checks),
+   via the proven `findVarBound` (`slotBound`-derived bounds: tuple slots, byte-limb memory
+   receives, and any retained range check). Otherwise two range checks of equal width on the same
+   variable could each justify the other and both would be dropped unsoundly.
+
+A recognized check `[x, w]` is dropped when the base bounds `x` by some `b' ≤ 2^w`: the retained
+source forces `x.val < b' ≤ 2^w`, and `w ≤ 25` (a wider check always violates and is never
+recognized), so the message `[x, w]` is accepted. No new `BusFacts`; the bound comparison is a
+plain `Nat` `≤`, so the direction is exactly "the retained check is at least as strong".
+
+Runs in the cleanup cycle (a bus win, `filterBus`-based, variable-neutral); the fixpoint reruns
+it after each shrink. -/
+
+namespace SubsumedRange
+
+variable {p : ℕ}
+
+/-- Recognize a single-variable range check `[x, width]` (multiplicity `1`) on a `varRangeBus`
+    bus whose width is a *satisfiable* constant (`width.val ≤ 25`), returning the checked variable
+    and the width constant. A width `> 25` check always violates, so dropping it would be unsound;
+    it is deliberately not recognized. -/
+def rangeCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Variable × ZMod p) :=
+  match bi.payload with
+  | [v, c] =>
+    match v with
+    | Expression.var x =>
+      match c.constValue? with
+      | some cv =>
+        if facts.varRangeBus bi.busId = true ∧ bi.multiplicity = Expression.const 1
+            ∧ cv.val ≤ 25 then some (x, cv) else none
+      | none => none
+    | _ => none
+  | _ => none
+
+/-- Structure of a recognized check: it lives on a `varRangeBus`, has multiplicity `1`, a
+    satisfiable width, and payload `[x, c]` with `c` the constant `cv`. -/
+theorem rangeCheck?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (cv : ZMod p)
+    (h : rangeCheck? bs facts bi = some (x, cv)) :
+    facts.varRangeBus bi.busId = true ∧ bi.multiplicity = Expression.const 1 ∧ cv.val ≤ 25 ∧
+      ∃ c, bi.payload = [Expression.var x, c] ∧ c.constValue? = some cv := by
+  unfold rangeCheck? at h
+  split at h
+  case h_2 => exact absurd h (by simp)
+  case h_1 v c hpay =>
+    split at h
+    case h_2 => exact absurd h (by simp)
+    case h_1 x' hv =>
+      split at h
+      case h_2 => exact absurd h (by simp)
+      case h_1 cv' hcv =>
+        split_ifs at h with hcond
+        obtain ⟨hvr, hm, hle⟩ := hcond
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        exact ⟨hvr, hm, hle, c, hpay, hcv⟩
+
+/-- A recognized range check lives on a stateless bus. -/
+theorem rangeCheck?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (cv : ZMod p)
+    (h : rangeCheck? bs facts bi = some (x, cv)) : bs.isStateful bi.busId = false :=
+  (facts.varRangeBus_sound bi.busId (rangeCheck?_spec bs facts bi x cv h).1).1
+
+/-- If the checked variable is in range (`< 2^width`), the recognized message is accepted. -/
+theorem rangeCheck?_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (cv : ZMod p)
+    (h : rangeCheck? bs facts bi = some (x, cv)) (env : Variable → ZMod p)
+    (hlt : (env x).val < 2 ^ cv.val) : bs.violatesConstraint (bi.eval env) = false := by
+  obtain ⟨hvr, hm, hle, c, hpay, hcv⟩ := rangeCheck?_spec bs facts bi x cv h
+  have hev : bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [env x, cv] } := by
+    unfold BusInteraction.eval
+    rw [hm, hpay]
+    simp only [List.map_cons, List.map_nil, Expression.eval, c.constValue?_sound cv hcv env]
+  rw [hev]
+  exact ((facts.varRangeBus_sound bi.busId hvr).2 (env x) cv 1).2 ⟨hle, hlt⟩
+
+/-! ## The pass -/
+
+/-- The justification base: interactions this pass can never drop (not recognized as
+    single-variable range checks). Bounding variables only against these makes the drop
+    non-circular. -/
+def dropBase (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (BusInteraction (Expression p)) :=
+  cs.busInteractions.filter (fun bi => (rangeCheck? bs facts bi).isNone)
+
+/-- Keep `bi` unless it is a recognized range check `[x, w]` whose variable is already bounded
+    `< 2^w` by a retained (base) interaction. -/
+def dropKeep (bs : BusSemantics p) (facts : BusFacts p bs)
+    (base : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
+  match rangeCheck? bs facts bi with
+  | some (x, cv) =>
+    match findVarBound bs facts base x with
+    | some b' => !decide (b' ≤ 2 ^ cv.val)
+    | none => true
+  | none => true
+
+/-- Drop every variable range check whose bound is already entailed by a stronger-or-equal
+    retained stateless check on the same variable. -/
+def subsumedRangeDropPass : VerifiedPassW p := fun cs bs facts =>
+  ⟨cs.filterBus (dropKeep bs facts (dropBase bs facts cs)), [],
+   cs.filterBusEntailed_correct bs _
+     (by
+       intro bi _ hkf
+       cases hr : rangeCheck? bs facts bi with
+       | none => exact absurd hkf (by simp [dropKeep, hr])
+       | some xcv =>
+         obtain ⟨x, cv⟩ := xcv
+         exact rangeCheck?_stateless bs facts bi x cv hr)
+     (by
+       intro bi hbimem hkf env hsat _
+       cases hr : rangeCheck? bs facts bi with
+       | none => exact absurd hkf (by simp [dropKeep, hr])
+       | some xcv =>
+         obtain ⟨x, cv⟩ := xcv
+         cases hb : findVarBound bs facts (dropBase bs facts cs) x with
+         | none => exact absurd hkf (by simp [dropKeep, hr, hb])
+         | some b' =>
+           -- `hkf` reduces to the bound comparison
+           have hble : b' ≤ 2 ^ cv.val := by
+             simp only [dropKeep, hr, hb, Bool.not_eq_false', decide_eq_true_eq] at hkf
+             exact hkf
+           -- every base interaction survives the filter, so `hsat` accepts it
+           have hbase : (env x).val < b' := by
+             refine findVarBound_sound bs facts (dropBase bs facts cs) x b' hb env
+               (fun bi' hbi' hmult => ?_)
+             have hbimem' : bi' ∈ cs.busInteractions := (List.mem_filter.1 hbi').1
+             have hnone : rangeCheck? bs facts bi' = none := by
+               have := (List.mem_filter.1 hbi').2
+               simpa using this
+             have hkeep : dropKeep bs facts (dropBase bs facts cs) bi' = true := by
+               simp only [dropKeep, hnone]
+             exact hsat.2 bi' (List.mem_filter.2 ⟨hbimem', hkeep⟩) hmult
+           exact rangeCheck?_accepted bs facts bi x cv hr env (lt_of_lt_of_le hbase hble))⟩
+
+end SubsumedRange

--- a/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
@@ -3,97 +3,153 @@ import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
 
 set_option autoImplicit false
 
-/-! # Width-0 range-check → equality (C3)
+/-! # Width-0 / width-1 range-check → equality / booleanity (C3 + idea 4(b))
 
-powdr-exported blocks that compute effective addresses keep, on the variable range checker, a family
-of **width-0 range checks** `[expr, 0]` (multiplicity `1`). A 0-bit range check asserts
-`expr < 2⁰ = 1`, i.e. `expr = 0`; it is powdr/OpenVM's encoding of "this linear form is exactly
-zero" — used to pin an intermediate address/data limb to a combination of others (e.g.
-`-a__2 + b__3 = 0`, `7864320·(a__3 − b__0) = 0`). Because the optimizer's Gaussian elimination only
-consumes *algebraic* constraints, these equalities — being carried on the **bus** — are never used
-to eliminate a variable, so the intermediate limbs survive. powdr substitutes them away.
+powdr-exported blocks keep, on the variable range checker, two families of degenerate range
+checks (multiplicity `1`):
 
-This pass converts each such interaction into the algebraic constraint `expr = 0` and drops the
-interaction: the two have the *same* satisfying set (a stateless range check `[x, 0]` is accepted iff
-`x = 0`, `BusFacts.zeroRangeEq`), so the transform is a sound, side-effect-preserving refinement.
-Placed early in the cleanup cycle, it feeds the new equalities to Gauss, which then eliminates the
-intermediate variables and cascades — a variable win (and, via the dropped interaction and the
-range checks the eliminated variables no longer need, a bus win).
+* **width-0** `[expr, 0]`: asserts `expr < 2⁰ = 1`, i.e. `expr = 0` — powdr/OpenVM's encoding of
+  "this linear form is exactly zero" (e.g. `-a__2 + b__3 = 0`). Converted to the algebraic
+  equality `expr = 0`, which Gauss consumes — a variable win.
+* **width-1** `[expr, 1]`: asserts `expr < 2`, i.e. booleanity. Converted to the degree-2
+  constraint `expr·(expr − 1) = 0` — a bus win (bus ≻ constraints in the effectiveness order),
+  and the booleanity feeds the finite-domain passes. The equivalence's backward direction
+  (`x·(x−1) = 0 → x < 2`) needs an integral domain, so this arm is gated on `p` prime — decided
+  once per pass invocation, the `deep`/`hdeep` pattern of `busPairCancel`. A per-candidate
+  degree gate (`expr.degree ≤ 1`) keeps every emitted constraint within the identity bound, so
+  the arm can never trip the whole-pass `guardDegree` revert.
+
+Both conversions are *equivalences* over the accepted set (`BusFacts.zeroRangeEq` for width-0;
+the mult-generic `BusFacts.varRangeBus` iff for width-1), so the transform is a sound,
+side-effect-preserving refinement: add the constraint (entailed by the accepted interaction),
+then drop the interaction (entailed by the kept constraint).
 
 Proof shape: two `PassCorrect` steps composed by `andThen`.
-1. **Add** the equality constraints, keeping every interaction — a `PassCorrect.ofEnvEq` whose only
-   content is "each width-0 interaction, being accepted, forces its value to zero" (so the added
-   constraints hold); side effects and admissibility are literally unchanged (same interactions).
-2. **Drop** the now-entailed width-0 interactions via `filterBusEntailed_correct`: each dropped
-   interaction is stateless, and is accepted under the filtered system because the equality
-   constraint added in step 1 (which the drop keeps) forces its value to zero.
+1. **Add** the constraints, keeping every interaction — a `PassCorrect.ofEnvEq` whose only
+   content is "each recognized interaction, being accepted, forces its constraint to zero";
+   side effects and admissibility are literally unchanged (same interactions).
+2. **Drop** the now-entailed interactions via `filterBusEntailed_correct`: each dropped
+   interaction is stateless, and is accepted under the filtered system because the constraint
+   added in step 1 (which the drop keeps) forces its value.
 
-The pass gates on `(1 : ZMod p) ≠ 0` (true for every prime field, in particular OpenVM's BabyBear);
-on the degenerate `ZMod 1` it degrades to the identity. -/
+The pass gates on `(1 : ZMod p) ≠ 0` (true for every prime field, in particular OpenVM's
+BabyBear); on the degenerate `ZMod 1` it degrades to the identity. -/
 
 namespace ZeroWidthRange
 
 variable {p : ℕ}
 
-/-- Recognize a width-0 range check `[value, 0]` (multiplicity `1`) on a `zeroRangeEq` bus, returning
-    the value expression whose zeroness it asserts; `none` otherwise. -/
-def zeroRangeValue? (bs : BusSemantics p) (facts : BusFacts p bs)
+/-- `v·(v − 1)` as an expression — the booleanity constraint of `v`. -/
+def boolC (v : Expression p) : Expression p := .mul v (.add v (.const (-1)))
+
+theorem boolC_eval (v : Expression p) (env : Variable → ZMod p) :
+    (boolC v).eval env = v.eval env * (v.eval env - 1) := by
+  simp only [boolC, Expression.eval]; ring
+
+theorem boolC_vars (v : Expression p) : ∀ x ∈ (boolC v).vars, x ∈ v.vars := by
+  intro x hx
+  simp only [boolC, Expression.vars, List.mem_append, List.not_mem_nil, or_false] at hx
+  tauto
+
+/-- On a prime field, `x < 2` (as a value) is exactly booleanity. -/
+theorem val_lt_two_iff (hp : Nat.Prime p) (x : ZMod p) :
+    x.val < 2 ↔ x * (x - 1) = 0 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  constructor
+  · intro hlt
+    have : x.val = 0 ∨ x.val = 1 := by omega
+    rcases this with h0 | h1
+    · rw [ZMod.val_eq_zero] at h0; rw [h0]; ring
+    · have hx1 : x = 1 := by
+        have := (ZMod.natCast_rightInverse x).symm
+        rw [this, h1]; norm_cast
+      rw [hx1]; ring
+  · intro hprod
+    rcases mul_eq_zero.1 hprod with h0 | h1
+    · rw [h0, ZMod.val_zero]; omega
+    · have hx1 : x = 1 := by linear_combination h1
+      rw [hx1, ZMod.val_one_eq_one_mod, Nat.mod_eq_of_lt hp.one_lt]; omega
+
+/-- Recognize a degenerate range check (multiplicity `1`) and return the equivalent algebraic
+    constraint: the value itself for width-0 (`zeroRangeEq` bus), its booleanity `boolC` for
+    width-1 (`varRangeBus` bus, degree-gated, only when `one = true` — i.e. `p` prime). -/
+def rangeEq? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (Expression p) :=
   match bi.payload with
   | [v, c] =>
-    if facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
-        ∧ c = Expression.const 0 then some v else none
+    if bi.multiplicity = Expression.const 1 then
+      if facts.zeroRangeEq bi.busId = true ∧ c = Expression.const 0 then some v
+      else if one = true ∧ facts.varRangeBus bi.busId = true ∧ c = Expression.const 1
+          ∧ v.degree ≤ 1 then some (boolC v)
+      else none
+    else none
   | _ => none
 
-/-- Structure of a recognized interaction: the bus admits the equality fact, the multiplicity is the
-    constant `1`, and the payload is `[value, 0]`. -/
-theorem zeroRangeValue?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    facts.zeroRangeEq bi.busId = true ∧ bi.multiplicity = Expression.const 1
-      ∧ bi.payload = [v, Expression.const 0] := by
-  unfold zeroRangeValue? at h
+/-- Structure of a recognized interaction: multiplicity `1`, payload `[v, width]`, and either
+    the width-0 or the width-1 case with the matching constraint. -/
+theorem rangeEq?_spec (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p)
+    (h : rangeEq? one bs facts bi = some e) :
+    bi.multiplicity = Expression.const 1 ∧
+      ∃ v, ((facts.zeroRangeEq bi.busId = true ∧ bi.payload = [v, Expression.const 0] ∧ e = v)
+        ∨ (one = true ∧ facts.varRangeBus bi.busId = true
+            ∧ bi.payload = [v, Expression.const 1] ∧ e = boolC v)) := by
+  unfold rangeEq? at h
   split at h
   · rename_i v' c hpay
-    split_ifs at h with hcond
-    obtain ⟨hz, hm, hc⟩ := hcond
-    simp only [Option.some.injEq] at h
-    subst h
-    exact ⟨hz, hm, by rw [hpay, hc]⟩
+    split_ifs at h with hm hA hB
+    · obtain ⟨hz, hc⟩ := hA
+      simp only [Option.some.injEq] at h
+      exact ⟨hm, e, Or.inl ⟨hz, by rw [hpay, hc, h], rfl⟩⟩
+    · obtain ⟨hone, hv, hc, _⟩ := hB
+      simp only [Option.some.injEq] at h
+      exact ⟨hm, v', Or.inr ⟨hone, hv, by rw [hpay, hc], h.symm⟩⟩
   · exact absurd h (by simp)
 
-/-- A recognized interaction evaluates to the message `[value.eval, 0]` with multiplicity `1`. -/
-theorem zeroRangeValue?_eval (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [v.eval env, 0] } := by
-  obtain ⟨_, hm, hp⟩ := zeroRangeValue?_spec bs facts bi v h
-  unfold BusInteraction.eval
-  rw [hm, hp]
-  simp [Expression.eval]
-
 /-- A recognized interaction lives on a stateless bus. -/
-theorem zeroRangeValue?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p)
-    (h : zeroRangeValue? bs facts bi = some v) : bs.isStateful bi.busId = false :=
-  (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).1
+theorem rangeEq?_stateless (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p)
+    (h : rangeEq? one bs facts bi = some e) : bs.isStateful bi.busId = false := by
+  obtain ⟨_, v, hcase⟩ := rangeEq?_spec one bs facts bi e h
+  rcases hcase with ⟨hz, _, _⟩ | ⟨_, hv, _, _⟩
+  · exact (facts.zeroRangeEq_sound bi.busId hz).1
+  · exact (facts.varRangeBus_sound bi.busId hv).1
 
-/-- The evaluated message is accepted iff the value evaluates to zero. -/
-theorem zeroRangeValue?_violates_iff (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (v : Expression p) (env : Variable → ZMod p)
-    (h : zeroRangeValue? bs facts bi = some v) :
-    bs.violatesConstraint (bi.eval env) = false ↔ v.eval env = 0 := by
-  rw [zeroRangeValue?_eval bs facts bi v env h]
-  exact (facts.zeroRangeEq_sound bi.busId (zeroRangeValue?_spec bs facts bi v h).1).2 (v.eval env)
+/-- The evaluated message is accepted iff the returned constraint evaluates to zero. -/
+theorem rangeEq?_violates_iff (one : Bool) (hone : one = true → Nat.Prime p)
+    (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p) (env : Variable → ZMod p)
+    (h : rangeEq? one bs facts bi = some e) :
+    bs.violatesConstraint (bi.eval env) = false ↔ e.eval env = 0 := by
+  obtain ⟨hm, v, hcase⟩ := rangeEq?_spec one bs facts bi e h
+  rcases hcase with ⟨hz, hp', rfl⟩ | ⟨hone', hv, hp', rfl⟩
+  · have hev : bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [e.eval env, 0] } := by
+      unfold BusInteraction.eval; rw [hm, hp']; simp [Expression.eval]
+    rw [hev]
+    exact (facts.zeroRangeEq_sound bi.busId hz).2 (e.eval env)
+  · have hev : bi.eval env = { busId := bi.busId, multiplicity := 1, payload := [v.eval env, 1] } := by
+      unfold BusInteraction.eval; rw [hm, hp']; simp [Expression.eval]
+    have hprime := hone hone'
+    rw [hev, boolC_eval, ← val_lt_two_iff hprime]
+    have h1val : (1 : ZMod p).val = 1 := by
+      rw [ZMod.val_one_eq_one_mod, Nat.mod_eq_of_lt hprime.one_lt]
+    rw [(facts.varRangeBus_sound bi.busId hv).2 (v.eval env) 1 1, h1val]
+    constructor
+    · exact fun ⟨_, hlt⟩ => by rwa [pow_one] at hlt
+    · exact fun hlt => ⟨by omega, by rwa [pow_one]⟩
 
-/-- Convert every width-0 range check into the equality `value = 0` and drop the interaction. -/
+/-- Convert every width-0 range check into the equality `value = 0`, and — on a prime field —
+    every width-1 range check into the booleanity `value·(value−1) = 0`, dropping the
+    interactions. -/
 def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
   if h1ne : (1 : ZMod p) ≠ 0 then
-    let newC := cs.busInteractions.filterMap (zeroRangeValue? bs facts)
+    let one : Bool := decide (Nat.Prime p)
+    have hone : one = true → Nat.Prime p := fun h => of_decide_eq_true h
+    let newC := cs.busInteractions.filterMap (rangeEq? one bs facts)
     let out1 : ConstraintSystem p :=
       { cs with algebraicConstraints := cs.algebraicConstraints ++ newC }
-    let keep := fun bi => (zeroRangeValue? bs facts bi).isNone
-    -- Step 1: add the equality constraints; interactions (hence side effects, admissibility) unchanged.
+    let keep := fun bi => (rangeEq? one bs facts bi).isNone
+    -- Step 1: add the constraints; interactions (hence side effects, admissibility) unchanged.
     have hstep1 : PassCorrect cs out1 [] bs := by
       refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
       · -- soundness: out1 has extra constraints, same interactions
@@ -110,40 +166,44 @@ def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
         · rcases List.mem_append.1 hc with hc | hc
           · exact Or.inl ⟨c, hc, hxc⟩
           · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
-            obtain ⟨_, _, hp⟩ := zeroRangeValue?_spec bs facts bi c hval
-            exact Or.inr ⟨bi, hbi, Or.inr ⟨c, by rw [hp]; simp, hxc⟩⟩
+            obtain ⟨_, v, hcase⟩ := rangeEq?_spec one bs facts bi c hval
+            rcases hcase with ⟨_, hp', rfl⟩ | ⟨_, _, hp', rfl⟩
+            · exact Or.inr ⟨bi, hbi, Or.inr ⟨c, by rw [hp']; simp, hxc⟩⟩
+            · exact Or.inr ⟨bi, hbi, Or.inr ⟨v, by rw [hp']; simp, boolC_vars v x hxc⟩⟩
         · exact Or.inr ⟨bi, hbi, hbrest⟩
-      · -- completeness: same env; the added equalities hold because the interactions are accepted
+      · -- completeness: same env; the added constraints hold because the interactions are accepted
         intro env hadm hsat
         refine ⟨⟨fun c hc => ?_, hsat.2⟩, hadm, BusState.equiv_refl _⟩
         rcases List.mem_append.1 hc with hc | hc
         · exact hsat.1 c hc
         · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
           have hmult : (bi.eval env).multiplicity = 1 := by
-            rw [zeroRangeValue?_eval bs facts bi c env hval]
+            obtain ⟨hm, _, _⟩ := rangeEq?_spec one bs facts bi c hval
+            unfold BusInteraction.eval
+            rw [hm]; simp [Expression.eval]
           have hviol : bs.violatesConstraint (bi.eval env) = false :=
             hsat.2 bi hbi (by rw [hmult]; exact h1ne)
-          exact (zeroRangeValue?_violates_iff bs facts bi c env hval).1 hviol
-    -- Step 2: drop the now-entailed width-0 interactions.
+          exact (rangeEq?_violates_iff one hone bs facts bi c env hval).1 hviol
+    -- Step 2: drop the now-entailed interactions.
     have hstep2 : PassCorrect out1 (out1.filterBus keep) [] bs := by
       refine out1.filterBusEntailed_correct bs keep ?_ ?_
       · intro bi _ hkf
-        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
-          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
-          cases hopt : zeroRangeValue? bs facts bi with
+        obtain ⟨e, he⟩ : ∃ e, rangeEq? one bs facts bi = some e := by
+          have hkf' : (rangeEq? one bs facts bi).isNone = false := hkf
+          cases hopt : rangeEq? one bs facts bi with
           | none => rw [hopt] at hkf'; simp at hkf'
-          | some v => exact ⟨v, rfl⟩
-        exact zeroRangeValue?_stateless bs facts bi v hv
+          | some e => exact ⟨e, rfl⟩
+        exact rangeEq?_stateless one bs facts bi e he
       · intro bi hbi hkf env hsatf _
-        obtain ⟨v, hv⟩ : ∃ v, zeroRangeValue? bs facts bi = some v := by
-          have hkf' : (zeroRangeValue? bs facts bi).isNone = false := hkf
-          cases hopt : zeroRangeValue? bs facts bi with
+        obtain ⟨e, he⟩ : ∃ e, rangeEq? one bs facts bi = some e := by
+          have hkf' : (rangeEq? one bs facts bi).isNone = false := hkf
+          cases hopt : rangeEq? one bs facts bi with
           | none => rw [hopt] at hkf'; simp at hkf'
-          | some v => exact ⟨v, rfl⟩
-        have hvmem : v ∈ (out1.filterBus keep).algebraicConstraints :=
-          List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, hv⟩)
-        rw [zeroRangeValue?_violates_iff bs facts bi v env hv]
-        exact hsatf.1 v hvmem
+          | some e => exact ⟨e, rfl⟩
+        have hemem : e ∈ (out1.filterBus keep).algebraicConstraints :=
+          List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, he⟩)
+        rw [rangeEq?_violates_iff one hone bs facts bi e env he]
+        exact hsatf.1 e hemem
     ⟨out1.filterBus keep, [], hstep1.andThen hstep2⟩
   else
     ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -9,18 +9,18 @@ this regeneration was in flight, **#117 (entry 77) and #119 (entry 78) merged**,
 on rebase from the entries' measured numbers. Older write-ups had stale or wrong gap
 attributions; re-measure before trusting anything, including this file.
 
-## Where we stand (main `9c92008`, post-#117/#119)
+## Where we stand (post-#117/#119 + entry 80 = idea 4(b)+(c))
 
 Absolute output totals (identical inputs, so `agg` effectiveness follows directly):
 
 | benchmark | axis | apc | powdr | apc − powdr |
 |---|---|---|---|---|
 | openvm-eth (100) | variables | 27,967 | 30,885 | **−2,918 (lead)** |
-| | bus interactions | 16,727 | 16,722 | **+5 (agg deficit −0.001)** |
-| | constraints | 11,213 | 20,299 | −9,086 (lead) |
+| | bus interactions | 16,595 | 16,722 | **−127 (lead; was +5)** |
+| | constraints | 11,303 | 20,299 | −8,996 (lead) |
 | keccak | variables | 2,025 | 2,021 | +4 |
-| | bus interactions | 2,027 | 1,734 | **+293** |
-| | constraints | 120 | 186 | −66 |
+| | bus interactions | 1,959 | 1,734 | **+225 (was +293)** |
+| | constraints | 188 | 186 | +2 (was −66; the width-1→booleanity trade) |
 
 Per-case standings on eth: variables **27 W / 29 L / 44 T** (+172 total over the losing cases).
 Bus per-case was **7 W / 67 L / 26 T** (+588 over losing cases) at the measurement base;
@@ -38,14 +38,16 @@ LANDED are done — the remainder still adds up to the current gaps):
 - **eth variables +172** = M1 constant decompositions **+135** · M2 comparison gadgets residue
   **≈ +57** (of the original +105, #114 landed −48) · M3 dead `bit_multiplier` **+14** ·
   everything else nets in apc's favor (−114 value cluster).
-- **eth bus** (was +588 over losing cases; −191 landed) = width-1 range checks **90** ·
-  ~~cancellable memory pairs 78~~ + op-0 coverage waste (**LANDED**: #117 −76, #119 −115) ·
-  long same-address chains **64** (apc_010 still 247 vs 239) · constant-family checks **~126**
-  (84 solvable directly) · tuple-slot coverage waste (**remainder of the ≥112 bucket**) ·
-  subsumed range checks **22** · NOT-form byte checks **23** · residual scattered.
-- **keccak bus +293** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste) =
-  NOT-form byte checks **200** · width-1 checks **68** · ~25 misc — the bus-3 width histograms
-  are otherwise *identical* to powdr's.
+- **eth bus** (was +588 over losing cases; −191 + −132 landed) = ~~width-1 range checks 90~~
+  (**LANDED**: entry 80 −89) · ~~cancellable memory pairs 78~~ + op-0 coverage waste
+  (**LANDED**: #117 −76, #119 −115) · long same-address chains **64** (apc_010 still 247 vs 239) ·
+  constant-family checks **~126** (84 solvable directly) · tuple-slot coverage waste
+  (**remainder of the ≥112 bucket**) · ~~subsumed range checks 22~~ (**LANDED**: entry 80 ≈ −43,
+  the base also catches byte/memory-subsumed wide checks) · NOT-form byte checks **23** ·
+  residual scattered.
+- **keccak bus +293** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste,
+  entry 80 −68 width-1) = NOT-form byte checks **200** · ~~width-1 checks 68~~ (**LANDED**) ·
+  ~25 misc — the bus-3 width histograms are otherwise *identical* to powdr's.
 
 ## In flight / recently landed — check `git log origin/main` and open PRs before picking anything up
 
@@ -181,8 +183,9 @@ none (its one gadget landed with #114).
 ## 4. Stateless-check hygiene: recognize, justify, repack  ·  *bus, both benchmarks*  ·  high value / low-medium effort per item
 
 Four convergent fixes to how byte/range obligations are recognized and laid out; (d)'s op-0
-half already landed as #119. The remainder is worth ~**270 keccak** (lands it on powdr's 1734
-floor) + ~**135+ eth** bus interactions. Independent items — land separately.
+half already landed as #119, and **(b)+(c) landed together** (entry 80): keccak −68, eth −132
+bus, 0 variable/bus regressions. The remainder — (a) NOT-form byte checks and (d)'s tuple half —
+is worth ~**270 keccak** + a few dozen eth bus interactions. Independent items — land separately.
 
 **(a) NOT-form byte checks** (keccak **200**, eth **23**). After C4b substitutes `z := 255 − x`,
 the interaction remains as `[x, 255, 255 − x, 1]` — semantically just "x is a byte" — but
@@ -196,22 +199,25 @@ genuine-XOR slot (96 as x, 8 as y, 12 as z, 84 via "255−v occurs as an XOR ope
 23 sit on raw memory-receive slots (slotBound-justified). Expected: keccak −200, eth −23, both
 variable-neutral.
 
-**(b) Width-≤1 range checks → booleanity** (keccak **68**, eth **90**). `[e, 1]` on the
-var-range bus ⟺ `e ∈ {0,1}` ⟺ `e·(e−1) = 0` (degree 2 ≤ 3; all current instances have e of
-degree 1). Extend `ZeroWidthRange.lean` (width-0 → equality) with a width-1 arm: same two-step
-proof — ADD the booleanity constraint via `PassCorrect.ofEnvEq` (an accepted `[e,1]` forces
-`e.val < 2`), then DROP the interaction via `filterBusEntailed_correct` (booleanity + `p` prime
-⟹ value < 2 ⟹ accepted). New `BusFacts` field `oneRangeBool` mirroring `zeroRangeEq`. Trades
-bus −1 for constraints +1: a strict lexicographic win, compatible with the fixpoint `sizeKey`.
-On eth, powdr additionally *eliminates* the freed boolean via the new constraint + an affine
-relation (e.g. the SRL-by-1 `bit_shift_carry` vars vanish entirely) — Gauss gets that for free
-once the equality is algebraic. Worked example (keccak, 68×): `[bit_shift_marker_k, 1]` →
-`bit_shift_marker_k² − bit_shift_marker_k = 0`.
+**(b) Width-1 range checks → booleanity — LANDED (entry 80).** `[e, 1]` on the var-range bus ⟺
+`e ∈ {0,1}` ⟺ `e·(e−1) = 0` (degree 2 ≤ 3). `ZeroWidthRange.lean` grew a width-1 arm: ADD the
+booleanity via `PassCorrect.ofEnvEq` (accepted `[e,1]` forces `e.val < 2`), DROP the interaction
+via `filterBusEntailed_correct`. **No new `BusFacts` field was needed** — the width-1 iff comes
+straight from the existing mult-generic `varRangeBus` fact, so the idea's proposed `oneRangeBool`
+was redundant. Gated on `p` prime (backward direction needs an integral domain) with a
+per-candidate degree gate (`e.degree ≤ 1`) so it never trips the whole-pass `guardDegree` revert.
+Measured: keccak −68 bus / +68 con, eth −89 bus / +90 con, **0 variable regressions**.
 
-**(c) Subsumed range checks** (eth **22**). apc keeps `[v, 13]` on bus 3 while the same `v`
-also sits in a tuple v2 slot (< 2048 ⊂ < 8192). Drop any bus-3 check whose bound is already
-entailed by a *stronger* retained check on the canonically-equal value (BoundsMap lookup; the
-drop is `filterBusEntailed_correct` again). Keep direction strict: only drop the *weaker* check.
+**(c) Subsumed range checks — LANDED (entry 80).** `SubsumedRange.lean` (coda) drops a var-range
+check `[x, w]` when the **non-circular base** (interactions this pass never drops) already bounds
+`x` by `b' ≤ 2^w`, via the proven `findVarBound` (`slotBound`-derived: tuple slots, byte-limb
+memory receives, any retained range check) + `filterBusEntailed_correct` — the exact structure of
+`RedundantByteDrop`. Two corrections to the original write-up: the direction is **`≤`, not strict
+`<`** (apc_038's `mem_ptr_limbs__1` sits in a `[256, 8192]` tuple slot bounding it by exactly
+`2^13`, which a strict test would miss; the non-circular base — not strictness — is what prevents
+mutual-subsumption double-drops), and because the base subsumes byte/memory sources too it reaches
+**~43 eth interactions**, not 22. Measured: eth ≈ −43 bus, **0 variable/bus regressions**; keccak
+has no such pairs (0).
 
 **(d) Coverage repack after unification — tuple-slot half** (op-0 half **LANDED as #119**,
 entry 78: explode `[a,b,0,0]` into single-value checks in the coda, dedup, drop justified

--- a/docs/log.md
+++ b/docs/log.md
@@ -2857,6 +2857,7 @@ measurement).
 *(Rebase note: entries 77 (#117, interior memory pair cancellation = the file's idea 2 items (a)+(b))
 and 78 (#119, coda byte-pair splitting = the op-0 half of idea 4d) merged while this regeneration was
 in flight; the ideas file's baselines and ideas 2/4 were refreshed accordingly on rebase.)*
+
 ### 79. Consolidate the is-equal collapse into a generalization of `hintCollapse` (supersedes the standalone `EqCollapse` pass)
 
 **Context.** Entry 76 (#114) landed the is-equal / is-zero sum-of-squares collapse as a **separate**
@@ -2891,3 +2892,57 @@ constraints **10.595× / 11.585×**, per-case **27 W / 29 L / 44 T**; `apc_033` 
 `lake build` green; `check-proof-integrity.sh` passes (the three `*_maintainsCorrectness` theorems
 `{propext, Classical.choice, Quot.sound}`-only); audited surface untouched. **Worked: yes** (same
 effectiveness as entry 76, fewer passes, ~half the collapse-stage runtime).
+
+## Entry 80: Width-1 range check → booleanity + subsumed range-check drop (idea 4(b)+(c))
+
+Bundled the two stateless-range-hygiene items from `docs/ideas.md` idea 4. Both are pure bus wins
+(variable-neutral), proven with **no new `BusFacts` and no audited-surface change**; correctness
+follows from each pass's own `PassCorrect`.
+
+**4(b) — width-1 → booleanity** (`ZeroWidthRange.lean`, cleanup cycle). A range check `[e, 1]` on
+the variable range checker is accepted iff `e < 2` — booleanity — so `zeroWidthRangePass` grew a
+width-1 arm alongside its width-0 arm: ADD the degree-2 constraint `e·(e−1) = 0` via
+`PassCorrect.ofEnvEq`, then DROP the interaction via `filterBusEntailed_correct`. The width-1 iff
+comes straight from the **existing mult-generic `varRangeBus` fact** — the ideas file's proposed
+new `oneRangeBool` field was redundant. The backward direction (`e·(e−1)=0 → e < 2`) needs an
+integral domain, so the arm gates on `decide (Nat.Prime p)` (the `deep` pattern); a per-candidate
+degree gate (`e.degree ≤ 1`) keeps every emitted constraint ≤ 2, so it can never trip the
+whole-pass `guardDegree` revert. Trades bus −1 for constraint +1 — a strict lexicographic win
+(bus ≻ constraints), compatible with the fixpoint `sizeKey`.
+
+**4(c) — subsumed range checks** (`SubsumedRange.lean`, new pass, coda). Drops a var-range check
+`[x, w]` when a **retained** interaction already bounds `x` by `b' ≤ 2^w`. Structure mirrors
+`RedundantByteDrop` exactly: a **non-circular justification base** (interactions this pass never
+drops = everything not recognized as a single-variable range check) plus the proven `findVarBound`,
+whose `slotBound`-derived bounds cover tuple-range slots, byte-limb memory receives, and any
+retained range check. The drop is `filterBusEntailed_correct` again (each base interaction survives
+the filter, so a satisfying assignment of the output accepts it, forcing `x` into range). Two
+corrections to the ideas-file write-up:
+- the bound test is **`≤`, not strict `<`**: apc_038's `mem_ptr_limbs__1` sits in a `[256, 8192]`
+  tuple slot bounding it by *exactly* `2^13`, which a strict test would miss. The non-circular
+  base — not strictness — is what prevents two equal-width checks from dropping each other.
+- the base subsumes byte/memory sources too, so it reaches **~43 eth interactions**, not the
+  estimated 22 (the extra hits are wide range checks on byte-guaranteed / smaller-tuple-slot vars).
+
+**Wiring.** 4(b) stays in the cleanup cycle (the booleanity feeds the finite-domain passes); 4(c)
+runs once in the coda after `redundantByteDrop` (a run-once, variable-neutral drop, so it never
+starves the mid-loop enumeration of a variable's range bound — the same discipline as
+`RedundantByteDrop`).
+
+**Measured (A/B: this branch vs `main` `5bcbb85`, full `benchmark.py` + keccak `run`).**
+- **openvm-eth (100 cases):** bus 16727 → **16595 (−132, 18 cases improved, 0 regressions)**;
+  aggregate bus effectiveness 3.479× → **3.506×** — the last trailing eth aggregate axis **flips
+  to a lead over powdr** (16595 vs 16722, was +5 → −127). Variables **bit-identical** (27967,
+  per-case W/L/T 27/29/44 unchanged — 0 regressions). Constraints 11213 → 11303 (+90, the
+  width-1→booleanity trade; still 10.5× vs powdr's 5.85×). Split: ≈ −89 bus is width-1 (con
+  +90), ≈ −43 bus is subsumed-range drops (constraint-neutral: apc_049 −9, apc_042 −6,
+  apc_005/009/015/036/044/067/068 −3 each, apc_038 −2, …). Biggest movers apc_100 −40,
+  apc_037 −25, apc_038 −14, apc_051 −12.
+- **keccak:** bus 2027 → **1959 (−68)** — all 68 width-1 checks (4(c) finds 0 subsumed pairs, as
+  predicted); vars **2025 unchanged**; constraints 120 → 188 (+68). Bus effectiveness 6.543× →
+  6.770×; gap to powdr +293 → +225.
+
+Build green; `Scripts/check-proof-integrity.sh` passes — the correctness theorems
+(`optimizerWithBusFacts_maintainsCorrectness`, `simpleOptimizer_maintainsCorrectness`,
+`openVmOptimizer_maintainsCorrectness`) depend only on `{propext, Classical.choice, Quot.sound}`.
+Worked: yes.


### PR DESCRIPTION
## What

Bundles the two stateless-range-hygiene items of `docs/ideas.md` idea 4. Both are **pure bus wins (variable-neutral)**, proven with **no new `BusFacts` and no change to the audited surface** — correctness follows from each pass's own `PassCorrect`.

### 4(b) — width-1 → booleanity (`ZeroWidthRange.lean`, cleanup cycle)

A range check `[e, 1]` on the variable range checker is accepted iff `e < 2` — booleanity — so the width-0 arm gains a width-1 sibling: **ADD** the degree-2 constraint `e·(e−1) = 0` (via `PassCorrect.ofEnvEq`), then **DROP** the interaction (via `filterBusEntailed_correct`). A strict lexicographic win (bus ≻ constraints), and the booleanity feeds the finite-domain passes.

- The width-1 iff comes straight from the existing mult-generic **`varRangeBus`** fact, so the ideas file's proposed new `oneRangeBool` field was **redundant** — no new fact needed.
- The backward direction (`e·(e−1)=0 → e < 2`) needs an integral domain, so the arm gates on `decide (Nat.Prime p)` (the `deep` pattern).
- A per-candidate degree gate (`e.degree ≤ 1`) keeps every emitted constraint ≤ 2, so the arm can never trip the whole-pass `guardDegree` revert.

### 4(c) — subsumed range checks (`SubsumedRange.lean`, new pass, coda)

Drops a var-range check `[x, w]` when a **retained** interaction already bounds `x` by `b' ≤ 2^w`. Structure mirrors `RedundantByteDrop` exactly: a **non-circular justification base** (everything not recognized as a single-variable range check) + the proven `findVarBound`, whose `slotBound`-derived bounds cover tuple-range slots, byte-limb memory receives, and any retained range check; the drop is `filterBusEntailed_correct` again.

Two corrections to the ideas-file write-up (the plan I was handed):
- The bound test is **`≤`, not strict `<`**: apc_038's `mem_ptr_limbs__1` sits in a `[256, 8192]` tuple slot bounding it by *exactly* `2^13`, which a strict test would miss. The **non-circular base** — not strictness — is what prevents two equal-width checks from dropping each other.
- Because the base subsumes byte/memory sources too, it reaches **~43 eth interactions**, not the estimated 22.

**Wiring:** 4(b) stays in the cleanup cycle; 4(c) runs once in the coda after `redundantByteDrop` (a run-once, variable-neutral drop that never starves the mid-loop enumeration of a variable's range bound — the same discipline as `RedundantByteDrop`).

## Effectiveness (A/B: full `benchmark.py` + keccak `run`, vs `main` `5bcbb85`; #112 rebase is effectiveness-neutral so the deltas are unchanged)

| benchmark | axis | main | this PR | Δ | per-case regressions |
|---|---|---|---|---|---|
| **openvm-eth** (100) | variables | 27,967 | 27,967 | **0** | **0** (W/L/T 27/29/44 unchanged) |
| | bus interactions | 16,727 | **16,595** | **−132** | **0** (18 cases improved) |
| | constraints | 11,213 | 11,303 | +90 | 4 (the width-1→booleanity trade) |
| **keccak** | variables | 2,025 | 2,025 | **0** | — |
| | bus interactions | 2,027 | **1,959** | **−68** | — |
| | constraints | 120 | 188 | +68 | — |

- **eth bus effectiveness 3.479× → 3.506×** — the last trailing eth aggregate axis **flips to a lead over powdr** (16,595 vs 16,722; was +5 → −127). Constraints still 10.5× vs powdr's 5.85×.
- eth split: ≈ −89 bus is width-1 (con +90); ≈ −43 bus is subsumed-range drops (constraint-neutral: apc_049 −9, apc_042 −6, apc_005/009/015/036/044/067/068 −3 each, apc_038 −2, …). Biggest movers apc_100 −40, apc_037 −25, apc_038 −14, apc_051 −12.
- keccak: all 68 width-1 checks convert; 4(c) finds 0 subsumed pairs there, as predicted.

## Proof

- No `sorry`/`admit`/`axiom`/`native_decide`; `Scripts/check-proof-integrity.sh` passes.
- `optimizerWithBusFacts_maintainsCorrectness` / `simpleOptimizer_maintainsCorrectness` / `openVmOptimizer_maintainsCorrectness` depend only on `{propext, Classical.choice, Quot.sound}`.
- `lake build` green; output within the degree bound.
- Audited surface (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`, `Basic.lean`) untouched.

`docs/ideas.md`: 4(b)/4(c) marked landed (standing table + bus decomposition refreshed). `docs/log.md`: **entry 80** (rebased past #112's entry 79).

Note: 4(b) overlaps the standalone #118; this PR bundles it with 4(c) per the requested scope, reproducing #118's proven width-1 arm and adding the subsumed-range drop on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01496xQhbAPfx3yWMbtavPss