### PR TITLE
addrAffineNeq: affine same-base address disequality — close the wasm-eth variable gap

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -260,3 +260,63 @@ theorem addrTwoRootNeq_sound (shape : MemoryBusShape) (T : TwoRootMap p constrai
       rw [hSp, hbp] at hcond key
       simp only [Option.map_some, Option.some.injEq] at key
       exact exprTwoRootNeq_sound T e e' hcond env hcon key
+
+/-! ## The affine (same-base) address-disequality certificate
+
+The two-root certificate above needs the limb-decomposition constraints and primality. A far more
+common shape — a wasm frame-pointer-relative stack pointer `c + fp`, or any two accesses off a
+*common base* with different immediates — needs neither: linearizing both address slots and
+subtracting yields a **nonzero field constant** (`(c₁ + fp) − (c₂ + fp) = c₁ − c₂`), so the
+addresses provably differ with pure linear arithmetic — no bounds, no primality, no `TwoRootMap`.
+This strictly generalizes `addrConstsNeq` (`const − const` is a constant difference too) and,
+unlike the two-root path, consults no constraints, so it is a total `Bool` predicate composable
+with the other two certificates. -/
+
+/-- Some address slot of `S` and `bi` linearizes to two affine forms differing by a nonzero field
+    constant: the two interactions provably have different addresses. Corpus-agnostic; any
+    common-base addressing (a shared symbolic base with distinct immediates) benefits. -/
+def addrAffineNeq (shape : MemoryBusShape) (S bi : BusInteraction (Expression p)) : Bool :=
+  shape.addressFields.any (fun slot =>
+    match S.payload[slot]?, bi.payload[slot]? with
+    | some e, some e' =>
+      (match linearize e, linearize e' with
+       | some L, some L' => constDiffNZ L L'
+       | _, _ => false)
+    | _, _ => false)
+
+theorem addrAffineNeq_sound (shape : MemoryBusShape) (S bi : BusInteraction (Expression p))
+    (h : addrAffineNeq shape S bi = true) (env : Variable → ZMod p) :
+    shape.address (S.eval env) ≠ shape.address (bi.eval env) := by
+  unfold addrAffineNeq at h
+  obtain ⟨slot, hslot, hcond⟩ := List.any_eq_true.1 h
+  intro heq
+  obtain ⟨j, hj⟩ : ∃ j, shape.addressFields[j]? = some slot := List.getElem?_of_mem hslot
+  have key : (S.eval env).payload[slot]? = (bi.eval env).payload[slot]? := by
+    have e1 : (shape.address (S.eval env))[j]? = some ((S.eval env).payload[slot]?) := by
+      simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+    have e2 : (shape.address (bi.eval env))[j]? = some ((bi.eval env).payload[slot]?) := by
+      simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+    rw [heq, e2] at e1; exact (Option.some.inj e1).symm
+  have keyS : (S.eval env).payload[slot]? = (S.payload[slot]?).map (fun e => e.eval env) := by
+    show (S.payload.map (fun e => e.eval env))[slot]? = _; rw [List.getElem?_map]
+  have keyB : (bi.eval env).payload[slot]? = (bi.payload[slot]?).map (fun e => e.eval env) := by
+    show (bi.payload.map (fun e => e.eval env))[slot]? = _; rw [List.getElem?_map]
+  rw [keyS, keyB] at key
+  cases hSp : S.payload[slot]? with
+  | none => rw [hSp] at hcond; simp at hcond
+  | some e =>
+    cases hbp : bi.payload[slot]? with
+    | none => rw [hSp, hbp] at hcond; simp at hcond
+    | some e' =>
+      rw [hSp, hbp] at key
+      simp only [Option.map_some, Option.some.injEq] at key
+      simp only [hSp, hbp] at hcond
+      cases hL : linearize e with
+      | none => simp [hL] at hcond
+      | some L =>
+        cases hL' : linearize e' with
+        | none => simp [hL, hL'] at hcond
+        | some L' =>
+          simp only [hL, hL'] at hcond
+          exact constDiffNZ_sound L L' hcond env
+            (by rw [← linearize_eval e L hL env, ← linearize_eval e' L' hL' env]; exact key)

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1017,7 +1017,7 @@ def firstMatchAt {constraints : List (Expression p)}
 def midRefuted (shape : MemoryBusShape) {constraints : List (Expression p)}
     (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
   decide (m.busId ≠ busId) || decide (multConst m = some 0) || addrConstsNeq shape S m
-    || addrTwoRootNeq shape T.get S m
+    || addrAffineNeq shape S m || addrTwoRootNeq shape T.get S m
 
 /-- Refute `m` as an active same-address *send* on `busId` (the "before" region test: earliest-send). -/
 def preRefuted (shape : MemoryBusShape) {constraints : List (Expression p)}
@@ -1032,11 +1032,12 @@ theorem midRefuted_sound (shape : MemoryBusShape) {constraints : List (Expressio
     (hbid : (m.eval env).busId = busId) (hmne : (m.eval env).multiplicity ≠ 0)
     (hmaddr : shape.address (m.eval env) = shape.address (S.eval env)) : False := by
   unfold midRefuted at h
-  rw [Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true] at h
-  rcases h with ((h | h) | h) | h
+  rw [Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true] at h
+  rcases h with (((h | h) | h) | h) | h
   · exact absurd hbid (of_decide_eq_true h)
   · exact hmne (m.multiplicity.constValue?_sound 0 (of_decide_eq_true h) env)
   · exact addrConstsNeq_sound shape S m h env hmaddr.symm
+  · exact addrAffineNeq_sound shape S m h env hmaddr.symm
   · exact addrTwoRootNeq_sound shape T.get S m h env hcon hmaddr.symm
 
 theorem preRefuted_sound (shape : MemoryBusShape) {constraints : List (Expression p)}

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -129,8 +129,8 @@ def checkPair (shape : MemoryBusShape) {constraints : List (Expression p)}
   decide (L = pre ++ S :: mid ++ R :: post) &&
   decide (multConst S = some 1) && decide (multConst R = some (-1)) &&
   addrConstsEq shape S R &&
-  mid.all (fun m => addrConstsNeq shape S m || addrTwoRootNeq shape T S m
-    || decide (multConst m = some 0))
+  mid.all (fun m => addrConstsNeq shape S m || addrAffineNeq shape S m
+    || addrTwoRootNeq shape T S m || decide (multConst m = some 0))
 
 theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0)
@@ -162,8 +162,10 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
       shape.address (m.eval env) = shape.address (S.eval env) → False := by
     intro m hm hmne hmaddr
     rcases (Bool.or_eq_true _ _).mp (List.all_eq_true.mp hmidall m hm) with hcond | hz
-    · rcases (Bool.or_eq_true _ _).mp hcond with hneq | h2r
-      · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
+    · rcases (Bool.or_eq_true _ _).mp hcond with hcond2 | h2r
+      · rcases (Bool.or_eq_true _ _).mp hcond2 with hneq | haff
+        · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
+        · exact addrAffineNeq_sound shape S m haff env (hmaddr.symm)
       · exact addrTwoRootNeq_sound shape T S m h2r env hcon (hmaddr.symm)
     · have : (m.eval env).multiplicity = 0 := by
         show m.multiplicity.eval env = 0
@@ -196,7 +198,7 @@ def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
   | revMid, r :: rest =>
       if decide (multConst r = some (-1)) && addrConstsEq shape S r then
         some (revMid.reverse, r, rest)
-      else if addrConstsNeq shape S r || addrTwoRootNeq shape T S r
+      else if addrConstsNeq shape S r || addrAffineNeq shape S r || addrTwoRootNeq shape T S r
           || decide (multConst r = some 0) then
         findConsumer shape T S (r :: revMid) rest
       else none

--- a/docs/log.md
+++ b/docs/log.md
@@ -3268,3 +3268,62 @@ vars, shrinking every enumerated point; attacks the dominant 51 % directly, self
 and per-point `substF`/`linearize`. A cheaper extension of *this* entry: index-compile
 `constOnSurvs` (à la `domainBatch`'s `IExpr`) to also drop the `envOf` linear scan, which would help
 the cases where the `evalFast` hoist alone barely moved.
+
+### 87. Affine same-base address disequality (`addrAffineNeq`): closes the wasm-eth variable gap — apc reaches powdr parity or better on every case (wasm-eth root cause 1)
+
+**The gap** (`../leanr-wasm/fable-wasm-1.md`, root cause 1). On the `wasm-eth` corpus (merged
+#131), memory forwarding never fired for the frame-pointer-relative shadow stack (address space
+1). A wasm stack pointer is `c + fp` — a symbolic base `fp` plus a constant offset — which
+neither existing disequality certificate can refute: `addrConstsNeq` needs both slots literal,
+and `addrTwoRootNeq` needs a two-root limb-wraparound decomposition + primality (`fp` has
+neither). So `busUnifyPass`'s consumer scan (`findConsumer`) and `busPairCancel`'s mid-region
+check (`midRefuted`) both aborted at the *first* interleaved other-stack-slot access
+(`140+fp` vs `108+fp` could not be refuted as a different address), and **no AS-1 access was ever
+forwarded** on the big blocks. The excess scaled with reuse count — the three worst offenders
+(apc_037/012/006, k256 square/mul + tiny_keccak `keccakf`) sat at **4.85× / 4.81× / 4.20×** the
+powdr variable count.
+
+**The fix.** A third disequality certificate `addrAffineNeq` (`AddrDiseq.lean`): for some address
+slot, `linearize` both expressions, subtract, `.norm`; if the difference has no variable terms
+and a nonzero constant, the slots provably differ — `(c₁+fp) − (c₂+fp) = c₁−c₂ ≠ 0`. No bounds,
+no primality, no `TwoRootMap`, no constraints consulted — a total `Bool` predicate. Soundness is
+three lines: `linearize_eval` on each slot + the existing `constDiffNZ_sound`. Wired as a third
+disjunct at the refutation sites — `findConsumer`/`checkPair` (`BusUnify.lean`) and `midRefuted`
+(`BusPairCancel.lean`, through which `preRefuted`/`shieldOk` and the aggressive-path array scan all
+funnel). The consumer *equality* side already worked (`addrConstsEq`'s syntactic `e = e'` branch
+matches two identical `fp+c` expressions), so only the mid-region disequality was missing. It
+**strictly generalizes** `addrConstsNeq` (const−const is a constant difference), so it can only
+enable *more* cancellation, never less; and it needs no primality/two-root, so it composes as a
+separate disjunct with `addrTwoRootNeq` (kept for the keccak heap, whose distinct-limb pointers
+have a variable-bearing difference that `addrAffineNeq` correctly declines).
+
+**Impact — wasm-eth (`apc-optimizer compare` vs powdr, variables the top-priority metric):**
+
+| case | apc vars (main) | apc vars (now) | powdr vars | ratio now | ratio main |
+|------|----:|----:|----:|----:|----:|
+| apc_037 k256 square | 9201 | 1929 | 1896 | 1.02× | 4.85× |
+| apc_012 k256 mul     | 12885 | 2705 | 2678 | 1.01× | 4.81× |
+| apc_006 keccakf      | 8021 | 1606 | 1908 | **0.84×** | 4.20× |
+| apc_028              | — | 1478 | 1478 | 1.00× | — |
+| apc_004              | — | 238 | 238 | 1.00× | — |
+| apc_005              | — | 184 | 200 | **0.92×** | — |
+| apc_022              | — | 21 | 21 | 1.00× | — |
+
+Variable effectiveness reaches **powdr parity or better on every case measured** (apc_006 and
+apc_005 beat powdr outright); constraints likewise at/near parity (apc_006 88 vs powdr 548;
+apc_012 1034 = 1034; apc_004 118 = 118). The residual is entirely **bus interactions** (apc_037
+2317 vs 1430, apc_006 1934 vs 1479, apc_022 19 vs 15): the byte-identical AS-5 fp-cell pairs and
+the fp-read chains — the target of the stacked step 2 (`recvByteSlots`).
+
+**openvm-eth (the merge-gating benchmark): no regression — a slight win.** 100-case sweep,
+aggregate / geo effectiveness: variables **4.552× / 3.887×** (powdr 4.092× / 3.787×; main was
+4.551× agg), bus **3.543× / 2.803×** (powdr 3.480×), constraints **10.845× / 12.026×** (powdr
+5.853×). Per-case variables W/L/T vs powdr **31 / 7 / 62** — vs the pre-change **31 / 9 / 60**,
+**two powdr-losses flip to ties** (affine addressing enabled an additional forward), zero
+regressions. Exactly what monotonicity predicts: the new disjunct only ever refutes *more*.
+keccak two-root heap path unchanged.
+
+Build + `Scripts/check-proof-integrity.sh` green (`{propext, Classical.choice, Quot.sound}` only);
+no `sorry`/`admit`/`axiom`/`native_decide`; no audited-surface / `Basic.lean` / `FactPass.lean` /
+pass-pipeline change (correctness rides on the pass's own `PassCorrect`, extended by one `rcases`
+branch per soundness theorem). **Worked: yes (major — the dominant wasm-eth variable lever).**


### PR DESCRIPTION
**Stacked PR 1/4** (base `main`). Chain: this → `wasm-recv-byte-slots-pattern` → `wasm-benchmark-log` → `wasm-residuals`.

## What

A third memory-address **disequality certificate** `addrAffineNeq` (`AddrDiseq.lean`): for some address slot, `linearize` both expressions, subtract, and check the difference is a nonzero field constant. This refutes two accesses off a **common symbolic base** with distinct constant offsets — e.g. a wasm frame-pointer stack pointer `c + fp`, where `(c₁+fp) − (c₂+fp) = c₁−c₂ ≠ 0`. No bounds, no primality, no `TwoRootMap`, no constraints consulted. Soundness is `linearize_eval` + the existing `constDiffNZ_sound`.

Wired as a third disjunct at the four refutation sites: `findConsumer`/`checkPair` (`BusUnify.lean`) and `midRefuted` (`BusPairCancel.lean`, through which `preRefuted`/`shieldOk` and the aggressive-path scan all funnel). It strictly generalizes `addrConstsNeq`, so it can only enable *more* cancellation.

## Why

On the `wasm-eth` corpus, in-block memory forwarding never fired for the frame-pointer shadow stack (address space 1): neither `addrConstsNeq` (needs literal slots) nor `addrTwoRootNeq` (needs a two-root limb decomposition) can refute `c + fp`. So the consumer scan aborted at the first other stack slot and **no AS-1 access was ever forwarded**, leaving the worst cases at 4.2–4.85× the powdr variable count.

## Impact (variables — the top-priority metric)

| case | apc vars (main) | apc vars (now) | powdr | ratio now |
|------|----:|----:|----:|----:|
| apc_037 k256 square | 9201 | 1929 | 1896 | 1.02× |
| apc_012 k256 mul | 12885 | 2705 | 2678 | 1.01× |
| apc_006 keccakf | 8021 | 1606 | 1908 | **0.84×** |

Variable effectiveness reaches powdr parity or better on every case; the residual is bus interactions (addressed by PR 2). **openvm-eth (merge gate): no regression** — aggregate variables 4.551× → 4.552×, per-case vars W/L/T vs powdr 31/9/60 → 31/7/62 (two losses flip to ties). keccak unchanged.

Build + `Scripts/check-proof-integrity.sh` green (`{propext, Classical.choice, Quot.sound}` only); no audited-surface / `Basic.lean` / `FactPass.lean` / pass-pipeline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)