### PR TITLE
NOT-form byte checks: recognize `[x, 255, 255 − x, 1]` (idea 4a) — keccak −200 bus, eth −20 bus, 0 regressions

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -256,6 +256,24 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       (∀ (y z : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [255, y, z, 1] }
           = false → z = 255 - y)
+  /-- Byte-check *via XOR-with-255* (the NOT form): the sibling of `xorZeroCheck`. On a stateless
+      bitwise-style bus the checks `[x, 255, 255 − x, 1]` (`x ⊕ 255 = 255 − x`) and its mirror
+      `[255, x, 255 − x, 1]` — multiplicity any — are each accepted **iff** `x` is a byte. After
+      `xorEqExtractPass` (C4b) linearizes a `255`-operand XOR and Gauss substitutes the NOT-result
+      `z := 255 − x`, exactly this shape is left on the bus; its sole obligation is "`x` is a byte"
+      (the third slot being `255 − x` is then vacuous), so the redundant-byte-check dropper and the
+      byte-check packer should treat it as a single-value byte check on `x`. Sound only when `255`
+      is a genuine byte of the field (`256 ≤ p`); a small field, and `trivial`, set it `false`. -/
+  xorComplCheck : (busId : Nat) → Bool
+  xorComplCheck_sound :
+    ∀ (busId : Nat), xorComplCheck busId = true →
+      bs.isStateful busId = false ∧
+      (∀ (x mult : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, 255, 255 - x, 1] }
+            = false ↔ x.val < 256) ∧
+      (∀ (x mult : ZMod p),
+        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [255, x, 255 - x, 1] }
+            = false ↔ x.val < 256)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -290,3 +308,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   xorZeroEq_sound := by intro _ h; exact absurd h (by simp)
   xorComplEq _ := false
   xorComplEq_sound := by intro _ h; exact absurd h (by simp)
+  xorComplCheck _ := false
+  xorComplCheck_sound := by intro _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -694,6 +694,61 @@ def openVmFacts (p : ℕ) [NeZero p]
         rw [hzxor, hc]; exact nat_xor_255 y.val hyb
       have hz : z = ((z.val : ℕ) : ZMod p) := (ZMod.natCast_rightInverse z).symm
       rw [hz, hzv, Nat.cast_sub (hle_of y hyb), ZMod.natCast_rightInverse y, hcast255]
