### PR TITLE
domainFold: hoist constant-on-survivors evaluation (runtime, output-preserving)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -27,13 +27,21 @@ variable {p : ℕ}
 
 /-! ## The domain-constant check -/
 
-/-- `some c` if `e` evaluates to the same constant `c` on every survivor, else `none`. -/
+/-- `some c` if `e` evaluates to the same constant `c` on every survivor, else `none`.
+
+    Two output-preserving speedups over the naive `e.eval (envOf s) = e.eval (envOf s₀)` form
+    (both extensionally equal, so the fold decision and the folded constant are unchanged):
+    evaluate through `Expression.evalFast` (field operations derived once per call rather than per
+    expression node, `evalFast_eq` — the entry-54 treatment the rest of the pass already uses), and
+    compute the reference value `e.evalFast (envOf s₀)` **once** with a `let` instead of
+    re-evaluating it against every survivor inside the `.all`. -/
 def constOnSurvs (survs : List (List (Variable × ZMod p))) (e : Expression p) : Option (ZMod p) :=
   match survs with
   | [] => none
   | s₀ :: rest =>
-    if (s₀ :: rest).all (fun s => decide (e.eval (envOf s) = e.eval (envOf s₀))) then
-      some (e.eval (envOf s₀))
+    let v₀ := e.evalFast (envOf s₀)
+    if (s₀ :: rest).all (fun s => decide (e.evalFast (envOf s) = v₀)) then
+      some v₀
     else none
 
 /-- If `constOnSurvs` accepts `e` with value `c`, then `e` evaluates to `c` on every survivor. -/
