### PR TITLE
One-hot annihilation: eliminate dead shift-multiplier variables (idea 5) — −14 eth vars / −252 constraints, 0 regressions

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -32,6 +32,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.SubsumedRange
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 import ApcOptimizer.Implementation.OptimizerPasses.SplitBytePair
+import ApcOptimizer.Implementation.OptimizerPasses.OneHotAnnihilate
 import ApcOptimizer.Implementation.OptimizerPasses.DigitFold
 import ApcOptimizer.Implementation.OptimizerPasses.SeqzCollapse
 
@@ -93,6 +94,7 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
     ("constFold2", constantFoldPass.withFacts.guardDegree),
     ("zeroRegister", zeroRegisterPass.guardDegree),
     ("digitFold", DigitFold.digitFoldPass.guardDegree),
+    ("oneHotAnnihilate", OneHotAnnihilate.oneHotAnnihilatePass.guardDegree),
     ("hintCollapse", hintCollapsePass.guardDegree),
     ("rootPairUnify", rootPairUnifyPass.guardDegree),
     ("flagUnify", flagUnifyPass.guardDegree),

--- a/ApcOptimizer/Implementation/OptimizerPasses/OneHotAnnihilate.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/OneHotAnnihilate.lean
@@ -1,0 +1,229 @@
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # One-hot annihilation (idea 5)
+
+A shift chip with a runtime shift amount but a fixed direction keeps *both* `bit_multiplier_left`
+and `bit_multiplier_right`; one of them is dead. It is forced to `0` by the existing constraints,
+but only through a linear combination *across the one-hot marker family* — a relation Gauss cannot
+see because the constraints are nonlinear (products `markerᵢ · x`). Concretely, for a marker set
+`{m₁, …, mₖ}` the block keeps
+
+* `mᵢ · x = 0`   for every `i`   (the direction `i` is not selected), and
+* `(m₁ + … + mₖ − 1) · x = 0`   (the "shift-by-0 / other-direction" closer),
+
+and these entail `x = 0`: writing `s = Σ mᵢ`, the products give `s · x = Σ (mᵢ · x) = 0`, while the
+closer gives `(s − 1) · x = 0`, i.e. `s · x − x = 0`; subtracting, `x = 0`.
+
+This pass adds the entailed constraint `x = 0` (`ConstraintSystem.addConstraints_correct`); the
+existing constant-fold / Gaussian elimination then substitutes the dead variable away and cascades.
+It is purely equational — no field/primality assumption, no bus facts — and the added constraint has
+degree 1, well within the bound. Soundness does not depend on the recognizer being precise: the added
+equality `x = 0` is discharged as a linear combination of constraints already present, so a spurious
+match either fails to find its supporting products (and emits nothing) or would add an equality that
+genuinely holds.
+
+The recognizer keys on the algebraic structure (a product `affine · x` whose affine cofactor has
+constant term `−1` and unit coefficients, with `markerᵢ · x = 0` present for each cofactor variable),
+not on any variable name or VM gadget, so it fires wherever a one-hot family annihilates a variable.
+The optimizer emits the multiplier as the right factor, so the recognizer matches `A · x`. -/
+
+namespace OneHotAnnihilate
+
+variable {p : ℕ}
+
+/-! ## Recognizing the closer `(Σ mᵢ − 1) · x` and the products `mᵢ · x` -/
+
+/-- View an affine expression as a one-hot *closer* cofactor `±(Σ mᵢ − 1)`: its linear form has all
+    coefficients equal to a common unit `k ∈ {1, −1}` and constant term `−k`, with at least one
+    term. Both signs occur (the optimizer flips the closer's sign across passes), and both entail the
+    same annihilation. -/
+def affineCloser (a : Expression p) : Option (LinExpr p) :=
+  match linearize a with
+  | some la =>
+      if ((la.const = -1 ∧ la.terms.all (fun t => t.2 == 1)) ∨
+          (la.const = 1 ∧ la.terms.all (fun t => t.2 == -1))) ∧ la.terms ≠ [] then some la else none
+  | none => none
+
+/-- The affine-closer recognizer's guarantee: the cofactor is `Σ mᵢ − 1` (`k = 1`) or `1 − Σ mᵢ`
+    (`k = −1`); in both, `const = −k` and every coefficient is `k`. -/
+theorem affineCloser_spec (a : Expression p) (la : LinExpr p) (h : affineCloser a = some la) :
+    linearize a = some la ∧
+      ((la.const = -1 ∧ ∀ t ∈ la.terms, t.2 = 1) ∨ (la.const = 1 ∧ ∀ t ∈ la.terms, t.2 = -1)) := by
+  unfold affineCloser at h
+  split at h
+  · rename_i l hl
+    split at h
+    · rename_i hcond
+      obtain ⟨hc, _⟩ := hcond
+      obtain rfl : l = la := by simpa using h
+      refine ⟨hl, ?_⟩
+      rcases hc with ⟨hc1, hc2⟩ | ⟨hc1, hc2⟩
+      · exact Or.inl ⟨hc1, fun t ht => eq_of_beq (List.all_eq_true.1 hc2 t ht)⟩
+      · exact Or.inr ⟨hc1, fun t ht => eq_of_beq (List.all_eq_true.1 hc2 t ht)⟩
+    · exact absurd h (by simp)
+  · exact absurd h (by simp)
+
+/-- Recognize a closer constraint `A · x` where `A` is a one-hot closer cofactor, returning the
+    annihilated variable `x` and the cofactor's linear form. -/
+def readCloser (c : Expression p) : Option (Variable × LinExpr p) :=
+  match c with
+  | .mul a (.var x) => (affineCloser a).map (fun la => (x, la))
+  | _ => none
+
+/-- `readCloser` succeeds only on `A · x` with `A` linearizing to `la`, `la.const = −1`, and every
+    coefficient `1`. -/
+theorem readCloser_spec (c : Expression p) (x : Variable) (la : LinExpr p)
+    (h : readCloser c = some (x, la)) :
+    (∃ A, c = .mul A (.var x) ∧ linearize A = some la) ∧
+      ((la.const = -1 ∧ ∀ t ∈ la.terms, t.2 = 1) ∨ (la.const = 1 ∧ ∀ t ∈ la.terms, t.2 = -1)) := by
+  cases c with
+  | const n => simp [readCloser] at h
+  | var y => simp [readCloser] at h
+  | add a b => simp [readCloser] at h
+  | mul a b =>
+    cases b with
+    | const n => simp [readCloser] at h
+    | var y =>
+      simp only [readCloser, Option.map_eq_some_iff] at h
+      obtain ⟨la', hla', heq⟩ := h
+      simp only [Prod.mk.injEq] at heq
+      obtain ⟨rfl, rfl⟩ := heq
+      obtain ⟨hlin, hform⟩ := affineCloser_spec a la' hla'
+      exact ⟨⟨a, rfl, hlin⟩, hform⟩
+    | add e1 e2 => simp [readCloser] at h
+    | mul e1 e2 => simp [readCloser] at h
+
+/-- Does `cs` contain the product constraint `v · x` (in either factor order)? -/
+def hasProd (cs : ConstraintSystem p) (v x : Variable) : Bool :=
+  cs.algebraicConstraints.any
+    (fun c => c == .mul (.var v) (.var x) || c == .mul (.var x) (.var v))
+
+/-- The dead variable a closer `c` annihilates, if all of its marker products are present. -/
+def deadFromCloser (cs : ConstraintSystem p) (c : Expression p) : Option Variable :=
+  match readCloser c with
+  | some (x, la) => if la.terms.all (fun t => hasProd cs t.1 x) then some x else none
+  | none => none
+
+/-- Every one-hot-annihilated variable, read off the closer constraints. -/
+def deadVars (cs : ConstraintSystem p) : List Variable :=
+  cs.algebraicConstraints.filterMap (deadFromCloser cs)
+
+/-! ## The entailment -/
+
+/-- `Σ (env mᵢ) · x = 0` from `env mᵢ · x = 0` for every marker. -/
+theorem sum_mul_eq_zero (terms : List (Variable × ZMod p)) (env : Variable → ZMod p) (xe : ZMod p)
+    (hv : ∀ t ∈ terms, env t.1 * xe = 0) : (terms.map (fun t => env t.1)).sum * xe = 0 := by
+  induction terms with
+  | nil => simp
+  | cons t rest ih =>
+    rw [List.map_cons, List.sum_cons, add_mul, hv t (List.mem_cons_self ..),
+      ih (fun t' ht' => hv t' (List.mem_cons_of_mem _ ht')), add_zero]
+
+/-- `Σ (k · env mᵢ) = k · Σ (env mᵢ)`. -/
+theorem sum_map_mul_left (l : List (Variable × ZMod p)) (k : ZMod p) (env : Variable → ZMod p) :
+    (l.map (fun t => k * env t.1)).sum = k * (l.map (fun t => env t.1)).sum := by
+  induction l with
+  | nil => simp
+  | cons t rest ih => rw [List.map_cons, List.sum_cons, ih, List.map_cons, List.sum_cons, mul_add]
+
+/-- The one-hot annihilation identity: `mᵢ·x = 0` for all markers plus `±(Σmᵢ − 1)·x = 0` force
+    `x = 0`. Writing `s = Σ mᵢ`: from the products, `s·x = 0`; the closer gives `(s−1)·x = 0` or
+    `(1−s)·x = 0`, either of which combines with `s·x = 0` to give `x = 0`. -/
+theorem annihilate {terms : List (Variable × ZMod p)} {env : Variable → ZMod p} {xe : ZMod p}
+    (hv : ∀ t ∈ terms, env t.1 * xe = 0)
+    (hq : ((terms.map (fun t => env t.1)).sum - 1) * xe = 0 ∨
+          (1 - (terms.map (fun t => env t.1)).sum) * xe = 0) : xe = 0 := by
+  have hsum := sum_mul_eq_zero terms env xe hv
+  rcases hq with h | h
+  · rw [sub_mul, one_mul, hsum, zero_sub, neg_eq_zero] at h; exact h
+  · rw [sub_mul, one_mul, hsum, sub_zero] at h; exact h
+
+/-- The affine cofactor of a closer with common coefficient `k` evaluates to
+    `la.const + k · Σ (env marker)`. -/
+theorem cofactor_eval {A : Expression p} {la : LinExpr p} (hlin : linearize A = some la)
+    (k : ZMod p) (hcoeff : ∀ t ∈ la.terms, t.2 = k) (env : Variable → ZMod p) :
+    A.eval env = la.const + k * (la.terms.map (fun t => env t.1)).sum := by
+  rw [linearize_eval A la hlin]
+  unfold LinExpr.eval
+  rw [show (la.terms.map (fun t => t.2 * env t.1)) = (la.terms.map (fun t => k * env t.1)) from
+    List.map_congr_left (fun t ht => by rw [hcoeff t ht])]
+  rw [sum_map_mul_left]
+
+/-- Every `x ∈ deadVars cs` is forced to `0` by the system's constraints. -/
+theorem deadVars_entailed (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (env : Variable → ZMod p) (hsat : cs.satisfies bs env) (x : Variable) (hx : x ∈ deadVars cs) :
+    (Expression.var x).eval env = 0 := by
+  obtain ⟨cq, hcq_mem, hdead⟩ := List.mem_filterMap.1 hx
+  have hconstr : ∀ c ∈ cs.algebraicConstraints, c.eval env = 0 := hsat.1
+  cases hrc : readCloser cq with
+  | none => simp only [deadFromCloser, hrc] at hdead; exact absurd hdead (by simp)
+  | some xla =>
+    obtain ⟨x', la⟩ := xla
+    simp only [deadFromCloser, hrc] at hdead
+    split_ifs at hdead with hgate
+    have hxeq : x' = x := by simpa using hdead
+    obtain ⟨⟨A, hcform, hlin⟩, hform⟩ := readCloser_spec cq x' la hrc
+    show env x = 0
+    rw [← hxeq]
+    -- closer: `(s − 1)·env x' = 0` or `(1 − s)·env x' = 0`
+    have hcq0 : A.eval env * env x' = 0 := by
+      have := hconstr cq hcq_mem; rw [hcform] at this; simpa only [Expression.eval] using this
+    have hqeval : ((la.terms.map (fun t => env t.1)).sum - 1) * env x' = 0 ∨
+        (1 - (la.terms.map (fun t => env t.1)).sum) * env x' = 0 := by
+      rcases hform with ⟨hconst, hcoeff⟩ | ⟨hconst, hcoeff⟩
+      · left
+        rw [cofactor_eval hlin 1 hcoeff env, hconst] at hcq0
+        linear_combination hcq0
+      · right
+        rw [cofactor_eval hlin (-1) hcoeff env, hconst] at hcq0
+        linear_combination hcq0
+    -- each marker product: `env v * env x' = 0`
+    have hveval : ∀ t ∈ la.terms, env t.1 * env x' = 0 := by
+      intro t ht
+      have hp : hasProd cs t.1 x' = true := (List.all_eq_true.1 hgate) t ht
+      unfold hasProd at hp
+      obtain ⟨cv, hcv_mem, hcv⟩ := List.any_eq_true.1 hp
+      have hcv0 : cv.eval env = 0 := hconstr cv hcv_mem
+      simp only [Bool.or_eq_true] at hcv
+      rcases hcv with he | he
+      · obtain rfl := eq_of_beq he
+        simpa only [Expression.eval] using hcv0
+      · obtain rfl := eq_of_beq he
+        simp only [Expression.eval] at hcv0
+        rw [mul_comm] at hcv0
+        exact hcv0
+    exact annihilate hveval hqeval
+
+/-! ## The pass -/
+
+/-- Add `x = 0` for every one-hot-annihilated variable. -/
+def oneHotAnnihilatePass : VerifiedPassW p := fun cs bs _ =>
+  let new := (deadVars cs).map (fun x => Expression.var x)
+  ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+    cs.addConstraints_correct bs new
+      (by
+        intro env _ hsat c hc
+        obtain ⟨x, hx, rfl⟩ := List.mem_map.1 hc
+        exact deadVars_entailed cs bs env hsat x hx)
+      (by
+        intro c hc z hz
+        obtain ⟨y, hy, rfl⟩ := List.mem_map.1 hc
+        have hzy : z = y := by simpa only [Expression.vars, List.mem_singleton] using hz
+        rw [hzy]
+        obtain ⟨cq, hcq_mem, hdead⟩ := List.mem_filterMap.1 hy
+        cases hrc : readCloser cq with
+        | none => simp only [deadFromCloser, hrc] at hdead; exact absurd hdead (by simp)
+        | some xla =>
+          obtain ⟨x', la⟩ := xla
+          simp only [deadFromCloser, hrc] at hdead
+          split_ifs at hdead with hgate
+          have hxeq : x' = y := by simpa using hdead
+          obtain ⟨⟨A, hcform, _⟩, _⟩ := readCloser_spec cq x' la hrc
+          rw [← hxeq]
+          refine ConstraintSystem.mem_vars_of_constraint hcq_mem ?_
+          rw [hcform]
+          exact List.mem_append_right _ (List.mem_singleton.2 rfl))⟩
+
+end OneHotAnnihilate

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -15,14 +15,14 @@ Absolute output totals (identical inputs, so `agg` effectiveness follows directl
 
 | benchmark | axis | apc | powdr | apc − powdr |
 |---|---|---|---|---|
-| openvm-eth (100) | variables | 27,802 | 30,885 | **−3,083 (lead)** |
-| | bus interactions | 16,434 | 16,722 | **−288 (lead; entry 82 −20)** |
-| | constraints | 11,267 | 20,299 | −9,032 (lead) |
+| openvm-eth (100) | variables | 27,768 | 30,885 | **−3,117 (lead; entry 83 seqz −20, entry 84 one-hot −14)** |
+| | bus interactions | 16,429 | 16,722 | **−293 (lead)** |
+| | constraints | 10,955 | 20,299 | −9,344 (lead; entry 83 −60, entry 84 −252) |
 | keccak | variables | 2,021 | 2,021 | **exact parity** |
 | | bus interactions | 1,752 | 1,734 | **+18 (was +218; entry 82 −200)** |
 | | constraints | 186 | 186 | **exact parity** |
 
-Per-case standings on eth: variables **30 W / 11 L / 59 T** (+56 total over the losing cases).
+Per-case standings on eth: variables **31 W / 9 L / 60 T** (entries 83/84 flipped 2 losses).
 Bus per-case was **7 W / 67 L / 26 T** (+588 over losing cases) at the measurement base;
 #117/#119 improved 37 case-measurements with 0 regressions (agg 3.439× → 3.479×, geo 2.723× →
 2.753×; powdr 3.480× / 2.822×) — re-measure the standings before quoting them. The reported
@@ -35,10 +35,11 @@ both benchmarks except keccak, where the identified fixes land exactly on powdr'
 Exact gap decomposition (verified on the live circuits at the measurement base; buckets marked
 LANDED are done — the remainder still adds up to the current gaps):
 
-- **eth variables +56 over 11 cases** (was +172 over 29) = ~~M1 constant decompositions +135~~
+- **eth variables ~+28 over 8 cases** (was +172 over 29) = ~~M1 constant decompositions +135~~
   (**LANDED**: entry 81 −165 incl. cascades; residual = full-byte-top `rd_data` ladders,
-  apc_034/066 +3 each) · M2 comparison gadgets residue (apc_037 +14, apc_018 +9 — idea 3) ·
-  M3 dead `bit_multiplier` **+14** · everything else nets in apc's favor.
+  apc_034/066 +3 each) · ~~M2 comparison gadgets (apc_037 +14, apc_018 +9)~~ (**LANDED**: entry 83
+  seqz collapse) · ~~M3 dead `bit_multiplier` +14~~ (**LANDED**: entry 84 −14, apc_038/051) ·
+  everything else nets in apc's favor.
 - **eth bus** (was +588 over losing cases; −191 + −132 + −141 landed) = ~~width-1 range checks
   90~~ (**LANDED**: entry 80 −89) · ~~cancellable memory pairs 78~~ + op-0 coverage waste
   (**LANDED**: #117 −76, #119 −115) · ~~constant-family checks ~126~~ (**LANDED**: entry 81
@@ -219,21 +220,18 @@ keccak are exactly 8 bits).
 
 ---
 