+  xorComplCheck busId := match busMap busId with
+    | some .bitwiseLookup => decide (256 ≤ p)
+    | _ => false
+  xorComplCheck_sound := by
+    intro busId h
+    have hbus : busMap busId = some OpenVmBusType.bitwiseLookup := by
+      revert h; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    have hple : 256 ≤ p := by
+      have h' : (match busMap busId with
+          | some OpenVmBusType.bitwiseLookup => decide (256 ≤ p) | _ => false) = true := h
+      rw [hbus] at h'; exact of_decide_eq_true h'
+    have hp2 : 1 < p := by omega
+    have h1val : (1 : ZMod p).val = 1 := by
+      rw [ZMod.val_one_eq_one_mod]; exact Nat.mod_eq_of_lt hp2
+    have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
+    have h255val : (255 : ZMod p).val = 255 := by
+      rw [← hcast255, ZMod.val_natCast_of_lt (by omega : (255 : ℕ) < p)]
+    -- `(255 − x).val = 255 − x.val` when `x` is a byte (no wrap: `x.val ≤ 255 < p`).
+    have hsubval : ∀ x : ZMod p, x.val < 256 → (255 - x).val = 255 - x.val := by
+      intro x hx
+      have hxle : x.val ≤ 255 := Nat.le_of_lt_succ (by omega)
+      have hx' : x = ((x.val : ℕ) : ZMod p) := (ZMod.natCast_rightInverse x).symm
+      calc (255 - x).val
+          = ((255 : ZMod p) - ((x.val : ℕ) : ZMod p)).val := by rw [← hx']
+        _ = (((255 - x.val : ℕ) : ZMod p)).val := by
+              rw [Nat.cast_sub hxle, hcast255]
+        _ = 255 - x.val := ZMod.val_natCast_of_lt (by omega)
+    -- both checks reduce to "`x` is a byte": op = 1, `255` is a byte, and `255 − x = x ⊕ 255`.
+    refine ⟨?_, ?_, ?_⟩
+    · show (match busMap busId with | some t => t.isStateful | none => false) = false
+      rw [hbus]; rfl
+    · intro x mult
+      show violates busMap { busId := busId, multiplicity := mult, payload := [x, 255, 255 - x, 1] }
+          = false ↔ x.val < 256
+      unfold violates; rw [hbus]
+      simp only [h1val, h255val, isByte, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq]
+      constructor
+      · rintro ⟨⟨hxb, _⟩, _⟩; exact hxb
+      · intro hxb
+        refine ⟨⟨hxb, by omega⟩, ?_⟩
+        rw [hsubval x hxb, ← nat_xor_255 x.val hxb]
+    · intro x mult
+      show violates busMap { busId := busId, multiplicity := mult, payload := [255, x, 255 - x, 1] }
+          = false ↔ x.val < 256
+      unfold violates; rw [hbus]
+      simp only [h1val, h255val, isByte, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq]
+      constructor
+      · rintro ⟨⟨_, hxb⟩, _⟩; exact hxb
+      · intro hxb
+        refine ⟨⟨by omega, hxb⟩, ?_⟩
+        have hc : Nat.xor 255 x.val = Nat.xor x.val 255 := Nat.xor_comm 255 x.val
+        rw [hsubval x hxb, hc]
+        exact (nat_xor_255 x.val hxb).symm
   varRangeBus busId := match busMap busId with
     | some .variableRangeChecker => true
     | _ => false

--- a/ApcOptimizer/Implementation/OptimizerPasses/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ByteCheckPack.lean
@@ -1,14 +1,19 @@
 import ApcOptimizer.Implementation.OptimizerPasses.TupleRange
+import ApcOptimizer.Implementation.OptimizerPasses.Normalize
+import ApcOptimizer.Implementation.OptimizerPasses.TautoBus
 
 set_option autoImplicit false
 
 /-! # Generalized single-value byte-check packing (`byteCheckPackPass`)
 
-On a bitwise-style lookup bus a single value is byte-range-checked in one of three multiplicity-1
+On a bitwise-style lookup bus a single value is byte-range-checked in one of several multiplicity-1
 encodings that all impose exactly "this value is a byte":
 
 * the self-check `[x, x, 0, 1]` (`BusFacts.byteCheck`),
-* the XOR-with-zero form `[x, 0, x, 1]` and its mirror `[0, x, x, 1]` (`BusFacts.xorZeroCheck`).
+* the XOR-with-zero form `[x, 0, x, 1]` and its mirror `[0, x, x, 1]` (`BusFacts.xorZeroCheck`),
+* the NOT (XOR-with-255) form `[x, 255, 255 − x, 1]` and its mirror `[255, x, 255 − x, 1]`
+  (`BusFacts.xorComplCheck`, where the third slot normalizes to `255 − x`) — the shape
+  `xorEqExtractPass` (C4b) + Gauss leave when a `255`-operand XOR's NOT-result is substituted.
 
 Two such single-value checks — in *any* combination of these forms — pack into **one** pair check
 `[eA, eB, 0, 0]` (`BusFacts.bytePairBus`), which imposes the identical obligation "both operands are
@@ -29,11 +34,34 @@ namespace ByteCheckPack
 
 variable {p : ℕ}
 
+/-! ## Recognizing the NOT-form complement -/
+
+/-- `255 − e` as an expression. -/
+def complExpr (e : Expression p) : Expression p := .add (.const 255) (.mul (.const (-1)) e)
+
+/-- Does `b` evaluate to the byte complement `255 − a` under every assignment? Decided by folding
+    `b − (255 − a)` to a constant and checking it is `0`. Recognizes the third slot of the NOT-form
+    byte check `[a, 255, 255 − a, 1]` that `xorEqExtractPass` (C4b) + Gauss leave on the bus. -/
+def isByteCompl (a b : Expression p) : Bool :=
+  (Expression.add b (.mul (.const (-1)) (complExpr a))).normalize.constValue? == some 0
+
+theorem isByteCompl_sound (a b : Expression p) (h : isByteCompl a b = true)
+    (env : Variable → ZMod p) : b.eval env = 255 - a.eval env := by
+  unfold isByteCompl at h
+  have hc : (Expression.add b (.mul (.const (-1)) (complExpr a))).normalize.constValue? = some 0 := by
+    simpa using h
+  have h0 : (Expression.add b (.mul (.const (-1)) (complExpr a))).eval env = 0 := by
+    have := Expression.constValue?_sound _ (0 : ZMod p) hc env
+    rwa [Expression.normalize_eval] at this
+  simp only [complExpr, Expression.eval] at h0
+  linear_combination h0
+
 /-! ## Recognizing a single-value byte check in any encoding -/
 
 /-- The value byte-checked by a multiplicity-1 single-value bitwise byte check: the self-check
-    `[x, x, 0, 1]` (`byteCheck`) and the two XOR-with-zero mirrors `[x, 0, x, 1]` / `[0, x, x, 1]`
-    (`xorZeroCheck`) all return `some x`; `none` otherwise. -/
+    `[x, x, 0, 1]` (`byteCheck`), the two XOR-with-zero mirrors `[x, 0, x, 1]` / `[0, x, x, 1]`
+    (`xorZeroCheck`), and the two NOT (XOR-with-255) forms `[x, 255, 255 − x, 1]` /
+    `[255, x, 255 − x, 1]` (`xorComplCheck`) all return `some x`; `none` otherwise. -/
 def svCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (Expression p) :=
   match bi.payload with
@@ -42,6 +70,8 @@ def svCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
       if facts.byteCheck bi.busId = true ∧ e1 = e2 ∧ e3 = Expression.const 0 then some e1
       else if facts.xorZeroCheck bi.busId = true ∧ e2 = Expression.const 0 ∧ e1 = e3 then some e1
       else if facts.xorZeroCheck bi.busId = true ∧ e1 = Expression.const 0 ∧ e2 = e3 then some e2
+      else if facts.xorComplCheck bi.busId = true ∧ e2 = Expression.const 255 ∧ isByteCompl e1 e3 = true then some e1
+      else if facts.xorComplCheck bi.busId = true ∧ e1 = Expression.const 255 ∧ isByteCompl e2 e3 = true then some e2
       else none
     else none
   | _ => none
@@ -66,7 +96,7 @@ theorem svCheck?_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     -- payload shape and multiplicity
     have hmem : ∀ x ∈ ([e1, e2, e3, e4] : List (Expression p)), x ∈ bi.payload := by
       intro x hx; rw [hpay]; exact hx
-    split_ifs at h with hmo hA hB hC
+    split_ifs at h with hmo hA hB hC hD hE
     · -- self-check `[x, x, 0, 1]`
       obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he12, he3⟩ := hA
       obtain rfl : e1 = e := by simpa using h
@@ -97,6 +127,30 @@ theorem svCheck?_sound (bs : BusSemantics p) (facts : BusFacts p bs)
         rw [hm, hpay, he1, ← he23, he4]; simp [Expression.eval]
       rw [heq]
       exact ((facts.xorZeroCheck_sound bi.busId hfact).2.2 (e2.eval env) 1)
+    · -- NOT-form `[x, 255, 255 - x, 1]`
+      obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he2, hcompl⟩ := hD
+      obtain rfl : e1 = e := by simpa using h
+      refine ⟨(facts.xorComplCheck_sound bi.busId hfact).1, hm, hmem e1 (by simp), fun env => ?_⟩
+      have he3 : e3.eval env = 255 - e1.eval env := isByteCompl_sound e1 e3 hcompl env
+      have heq : bi.eval env
+          = { busId := bi.busId, multiplicity := 1,
+              payload := [e1.eval env, 255, 255 - e1.eval env, 1] } := by
+        unfold BusInteraction.eval
+        rw [hm, hpay, he2, he4]; simp [Expression.eval, he3]
+      rw [heq]
+      exact ((facts.xorComplCheck_sound bi.busId hfact).2.1 (e1.eval env) 1)
+    · -- mirror NOT-form `[255, x, 255 - x, 1]`
+      obtain ⟨hm, he4⟩ := hmo; obtain ⟨hfact, he1, hcompl⟩ := hE
+      obtain rfl : e2 = e := by simpa using h
+      refine ⟨(facts.xorComplCheck_sound bi.busId hfact).1, hm, hmem e2 (by simp), fun env => ?_⟩
+      have he3 : e3.eval env = 255 - e2.eval env := isByteCompl_sound e2 e3 hcompl env
+      have heq : bi.eval env
+          = { busId := bi.busId, multiplicity := 1,
+              payload := [255, e2.eval env, 255 - e2.eval env, 1] } := by
+        unfold BusInteraction.eval
+        rw [hm, hpay, he1, he4]; simp [Expression.eval, he3]
+      rw [heq]
+      exact ((facts.xorComplCheck_sound bi.busId hfact).2.2 (e2.eval env) 1)
 
 /-! ## Acceptance of a pair check -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -39,12 +39,37 @@ namespace RedundantByteDrop
 
 variable {p : ℕ}
 
+/-! ## Recognizing the NOT-form complement -/
+
+/-- `255 − e` as an expression. -/
+def complExpr (e : Expression p) : Expression p := .add (.const 255) (.mul (.const (-1)) e)
+
+/-- Does `b` evaluate to the byte complement `255 − a` under every assignment? Decided by folding
+    `b − (255 − a)` to a constant and checking it is `0` (`normalize` collects the affine terms so a
+    genuine complement cancels to the literal `0`). Used to recognize the NOT-form byte check
+    `[a, 255, 255 − a, 1]` that `xorEqExtractPass` (C4b) + Gauss leave on the bus. -/
+def isByteCompl (a b : Expression p) : Bool :=
+  (Expression.add b (.mul (.const (-1)) (complExpr a))).normalize.constValue? == some 0
+
+theorem isByteCompl_sound (a b : Expression p) (h : isByteCompl a b = true)
+    (env : Variable → ZMod p) : b.eval env = 255 - a.eval env := by
+  unfold isByteCompl at h
+  have hc : (Expression.add b (.mul (.const (-1)) (complExpr a))).normalize.constValue? = some 0 := by
+    simpa using h
+  have h0 : (Expression.add b (.mul (.const (-1)) (complExpr a))).eval env = 0 := by
+    have := Expression.constValue?_sound _ (0 : ZMod p) hc env
+    rwa [Expression.normalize_eval] at this
+  simp only [complExpr, Expression.eval] at h0
+  linear_combination h0
+
 /-! ## Recognizing pure byte-check interactions -/
 
 /-- The operands whose byte-ness *implies* this interaction's acceptance (for any multiplicity):
     `some ops` for the self-check form `[x, x, 0, 1]` (`BusFacts.byteCheck`), the two XOR-with-zero
-    mirrors `[x, 0, x, 1]` and `[0, x, x, 1]` (`BusFacts.xorZeroCheck`), and the packed-pair form
-    `[x, y, 0, 0]` (`BusFacts.bytePairBus` + `byteCheck`); `none` otherwise. -/
+    mirrors `[x, 0, x, 1]` and `[0, x, x, 1]` (`BusFacts.xorZeroCheck`), the two NOT (XOR-with-255)
+    forms `[x, 255, 255 − x, 1]` and `[255, x, 255 − x, 1]` (`BusFacts.xorComplCheck`, where the
+    third slot normalizes to `255 − x`), and the packed-pair form `[x, y, 0, 0]`
+    (`BusFacts.bytePairBus` + `byteCheck`); `none` otherwise. -/
 def byteCheckOperands? (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (List (Expression p)) :=
   match bi.payload with
@@ -56,6 +81,12 @@ def byteCheckOperands? (bs : BusSemantics p) (facts : BusFacts p bs)
         && e4.constValue? == some 1 then
       some [e1]
     else if facts.xorZeroCheck bi.busId && e1.constValue? == some 0 && e2 == e3
+        && e4.constValue? == some 1 then
+      some [e2]
+    else if facts.xorComplCheck bi.busId && e2.constValue? == some 255 && isByteCompl e1 e3
+        && e4.constValue? == some 1 then
+      some [e1]
+    else if facts.xorComplCheck bi.busId && e1.constValue? == some 255 && isByteCompl e2 e3
         && e4.constValue? == some 1 then
       some [e2]
     else if facts.bytePairBus bi.busId && facts.byteCheck bi.busId
@@ -70,7 +101,7 @@ theorem byteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p b
     (h : byteCheckOperands? bs facts bi = some ops) : bs.isStateful bi.busId = false := by
   unfold byteCheckOperands? at h
   split at h
-  · split_ifs at h with h1 h2 h3 h4
+  · split_ifs at h with h1 h2 h3 h4 h5 h6
     · exact (facts.byteCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
         exact h1.1.1.1)).1
@@ -80,9 +111,15 @@ theorem byteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p b
     · exact (facts.xorZeroCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h3
         exact h3.1.1.1)).1
