### PR TITLE
Probed slot bounds: read XOR-mask range facts — idea 1's residual JAL ladders fold to exact powdr parity (entry 85)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
@@ -348,6 +348,238 @@ theorem interactionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
         (bi.payload.map Expression.constValue?) slot bound (env x) h
         (matches_evalPattern bi.payload env) hviol hget
 
+/-! ## Probed slot bounds
+
+A bound for `x` that no single `slotBound` fact states, derived by *probing* a functional
+dependence (`slotFun`) against the payload's own syntax. The motivating instance is OpenVM's
+6-bit top-limb bound on pc-derived byte decompositions, which ships as a genuine-XOR identity
+`[x, 192, 192 + x, 1]` rather than a range check: the accepted message forces
+`x ⊕ 192 = x + 192`, which only bytes `< 64` satisfy. Generically: if payload slot `j` is an
+affine function `l.const + c·x` of a variable `x` sitting raw in slot `i`, every other slot is
+a constant, and a `slotFun` fact computes slot `j` from the rest of the payload, then `x`'s
+value must be a *survivor* of the probe `f (payload with x := v, slot j zeroed) = l.const + c·v`
+over `v < B₀` (the slot-fact bound for `x` itself, capped at 256 probes). The returned bound is
+one plus the largest survivor. No bus specifics — any `slotFun` instance works. -/
+
+/-- One plus the largest `v < n` passing `test` (`0` if none) — the least strict upper bound on
+    the survivors of a probe. -/
+def probeMax (test : Nat → Bool) : Nat → Nat
+  | 0 => 0
+  | n + 1 => if test n then n + 1 else probeMax test n
+
+theorem probeMax_lt (test : Nat → Bool) :
+    ∀ (n v : Nat), v < n → test v = true → v < probeMax test n
+  | 0, v, hv, _ => absurd hv (by omega)
+  | n + 1, v, hv, htest => by
+    rw [probeMax]
+    split
+    · omega
+    · rename_i hn
+      have hvn : v ≠ n := fun h => by rw [h] at htest; rw [htest] at hn; exact hn rfl
+      exact probeMax_lt test n v (by omega) htest
+
+/-- The probe payload: constant slots at their constants, slot `i` at the candidate value,
+    non-constant slots at `0`. -/
+def probeBase (payload : List (Expression p)) (i : Nat) (v : ZMod p) : List (ZMod p) :=
+  (payload.map (fun e => (e.constValue?).getD 0)).set i v
+
+/-- With slot `i` a raw variable, slot `j` arbitrary, and every other slot a constant, the
+    evaluated payload with slot `j` zeroed *is* the probe payload at `env x`. -/
+theorem probeBase_eq_set (payload : List (Expression p)) (env : Variable → ZMod p)
+    (i j : Nat) (hij : i ≠ j) (x : Variable)
+    (hi : payload[i]? = some (.var x))
+    (hconst : ∀ k, k ≠ i → k ≠ j → ∀ e', payload[k]? = some e' → (e'.constValue?).isSome) :
+    ((payload.map (fun e => e.eval env)).set j 0)
+      = (probeBase payload i (env x)).set j 0 := by
+  have hilen : i < payload.length := by
+    by_contra hge
+    rw [List.getElem?_eq_none (by omega)] at hi
+    exact absurd hi (by simp)
+  apply List.ext_getElem?
+  intro k
+  by_cases hkj : k = j
+  · subst hkj
+    rw [List.getElem?_set, List.getElem?_set]
+    simp [probeBase]
+  · rw [List.getElem?_set_ne (fun h => hkj h.symm), List.getElem?_set_ne (fun h => hkj h.symm)]
+    by_cases hki : k = i
+    · subst hki
+      rw [List.getElem?_map, hi, probeBase, List.getElem?_set, if_pos rfl]
+      rw [List.length_map, if_pos hilen]
+      rfl
+    · rw [List.getElem?_map, probeBase, List.getElem?_set_ne (fun h => hki h.symm),
+        List.getElem?_map]
+      cases hk : payload[k]? with
+      | none => rfl
+      | some e' =>
+        have hcv := hconst k hki hkj e' hk
+        obtain ⟨cv, hcveq⟩ := Option.isSome_iff_exists.1 hcv
+        simp only [Option.map_some]
+        rw [e'.constValue?_sound cv hcveq env, hcveq]
+        rfl
+
+/-- `some bnd` exactly when it strictly improves on the base bound. -/
+def capBound (bnd B₀ : Nat) : Option Nat := if bnd < B₀ then some bnd else none
+
+/-- The probed bound for `x` from interaction `bi` with output slot `j` (see the section
+    header): the capped `probeMax` when the shape matches. -/
+def probedSlotBoundAt (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (j : Nat) : Option Nat :=
+  if p = 0 then none
+  else
+  match bi.multiplicity.constValue? with
+  | none => none
+  | some mval =>
+    if mval = 0 then none
+    else
+      match varSlot x bi.payload with
+      | none => none
+      | some i =>
+        if i = j then none
+        else
+          match facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) i with
+          | none => none
+          | some B₀ =>
+            if 256 < B₀ then none
+            else
+              match facts.slotFun bi.busId (bi.payload.map Expression.constValue?) j with
+              | none => none
+              | some f =>
+                match bi.payload[j]? with
+                | none => none
+                | some e =>
+                  match linearize e with
+                  | none => none
+                  | some l =>
+                    match l.terms with
+                    | [(y, c)] =>
+                      if y = x ∧ (List.range bi.payload.length).all (fun k =>
+                          k == i || k == j ||
+                            ((bi.payload[k]?.map
+                              (fun e' => (e'.constValue?).isSome)).getD false)) then
+                        capBound (probeMax (fun v =>
+                          f ((probeBase bi.payload i ((v : ℕ) : ZMod p)).set j 0)
+                            == l.const + c * ((v : ℕ) : ZMod p)) B₀) B₀
+                      else none
+                    | _ => none
+
+theorem probedSlotBoundAt_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (j : Nat) (bound : Nat)
+    (h : probedSlotBoundAt bs facts bi x j = some bound) (env : Variable → ZMod p)
+    (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
+    (env x).val < bound := by
+  unfold probedSlotBoundAt at h
+  split_ifs at h with hp0
+  haveI : NeZero p := ⟨hp0⟩
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i mval hm
+  split_ifs at h with hmz
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i i hslot
+  split_ifs at h with hij
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i B₀ hB
+  split_ifs at h with hcap
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i f hf
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i e hj
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i l hlin
+  split at h
+  any_goals simp only [reduceCtorEq] at h
+  rename_i y c heq_terms
+  split_ifs at h with hcond
+  obtain ⟨hyx, hall⟩ := hcond
+  rw [hyx] at heq_terms
+  unfold capBound at h
+  split_ifs at h with hbnd
+  simp only [Option.some.injEq] at h
+  subst h
+  -- the obligation is active
+  have hmeval : (bi.eval env).multiplicity = mval :=
+    bi.multiplicity.constValue?_sound mval hm env
+  have hviol : bs.violatesConstraint (bi.eval env) = false := by
+    apply hob; rw [hmeval]; exact hmz
+  have hpat : Matches (bi.eval env).payload
+      (bi.payload.map Expression.constValue?) :=
+    matches_evalPattern bi.payload env
+  -- base bound for x
+  have hgeti : bi.payload[i]? = some (.var x) := varSlot_sound x bi.payload i hslot
+  have hgetiE : (bi.eval env).payload[i]? = some (env x) := by
+    show (bi.payload.map (fun e' => e'.eval env))[i]? = some (env x)
+    rw [List.getElem?_map, hgeti]
+    rfl
+  have hB' : facts.slotBound (bi.eval env).busId (bi.eval env).multiplicity
+      (bi.payload.map Expression.constValue?) i = some B₀ := by
+    rw [hmeval]; exact hB
+  have hbase : (env x).val < B₀ :=
+    facts.slotBound_sound (bi.eval env) (bi.payload.map Expression.constValue?)
+      i B₀ (env x) hB' hpat hviol hgetiE
+  -- functional dependence at slot j
+  have hgetjE : (bi.eval env).payload[j]? = some (e.eval env) := by
+    show (bi.payload.map (fun e' => e'.eval env))[j]? = some (e.eval env)
+    rw [List.getElem?_map, hj]
+    rfl
+  have hf' : facts.slotFun (bi.eval env).busId
+      (bi.payload.map Expression.constValue?) j = some f := hf
+  have hfun : e.eval env = f ((bi.eval env).payload.set j 0) :=
+    facts.slotFun_sound (bi.eval env) (bi.payload.map Expression.constValue?)
+      j f (e.eval env) hf' hpat hviol hgetjE
+  -- the zeroed evaluated payload is the probe payload at env x
+  have hconst : ∀ k, k ≠ i → k ≠ j → ∀ e',
+      bi.payload[k]? = some e' → (e'.constValue?).isSome := by
+    intro k hki hkj e' hk
+    have hklen : k < bi.payload.length := by
+      by_contra hge
+      rw [List.getElem?_eq_none (by omega)] at hk
+      exact absurd hk (by simp)
+    have := List.all_eq_true.1 hall k (List.mem_range.2 hklen)
+    simp only [beq_iff_eq, Bool.or_eq_true] at this
+    rcases this with (h' | h') | h'
+    · exact absurd h' hki
+    · exact absurd h' hkj
+    · rw [hk] at h'
+      simpa using h'
+  have hpay : ((bi.eval env).payload).set j 0
+      = (probeBase bi.payload i (env x)).set j 0 := by
+    show ((bi.payload.map (fun e' => e'.eval env)).set j 0)
+        = (probeBase bi.payload i (env x)).set j 0
+    exact probeBase_eq_set bi.payload env i j hij x hgeti hconst
+  -- the value equation e = l.const + c·x
+  have heval : e.eval env = l.const + c * env x := by
+    rw [linearize_eval e l hlin]
+    simp [LinExpr.eval, heq_terms]
+  -- the test passes at v = (env x).val
+  have henvx : (((env x).val : ℕ) : ZMod p) = env x :=
+    ZMod.natCast_rightInverse (env x)
+  have htest : (f ((probeBase bi.payload i (((env x).val : ℕ) : ZMod p)).set j 0)
+      == l.const + c * (((env x).val : ℕ) : ZMod p)) = true := by
+    rw [beq_iff_eq, henvx, ← hpay, ← hfun, heval]
+  exact probeMax_lt _ B₀ (env x).val hbase htest
+
+/-- The probed bound for `x` from interaction `bi`: the first output slot that yields one. -/
+def probedSlotBound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) : Option Nat :=
+  ((List.range bi.payload.length).filterMap (probedSlotBoundAt bs facts bi x)).head?
+
+theorem probedSlotBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (bound : Nat)
+    (h : probedSlotBound bs facts bi x = some bound) (env : Variable → ZMod p)
+    (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
+    (env x).val < bound := by
+  unfold probedSlotBound at h
+  have hmem : bound ∈ (List.range bi.payload.length).filterMap
+      (probedSlotBoundAt bs facts bi x) := List.mem_of_mem_head? h
+  obtain ⟨j, _, hAt⟩ := List.mem_filterMap.1 hmem
+  exact probedSlotBoundAt_sound bs facts bi x j bound hAt env hob
+
 /-- The value bound of `x` derived from the first bus obligation that bounds it. -/
 def findVarBound (bs : BusSemantics p) (facts : BusFacts p bs) :
     List (BusInteraction (Expression p)) → Variable → Option Nat

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
@@ -564,22 +564,6 @@ theorem probedSlotBoundAt_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     rw [beq_iff_eq, henvx, ← hpay, ← hfun, heval]
   exact probeMax_lt _ B₀ (env x).val hbase htest
 
-/-- The probed bound for `x` from interaction `bi`: the first output slot that yields one. -/
-def probedSlotBound (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : Variable) : Option Nat :=
-  ((List.range bi.payload.length).filterMap (probedSlotBoundAt bs facts bi x)).head?
-
-theorem probedSlotBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bi : BusInteraction (Expression p)) (x : Variable) (bound : Nat)
-    (h : probedSlotBound bs facts bi x = some bound) (env : Variable → ZMod p)
-    (hob : (bi.eval env).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval env) = false) :
-    (env x).val < bound := by
-  unfold probedSlotBound at h
-  have hmem : bound ∈ (List.range bi.payload.length).filterMap
-      (probedSlotBoundAt bs facts bi x) := List.mem_of_mem_head? h
-  obtain ⟨j, _, hAt⟩ := List.mem_filterMap.1 hmem
-  exact probedSlotBoundAt_sound bs facts bi x j bound hAt env hob
-
 /-- The value bound of `x` derived from the first bus obligation that bounds it. -/
 def findVarBound (bs : BusSemantics p) (facts : BusFacts p bs) :
     List (BusInteraction (Expression p)) → Variable → Option Nat