-## 5. One-hot annihilation  ·  *variables*  ·  small, clean / low effort
+## 5. One-hot annihilation — **LANDED (entry 84, `OneHotAnnihilate.lean`)**  ·  *variables*
 
-**Gap (+14 eth vars: apc_051 +7, apc_038 +7).** Shift chips with a runtime shift amount but a
-fixed direction keep BOTH `bit_multiplier_left` and `bit_multiplier_right`; one of them is dead —
-forced to 0 by the existing constraints, but only through a *linear combination across the
-one-hot family*: with markers `Σ mᵢ = 1`, `mᵢ · x = 0` for all i ⟹ `x = 0`. Gauss can't see it
-(the products are nonlinear); powdr's monomial-level elimination does.
-
-**Mechanism.** A small pass (or a `domainBatch` rule): find a variable `x` such that for a
-marker set {mᵢ} with a proven `Σ mᵢ = 1` constraint, every `mᵢ·x = 0` is present (syntactically,
-after normalize); add `x = 0` and let constant-fold cascade. Soundness: summing the constraints
-gives `x·Σmᵢ = x = 0` — a one-line entailed equality (`addConstraints_correct`).
-
-**Expected impact.** −14 vars, a few dropped checks; flips apc_051/apc_038 closer to parity.
-Check the census for non-shift instances of the same pattern before scoping.
+`OneHotAnnihilate.lean` (cleanup cycle): a dead shift-multiplier `x` is kept alongside
+`mᵢ · x = 0` (for each one-hot marker) and the closer `±(Σ mᵢ − 1) · x = 0`; these force `x = 0`
+(`s·x = 0` from the products, `(s∓1)·x = 0` from the closer). The pass recognizes the closer's
+affine cofactor `±(Σ mᵢ − 1)`, checks each marker product is present, and adds the entailed
+`x = 0` (`addConstraints_correct`); Gauss then eliminates `x` and its ~18 product constraints.
+Measured (vs #125): **eth −14 vars / −252 constraints over 2 cases (apc_038, apc_051), 0
+regressions** (agg vars 4.548× → 4.551×, W/L/T 31/10/59 → 31/9/60); keccak unchanged (no-op),
+runtime neutral.
+The `Σ mᵢ = 1` need not be a standalone constraint — the recognizer works from the closer alone,
+and accepts both closer signs (mid-cycle the optimizer holds the negated `(1 − Σ mᵢ)·x` form).
 
 ---
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -3127,3 +3127,40 @@ result/limbs carrying powdr IDs (so witgen can compute `inv`). Wired coda-only, 
 surface touched, no new `BusFacts` (reuses the OpenVM `bytePairBus`/`byteCheck` instances). `lake
 build` green; proof integrity green (no `sorry`/`admit`/`axiom`/`native_decide`; the top-level
 theorems still depend only on `{propext, Classical.choice, Quot.sound}`).
+
+### 84. One-hot annihilation: eliminate dead shift-multiplier variables (idea 5) — −14 eth vars / −252 constraints, 0 regressions
+
+**Idea.** A shift chip with a runtime shift amount but a fixed direction keeps *both*
+`bit_multiplier_left` and `bit_multiplier_right`; one is dead. It is forced to `0` by the existing
+constraints, but only through a linear combination *across the one-hot marker family* that Gauss
+cannot see (the constraints are the nonlinear products `markerᵢ · x`). For a marker set `{mᵢ}` the
+block keeps `mᵢ · x = 0` for every `i` plus the closer `±(Σ mᵢ − 1) · x = 0`; writing `s = Σ mᵢ`,
+the products give `s·x = 0` and the closer `(s−1)·x = 0` (or `(1−s)·x = 0`), which together force
+`x = 0`.
+
+**Pass (`OneHotAnnihilate.lean`, cleanup cycle).** Recognize a closer constraint `A · x` whose
+affine cofactor `A` linearizes to `±(Σ mᵢ − 1)` (all coefficients a common unit `k ∈ {1, −1}`,
+constant `−k`), and check that every marker's product `mᵢ · x = 0` is present; then **add the
+entailed constraint `x = 0`** (`ConstraintSystem.addConstraints_correct`) and let the existing
+Gaussian elimination substitute the dead variable away and cascade (each eliminated multiplier
+collapses ~18 product constraints). Purely equational — no `BusFacts`, no field/primality
+assumption; the added constraint is degree 1. Soundness does not depend on the recognizer being
+precise (the added `x = 0` is a linear combination of constraints already present).
+
+*Sign subtlety, found by measurement:* the recognizer initially matched only `(Σmᵢ − 1)·x`
+(`const −1`, `coeff 1`), but mid-cycle the optimizer holds the **negated** form `(1 − Σmᵢ)·x`
+(`const 1`, `coeff −1 = p−1`) — a later pass flips the sign, so the final render's `(−1 + Σmᵢ)` was
+misleading. The recognizer now accepts both signs; both entail the same `x = 0`.
+
+**Measured (per-case JSON A/B vs `main` = #125 `bd367dd`; delta identical when first measured vs
+#124 — fully independent of the seqz collapse, which touches different cases).**
+- openvm-eth (100 cases): **2 cases improved (apc_038, apc_051), 0 regressions**; each −7 vars /
+  −126 constraints, bus-neutral. Corpus totals: vars 27782 → **27768 (−14)**, constraints
+  11207 → **10955 (−252)**, bus 16429 unchanged. Aggregate variable effectiveness 4.548× →
+  **4.551×**; per-case variables W/L/T vs powdr 31/10/59 → **31/9/60** (one loss flips to a tie).
+- keccak: **unchanged** (2021 v / 186 c / 1752 bus) — the pass finds no dead shift-multiplier there
+  (the ρ-rotations are encoded differently); it is a no-op, `profile` shows `oneHotAnnihilate` at
+  726 ms of ~420 s (0.17%, machine-noise territory). Runtime neutral on both benchmarks.
+
+Build + `Scripts/check-proof-integrity.sh` green — the correctness theorems depend only on
+`{propext, Classical.choice, Quot.sound}`. **Worked: yes.**


### PR DESCRIPTION
## What

New cleanup pass `OneHotAnnihilate.lean` implementing `docs/ideas.md` idea 5. A fixed-direction shift chip keeps *both* `bit_multiplier_left` and `bit_multiplier_right`; one is dead. It is forced to `0` by the existing constraints, but only through a linear combination *across the one-hot marker family* that Gaussian elimination cannot see — the constraints are the nonlinear products `markerᵢ · x`.

For a marker set `{mᵢ}` the block keeps `mᵢ · x = 0` for every `i` plus the closer `±(Σ mᵢ − 1) · x = 0`. Writing `s = Σ mᵢ`: the products give `s·x = 0`, and the closer gives `(s−1)·x = 0` (or `(1−s)·x = 0`), which together force `x = 0`.

The pass recognizes a closer constraint `A · x` whose affine cofactor `A` linearizes to `±(Σ mᵢ − 1)` (all coefficients a common unit `k ∈ {1, −1}`, constant `−k`), checks that every marker's product `mᵢ · x = 0` is present, and **adds the entailed constraint `x = 0`** (`ConstraintSystem.addConstraints_correct`). The existing Gaussian elimination then substitutes the dead variable away and cascades — each eliminated multiplier collapses ~18 product constraints.

## Correctness

Purely equational: **no new `BusFacts`, no field/primality assumption**, and the added constraint is degree 1 (well within the bound). Soundness does not depend on the recognizer being precise — the added `x = 0` is discharged as a linear combination of constraints already present (`s·x = 0` from the products, minus/plus the closer), so a spurious match either fails to find its supporting products or would add an equality that genuinely holds. No audited-surface change; correctness follows from the pass's own `PassCorrect`. `Scripts/check-proof-integrity.sh` passes — `{propext, Classical.choice, Quot.sound}`-only.

*Sign subtlety (found by measurement):* mid-cycle the optimizer holds the **negated** closer `(1 − Σ mᵢ)·x` (`const 1`, `coeff −1`), even though the final render shows `(−1 + Σ mᵢ)·x` — a later pass flips the sign. The recognizer accepts both; both entail the same `x = 0`.

## Effectiveness (per-case JSON A/B vs `main` = #125 `bd367dd`; rebased onto #125 — the seqz collapse landed after this PR was opened and raised the baseline. My pass's delta is identical to the original #124-based measurement: seqz touches different cases (apc_037/018) than one-hot (apc_038/051), so they don't interact.)

| | main | this PR |
|---|---|---|
| openvm-eth variables (total) | 27,782 | **27,768 (−14)** |
| openvm-eth constraints (total) | 11,207 | **10,955 (−252)** |
| openvm-eth bus | 16,429 | 16,429 (unchanged) |
| variable effectiveness (agg) | 4.548× | **4.551×** |
| per-case variables W/L/T vs powdr | 31/10/59 | **31/9/60** (one loss → tie) |
| keccak | 2021 v / 186 c / 1752 bus | **unchanged** |

**2 cases improved (apc_038, apc_051), 0 regressions** — each −7 vars / −126 constraints, bus-neutral. keccak is a no-op (its ρ-rotations are encoded differently, so no dead shift-multiplier); `profile` shows `oneHotAnnihilate` at 726 ms of ~420 s (0.17%). Runtime neutral on both benchmarks.

The pass is a general algebraic recognizer (one-hot-family annihilation keyed on constraint *shape*, not on any variable name or VM gadget); it happens to fire on the two shift-heavy cases in this corpus. Log entry 84; `docs/ideas.md` idea 5 marked landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