@@ -46,10 +54,10 @@ theorem constOnSurvs_sound (survs : List (List (Variable × ZMod p))) (e : Expre
     simp only [constOnSurvs] at h
     split at h
     · next hall =>
-        have hc : e.eval (envOf s₀) = c := Option.some.inj h
+        have hc : e.evalFast (envOf s₀) = c := Option.some.inj h
         have hthis := List.all_eq_true.mp hall s hs
         rw [decide_eq_true_iff] at hthis
-        rw [hthis, hc]
+        rw [← Expression.evalFast_eq, hthis]; exact hc
     · next => exact absurd h (by simp)
 
 /-! ## The fold rewrite -/

--- a/docs/log.md
+++ b/docs/log.md
@@ -3214,3 +3214,57 @@ Needs `p ≠ 0` only (val/cast round-trip); no primality.
 
 Build + `check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound}-only).
 **Worked: yes.**
+
+### 86. Optimizer runtime: hoist `domainFold`'s constant-on-survivors evaluation (effectiveness unchanged)
+
+Pure **performance** work in the entry-45/54 style — output-preserving, so effectiveness is
+untouched and only wall-clock cost drops. Closes entry 54's documented `domainFold` leftover
+("`domainFold` evaluates through the plain per-node-instance `Expression.eval` — the `evalFast`
+treatment applies almost verbatim"). Entry 54 had upgraded `domainFold`'s survivor *filter*
+(`groupSurvivorsE`) to `evalFast`, but the fold-decision core `constOnSurvs` was still on the slow
+path.
+
+**The two fixes (both extensionally equal to the old form, so the fold decision and the folded
+constant are unchanged):**
+1. Evaluate through `Expression.evalFast` (field operations derived once per call instead of
+   re-projecting the `ZMod p` `CommRing` instance chain at every expression node — the entry-54
+   tax), via the existing `Expression.evalFast_eq`.
+2. Compute the reference value `e.evalFast (envOf s₀)` **once** with a `let` rather than
+   re-evaluating it against every survivor inside the `.all` (the old
+   `fun s => e.eval (envOf s) = e.eval (envOf s₀)` recomputed the `s₀` value once per survivor).
+
+Only `constOnSurvs` and its soundness lemma `constOnSurvs_sound` change; `foldRewrite` /
+`foldRewrite_agree` consume `constOnSurvs` abstractly (via the soundness lemma and a `cases` on its
+`Option` result), so they are untouched. The folded constant is numerically identical
+(`evalFast_eq`), so the circuit the pass emits is unchanged.
+
+**Measured (clean A/B, both binaries built from the current source; the session's pre-built binary
+turned out to be stale — an older commit with a slower `domainBatch` — so it is not a valid
+baseline and was discarded).** Output byte-for-byte identical (`vars/constraints/bus`) on
+apc_001/005/006/009/012. `domainFold` per-pass time (profiler, same-process, so binary-load is
+amortised):
+- apc_005 / apc_009 (same load/store block, the heaviest fold case): **6221 → 4691 ms (−25 %)**.
+- apc_006: 2416 → 2274 ms (−6 %); apc_012: 1767 → 1732 ms (−2 %).
+
+The win is concentrated on the constant-fold-heavy load/store cases (where `constOnSurvs` runs over
+many survivors × many fold candidates) and is within noise on the rest; whole-optimizer totals move
+only within run-to-run noise. keccak is unaffected in practice (186 constraints — `domainFold` does
+little there). The change never does *more* work in `domainFold`.
+
+`lake build` green; `Scripts/check-proof-integrity.sh` green — the correctness theorems still depend
+only on `{propext, Classical.choice, Quot.sound}`; no `sorry`/`admit`/`axiom`/`native_decide`; no
+audited surface, `Basic.lean`/`FactPass.lean`, or pass-pipeline change. **Worked: yes (modest).**
+
+**Runtime picture / bigger levers (measured this session; documented for future work).** Per-pass
+share over the top-12 eth cases: `busPairCancel` 31 %, `domainBatch` 24 %, `domainFold` 14 %,
+`reencode` 13 % (top-4 = 82 %; the finite-domain family alone = 51 %); the cleanup cycle iterates
+4–7× on the expensive cases. The two largest remaining levers both need real proof effort, not just
+a hoist: (a) the **pinned-variable box reduction** in the finite-domain enumeration (entries 45 &
+54) — substitute the domain-1 (pinned) variables as constants and enumerate/compile only the free
+vars, shrinking every enumerated point; attacks the dominant 51 % directly, self-contained in
+`DomainBatch.lean`, needs `forcedOver`'s soundness re-proven against the reduced box. (b)
+`busPairCancel` (top on eth, and dominant on memory-heavy keccak) — already heavily tuned
+(entries 55/56); the residual is the deep byte-justification's per-candidate `findVarBound` rescan
+and per-point `substF`/`linearize`. A cheaper extension of *this* entry: index-compile
+`constOnSurvs` (à la `domainBatch`'s `IExpr`) to also drop the `envOf` linear scan, which would help
+the cases where the `evalFast` hoist alone barely moved.


### PR DESCRIPTION
## Summary

Pure **runtime** work — output-preserving, so effectiveness is unchanged; only the optimizer's wall-clock cost drops. It closes the `domainFold` leftover documented in log entry 54 ("`domainFold` evaluates through the plain per-node-instance `Expression.eval` — the `evalFast` treatment applies almost verbatim").

`domainFold`'s fold-decision core `constOnSurvs` was still on the slow path (the rest of the pass had already moved to `evalFast` in entry 54). Two fixes, **both extensionally equal to the old form**:

1. Evaluate through `Expression.evalFast` — field operations derived **once per call** instead of re-projecting the `ZMod p` `CommRing` instance chain at every expression node (the entry-54 tax), via the existing `Expression.evalFast_eq`.
2. Compute the reference value `e.evalFast (envOf s₀)` **once** with a `let`, instead of re-evaluating it against every survivor inside the `.all`.

Only `constOnSurvs` and its soundness lemma `constOnSurvs_sound` change. `foldRewrite` / `foldRewrite_agree` consume `constOnSurvs` abstractly (its soundness lemma + a `cases` on the `Option` result), so they are untouched. The folded constant is numerically identical (`evalFast_eq`), so **the circuit the pass emits is unchanged**.

## Why it's safe

Output-invariance follows from `Expression.evalFast_eq` (a Lean proof, `evalFast = eval`), not from empirical luck — the two forms decide the same boolean and return the same value. Verified byte-for-byte identical (`vars/constraints/bus`) on apc_001/005/006/009/012 via a clean A/B (both baseline and change built from this source).

No audited surface, `Basic.lean`/`FactPass.lean`, or pass-pipeline change. `lake build` green; `Scripts/check-proof-integrity.sh` green — the correctness theorems still depend only on `{propext, Classical.choice, Quot.sound}`; no `sorry`/`admit`/`axiom`/`native_decide`.

## Measured

Clean A/B, both binaries built from the current source. `domainFold` per-pass time (profiler, same-process so binary-load is amortised):

| case | main | this branch | Δ |
|---|---|---|---|
| apc_005 / apc_009 (heaviest fold case) | 6221 ms | 4691 ms | **−25%** |
| apc_006 | 2416 ms | 2274 ms | −6% |
| apc_012 | 1767 ms | 1732 ms | −2% |

The win is concentrated on the constant-fold-heavy load/store cases (where `constOnSurvs` runs over many survivors × many fold candidates); it is within noise elsewhere and never does *more* work. keccak is unaffected in practice (186 constraints — `domainFold` does little there). This is a **modest** win; I kept it strictly to the provably-output-preserving change rather than a larger, riskier one.

## Runtime picture & bigger levers (from this session's investigation)

Per-pass share over the top-12 eth cases: `busPairCancel` 31%, `domainBatch` 24%, `domainFold` 14%, `reencode` 13% (top-4 = 82%; the finite-domain family alone = 51%). The cleanup cycle iterates 4–7× on the expensive cases. The two largest remaining levers need real proof effort (not just a hoist), and are noted in the log for follow-up:

- **Pinned-variable box reduction** in the finite-domain enumeration (entries 45 & 54): substitute the domain-1 (pinned) variables as constants and enumerate/compile only the free vars, shrinking every enumerated point. Attacks the dominant 51% directly; self-contained in `DomainBatch.lean`; needs `forcedOver`'s soundness re-proven against the reduced box.
- **`busPairCancel`** (top on eth, dominant on memory-heavy keccak): already heavily tuned (entries 55/56); the residual is the deep byte-justification's per-candidate `findVarBound` rescan.

A cheaper extension of *this* PR: index-compile `constOnSurvs` (à la `domainBatch`'s `IExpr`) to also drop the `envOf` linear scan, which would help the cases where the `evalFast` hoist alone barely moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxRirHvKjJ91okYkYuGtL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxRirHvKjJ91okYkYuGtL1)_