-    · exact (facts.bytePairBus_sound bi.busId (by
+    · exact (facts.xorComplCheck_sound bi.busId (by
         rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h4
         exact h4.1.1.1)).1
+    · exact (facts.xorComplCheck_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h5
+        exact h5.1.1.1)).1
+    · exact (facts.bytePairBus_sound bi.busId (by
+        rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h6
+        exact h6.1.1.1)).1
   · exact absurd h (by simp)
 
 /-- If every recognized operand evaluates to a byte, the evaluated message is accepted. -/
@@ -98,7 +135,7 @@ theorem byteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts p bs
   case h_1 e1 e2 e3 e4 hpay =>
     simp only at hpay
     subst hpay
-    split_ifs at h with h1 h2 h3 h4
+    split_ifs at h with h1 h2 h3 h4 h5 h6
     · -- self-check form `[x, x, 0, 1]`
       rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h1
       obtain ⟨⟨⟨hfact, heq⟩, hz⟩, ho⟩ := h1
@@ -138,9 +175,35 @@ theorem byteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts p bs
       rw [e1.constValue?_sound 0 hz' env, e4.constValue?_sound 1 ho' env]
       exact ((facts.xorZeroCheck_sound busId hfact).2.2 (e2.eval env) (mult.eval env)).2
         (hops e2 (by simp))
-    · -- packed-pair form `[x, y, 0, 0]`
+    · -- NOT-form `[x, 255, 255 - x, 1]`
       rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h4
-      obtain ⟨⟨⟨hpair, hfact⟩, hz⟩, ho⟩ := h4
+      obtain ⟨⟨⟨hfact, h255⟩, hcompl⟩, ho⟩ := h4
+      obtain rfl : [e1] = ops := by simpa using h
+      have h255' : e2.constValue? = some 255 := by simpa using h255
+      have ho' : e4.constValue? = some 1 := by simpa using ho
+      have he3 : e3.eval env = 255 - e1.eval env := isByteCompl_sound e1 e3 hcompl env
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e2.eval env, e3.eval env, e4.eval env] } = false
+      rw [e2.constValue?_sound 255 h255' env, e4.constValue?_sound 1 ho' env, he3]
+      exact ((facts.xorComplCheck_sound busId hfact).2.1 (e1.eval env) (mult.eval env)).2
+        (hops e1 (by simp))
+    · -- mirror NOT-form `[255, x, 255 - x, 1]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h5
+      obtain ⟨⟨⟨hfact, h255⟩, hcompl⟩, ho⟩ := h5
+      obtain rfl : [e2] = ops := by simpa using h
+      have h255' : e1.constValue? = some 255 := by simpa using h255
+      have ho' : e4.constValue? = some 1 := by simpa using ho
+      have he3 : e3.eval env = 255 - e2.eval env := isByteCompl_sound e2 e3 hcompl env
+      show bs.violatesConstraint
+        { busId := busId, multiplicity := mult.eval env,
+          payload := [e1.eval env, e2.eval env, e3.eval env, e4.eval env] } = false
+      rw [e1.constValue?_sound 255 h255' env, e4.constValue?_sound 1 ho' env, he3]
+      exact ((facts.xorComplCheck_sound busId hfact).2.2 (e2.eval env) (mult.eval env)).2
+        (hops e2 (by simp))
+    · -- packed-pair form `[x, y, 0, 0]`
+      rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h6
+      obtain ⟨⟨⟨hpair, hfact⟩, hz⟩, ho⟩ := h6
       obtain rfl : [e1, e2] = ops := by simpa using h
       have hz' : e3.constValue? = some 0 := by simpa using hz
       have ho' : e4.constValue? = some 0 := by simpa using ho

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -9,17 +9,17 @@ this regeneration was in flight, **#117 (entry 77) and #119 (entry 78) merged**,
 on rebase from the entries' measured numbers. Older write-ups had stale or wrong gap
 attributions; re-measure before trusting anything, including this file.
 
-## Where we stand (post-#117/#119 + entry 80 = idea 4(b)+(c) + entry 81 = the digit fold)
+## Where we stand (post-#117/#119 + entry 80 = idea 4(b)+(c) + entry 81 = digit fold + entry 82 = NOT-form byte checks)
 
 Absolute output totals (identical inputs, so `agg` effectiveness follows directly):
 
 | benchmark | axis | apc | powdr | apc − powdr |
 |---|---|---|---|---|
 | openvm-eth (100) | variables | 27,802 | 30,885 | **−3,083 (lead)** |
-| | bus interactions | 16,454 | 16,722 | **−268 (lead; was +5)** |
+| | bus interactions | 16,434 | 16,722 | **−288 (lead; entry 82 −20)** |
 | | constraints | 11,267 | 20,299 | −9,032 (lead) |
 | keccak | variables | 2,021 | 2,021 | **exact parity** |
-| | bus interactions | 1,952 | 1,734 | **+218 (was +293)** |
+| | bus interactions | 1,752 | 1,734 | **+18 (was +218; entry 82 −200)** |
 | | constraints | 186 | 186 | **exact parity** |
 
 Per-case standings on eth: variables **30 W / 11 L / 59 T** (+56 total over the losing cases).
@@ -44,11 +44,11 @@ LANDED are done — the remainder still adds up to the current gaps):
   (**LANDED**: #117 −76, #119 −115) · ~~constant-family checks ~126~~ (**LANDED**: entry 81
   −141) · long same-address chains **64** (apc_010 still 247 vs 239) · tuple-slot coverage waste
   (**remainder of the ≥112 bucket**) · ~~subsumed range checks 22~~ (**LANDED**: entry 80 ≈ −43,
-  the base also catches byte/memory-subsumed wide checks) · NOT-form byte checks **23** ·
-  residual scattered.
-- **keccak bus +218** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste,
-  entry 80 −68 width-1, entry 81 −7) = NOT-form byte checks **200** · ~18 misc — the bus-3
-  width histograms are otherwise *identical* to powdr's.
+  the base also catches byte/memory-subsumed wide checks) · ~~NOT-form byte checks 23~~
+  (**LANDED**: entry 82 −20) · residual scattered.
+- **keccak bus +218 → +18** (was +614; #117 −276 memory = exact powdr parity, #119 −45 op-0 waste,
+  entry 80 −68 width-1, entry 81 −7, **entry 82 −200 NOT-form**) = ~18 misc — the bus-3
+  width histograms are otherwise *identical* to powdr's, and NOT-form byte checks are gone.
 
 ## In flight / recently landed — check `git log origin/main` and open PRs before picking anything up
 
@@ -159,21 +159,21 @@ none (its one gadget landed with #114).
 ## 4. Stateless-check hygiene: recognize, justify, repack  ·  *bus, both benchmarks*  ·  high value / low-medium effort per item
 
 Four convergent fixes to how byte/range obligations are recognized and laid out; (d)'s op-0
-half already landed as #119, and **(b)+(c) landed together** (entry 80): keccak −68, eth −132
-bus, 0 variable/bus regressions. The remainder — (a) NOT-form byte checks and (d)'s tuple half —
-is worth ~**270 keccak** + a few dozen eth bus interactions. Independent items — land separately.
+half landed as #119, **(b)+(c)** as entry 80, and **(a)** as entry 82 (below). The remainder —
+(d)'s tuple half — is worth a few dozen eth bus interactions. Independent items — land separately.
 
-**(a) NOT-form byte checks** (keccak **200**, eth **23**). After C4b substitutes `z := 255 − x`,
-the interaction remains as `[x, 255, 255 − x, 1]` — semantically just "x is a byte" — but
-`RedundantByteDrop.byteCheckOperands?` / `ByteCheckPack.svCheck?` only match
-`[x,x,0,1] / [x,0,x,1] / [0,x,x,1] / [x,y,0,0]`. Add the two NOT arms: payload `(x, 255, z, 1)`
-(or mirrored) where `z` normalizes to `255 − x`. Fact side: mirror `xorZeroCheck` as
-`xorComplCheck` (needs `256 ≤ p` like C4b — over small fields `255 − x` is not the complement).
-On keccak **all 200 are droppable outright** — every checked operand is already forced < 256 by a
-genuine-XOR slot (96 as x, 8 as y, 12 as z, 84 via "255−v occurs as an XOR operand and
-`255−v ∈ [0,256) ⟺ v ∈ [0,256)`" — add that reflection rule to `byteJustified` too). On eth the
-23 sit on raw memory-receive slots (slotBound-justified). Expected: keccak −200, eth −23, both
-variable-neutral.
+**(a) NOT-form byte checks — LANDED (entry 82).** New fact `BusFacts.xorComplCheck` (bitwise bus,
+gated `256 ≤ p`); `RedundantByteDrop.byteCheckOperands?` and `ByteCheckPack.svCheck?` gained the two
+NOT arms `[x, 255, 255 − x, 1]` / `[255, x, 255 − x, 1]` (third slot decided `= 255 − x` by
+`normalize`/`constValue?`), so the coda drops them when the operand is byte-justified and the
+cleanup-cycle packer folds them into pairs. **keccak −200 bus** (1952 → 1752; variables and
+constraints unchanged — DigitFold/#120 already reached 2021-var parity, so no further var cascade
+and no runtime cost); **eth −20 bus over 3 cases, 0 regressions, variable-neutral** (bus agg
+3.536× → 3.541×). *The "reflection / AND-OR justification rule" the earlier write-up demanded (84
+keccak operands via a `255 − v` rule in `byteJustified`) was unnecessary: re-measured, every one of
+the 200 NOT-form operands also occurs as a raw variable in a genuine-XOR slot that `slotBound`
+already bounds to 256, so `byteJustified` justifies all 200 with the existing machinery — the
+84-via-reflection figure was a stale attribution from base 656a9d8.*
 
 **(b) Width-1 range checks → booleanity — LANDED (entry 80).** `[e, 1]` on the var-range bus ⟺
 `e ∈ {0,1}` ⟺ `e·(e−1) = 0` (degree 2 ≤ 3). `ZeroWidthRange.lean` grew a width-1 arm: ADD the

--- a/docs/log.md
+++ b/docs/log.md
@@ -3015,3 +3015,57 @@ fold, so deferred — recorded in ideas.md #3 with the corrected mechanism.
 Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
 **Worked: yes.**
 
+### 82. NOT-form byte checks: recognize `[x, 255, 255 − x, 1]` as a byte check (idea 4a) — keccak −200 bus, eth −20 bus, 0 regressions
+
+**Idea (ideas.md #4a).** `xorEqExtractPass` (C4b) linearizes a `255`-operand bitwise XOR
+`[x, 255, z, 1]` into `z = 255 − x`; Gauss substitutes the NOT-result, leaving `[x, 255, 255 − x, 1]`
+on the bitwise-lookup bus — semantically just "x is a byte", but no recognizer matched the shape, so
+it was neither dropped nor packed (keccak keeps 200 of these; eth 23). It is the largest remaining
+keccak bus family: after #117/#119/#122/#120, the keccak bus gap decomposes to "NOT-form byte checks
+200 · ~18 misc".
+
+**Mechanism.**
+- New proven fact `BusFacts.xorComplCheck` (OpenVM instance: bitwise-lookup bus, gated `256 ≤ p`
+  exactly like its sibling `xorComplEq`): `[x, 255, 255 − x, 1]` and mirror `[255, x, 255 − x, 1]`
+  (any multiplicity) are accepted **iff** `x.val < 256`. `trivial` sets it `false`, so the pass is
+  VM-agnostic; zero audit surface.
+- Both single-value byte-check recognizers gain the two NOT arms. The third slot is decided to be
+  `255 − x` by folding `e3 − (255 − e1)` and checking it is the constant `0` via
+  `normalize`/`constValue?` (`isByteCompl`; sound by `normalize_eval`):
+  - `RedundantByteDrop.byteCheckOperands?` returns `[x]`, so the existing `byteJustified` machinery
+    **drops** the interaction (coda) when `x` is byte-justified from the rest of the system;
+  - `ByteCheckPack.svCheck?` recognizes it as a single-value check, so `byteCheckPackPass` **packs**
+    it (with any other single byte check) into a pair `[x, y, 0, 0]` in the cleanup cycle.
+
+**The "reflection / AND-OR justification rule" ideas.md #4a demanded is NOT needed — stale
+attribution.** The file claimed 84 of the 200 keccak operands would need a `255 − v` reflection rule
+in `byteJustified`. Re-measured: every one of the 200 NOT-form operands `x` *also* occurs as a raw
+variable in a genuine-XOR slot (0/1/2) of a *retained* interaction, and `slotBound` already bounds
+those slots to 256, so `findVarBound`/`byteJustified` justify all 200 with the existing machinery —
+the coda drop alone removes exactly 200 keccak bitwise interactions. The 84-via-reflection figure
+was a stale attribution from base 656a9d8; **no reflection/AND-OR rule was added** (it would be dead
+code).
+
+**Why `svCheck?` (cycle packing) too, not just the coda drop.** Coda-drop-only regressed two eth
+cases by +1 bus each: recognizing a NOT-form removes it from `RedundantByteDrop`'s non-circular
+justification base, so a *second* byte-check on the same operand — previously dropped because the
+NOT-form (then in the base) bounded the operand — no longer drops when the operand is not otherwise
+justified. Recognizing the NOT-form in `svCheck?` fixes this: the cleanup-cycle packer folds the
+operand's two checks into one pair, which the coda `splitBytePair`/`dedupLate` collapse to a single
+retained check (net "drop one", not "drop none"). With it both cases become **improvements**.
+(On the pre-#120 base the cycle packing also unlocked a −4-var keccak cascade; #120's digit fold now
+owns those variables — keccak is already at 2021-var parity — so on this base the change is
+variable-neutral and, unlike the pre-#120 measurement, adds **no** keccak runtime.)
+
+**Measured (per-case JSON A/B vs main 851198d; effectiveness is deterministic):**
+- keccak: vars 2021 (unchanged, = powdr parity), **bus 1952 → 1752 (−200)**, constraints 186
+  (unchanged); bus effectiveness 6.794× → 7.569×. Runtime neutral (587 s vs 619 s back-to-back
+  single-threaded — noise on a transiently-slow runner).
+- openvm-eth (100 cases): vars agg **4.545× (identical)**, constraints **10.544× (identical)**, bus
+  agg 3.536× → **3.541×** (geo 2.796× → 2.799×; powdr 3.480× — the eth bus aggregate leads powdr by
+  +0.061×). **3 cases improved (apc_071 −16, apc_037 −2, apc_064 −2) = −20 bus, 0 regressions**;
+  per-case W/L/T vs powdr 30/11/59 unchanged; runtime +3% (rough, parallel-contended).
+
+Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only); audited
+surface untouched. **Worked: yes.**
+


### PR DESCRIPTION
## What

Implements idea 4(a) from `docs/ideas.md` (rebased onto current `main`, incl. #112/#120/#122). `xorEqExtractPass` (C4b) linearizes a 255-operand bitwise XOR `[x, 255, z, 1]` into `z = 255 − x`; Gauss then substitutes the NOT-result, leaving `[x, 255, 255 − x, 1]` on the bitwise-lookup bus. Semantically this is just "x is a byte" (the third slot is entailed), but no recognizer matched the shape, so it was neither dropped nor packed. It is the **largest remaining keccak bus family** — main's own gap decomposition reads "NOT-form byte checks 200 · ~18 misc"; eth keeps 23.

- **New proven fact `BusFacts.xorComplCheck`** (OpenVM instance: bitwise-lookup bus, gated `256 ≤ p` exactly like its sibling `xorComplEq`): `[x, 255, 255 − x, 1]` and its mirror `[255, x, 255 − x, 1]` (any multiplicity) are accepted **iff** `x` is a byte. `trivial` sets it `false`, so the pass stays VM-agnostic; zero audit surface (a wrong fact would not compile).
- **`RedundantByteDrop.byteCheckOperands?` and `ByteCheckPack.svCheck?` gain the two NOT arms.** The third slot is decided to be `255 − x` by folding `e3 − (255 − e1)` to the constant `0` via `normalize`/`constValue?` (`isByteCompl`, sound by `normalize_eval`). The coda **drops** the interaction when the operand is byte-justified from the rest of the system; the cleanup-cycle packer **folds** surviving NOT-forms into pairs.

## The idea file's "reflection / AND-OR justification rule" was not needed (stale attribution)

`docs/ideas.md` #4a claimed 84 of the 200 keccak operands would need a `255 − v` reflection rule added to `byteJustified`. Re-measured on current `main`: **every one of the 200 NOT-form operands also occurs as a raw variable in a genuine-XOR slot (0/1/2) of a retained interaction, and `slotBound` already bounds those slots to 256** — so `findVarBound`/`byteJustified` justify all 200 with the existing machinery. Confirmed empirically: the coda drop alone removes exactly 200 keccak bitwise interactions (= the NOT-form count). That figure was a stale attribution from the older base `656a9d8`; **no reflection/AND-OR rule was added** (it would have been dead code).

## Why `svCheck?` (cycle packing) too, not just the coda drop

Coda-drop-only regressed two eth cases by +1 bus each: recognizing a NOT-form removes it from `RedundantByteDrop`'s non-circular justification base, so a *second* byte-check on the same operand — previously dropped because the NOT-form (then in the base) bounded the operand — no longer drops when the operand is not otherwise justified. Recognizing the NOT-form in `svCheck?` fixes this: the cleanup-cycle packer folds the operand's two checks into one pair, which the coda `splitBytePair`/`dedupLate` collapse to a single retained check (net "drop one", not "drop none"). With this, both cases become **improvements**.

## Effectiveness (per-case JSON A/B vs `main` `851198d`; sizes are deterministic)

- **keccak: bus 1952 → 1752 (−200)**; variables (2021 = exact powdr parity) and constraints (186) unchanged. Bus effectiveness 6.794× → 7.569×. The keccak bus gap to powdr closes from +218 to **+18**.
- **openvm-eth (100 cases): variables and constraints identical** (agg 4.545× / 10.544×); **bus agg 3.536× → 3.541×** (geo 2.796× → 2.799×; powdr 3.480× — the eth bus aggregate leads powdr by +0.061×). **3 cases improved (apc_071 −16, apc_037 −2, apc_064 −2) = −20 bus, 0 regressions**; per-case W/L/T vs powdr 30/11/59 unchanged.
- **Runtime: neutral** (keccak back-to-back single-threaded 587 s vs 619 s; eth +3% rough/parallel-contended). Unlike the pre-#120 measurement, there is no runtime cost — #120's digit fold already owns the keccak variable cascade the packing used to trigger.

## Proof

- No audited-surface change (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`, `Basic.lean` untouched); correctness follows from each pass's own `PassCorrect` and the new fact's soundness proof.
- No `sorry`/`admit`/`axiom`/`native_decide`; `Scripts/check-proof-integrity.sh` passes — `openVmOptimizer_maintainsCorrectness` / `simpleOptimizer_maintainsCorrectness` depend only on `{propext, Classical.choice, Quot.sound}`.
- `lake build` green; output within the degree bound.

`docs/log.md` entry 82 records the design, the stale-attribution finding, and the measured impact; `docs/ideas.md` marks idea 4(a) landed and refreshes the gap decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012udokuMFUiq5t2NEZrYf5L