### PR TITLE
Pattern-aware recvByteSlots: cancel non-{1,2} address-space memory pairs

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -61,17 +61,22 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (m : BusInteraction (ZMod p)),
       neverViolates m.busId = true → bs.violatesConstraint m = false
   /-- Send/receive table obligations of a memory-style stateful bus, for pair cancellation:
-      `recvByteSlots busId = some slots` asserts that a *send* (multiplicity `1`) on `busId`
-      never violates a constraint, and a *receive* (multiplicity `-1`) does not violate provided
-      every payload slot listed in `slots` (where present) holds a value `< 256`. `some []` is
-      "sends and receives never violate" — the right instance for a stateful bus with no table
-      at all (e.g. an execution bridge); `none` claims nothing. -/
-  recvByteSlots : (busId : Nat) → Option (List Nat)
+      `recvByteSlots busId pattern = some slots` asserts that a *send* (multiplicity `1`) on
+      `busId` never violates a constraint (regardless of the pattern), and a *receive*
+      (multiplicity `-1`) whose payload matches `pattern` does not violate provided every payload
+      slot listed in `slots` (where present) holds a value `< 256`. The pattern lets a fact make
+      the receive obligation conditional on constant payload entries — e.g. a memory receive
+      whose address-space slot is a known constant ∉ {1,2} carries *no* byte obligation
+      (`slots = []`), because the VM's `violates` only rejects non-byte data on address spaces
+      1/2. `some []` is "this receive (and every send) never violates"; `none` claims nothing.
+      Pattern-blind facts simply ignore the argument. -/
+  recvByteSlots : (busId : Nat) → (pattern : List (Option (ZMod p))) → Option (List Nat)
   recvByteSlots_sound :
-    ∀ (busId : Nat) (slots : List Nat), recvByteSlots busId = some slots →
+    ∀ (busId : Nat) (pattern : List (Option (ZMod p))) (slots : List Nat),
+      recvByteSlots busId pattern = some slots →
       ∀ (m : BusInteraction (ZMod p)), m.busId = busId →
         (m.multiplicity = 1 → bs.violatesConstraint m = false) ∧