--- a/ApcOptimizer/Implementation/OptimizerPasses/MemoryUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/MemoryUnify.lean
@@ -164,6 +164,23 @@ def insertEntry (T : BoundsMap p cs bs) (x : Variable) (b : Nat)
 private def rawVarsOf (bi : BusInteraction (Expression p)) : List Variable :=
   bi.payload.filterMap (fun e => match e with | .var x => some x | _ => none)
 
+/-- Cheap once-per-interaction pre-scan for probed-bound candidates: an output slot `j` whose
+    content is affine in a single variable `y` can only ever bound `y`, so the expensive
+    `probedSlotBoundAt` (which rebuilds the pattern and probes up to 256 values) runs only on
+    these `(y, j)` pairs instead of every (variable, slot) combination. -/
+private def probeCandidatesOf (bi : BusInteraction (Expression p)) : List (Variable × Nat) :=
+  if (bi.multiplicity.constValue?).isSome then
+    (List.range bi.payload.length).filterMap (fun j =>
+      match bi.payload[j]? with
+      | some e =>
+        match linearize e with
+        | some l => match l.terms with
+          | [(y, _)] => some (y, j)
+          | _ => none
+        | none => none
+      | none => none)
+  else []
+
 /-- Collect bounds from all interactions' fact-bounded raw payload slots. -/
 def addAll (facts : BusFacts p bs) :
     (pending : List (BusInteraction (Expression p))) →
