### PR TITLE
wasm-eth log entries 88 (recvByteSlots) + 89 (corpus measurement)

### DIFF
--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,6 +77,70 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
+## 0. wasm-eth: variable gap closed; global range-obligation repack is the last axis (after entries 87–89)
+
+The `wasm-eth` corpus (100 cases, merged #131) had apc **far behind** powdr — the worst cases
+(k256 `FieldElement10x26` square/mul, tiny_keccak `keccakf`) sat at 4.2–4.85× the powdr variable
+count. Entries 87 (`addrAffineNeq`, the affine same-base address-disequality certificate) and 88
+(pattern-aware `recvByteSlots`, which drops the vacuous byte obligation on non-{1,2} address-space
+memory receives) closed the memory-forwarding failure that caused it. Re-measured full-corpus
+(stack vs pre-fix `c6a167b`):
+
+| axis | apc | powdr | apc − powdr |
+|---|---|---|---|
+| variables | 17,035 | 19,628 | **−2,593 (lead)** |
+| bus interactions | 13,535 | 12,552 | +983 (**trails, +8%**) |
+| constraints | 15.2× agg | 9.7× agg | lead |
+
+Per-case variables W/L/T vs powdr **16/11/73**; worst variable-ratio case now **1.15×** (was 4.85×).
+**Variables and constraints are won; the one remaining axis is bus interactions**, concentrated in
+the two big k256 cases (apc_037 +351, apc_012 +511; mid cases small). Memory is fully telescoped
+(apc_004 bus-1 44 = powdr 44).
+
+### The remaining bus gap: global range-obligation rebuild  ·  *bus, wasm-eth*  ·  high value / medium effort
+
+Measured on apc_004 (bus-1 memory already at parity), the excess is entirely **range-check
+packing** — the large-corpus version of the existing repack ideas (§4, `TupleRange.lean` /
+`ByteCheckPack.lean`), which apc's *pairwise* packers cannot recover after large-scale unification:
+
+- apc emits **one tuple-range check (bus 7) per timestamp `lower_decomp` limb** —
+  `[a__i, …timestamp_lt…lower_decomp__1]` — where powdr **batches** several decomposition limbs
+  into a single arg as a linear combination: `[a__i, 15360·prev_ts + 15360·decomp + …]`.
+  apc bus-7 **68** vs powdr **22** on apc_004.
+- apc range-checks single `a__` result byte limbs on the tuple bus; powdr uses **byte-*pair***
+  checks on the bitwise bus (bus 6): `[a__i, a__j, 0, 0]`. apc bus-6 **1** vs powdr **24**.
+
+A **global** range-obligation rebuild would: collect every surviving range obligation, drop the
+solver-implied ones, keep the strongest per normalized expression, and re-pack into batched
+tuple/byte-pair checks. Bus-only (variable-neutral), so lexicographically acceptable. Highest-value
+wasm follow-up; touches no audited surface.
+
+### Residuals that fell out of the cascade — do NOT build (re-measured, now minor)
+
+- **`bit_shift_carry` / `a__` result-limb variable excess.** The naive pre-fix estimate feared
+  ~500 excess vars on apc_037; post-forwarding apc_037 is **+33 vars** and the corpus leads powdr.
+  There is no var-side pass to write here (consistent with the `bit_shift_carry` dead-end below —
+  representation choice is count-neutral).
+- **Functional (op-1) bitwise XOR/rotate lookups.** Partly collapsed once forwarding turned the
+  `b`/`c` operand limbs into actual values; re-measure on apc_037 before pursuing, and only after
+  the range repack (smaller residual).
+- **The ≤1-emitted-check cap** (`BusPairCancel.findCancelGoIdx`) is **not binding on wasm**:
+  apc_004 memory is at exact parity, so write-back `prev_data` pairs telescope without needing
+  multiple emitted checks. Leave the cap alone (it guards a measured apc_005-class eth regression).
+
+### Runtime note (profiling target, not a regression)
+
+The fixes are output-size wins at **flat runtime**: wasm-eth wall 1924 s (pre-fix) → 1965 s (stack),
+*not* a collapse. Forwarding now succeeds, but the enabling scans (`findConsumer`/`midRefuted`
+crossing the newly-refutable slots, plus the extra cancellations that now land) cost about what the
+shrink saves; the big k256 cases still spend ~300–490 s each in the cleanup fixpoint. A cheap lever,
+deliberately *not* taken in entry 87 (correctness-first): the affine disequality re-runs
+`linearize` on both address slots per (S, m) pair; a memoized pre-linearized address-slot side
+table (like `TwoRootMap`, passed as a plain argument) would cut the `busPairCancel`/`busUnify` scan
+cost. Profile apc_037 first to confirm that is where the time goes.
+
+---
+
 ## 1. Constant-decomposition folding — **CORE LANDED (entry 81, the bounded-payload digit fold)**
 
 **What landed.** `DigitFold.lean` (cleanup cycle): a bitwise pair check asserting an affine

--- a/docs/log.md
+++ b/docs/log.md
@@ -3327,3 +3327,94 @@ Build + `Scripts/check-proof-integrity.sh` green (`{propext, Classical.choice, Q
 no `sorry`/`admit`/`axiom`/`native_decide`; no audited-surface / `Basic.lean` / `FactPass.lean` /
 pass-pipeline change (correctness rides on the pass's own `PassCorrect`, extended by one `rcases`
 branch per soundness theorem). **Worked: yes (major — the dominant wasm-eth variable lever).**
+
+### 88. Pattern-aware `recvByteSlots`: cancel non-{1,2} address-space memory pairs (wasm-eth root cause 2)
+
+**The gap** (`../leanr-wasm/fable-wasm-1.md`, root cause 2). After entry 87's forwarding,
+`busPairCancel` still refused to drop the byte-identical AS-5 pairs — the wasm frame-pointer cell
+`send(5,0,fp,0,0,0,k+ts)` immediately followed by its `receive` — because dropping a memory
+*receive* re-imposes its byte obligation, and the `recvByteSlots` fact declared the byte slots
+`[2,3,4,5]` **per bus, unconditionally**. The fp payload has `fp` at slot 2, which is not a byte,
+so justification failed and no cancellation ever fired. But the obligation is **vacuous**:
+`violates` (`OpenVmSemantics.lean`) only rejects a non-byte memory receive when its address-space
+slot is 1 or 2; an AS-5 receive never violates, whatever its data.
+
+**The fix.** Make the `recvByteSlots` `BusFacts` field pattern-aware, mirroring `slotBound`'s
+signature — `recvByteSlots busId pattern`. The OpenVM instance (`recvByteSlotsImpl`) returns `[]`
+(no obligation) for a memory receive whose AS slot is a known constant ∉ {1,2}, and `[2,3,4,5]`
+otherwise (AS ∈ {1,2}, or a symbolic AS — conservative). The new soundness lemma
+`memory_recv_nonByte_ok`: a memory message with a constant AS ∉ {1,2} never violates, whatever its
+data (that arm of `violates` is `false`). `recvByteSlots_sound`'s **send** clause stays
+pattern-free (sends never violate); the **receive** clause gains a `Matches m.payload pattern`
+hypothesis, discharged by the existing `matches_evalPattern`. Threaded through `BusPairCancel`:
+`slots` moves from per-bus to **per-candidate**, resolved from `R.payload.map constValue?` at each
+candidate receive (`findCancel`/`findCancelForBus`/`findCancelGoIdx` shed the per-bus `slots`
+argument); `dropPair_correct`/`checkCancel_sound` gain the pattern and its `Matches` witness. All
+of this is `Implementation/` — `BusFacts.lean` is zero audit surface (a wrong fact would not
+compile); the trivial instance adapts mechanically.
+
+**Impact — wasm-eth (bus interactions; variables unchanged from entry 87):**
+
+| case | apc bus (entry 87) | apc bus (now) | powdr bus |
+|------|----:|----:|----:|
+| apc_006 keccakf | 1934 | 1498 | 1479 |
+| apc_022         | 19 | **15** | 15 |
+| apc_004         | 246 | 176 | 146 |
+| apc_005         | 140 | 106 | 92 |
+
+apc_022 reaches **exact bus parity** (15 = 15, plus var/constraint parity); apc_006 drops −436
+(1934 → 1498, near powdr's 1479) and is now **at or better than powdr on all three axes**
+(vars 1606 < 1908, bus 1498 ≈ 1479, constraints 88 ≪ 548). Exactly the plan's predicted −436 on
+apc_006 — the AS-5 identical-payload fp cells now telescope. The residual bus gap on the mid cases
+(apc_004/005) is the shift-carry / range-rebuild residue (step 4).
+
+**openvm-eth (merge-gating): byte-for-byte identical to entry 87** — 100-case `--compare` reports
+Δ **+0.000×** on every axis, "per-case circuit sizes identical". eth has no non-{1,2} address
+spaces, so `recvByteSlots` returns `[2,3,4,5]` for every receive exactly as the old unconditional
+form did. keccak unchanged (2021v/186c/1752bus; its heap is AS 2 ∈ {1,2}). No regression anywhere.
+
+Build + `Scripts/check-proof-integrity.sh` green ({propext, Classical.choice, Quot.sound} only);
+no `sorry`/`admit`/`axiom`/`native_decide`; no audited-surface / `Basic.lean` / `FactPass.lean` /
+pass-pipeline change. **Worked: yes (bus-effectiveness lever; prerequisite for full AS-5
+telescoping).**
+
+### 89. wasm-eth corpus measurement + re-ranking (entries 87 + 88 combined): apc goes from far behind to ahead of powdr on variables
+
+Full-corpus A/B of the two wasm-eth fixes (entries 87 + 88 together) against pre-fix `main`
+(`c6a167b`), plus the openvm-eth merge gate. Both binaries built from source; `benchmark.py`
+`--jobs` default (parallel, so per-case runtimes are rough).
+
+**wasm-eth, 100 cases — apc-optimizer effectiveness (size before / after; agg / geomean), main → stack:**
+
+| measure | main | stack | Δ (agg) | powdr |
+|---|---|---|---|---|
+| variables | 1.979× / 2.756× | **7.228× / 3.588×** | **+5.248×** | 6.273× / 3.542× |
+| bus interactions | 1.547× / 1.840× | **5.254× / 2.714×** | +3.707× | 5.666× / 2.868× |
+| constraints | 14.664× / 10.279× | **15.165× / 10.438×** | +0.501× | 9.671× / 11.949× |
+
+Circuit sizes changed on **100 of 100** cases. On the **top-priority variable** axis apc now
+**leads powdr** (7.228× vs 6.273×): total surviving variables **apc 17035 vs powdr 19628** — apc
+uses **13% fewer** than powdr corpus-wide. Per-case variables W/L/T vs powdr: **1/56/43 → 16/11/73**
+(main lost 56 cases to powdr; the stack loses 11, all by a handful of vars on tiny blocks). The
+worst variable-ratio offender went from **4.85×** (apc_037 on main) to **1.15×** (apc_060, a
+23-vs-20-var block); the three headline cases: apc_037 4.85→1.02, apc_012 4.81→1.01, apc_006
+4.20→**0.84** (beats powdr). Constraints already crushed powdr and improved further. Bus
+interactions closed most of the gap (1.547×→5.254×, near powdr's 5.666×); the residual (apc 13535
+vs powdr 12552 total, +8%) is concentrated in apc_037/012 — the shift-carry / functional-XOR /
+range-rebuild residue (entry-90 / ideas.md follow-ups). Re-ranking saved to
+`../leanr-wasm/worst_vars_wasm.txt`.
+
+**Runtime:** essentially **flat** — main 1924 s vs stack 1965 s (+2 %, within parallel-contention
+noise), *not* the 5–8× collapse the investigation hoped for. Forwarding now succeeds (far fewer
+surviving interactions), but the enabling scans (`findConsumer`/`midRefuted` crossing refutable
+slots, plus the extra cancellations that now land) cost about what the shrink saves. So the win is
+entirely output size at flat cost; the fixpoint is still doing real per-cycle work on the big k256
+cases — a profiling target noted for step 4, not a regression.
+
+**openvm-eth (merge gate): no regression.** vs pre-fix main, aggregate variables 4.551× → **4.552×**
+(bus 3.543×, constraints 10.845×; all ≥ main), per-case vars W/L/T vs powdr 31/9/60 → **31/7/62**
+(two powdr-losses flip to ties, entry 87). Entry 88 is byte-identical to entry 87 on eth. **keccak
+unchanged** (2021 v / 186 c / 1752 bus). Build + `Scripts/check-proof-integrity.sh` green
+throughout ({propext, Classical.choice, Quot.sound} only). **Worked: yes — the wasm-eth variable
+gap that motivated the investigation (`../leanr-wasm/fable-wasm-1.md`) is closed; apc now leads
+powdr on variables and constraints, trails only slightly on bus.**


### PR DESCRIPTION
**Stacked PR 3/4** (base `wasm-recv-byte-slots-pattern` = PR #133). Docs-only.

This PR carries the `docs/log.md` entries for **both** step 2 (#133, recvByteSlots) and step 3 (this measurement) — consolidated here so the code PR #133 does **not** touch `log.md`. That keeps the stacked PRs conflict-free on squash-merge: #133 (code only) → main leaves `log.md` untouched, so this PR then appends cleanly.

## Entry 88 — pattern-aware recvByteSlots
wasm-eth bus interactions drop toward powdr: apc_022 19 → 15 (exact bus parity), apc_006 1934 → 1498 (near powdr 1479, −436). openvm-eth byte-for-byte identical; keccak unchanged.

## Entry 89 — full-corpus A/B (stack vs pre-fix main `c6a167b`), 100 cases

| measure | main | this stack | Δ | powdr |
|---|---|---|---|---|
| variables | 1.979× / 2.756× | **7.228× / 3.588×** | **+5.248×** | 6.273× / 3.542× |
| bus interactions | 1.547× / 1.840× | 5.254× / 2.714× | +3.707× | 5.666× / 2.868× |
| constraints | 14.664× / 10.279× | 15.165× / 10.438× | +0.501× | 9.671× / 11.949× |

apc now **leads powdr on variables** (7.228× vs 6.273×): total surviving vars **apc 17035 vs powdr 19628**. Per-case vars W/L/T vs powdr **1/56/43 → 16/11/73**; worst variable-ratio offender **4.85× → 1.15×**. Runtime flat (1924 → 1965 s). openvm-eth no regression (vars 4.551× → 4.552×, W/L/T 31/9/60 → 31/7/62); keccak unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)