-        (m.multiplicity = -1 →
+        (m.multiplicity = -1 → Matches m.payload pattern →
           (∀ slot ∈ slots, ∀ x : ZMod p, m.payload[slot]? = some x → x.val < 256) →
           bs.violatesConstraint m = false)
   /-- The last-write-wins shape declared for a bus, or `none`. Passes read `addressFields` to
@@ -284,8 +289,8 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   slotFun_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
   neverViolates _ := false
   neverViolates_sound := by intro _ h; exact absurd h (by simp)
-  recvByteSlots _ := none
-  recvByteSlots_sound := by intro _ _ h; exact absurd h (by simp)
+  recvByteSlots _ _ := none
+  recvByteSlots_sound := by intro _ _ _ h; exact absurd h (by simp)
   memShape _ := none
   memShape_stateful := by intro _ _ h; exact absurd h (by simp)
   admissible_sound := by intro _ _ _ _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -77,6 +77,22 @@ private def neverViolatesImpl (busMap : Nat → Option OpenVmBusType) (busId : N
   -- length is not 9, so it can violate and is not unconditionally sound.
   | _ => false
 
+/-- Byte-slot obligation for a memory-style pair cancellation, conditioned on the receive's
+    constant pattern. A memory receive whose address-space slot (payload slot 0) is a known
+    constant ∉ {1,2} carries **no** byte obligation (`some []`) — the VM's `violates` only rejects
+    non-byte data on address spaces 1 and 2 — so it can be cancelled freely (e.g. the wasm
+    frame-pointer cell at AS 5). Otherwise the data limbs (slots 2–5) must be bytes, as before.
+    The execution bridge never violates (`some []`); every other bus claims nothing (`none`). -/
+private def recvByteSlotsImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat)
+    (pattern : List (Option (ZMod p))) : Option (List Nat) :=
+  match busMap busId with
+  | some .memory =>
+    match pattern[0]? with
+    | some (some as) => some (if as.val = 1 ∨ as.val = 2 then [2, 3, 4, 5] else [])
+    | _ => some [2, 3, 4, 5]
+  | some .executionBridge => some []
+  | _ => none
+
 /-- The fixed-zero cell of the OpenVM memory bus: register `x0` = address `(as, ptr) = (1, 0)`,
     with the four data limbs at payload slots `2..5`. Backs the `zeroRegisterReads` admissibility
     clause; `none` for every non-memory bus. -/
@@ -188,6 +204,31 @@ private theorem memory_recv_ok (busMap : Nat → Option OpenVmBusType)
   have h2 : d2.val < 256 := hslots 4 (by simp) d2 rfl
   have h3 : d3.val < 256 := hslots 5 (by simp) d3 rfl
   simp [isByte, h0, h1, h2, h3]
+
+/-- A memory message whose address-space slot (payload slot 0) is a known constant ∉ {1, 2}
+    never violates, regardless of its multiplicity or data limbs: the VM's `violates` only
+    rejects non-byte data on address spaces 1 and 2. This is what lets a memory receive from a
+    non-register/non-main-memory address space (e.g. the wasm frame-pointer cell at AS 5) be
+    dropped with an empty byte obligation. -/
+private theorem memory_recv_nonByte_ok (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
+    (as : ZMod p) (hasval : ¬ (as.val = 1 ∨ as.val = 2)) (has : m.payload[0]? = some as) :
+    violates busMap m = false := by
+  obtain ⟨bid, mult, payload⟩ := m
+  simp only at hbus has
+  unfold violates
+  rw [hbus]
+  rcases payload with _ | ⟨a0, _ | ⟨a1, _ | ⟨b0, _ | ⟨b1, _ | ⟨b2, _ | ⟨b3, rest⟩⟩⟩⟩⟩⟩ <;>
+    try rfl
+  -- only the 6+-element case remains; `a0` is the address space, equal to `as`
+  simp only [List.getElem?_cons_zero, Option.some.injEq] at has
+  push_neg at hasval
+  obtain ⟨hne1, hne2⟩ := hasval
+  have hmid : (a0.val == 1 || a0.val == 2) = false := by
+    rw [has]
+    simp only [Bool.or_eq_false_iff, beq_eq_false_iff_ne]
+    exact ⟨hne1, hne2⟩
+  simp only [hmid, Bool.and_false, Bool.false_and]
 
 /-- A bus with a declared last-write-wins shape (memory or execution bridge) is stateful. -/
 theorem openVm_isStateful_of_memShape {p : ℕ} (busMap : Nat → Option OpenVmBusType)
@@ -398,25 +439,49 @@ def openVmFacts (p : ℕ) [NeZero p]
     split at h
     · rename_i hbus; exact execBridge_ok busMap m hbus
     · exact absurd h (by simp)
-  recvByteSlots busId := match busMap busId with
-    | some .memory => some [2, 3, 4, 5]
-    | some .executionBridge => some []
-    | _ => none
+  recvByteSlots := recvByteSlotsImpl busMap
   recvByteSlots_sound := by
-    intro busId slots hfact m hbusId
+    intro busId pattern slots hfact m hbusId
     subst hbusId
-    split at hfact
-    · -- memory: sends never violate; receives need byte data limbs (slots 2–5)
-      rename_i hbus
-      simp only [Option.some.injEq] at hfact
-      subst hfact
-      exact ⟨fun hm => memory_send_ok busMap m hbus hm,
-             fun hm hbytes => memory_recv_ok busMap m hbus hm hbytes⟩
-    · -- execution bridge: never violates
-      rename_i hbus
-      exact ⟨fun _ => execBridge_ok busMap m hbus,
-             fun _ _ => execBridge_ok busMap m hbus⟩
-    · exact absurd hfact (by simp)
+    unfold recvByteSlotsImpl at hfact
+    cases hbus : busMap m.busId with
+    | none => rw [hbus] at hfact; simp at hfact
+    | some bt =>
+      cases bt with
+      | executionBridge =>
+        rw [hbus] at hfact
+        simp only [Option.some.injEq] at hfact
+        subst hfact
+        exact ⟨fun _ => execBridge_ok busMap m hbus, fun _ _ _ => execBridge_ok busMap m hbus⟩
+      | memory =>
+        rw [hbus] at hfact
+        cases hp0 : pattern[0]? with
+        | none =>
+          rw [hp0] at hfact
+          simp only [Option.some.injEq] at hfact
+          subst hfact
+          exact ⟨fun hm => memory_send_ok busMap m hbus hm,
+                 fun hm _ hbytes => memory_recv_ok busMap m hbus hm hbytes⟩
+        | some oas =>
+          cases oas with
+          | none =>
+            rw [hp0] at hfact
+            simp only [Option.some.injEq] at hfact
+            subst hfact
+            exact ⟨fun hm => memory_send_ok busMap m hbus hm,
+                   fun hm _ hbytes => memory_recv_ok busMap m hbus hm hbytes⟩
+          | some as =>
+            rw [hp0] at hfact
+            simp only [Option.some.injEq] at hfact
+            subst hfact
+            refine ⟨fun hm => memory_send_ok busMap m hbus hm, fun hm hmatch hbytes => ?_⟩
+            split_ifs at hbytes with hcase
+            · exact memory_recv_ok busMap m hbus hm hbytes
+            · exact memory_recv_nonByte_ok busMap m hbus as hcase (hmatch.2 0 as hp0)
+      | pcLookup => rw [hbus] at hfact; simp at hfact
+      | variableRangeChecker => rw [hbus] at hfact; simp at hfact
+      | bitwiseLookup => rw [hbus] at hfact; simp at hfact
+      | tupleRangeChecker s1 s2 => rw [hbus] at hfact; simp at hfact
   memShape := memShapeOf busMap
   memShape_stateful := fun busId shape hshape =>
     openVm_isStateful_of_memShape busMap busId shape hshape

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -627,7 +627,9 @@ theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts 
     (hp1 : (1 : ZMod p) ≠ 0)
     (A B C : List (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
-    (slots : List Nat) (hslots : facts.recvByteSlots busId = some slots)
+    (pattern : List (Option (ZMod p))) (slots : List Nat)
+    (hslots : facts.recvByteSlots busId pattern = some slots)
+    (hRmatch : ∀ env, Matches (R.eval env).payload pattern)
     (checks : List (BusInteraction (Expression p)))
     (hchecks : ∀ ck ∈ checks,
       bs.isStateful ck.busId = false ∧
@@ -690,12 +692,12 @@ theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts 
   -- `recvByteSlots` contract), and the receive's byte slots are justified from the remaining
   -- interactions, whose obligations hold under any `out`-satisfying assignment.
   have hnvS : ∀ env, bs.violatesConstraint (S.eval env) = false := fun env =>
-    (facts.recvByteSlots_sound busId slots hslots (S.eval env)
+    (facts.recvByteSlots_sound busId pattern slots hslots (S.eval env)
       (show (S.eval env).busId = busId from hSbus)).1 (hSmEv env)
   have hnvR : ∀ env, out.satisfies bs env → bs.violatesConstraint (R.eval env) = false := by
     intro env hsat
-    refine (facts.recvByteSlots_sound busId slots hslots (R.eval env)
-      (show (R.eval env).busId = busId from hRbus)).2 (hRmEv env)
+    refine (facts.recvByteSlots_sound busId pattern slots hslots (R.eval env)
+      (show (R.eval env).busId = busId from hRbus)).2 (hRmEv env) (hRmatch env)
       (hbyte env (fun c hc => hsat.1 c hc) ?_)
     intro bi hbi hne
     exact hsat.2 bi (by rw [houtb]; exact hbi) hne
@@ -1285,12 +1287,13 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
-    (slots : List Nat) (hslots : facts.recvByteSlots busId = some slots)
+    (slots : List Nat)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
     (A : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
     (B : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (C : List (BusInteraction (Expression p)))
+    (hslots : facts.recvByteSlots busId (R.payload.map Expression.constValue?) = some slots)
     (checks : List (BusInteraction (Expression p)))
     (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C)
     (h : checkCancel deep cs.algebraicConstraints bs facts T M shape busId slots A S B R C checks
@@ -1301,7 +1304,9 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
   obtain ⟨⟨⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hmid⟩, hpre⟩, hemit⟩, hjust⟩ := h
   have hRmEv : ∀ env, (R.eval env).multiplicity = -1 :=
     fun env => R.multiplicity.constValue?_sound (-1) (of_decide_eq_true hRm) env
-  refine dropPair_correct cs bs facts hp1 A B C S R busId shape hshape slots hslots checks
+  refine dropPair_correct cs bs facts hp1 A B C S R busId shape hshape
+    (R.payload.map Expression.constValue?) slots hslots
+    (fun env => matches_evalPattern R.payload env) checks
     (fun ck hck => emitOk_sound bs facts busId slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
     (fun env hall hbus => recvSlotsJustified_sound deep cs.algebraicConstraints bs facts
@@ -1333,7 +1338,6 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     (aggressive : Bool)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
-    (slots : List Nat) (hslots : facts.recvByteSlots busId = some slots)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
     (bcBus? : Option Nat)
@@ -1345,7 +1349,7 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     let S := arr[i]
     -- (thunked: Lean is strict, and the continuation must not run once a pair is accepted)
     let next := fun (_ : Unit) => findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape
-      slots hslots T M bcBus? arr idx (i + 1)
+      T M bcBus? arr idx (i + 1)
     if decide (multConst S = some 1) && decide (S.busId = busId) then
       match firstMatchAt M arr S i (idx.getD
           (if aggressive then addrHash shape S.payload else payloadHash S.payload) []) with
@@ -1361,6 +1365,12 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
               && shieldOk shape T busId S A then
           let B := (arr.extract (i + 1) j).toList
           let C := (arr.extract (j + 1) arr.size).toList
+          -- The receive `R`'s byte obligation depends on its own constant pattern (e.g. a
+          -- memory receive whose address-space slot is a known constant ∉ {1,2} carries no
+          -- obligation), so `slots` is resolved per candidate, not per bus.
+          match hslots : facts.recvByteSlots busId (R.payload.map Expression.constValue?) with
+          | none => next ()
+          | some slots =>
           -- Try the certificate with no emitted checks first: every non-justification conjunct
           -- of `checkCancel` is guaranteed by the scan's own gates, so it passes iff every
           -- declared byte slot is justified — the same predicate `unjustifiedSlots` decides —
@@ -1369,8 +1379,8 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
               A S B R C [] = true then
             if hsplit : cs.busInteractions = A ++ S :: B ++ R :: C then
               some (⟨⟨{ cs with busInteractions := A ++ B ++ C ++ [] }, [],
-                    checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots hslots
-                      T M A S B R C [] hsplit hchk0⟩, rfl⟩, i, false)
+                    checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots
+                      T M A S B R C hslots [] hsplit hchk0⟩, rfl⟩, i, false)
             else next ()
           else
           -- Some slot is unjustified. Such slots are materialized as a single explicit
@@ -1398,8 +1408,8 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
               A S B R C checks = true then
             if hsplit : cs.busInteractions = A ++ S :: B ++ R :: C then
               some (⟨⟨{ cs with busInteractions := A ++ B ++ C ++ checks }, [],
-                    checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots hslots
-                      T M A S B R C checks hsplit hchk⟩, rfl⟩, i, true)
+                    checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots
+                      T M A S B R C hslots checks hsplit hchk⟩, rfl⟩, i, true)
             else next ()
           else next ()
           else next ()
@@ -1417,14 +1427,13 @@ def findCancelForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
     (aggressive : Bool)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
-    (slots : List Nat) (hslots : facts.recvByteSlots busId = some slots)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
     (bcBus? : Option Nat) (startPos : Nat) :
     Option ({ r : PassResult cs bs // r.out.algebraicConstraints = cs.algebraicConstraints }
       × Nat × Bool) :=
   let arr := cs.busInteractions.toArray
-  findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape slots hslots T M bcBus?
+  findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape T M bcBus?
     arr (recvIndex busId shape aggressive arr) startPos
 
 /-- Search declared buses from list index `curIdx` for a droppable pair, honouring a resume hint:
@@ -1450,12 +1459,9 @@ def findCancel (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
-        match hslots : facts.recvByteSlots busId with
-        | some slots =>
-          match findCancelForBus cs bs facts hp1 deep hdeep aggressive busId shape hshape slots hslots
-              T M bcBus? startPos with
-          | some (r, pos, emitted) => some (r, curIdx, pos, emitted)
-          | none => findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
+        match findCancelForBus cs bs facts hp1 deep hdeep aggressive busId shape hshape
+            T M bcBus? startPos with
+        | some (r, pos, emitted) => some (r, curIdx, pos, emitted)
         | none => findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
       | none => findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
 


### PR DESCRIPTION
**Stacked PR 2/4** (base `wasm-addr-affine-neq` = PR #132). Merge #132 first.

## What

Make the `recvByteSlots` `BusFacts` field take the receive's constant **pattern** (mirroring `slotBound`). The OpenVM instance returns `[]` (no byte obligation) for a memory receive whose address-space slot is a known constant ∉ {1,2}, and `[2,3,4,5]` otherwise. Soundness: new lemma `memory_recv_nonByte_ok` — a memory message with a constant AS ∉ {1,2} never violates, whatever its data (that arm of `violates` is `false`). `recvByteSlots_sound`'s send clause stays pattern-free; the receive clause gains a `Matches m.payload pattern` hypothesis (discharged by `matches_evalPattern`). `slots` moves from per-bus to per-candidate in `BusPairCancel`, resolved from `R.payload.map constValue?`.

## Why

After PR #132's forwarding, `busPairCancel` still refused to drop the byte-identical AS-5 pairs (the wasm frame-pointer cell `send(5,0,fp,…)` / `receive(5,0,fp,…)`): dropping a memory receive re-imposed its byte obligation, and the old contract declared slots `[2,3,4,5]` unconditionally — `fp` at slot 2 is not a byte, so justification failed. But the obligation is **vacuous**: `violates` only rejects non-byte data on address spaces 1/2.

## Impact (bus interactions; variables unchanged from PR #132)

| case | apc bus (PR #132) | apc bus (now) | powdr bus |
|------|----:|----:|----:|
| apc_006 keccakf | 1934 | 1498 | 1479 |
| apc_022 | 19 | **15** | 15 |
| apc_004 | 246 | 176 | 146 |

apc_022 reaches exact bus parity; apc_006 drops −436 and is now at-or-better than powdr on **all three axes** (vars 1606 < 1908, bus 1498 ≈ 1479, constraints 88 ≪ 548). **openvm-eth: byte-for-byte identical to PR #132** (Δ +0.000× on every axis — eth has no non-{1,2} address spaces); keccak unchanged.

`BusFacts.lean` is zero audit surface. Build + `check-proof-integrity.sh` green (`{propext, Classical.choice, Quot.sound}` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note (stacked-PR hygiene):** this code PR intentionally does **not** touch `docs/log.md`. Its log entry (88) lives in the follow-up log PR #134, alongside the measurement (89), so the stacked PRs never conflict on the append-only log file when squash-merged in order.