@@ -172,6 +189,7 @@ def addAll (facts : BusFacts p bs) :
   | bi :: rest, hmem, T =>
     let hbi := hmem bi (List.mem_cons_self ..)
     let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
+    let cands := probeCandidatesOf bi
     let rec addVars (xs : List Variable) (T : BoundsMap p cs bs) : BoundsMap p cs bs :=
       match xs with
       | [] => T
@@ -181,13 +199,22 @@ def addAll (facts : BusFacts p bs) :
               T.insertEntry x b
                 (fun env hbus => interactionBound_sound bs facts bi x b hr env (hbus bi hbi))
           | none => T
-        -- Also try the probed bound (slotFun consistency; e.g. the XOR-mask 6-bit top-limb
+        -- Also try the probed bounds (slotFun consistency; e.g. the XOR-mask 6-bit top-limb
         -- bound `[x, 192, 192 + x, 1]` ⟹ `x < 64`); `insertEntry` keeps the smaller bound.
-        match hr2 : probedSlotBound bs facts bi x with
-        | some b =>
-            addVars xs (T1.insertEntry x b
-              (fun env hbus => probedSlotBound_sound bs facts bi x b hr2 env (hbus bi hbi)))
-        | none => addVars xs T1
+        -- Only slots the pre-scan names for `x` are tried; the recognizer re-checks everything.
+        let rec goCands (cl : List (Variable × Nat)) (T : BoundsMap p cs bs) :
+            BoundsMap p cs bs :=
+          match cl with
+          | [] => T
+          | (y, j) :: cl =>
+            if y = x then
+              match hr2 : probedSlotBoundAt bs facts bi x j with
+              | some b =>
+                  goCands cl (T.insertEntry x b (fun env hbus =>
+                    probedSlotBoundAt_sound bs facts bi x j b hr2 env (hbus bi hbi)))
+              | none => goCands cl T
+            else goCands cl T
+        addVars xs (goCands cands T1)
     addAll facts rest hrest (addVars (rawVarsOf bi) T)
 
 /-- Build the bounds map for a system (one pass over the interactions). -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/MemoryUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/MemoryUnify.lean
@@ -176,11 +176,18 @@ def addAll (facts : BusFacts p bs) :
       match xs with
       | [] => T
       | x :: xs =>
-        match hr : interactionBound bs facts bi x with
+        let T1 := match hr : interactionBound bs facts bi x with
+          | some b =>
+              T.insertEntry x b
+                (fun env hbus => interactionBound_sound bs facts bi x b hr env (hbus bi hbi))
+          | none => T
+        -- Also try the probed bound (slotFun consistency; e.g. the XOR-mask 6-bit top-limb
+        -- bound `[x, 192, 192 + x, 1]` ⟹ `x < 64`); `insertEntry` keeps the smaller bound.
+        match hr2 : probedSlotBound bs facts bi x with
         | some b =>
-            addVars xs (T.insertEntry x b
-              (fun env hbus => interactionBound_sound bs facts bi x b hr env (hbus bi hbi)))
-        | none => addVars xs T
+            addVars xs (T1.insertEntry x b
+              (fun env hbus => probedSlotBound_sound bs facts bi x b hr2 env (hbus bi hbi)))
+        | none => addVars xs T1
     addAll facts rest hrest (addVars (rawVarsOf bi) T)
 
 /-- Build the bounds map for a system (one pass over the interactions). -/

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -15,14 +15,15 @@ Absolute output totals (identical inputs, so `agg` effectiveness follows directl
 
 | benchmark | axis | apc | powdr | apc − powdr |
 |---|---|---|---|---|
-| openvm-eth (100) | variables | 27,768 | 30,885 | **−3,117 (lead; entry 83 seqz −20, entry 84 one-hot −14)** |
-| | bus interactions | 16,429 | 16,722 | **−293 (lead)** |
+| openvm-eth (100) | variables | 27,762 | 30,885 | **−3,123 (lead; entry 85 JAL ladders −6)** |
+| | bus interactions | 16,424 | 16,722 | **−298 (lead)** |
 | | constraints | 10,955 | 20,299 | −9,344 (lead; entry 83 −60, entry 84 −252) |
 | keccak | variables | 2,021 | 2,021 | **exact parity** |
 | | bus interactions | 1,752 | 1,734 | **+18 (was +218; entry 82 −200)** |
 | | constraints | 186 | 186 | **exact parity** |
 
-Per-case standings on eth: variables **31 W / 9 L / 60 T** (entries 83/84 flipped 2 losses).
+Per-case standings on eth: variables **31 W / 7 L / 62 T** (entries 83/84 flipped 2 losses;
+entry 85 flipped apc_034/066 to exact parity).
 Bus per-case was **7 W / 67 L / 26 T** (+588 over losing cases) at the measurement base;
 #117/#119 improved 37 case-measurements with 0 regressions (agg 3.439× → 3.479×, geo 2.723× →
 2.753×; powdr 3.480× / 2.822×) — re-measure the standings before quoting them. The reported
@@ -35,9 +36,10 @@ both benchmarks except keccak, where the identified fixes land exactly on powdr'
 Exact gap decomposition (verified on the live circuits at the measurement base; buckets marked
 LANDED are done — the remainder still adds up to the current gaps):
 
-- **eth variables ~+28 over 8 cases** (was +172 over 29) = ~~M1 constant decompositions +135~~
-  (**LANDED**: entry 81 −165 incl. cascades; residual = full-byte-top `rd_data` ladders,
-  apc_034/066 +3 each) · ~~M2 comparison gadgets (apc_037 +14, apc_018 +9)~~ (**LANDED**: entry 83
+- **eth variables ~+22 over 7 cases** (was +172 over 29) = ~~M1 constant decompositions +135~~
+  (**LANDED**: entry 81 −165 incl. cascades; entry 85 −6 = the mask-bounded `JAL` ladders,
+  apc_034/066 now exact parity; residual = ladders with no mask check on the top limb, parts of
+  apc_038/042/064) · ~~M2 comparison gadgets (apc_037 +14, apc_018 +9)~~ (**LANDED**: entry 83
   seqz collapse) · ~~M3 dead `bit_multiplier` +14~~ (**LANDED**: entry 84 −14, apc_038/051) ·
   everything else nets in apc's favor.
 - **eth bus** (was +588 over losing cases; −191 + −132 + −141 landed) = ~~width-1 range checks
@@ -62,12 +64,16 @@ LANDED are done — the remainder still adds up to the current gaps):
   effectiveness-neutral, ~half the collapse-stage runtime.
 - **#122 merged** (entry 80 = idea 4(b)+(c)): width-1 → booleanity + subsumed range-check drop;
   eth bus −132 (aggregate flips to a lead), keccak bus −68.
-- **Entry 81 (this branch): the bounded-payload digit fold** — lands the payload-ladder core of
+- **Entry 81 (#120 merged): the bounded-payload digit fold** — lands the payload-ladder core of
   idea 1 below; see the re-scoped idea 1.
-- **#116 open** (gated constant-decomposition fold): eth-neutral because its gate skips every
-  profitable case; the digit fold (entry 81) lands the same family from the payload side, so
-  #116 is now fully subsumed — close it, but its proven digit-uniqueness core (`annDecode_forces`,
-  `annSum_val`) remains the natural starting point for the constraint-side remainder of idea 1.
+- **Entry 85 (PR #123): probed slot bounds** — reads the XOR-mask range facts
+  (`[x, 192, 192 + x, 1]` ⟺ `x < 64`) into `BoundsMap`, closing idea 1's mask-bounded `JAL`
+  ladder slice (apc_034/066 to exact parity). The same session built and *withdrew* the
+  constraint-side fold after measuring it at +0 vars / +12 bus on top of the digit fold —
+  see idea 1's closed slice and the dead ends.
+- **#116 open** (gated constant-decomposition fold): fully subsumed — the digit fold (entry 81)
+  lands the family from the payload side, and the ungated constraint-side angle measured at
+  zero residual value (idea 1's closed slice). Close it.
 
 ---
 
@@ -87,17 +93,23 @@ link-register family; no keccak pair-matching regression (unlike #116's ungated 
 attempt).
 
 **Remaining slices of this idea:**
-- **Shifted `rd_data__{1,2,3}` ladders whose top limb is a full byte** (apc_034/066 +3 each,
-  parts of apc_038/042/064): all-byte bounds genuinely admit wrap phantoms; needs a tighter
-  top-limb bound from another constraint, if one exists. Low ceiling (~6–15 vars).
+- ~~**Mask-bounded `JAL` link ladders** (apc_034/066 +3 each)~~ (**LANDED**: entry 85 — the
+  "missing" top-limb bound existed as the genuine-XOR identity `[rd₃, 192, 192 + rd₃, 1]`
+  ⟺ `rd₃ < 64`; the probed slot bound (`probedSlotBoundAt`) reads it into `BoundsMap` and the
+  entry-81 fold does the rest. Both cases at exact powdr parity.)
+- **Ladders with no mask check on the top limb** (parts of apc_038/042/064, ≲ +10 vars): the
+  mod-p alias (digits of `K + p`) is then a satisfying *admissible* assignment, so no per-check
+  fold is sound (`isCompleteReplacementOf` quantifies over all admissible assignments) — see
+  dead ends. The only route is joint multi-constraint refutation (enumerate the adder cluster's
+  carry booleans against the range facts, fold on a singleton). Census the exact residue before
+  building anything; low ceiling.
 - **Constraint-side affine seeds** (`Σ cᵢ·xᵢ = K` as an algebraic constraint rather than a
-  payload ladder), which Gauss unit-pivots away before any digit solver sees them. #116's
-  `ConstDecomp.lean` proves the digit-uniqueness core (`annDecode_forces`, `annSum_val`); if
-  built, substitute all digits at once via `SubstMap` *before* `gauss`, and heed #116's measured
-  traps: the ungated version cost keccak +187 bus (folded constant send payloads stop matching
-  unfolded receives in `busUnify`/`busPairCancel` — fix the matcher, don't re-add the gate) and
-  +16% runtime (don't emit equalities for Gauss to rediscover). Unclear residual value now that
-  the payload side landed — re-census first.
+  payload ladder): **measured dead end** — built in full (entry 82's session: ungated batch
+  `SubstMap` fold before `gauss` + seed-aware pivot declining + slot-form decode with remainder
+  bound) and A/B'd on top of the digit fold at **+0 vars on all 100 eth cases / +12 bus**.
+  Gauss's pivot mangling is what *feeds* the payload-side fold (`g`-scaled slot ladders are
+  more rigid than raw seeds: `M % g = 0` kills wrap phantoms); protecting seeds starves it.
+  Do not rebuild; close #116.
 
 ---
 
@@ -247,6 +259,18 @@ and accepts both closer signs (mid-cycle the optimizer holds the negated `(1 −
 
 ## Measured dead ends (all re-verified this session — do not re-propose without new evidence)
 
+- **Constraint-side digit folding / pre-Gauss seed protection** (entry 85's session): the
+  complete mechanism (ungated batch `SubstMap` fold before `gauss`, seed-aware pivot
+  declining/deferral under optimistic bounds, slot-form decode with a remainder bound) measures
+  **+0 vars on all 100 eth cases / +12 bus** on top of the payload-side digit fold. Pivot
+  mangling *feeds* the digit fold; protecting seeds starves it. Also learned: `BoundsMap` is
+  empty in cleanup cycle 1 (every multiplicity is validity-flag-guarded until the first `gauss`
+  pins the flag), so bounds-gated passes are inert there.
+- **Per-check folding of ladders whose limbs are genuinely all-byte**: the mod-p alias (digits
+  of `K + p`) is a satisfying, admissible assignment, so a per-constraint/per-check fold breaks
+  `isCompleteReplacementOf` — not merely unproven, *incorrect*. Check for a mask/range fact on
+  the top limb first (entry 85 reads the XOR-mask encoding); only genuinely uncovered ladders
+  need joint refutation.
 - **Keccak below powdr**: nothing exists. XOR dag is *perfectly clean* — 0 duplicate operand
   pairs, 0 trivial identities, 0 dead results, 0 collapsible `(a⊕b)⊕a` chains; apc's 862 genuine
   XORs ≡ powdr's 862 (87 differ only in inlining depth). Memory: no semantic pairs beyond the

--- a/docs/log.md
+++ b/docs/log.md
@@ -3164,3 +3164,53 @@ misleading. The recognizer now accepts both signs; both entail the same `x = 0`.
 
 Build + `Scripts/check-proof-integrity.sh` green — the correctness theorems depend only on
 `{propext, Classical.choice, Quot.sound}`. **Worked: yes.**
+### 85. Probed slot bounds: reading the XOR-mask range facts (idea 1's residual `JAL` ladders) — −6 eth vars, 2 losses flip to powdr parity, 0 regressions
+
+**The gap.** After entry 81 the residual eth variable losses attributed to constant
+decompositions were the `JAL` link ladders (apc_034/066 +3 vars each): the digit fold saw the
+byte-checked ladder `[K − 256·rd₁ − 65536·rd₂ − 16777216·rd₃, rd₁, 0, 0]`, but with all-byte
+limb bounds the (byte, wrap) grid admits a mod-p phantom digit vector per wrap count and never
+collapses to a singleton. Entry 81 recorded "needs a tighter top-limb bound from another
+constraint, if one exists". **Rendering the residue shows it exists in every instance** — as
+the genuine-XOR check `[rd₃, 192, 192 + rd₃, 1]`: an accepted message forces
+`rd₃ ⊕ 192 = rd₃ + 192`, i.e. `rd₃ ∧ 0b11000000 = 0`, i.e. `rd₃ < 64` — OpenVM's 6-bit
+top-limb bound for `pc < 2³⁰`, shipped as bit-disjointness rather than a range check. No bound
+recognizer read that encoding.
+
+**Mechanism (`probedSlotBoundAt`, DomainProp.lean — generic: no XOR, mask, or OpenVM
+specifics).** For an interaction with constant nonzero multiplicity, a variable `x` raw in slot
+`i` with a `slotBound` fact `x < B₀ ≤ 256`, a slot `j ≠ i` whose content linearizes to
+`l.const + c·x`, a `slotFun` fact computing slot `j` from the rest of the payload, and every
+other slot constant: probe all `v < B₀` for `f(payload[x := v, j := 0]) = l.const + c·v` and
+bound `x` by one plus the largest survivor (`probeMax`), kept only when it strictly improves on
+`B₀`. For the mask check the survivors are exactly `[0, 64)`; for the NOT-form checks
+`[x, 255, 255 − x, 1]` every byte survives and nothing is inserted. `BoundsMap.addAll` feeds the
+probed bound through the existing `insertEntry` (keeping the smaller); `digitFold`'s grid then
+collapses to a singleton and the existing cascade folds the ladder — **no new pass, no
+`digitFold` change**. A once-per-interaction pre-scan (`probeCandidatesOf`: a slot affine in a
+single variable `y` can only ever bound `y`) keeps the recognizer off the hot path; the first
+cut without it re-linearized per (variable, slot) pair and looked like +37% keccak runtime —
+which turned out to be measurement error against entry 81's runtime from a different machine
+(see below), but the pre-scan is the right shape regardless.
+
+**Why sound.** `slotFun_sound` pins the evaluated slot `j` to `f` of the zeroed payload; with
+slots `≠ i, j` constant and slot `i` a raw variable, that zeroed payload *is* the probe payload
+at `v = x.val` (`probeBase_eq_set`, a `getElem?`-extensionality argument); `linearize` pins slot
+`j`'s value to `l.const + c·x`; so `x.val` survives the probe and `probeMax_lt` bounds it.
+Needs `p ≠ 0` only (val/cast round-trip); no primality.
+
+**Measured (per-case JSON A/B vs main `2b1e5c1`, all 100 eth cases + keccak):**
+- openvm-eth: vars **27,768 → 27,762 (−6)**, bus 16,429 → 16,424 (−5), constraints unchanged;
+  exactly two cases move — apc_034 −3 vars/−3 bus → **105/22/80 = exact powdr parity**, apc_066
+  −3 vars/−2 bus → **49/10/37 = exact powdr parity** — and nothing else changes. Variable
+  W/L/T vs powdr **31/9/60 → 31/7/62**; agg vars 4.551× → 4.552× (geo 3.884× → 3.887×), bus
+  3.542× → 3.543× (geo 2.800× → 2.803×).
+- keccak: bit-identical (2021 / 1752 / 186); runtime 369 s vs main 383 s **solo on the same
+  container** (parity). Note for future entries: entry 81's ~275 s keccak runtime was measured
+  on different hardware — always re-measure the baseline on the machine at hand before calling
+  a runtime regression (this iteration chased a phantom +37% for one round because of it).
+- The remaining "parts of apc_038/042/064" residue did not move — their ladders lack a mask
+  check on the top limb; they stay with the joint-refutation slice in ideas.md.
+
+Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
+**Worked: yes.**


### PR DESCRIPTION
## What this does

The residual `JAL` link ladders (apc_034/066, +3 vars each vs powdr) carry OpenVM's 6-bit
top-limb bound **encoded as a genuine-XOR identity** `[rd₃, 192, 192 + rd₃, 1]` — an accepted
message forces `rd₃ ⊕ 192 = rd₃ + 192`, i.e. `rd₃ ∧ 0b11000000 = 0`, i.e. `rd₃ < 64` — which no
bound recognizer read, so `digitFold`'s (byte, wrap) grid kept a mod-p phantom digit vector and
never collapsed.

New generic derivation (`probedSlotBoundAt`, `DomainProp.lean` — no XOR, mask, or OpenVM
specifics): for an interaction with constant nonzero multiplicity, a variable `x` raw in slot
`i` with a `slotBound` fact `x < B₀ ≤ 256`, a slot `j` whose content linearizes to
`l.const + c·x`, a `slotFun` fact computing slot `j` from the rest of the payload, and constants
elsewhere — probe all `v < B₀` for `f(payload[x := v, j := 0]) = l.const + c·v` and bound `x` by
one plus the largest survivor (kept only when it strictly improves). `BoundsMap.addAll` inserts
it alongside `interactionBound` (keeping the smaller); the existing `digitFold` cascade does the
rest — **no new pass**. A once-per-interaction pre-scan (`probeCandidatesOf`) keeps the
recognizer off the hot path.

Soundness: `slotFun_sound` pins the evaluated output slot to `f` of the zeroed payload, which
`probeBase_eq_set` identifies with the probe payload at `v = x.val`; `linearize` pins the slot
to `l.const + c·x`; `probeMax_lt` bounds the surviving value. Needs `p ≠ 0` only.

## Measured (per-case JSON A/B vs main `2b1e5c1`, all 100 eth cases + keccak)

- **openvm-eth**: vars 27,768 → **27,762 (−6)**, bus 16,429 → 16,424 (−5), constraints
  unchanged. Exactly two cases move, both to **exact powdr parity**: apc_034 −3 vars/−3 bus
  (105/22/80), apc_066 −3 vars/−2 bus (49/10/37). **0 regressions.** Variable W/L/T vs powdr
  **31/9/60 → 31/7/62**; agg vars 4.551× → 4.552× (geo 3.884× → 3.887×), bus 3.542× → 3.543×.
- **keccak**: bit-identical (2021 / 1752 / 186); runtime 369 s vs main's 383 s solo on the same
  container (parity — entry 81's ~275 s baseline was different hardware; noted in the log as a
  measurement rule).

## Also in this PR's log/ideas updates (entry 85 + ideas.md)

The same session first built the full **constraint-side** fold idea 1 specified (ungated batch
`SubstMap` fold before `gauss` + seed-aware Gauss + slot-form decode with remainder bound) —
in parallel, it turned out, with #120 — and measured it on top of the digit fold at
**+0 vars on all 100 cases / +12 bus / no runtime win**: withdrawn, recorded as a measured dead
end (Gauss's pivot mangling *feeds* the payload-side fold; protecting seeds starves it). Ladders
with no mask check on the top limb are recorded as per-check **unfoldable under the spec** (the
digits of `K + p` are a satisfying, admissible assignment — `isCompleteReplacementOf` forbids
the fold); only joint multi-constraint refutation can reach them. ideas.md standings, idea 1
slices, and dead ends refreshed accordingly; #116 can be closed.

Build + `Scripts/check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cv6DWetGUthkKetSfbWaB