### PR TITLE
Runtime overhaul: ~2× on keccak, faster eth, effectiveness unchanged

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -114,12 +114,19 @@ def pointByteOk (x : Variable) (c : Expression p) (byteVars : List Variable)
     | _ => false
 
 /-- The variables of `c` (other than `x`) with a proven byte bound from the remaining
-    interactions — computed once per candidate, not once per enumeration point. -/
+    interactions — computed once per candidate, not once per enumeration point.
+
+    The remaining interactions are consulted through a *witness lookup* `wits`: a function
+    returning, per variable, a short list of interactions to try (`findVarBound` scans just
+    those). Instantiating `wits := fun _ => rest` recovers the plain full-scan behaviour; the
+    pass instead passes a per-sweep hash-indexed witness map (`ByteWits`), turning the
+    per-candidate O(#interactions) rescan into an O(1) lookup. Soundness only ever needs
+    `wits v ⊆ rest` (hypothesis `hwits` in the `_sound` lemmas). -/
 def deepByteVars (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (Expression p))) (x : Variable) (c : Expression p) :
+    (wits : Variable → List (BusInteraction (Expression p))) (x : Variable) (c : Expression p) :
     List Variable :=
   (c.vars.dedup.filter (fun v => v ≠ x)).filter (fun v =>
-    match findVarBound bs facts rest v with
+    match findVarBound bs facts (wits v) v with
     | some b => decide (b ≤ 256)
     | none => false)
 
@@ -142,22 +149,23 @@ def deepEnumDoms (domCs : List (Expression p)) (x : Variable) (c : Expression p)
     point. This resolves byte *selections* `x = Σ (flag polynomial)·yⱼ` over byte-bounded `yⱼ` —
     the shape a memory receive of an unaligned sub-word load leaves behind. -/
 def deepBoundOk (domCs : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (Expression p))) (x : Variable) (c : Expression p) : Bool :=
+    (wits : Variable → List (BusInteraction (Expression p))) (x : Variable) (c : Expression p) :
+    Bool :=
   let enum := deepEnumDoms domCs x c
   if (c.vars.dedup.filter (fun v => v ≠ x)).length ≤ maxDeepVars &&
       (enum.map (fun vd => vd.2.length)).prod ≤ maxDeepPoints then
     (assignments enum).all
-      (pointByteOk x c (deepByteVars bs facts rest x c) (enum.map Prod.fst))
+      (pointByteOk x c (deepByteVars bs facts wits x c) (enum.map Prod.fst))
   else false
 
 /-- Deep byte justification for `x`: one of the first `maxDeepConstraints` constraints
-    mentioning `x` pins it via `deepBoundOk`. Domains are looked up only in the
-    single-variable constraints (the only ones `findDomainAlg` can use). -/
-def deepByteJustified (all : List (Expression p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (Expression p))) (x : Variable) : Bool :=
-  let domCs := all.filter Expression.isSingleVar
-  ((all.filter (Expression.containsVar x)).take maxDeepConstraints).any
-    (fun c => deepBoundOk domCs bs facts rest x c)
+    mentioning `x` (the caller passes them as `cands`, e.g. from a prebuilt variable→constraints
+    index) pins it via `deepBoundOk`. `domCs` are the single-variable constraints (the only ones
+    `findDomainAlg` can use), likewise precomputed by the caller. -/
+def deepByteJustified (domCs cands : List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs)
+    (wits : Variable → List (BusInteraction (Expression p))) (x : Variable) : Bool :=
+  (cands.take maxDeepConstraints).any (fun c => deepBoundOk domCs bs facts wits x c)
 
 theorem pointByteOk_sound [Fact p.Prime] (x : Variable) (c : Expression p)
     (byteVars : List Variable)
@@ -260,10 +268,10 @@ theorem pointByteOk_sound [Fact p.Prime] (x : Variable) (c : Expression p)
 
 theorem deepBoundOk_sound [Fact p.Prime] (domCs : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (Expression p))) (x : Variable) (c : Expression p)
-    (h : deepBoundOk domCs bs facts rest x c = true) (env : Variable → ZMod p)
+    (wits : Variable → List (BusInteraction (Expression p))) (x : Variable) (c : Expression p)
+    (h : deepBoundOk domCs bs facts wits x c = true) (env : Variable → ZMod p)
     (hdom : ∀ c' ∈ domCs, c'.eval env = 0) (hc0 : c.eval env = 0)
-    (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
+    (hbus : ∀ v, ∀ bi ∈ wits v, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
     (env x).val < 256 := by
   unfold deepBoundOk at h
@@ -284,41 +292,42 @@ theorem deepBoundOk_sound [Fact p.Prime] (domCs : List (Expression p))
       subst hfn
       exact findDomainAlg_sound domCs v d hfd env hdom
   -- the precomputed byte-bounded variables really are bytes under `env`
-  have hbyteVars : ∀ v ∈ deepByteVars bs facts rest x c, (env v).val < 256 := by
+  have hbyteVars : ∀ v ∈ deepByteVars bs facts wits x c, (env v).val < 256 := by
     intro v hv
     unfold deepByteVars at hv
     obtain ⟨hv1, hv2⟩ := List.mem_filter.mp hv
-    cases hb : findVarBound bs facts rest v with
+    cases hb : findVarBound bs facts (wits v) v with
     | none => rw [hb] at hv2; simp at hv2
     | some b =>
       rw [hb] at hv2
       dsimp only at hv2
-      exact lt_of_lt_of_le (findVarBound_sound bs facts rest v b hb env hbus)
+      exact lt_of_lt_of_le (findVarBound_sound bs facts (wits v) v b hb env (hbus v))
         (of_decide_eq_true hv2)
   -- `env`'s restriction to the enumerated domains is one of the checked points
   have hmem : (deepEnumDoms domCs x c).map (fun vd => (vd.1, env vd.1))
       ∈ assignments (deepEnumDoms domCs x c) :=
     mem_assignments _ env hdomsound
   have hpoint := List.all_eq_true.mp h _ hmem
-  refine pointByteOk_sound x c (deepByteVars bs facts rest x c)
+  refine pointByteOk_sound x c (deepByteVars bs facts wits x c)
     ((deepEnumDoms domCs x c).map Prod.fst)
     ((deepEnumDoms domCs x c).map (fun vd => (vd.1, env vd.1))) hpoint env ?_
     hc0 hbyteVars
   intro y hy
   exact envOf_map (deepEnumDoms domCs x c) env y (List.contains_iff_mem.mp hy)
 
-theorem deepByteJustified_sound [Fact p.Prime] [NeZero p] (all : List (Expression p))
+theorem deepByteJustified_sound [Fact p.Prime] [NeZero p] (all domCs cands : List (Expression p))
     (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (Expression p))) (x : Variable)
-    (h : deepByteJustified all bs facts rest x = true) (env : Variable → ZMod p)
+    (wits : Variable → List (BusInteraction (Expression p))) (x : Variable)
+    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ c ∈ cands, c ∈ all)
+    (h : deepByteJustified domCs cands bs facts wits x = true) (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
-    (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
+    (hbus : ∀ v, ∀ bi ∈ wits v, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
     (env x).val < 256 := by
   obtain ⟨c, hc, hck⟩ := List.any_eq_true.1 h
-  have hc' : c ∈ all := List.mem_of_mem_filter (List.mem_of_mem_take hc)
-  exact deepBoundOk_sound (all.filter Expression.isSingleVar) bs facts rest x c hck env
-    (fun c' hc'' => hall c' (List.mem_of_mem_filter hc'')) (hall c hc') hbus
+  have hc' : c ∈ all := hcands c (List.mem_of_mem_take hc)
+  exact deepBoundOk_sound domCs bs facts wits x c hck env
+    (fun c' hc'' => hall c' (hdomCs c' hc'')) (hall c hc') hbus
 
 /-- Evaluate the single-variable expression `e` with its variable fixed to `d` and check the
     result is a byte constant. `constValue? = none` (so `false`) whenever the fold is not a
@@ -388,35 +397,56 @@ theorem domainByteJustified_sound [Fact p.Prime] (domCs : List (Expression p)) (
 
 /-- Is `e` provably a byte under every assignment satisfying the remaining system? Either a
     constant `< 256`, a variable with a proven bus-fact bound `≤ 256` derived from the remaining
-    interactions `rest` (e.g. another receive of the same word, or an explicit byte-check
+    interactions (e.g. another receive of the same word, or an explicit byte-check
     lookup), or — when `deep` is set (prime `p` only) — a variable a constraint pins to a byte
     on every point of its selector flags' finite domains (`deepBoundOk`), or a single-variable
     expression whose variable's finite domain makes `e` a byte at every point
-    (`domainByteJustified`, e.g. the `255·b` sign-extension limbs). -/
-def byteJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
+    (`domainByteJustified`, e.g. the `255·b` sign-extension limbs).
+
+    Parameterized form: the remaining interactions are consulted through the witness lookup
+    `wits` (see `deepByteVars`), the single-variable constraints `domCs` and the per-variable
+    candidate constraints `candsOf` are precomputed by the caller (once per pass invocation,
+    instead of two full filters of the constraint list per query). -/
+def byteJustifiedW (deep : Bool) (domCs : List (Expression p))
+    (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
     (e : Expression p) : Bool :=
   match e.constValue? with
   | some c => decide (c.val < 256)
   | none =>
     (match e with
      | .var x =>
-       (match findVarBound bs facts rest x with
+       (match findVarBound bs facts (wits x) x with
         | some bound => decide (bound ≤ 256)
         | none => false) ||
-       (deep && deepByteJustified all bs facts rest x)
+       (deep && deepByteJustified domCs (candsOf x) bs facts wits x)
      | _ => false) ||
-    (deep && domainByteJustified (all.filter Expression.isSingleVar) e)
+    (deep && domainByteJustified domCs e)
 
-theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (e : Expression p)
+/-- The plain full-scan form (used by the coda's `RedundantByteDrop`): witness lookup and
+    precomputed constraint lists instantiated with the naive per-query filters. -/
+def byteJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
+    (e : Expression p) : Bool :=
+  byteJustifiedW deep (all.filter Expression.isSingleVar)
+    (fun x => all.filter (Expression.containsVar x)) bs facts (fun _ => rest) e
+
+theorem byteJustifiedW_sound (deep : Bool) (all domCs : List (Expression p))
+    (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
+    (wits : Variable → List (BusInteraction (Expression p))) (e : Expression p)
     (hdeep : deep = true → p.Prime)
-    (h : byteJustified deep all bs facts rest e = true) (env : Variable → ZMod p)
+    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
+    (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
+    (h : byteJustifiedW deep domCs candsOf bs facts wits e = true) (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
     (e.eval env).val < 256 := by
-  unfold byteJustified at h
+  have hbusW : ∀ v, ∀ bi ∈ wits v, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false :=
+    fun v bi hbi => hbus bi (hwits v bi hbi)
+  unfold byteJustifiedW at h
   cases hc : e.constValue? with
   | some c =>
     rw [hc] at h
@@ -434,39 +464,59 @@ theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusS
         dsimp only at h
         show (env x).val < 256
         rcases Bool.or_eq_true _ _ |>.mp h with h' | h'
-        · cases hb : findVarBound bs facts rest x with
+        · cases hb : findVarBound bs facts (wits x) x with
           | some bound =>
             rw [hb] at h'
             dsimp only at h'
-            exact lt_of_lt_of_le (findVarBound_sound bs facts rest x bound hb env hbus)
+            exact lt_of_lt_of_le (findVarBound_sound bs facts (wits x) x bound hb env (hbusW x))
               (of_decide_eq_true h')
           | none => rw [hb] at h'; simp at h'
         · rw [Bool.and_eq_true] at h'
           haveI : Fact p.Prime := ⟨hdeep h'.1⟩
           haveI : NeZero p := ⟨(hdeep h'.1).ne_zero⟩
-          exact deepByteJustified_sound all bs facts rest x h'.2 env hall hbus
+          exact deepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
+            h'.2 env hall hbusW
       | const n => simp at h
       | add a b => simp at h
       | mul a b => simp at h
     · -- single-variable finite-domain expression path
       rw [Bool.and_eq_true] at h
       haveI : Fact p.Prime := ⟨hdeep h.1⟩
-      exact domainByteJustified_sound (all.filter Expression.isSingleVar) e h.2 env
-        (fun c' hc' => hall c' (List.mem_of_mem_filter hc'))
+      exact domainByteJustified_sound domCs e h.2 env
+        (fun c' hc' => hall c' (hdomCs c' hc'))
 
-/-- Are all of `R`'s payload entries at the declared byte slots justified from `rest`? -/
-def recvSlotsJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (slots : List Nat)
-    (R : BusInteraction (Expression p)) : Bool :=
+theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (e : Expression p)
+    (hdeep : deep = true → p.Prime)
+    (h : byteJustified deep all bs facts rest e = true) (env : Variable → ZMod p)
+    (hall : ∀ c' ∈ all, c'.eval env = 0)
+    (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi.eval env) = false) :
+    (e.eval env).val < 256 :=
+  byteJustifiedW_sound deep all (all.filter Expression.isSingleVar)
+    (fun x => all.filter (Expression.containsVar x)) bs facts rest (fun _ => rest) e hdeep
+    (fun _ hc => List.mem_of_mem_filter hc) (fun _ _ hc => List.mem_of_mem_filter hc)
+    (fun _ _ hbi => hbi) h env hall hbus
+
+/-- Are all of `R`'s payload entries at the declared byte slots justified (through the witness
+    lookup `wits` and precomputed `domCs`/`candsOf`, see `byteJustifiedW`)? -/
+def recvSlotsJustified (deep : Bool) (domCs : List (Expression p))
+    (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
+    (slots : List Nat) (R : BusInteraction (Expression p)) : Bool :=
   slots.all (fun slot =>
     match R.payload[slot]? with
-    | some e => byteJustified deep all bs facts rest e
+    | some e => byteJustifiedW deep domCs candsOf bs facts wits e
     | none => true)
 
-theorem recvSlotsJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (slots : List Nat)
+theorem recvSlotsJustified_sound (deep : Bool) (all domCs : List (Expression p))
+    (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
+    (wits : Variable → List (BusInteraction (Expression p))) (slots : List Nat)
     (R : BusInteraction (Expression p)) (hdeep : deep = true → p.Prime)
-    (h : recvSlotsJustified deep all bs facts rest slots R = true)
+    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
+    (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
+    (h : recvSlotsJustified deep domCs candsOf bs facts wits slots R = true)
     (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
@@ -484,7 +534,8 @@ theorem recvSlotsJustified_sound (deep : Bool) (all : List (Expression p)) (bs :
     rw [he] at hget' hcheck
     simp only [Option.map_some, Option.some.injEq] at hget'
     subst hget'
-    exact byteJustified_sound deep all bs facts rest e hdeep hcheck env hall hbus
+    exact byteJustifiedW_sound deep all domCs candsOf bs facts rest wits e hdeep
+      hdomCs hcands hwits hcheck env hall hbus
 
 /-! ## Net-multiplicity bookkeeping -/
 
@@ -852,19 +903,172 @@ def payloadHash (pl : List (Expression p)) : UInt64 :=
 def addrHash (shape : MemoryBusShape) (pl : List (Expression p)) : UInt64 :=
   shape.addressFields.foldl (fun h slot => mixHash h ((pl[slot]?).elim 5 Expression.structHash)) 7
 
-/-- Positions (ascending) of the candidate receives (constant `-1` multiplicity, on `busId`).
-    In the cycle (`aggressive = false`) the key is the exact payload hash — tiny buckets, cheap
-    syntactic probes. In the coda (`aggressive = true`) it is the *address-slot* hash
-    (`addrHash`), a coarsening under which entailed-equal value slots still land in the probed
-    bucket while addresses must agree syntactically to be found at all. -/
-def recvIndex (busId : Nat) (shape : MemoryBusShape) (aggressive : Bool)
+/-- Positions (ascending) of the candidate receives (constant `-1` multiplicity) on **every**
+    memory-shaped bus, keyed by the bus id mixed with the payload hash — one build serves the
+    whole sweep, instead of one O(#interactions) rebuild per bus. In the cycle
+    (`aggressive = false`) the payload part of the key is the exact payload hash — tiny buckets,
+    cheap syntactic probes. In the coda (`aggressive = true`) it is the *address-slot* hash
+    (`addrHash`, computed against the bus's own declared shape), a coarsening under which
+    entailed-equal value slots still land in the probed bucket while addresses must agree
+    syntactically to be found at all. Purely heuristic: probes re-verify the bus id and payload,
+    so a hash collision can only cost time, never a wrong drop. -/
+def recvIndexAll {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
     (arr : Array (BusInteraction (Expression p))) :
     Std.HashMap UInt64 (List Nat) :=
   (arr.toList.zipIdx).foldr (fun bij m =>
-    if decide (multConst bij.1 = some (-1)) && decide (bij.1.busId = busId) then
-      let h := if aggressive then addrHash shape bij.1.payload else payloadHash bij.1.payload
-      m.insert h (bij.2 :: m.getD h [])
+    if decide (multConst bij.1 = some (-1)) then
+      match facts.memShape bij.1.busId with
+      | some shape =>
+        let h := mixHash (hash bij.1.busId)
+          (if aggressive then addrHash shape bij.1.payload else payloadHash bij.1.payload)
+        m.insert h (bij.2 :: m.getD h [])
+      | none => m
     else m) ∅
+
+/-- Every element of a two-point split other than the two distinguished ones lies in the
+    remaining region. -/
+theorem mem_core_of_ne {α : Type _} {l A B C : List α} {S R x : α}
+    (hsplit : l = A ++ S :: B ++ R :: C) (hx : x ∈ l) (hxS : x ≠ S) (hxR : x ≠ R) :
+    x ∈ A ++ B ++ C := by
+  subst hsplit
+  simp only [List.mem_append, List.mem_cons] at hx ⊢
+  tauto
+
+/-! ### The per-invocation candidate-constraint index
+
+`deepByteJustified` consulted the constraint list through two full filters per queried variable
+(`all.filter Expression.isSingleVar` and `all.filter (containsVar x) |>.take maxDeepConstraints`).
+Both are precomputed once per pass invocation — the constraints never change across the drops of
+one invocation (`cancelLoop` transports the thunks) — as the plain `domCs` list and this
+proof-carrying variable→constraints index (first `maxDeepConstraints` per variable, in list
+order, exactly what the filters produced). -/
+
+structure VarCsIdx (p : ℕ) (constraints : List (Expression p)) where
+  map : Std.HashMap Variable (List (Expression p))
+  sound : ∀ (x : Variable) (l : List (Expression p)),
+    map[x]? = some l → ∀ c ∈ l, c ∈ constraints
+
+namespace VarCsIdx
+
+variable {constraints : List (Expression p)}
+
+def empty : VarCsIdx p constraints where
+  map := ∅
+  sound := by
+    intro x l h
+    rw [Std.HashMap.getElem?_empty] at h
+    exact absurd h (by simp)
+
+/-- Append `c` at the end of `x`'s bucket (so buckets stay in traversal order), capped. -/
+def insertC (I : VarCsIdx p constraints) (x : Variable) (c : Expression p)
+    (hc : c ∈ constraints) : VarCsIdx p constraints :=
+  match hb : I.map[x]? with
+  | none =>
+    { map := I.map.insert x [c],
+      sound := by
+        intro y l hl c' hc'
+        rw [Std.HashMap.getElem?_insert] at hl
+        by_cases hxy : (x == y) = true
+        · rw [if_pos hxy] at hl
+          have hle : [c] = l := by simpa using hl
+          rw [← hle, List.mem_singleton] at hc'
+          exact hc' ▸ hc
+        · rw [if_neg hxy] at hl
+          exact I.sound y l hl c' hc' }
+  | some old =>
+    if old.length < maxDeepConstraints then
+      { map := I.map.insert x (old ++ [c]),
+        sound := by
+          intro y l hl c' hc'
+          rw [Std.HashMap.getElem?_insert] at hl
+          by_cases hxy : (x == y) = true
+          · rw [if_pos hxy] at hl
+            have hle : old ++ [c] = l := by simpa using hl
+            rw [← hle, List.mem_append] at hc'
+            rcases hc' with h' | h'
+            · exact I.sound x old hb c' h'
+            · rw [List.mem_singleton] at h'
+              exact h' ▸ hc
+          · rw [if_neg hxy] at hl
+            exact I.sound y l hl c' hc' }
+    else I
+
+/-- Record `c` under each of its variables. -/
+def addConstraint (I : VarCsIdx p constraints) (c : Expression p)
+    (hc : c ∈ constraints) : VarCsIdx p constraints :=
+  c.vars.dedup.foldl (fun I x => I.insertC x c hc) I
+
+def addAll : VarCsIdx p constraints → (pending : List (Expression p)) →
+    (∀ c ∈ pending, c ∈ constraints) → VarCsIdx p constraints
+  | I, [], _ => I
+  | I, c :: rest, hmem =>
+    addAll (I.addConstraint c (hmem c (List.mem_cons_self ..))) rest
+      (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
+
+def build (constraints : List (Expression p)) : VarCsIdx p constraints :=
+  addAll empty constraints (fun _ h => h)
+
+def lookup (I : VarCsIdx p constraints) (x : Variable) : List (Expression p) :=
+  (I.map[x]?).getD []
+
+theorem lookup_mem (I : VarCsIdx p constraints) (x : Variable) :
+    ∀ c ∈ I.lookup x, c ∈ constraints := by
+  intro c hc
+  unfold lookup at hc
+  cases hb : I.map[x]? with
+  | none => rw [hb] at hc; simp at hc
+  | some l =>
+    rw [hb] at hc
+    exact I.sound x l hb c hc
+
+end VarCsIdx
+
+/-! ### The split equation, by construction
+
+The scan walks the interaction *array*; a drop certificate needs the list-level split
+`cs.busInteractions = A ++ S :: B ++ R :: C`. Deciding that equation at runtime is an
+O(#interactions) deep structural comparison per accepted drop; instead it follows by
+construction from the way `A`/`B`/`C` are extracted. -/
+
+/-- A list splits at two positions into take/drop segments, nested-parenthesization form. -/
+theorem list_split_two_aux {α : Type _} {l : List α} {i j : Nat} (hij : i < j)
+    (hj : j < l.length) :
+    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
+      ((l.drop (i + 1)).take (j - (i + 1)) ++ (l[j]'hj :: l.drop (j + 1))) := by
+  have hi : i < l.length := Nat.lt_trans hij hj
+  conv_lhs => rw [← List.take_append_drop i l]
+  congr 1
+  rw [List.drop_eq_getElem_cons hi]
+  congr 1
+  conv_lhs => rw [← List.take_append_drop (j - (i + 1)) (l.drop (i + 1))]
+  congr 1
+  rw [List.drop_drop]
+  have hjj : i + 1 + (j - (i + 1)) = j := by omega
+  rw [hjj, List.drop_eq_getElem_cons hj]
+
+/-- A list splits at two positions into take/drop segments (the `A ++ S :: B ++ R :: C`
+    parenthesization the drop certificate uses). -/
+theorem list_split_two {α : Type _} {l : List α} {i j : Nat} (hij : i < j) (hj : j < l.length) :
+    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
+      (l.drop (i + 1)).take (j - (i + 1)) ++ l[j]'hj :: l.drop (j + 1) := by
+  conv_lhs => rw [list_split_two_aux hij hj]
+  simp [List.append_assoc, List.cons_append]
+
+/-- The array-extract form of `list_split_two`: the segments the scan materializes recompose to
+    the underlying list, so the split equation holds with no runtime comparison. -/
+theorem split_of_extracts {α : Type _} {l : List α} {arr : Array α}
+    (harr : arr = l.toArray) {i j : Nat} (hij : i < j) (hi : i < arr.size) {R : α}
+    (hR : arr[j]? = some R) :
+    l = (arr.extract 0 i).toList ++ arr[i] ::
+        (arr.extract (i + 1) j).toList ++ R :: (arr.extract (j + 1) arr.size).toList := by
+  subst harr
+  obtain ⟨hj, hRj⟩ := Array.getElem?_eq_some_iff.mp hR
+  have hjl : j < l.length := by simpa using hj
+  subst hRj
+  simp only [Array.toList_extract, List.extract_eq_take_drop, List.getElem_toArray,
+    List.size_toArray, List.drop_zero, Nat.sub_zero]
+  rw [List.take_of_length_le (l := l.drop (j + 1)) (by simp)]
+  exact list_split_two hij hjl
 
 /-! ### Constraint-entailed payload matching
 
@@ -996,20 +1200,21 @@ theorem payloadEntailedEq_sound {constraints : List (Expression p)}
   | [], _ :: _, h, _, _ => by simp [payloadEntailedEq] at h
   | _ :: _, [], h, _, _ => by simp [payloadEntailedEq] at h
 
-/-- The first indexed position strictly after `i` whose payload matches `S.payload` (positions
-    ascending; the hash bucket pre-filters, the slot-wise entailed comparison decides). -/
+/-- The first indexed position strictly after `i` on `busId` whose payload matches `S.payload`
+    (positions ascending; the hash bucket pre-filters, the bus-id check and the slot-wise
+    entailed comparison decide). -/
 def firstMatchAt {constraints : List (Expression p)}
     (M : Thunk (EqConstraintMap p constraints)) (arr : Array (BusInteraction (Expression p)))
-    (S : BusInteraction (Expression p)) (i : Nat) : List Nat → Option Nat
+    (busId : Nat) (S : BusInteraction (Expression p)) (i : Nat) : List Nat → Option Nat
   | [] => none
   | j :: rest =>
     if i < j then
       match arr[j]? with
       | some R =>
-        if payloadEntailedEq M S.payload R.payload then some j
-        else firstMatchAt M arr S i rest
-      | none => firstMatchAt M arr S i rest
-    else firstMatchAt M arr S i rest
+        if decide (R.busId = busId) && payloadEntailedEq M S.payload R.payload then some j
+        else firstMatchAt M arr busId S i rest
+      | none => firstMatchAt M arr busId S i rest
+    else firstMatchAt M arr busId S i rest
 
 /-- Refute `m` as an active same-address message on `busId` (the "between" region test). The
     two-root address-disequality (`addrTwoRootNeq`) lets this step over interleaved other-pointer
@@ -1250,39 +1455,39 @@ theorem emitOk_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat)
       exact Or.inr (List.mem_flatMap.2 ⟨e1, he1mem, hvE⟩)
   · exact absurd hrest (by simp)
 
-/-- The declared byte slots of `R` whose payload entries `rest` does not justify. -/
-def unjustifiedSlots (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (slots : List Nat)
-    (R : BusInteraction (Expression p)) : List Nat :=
+/-- The declared byte slots of `R` whose payload entries the witnesses do not justify. -/
+def unjustifiedSlots (deep : Bool) (domCs : List (Expression p))
+    (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
+    (slots : List Nat) (R : BusInteraction (Expression p)) : List Nat :=
   slots.filter (fun slot =>
     match R.payload[slot]? with
-    | some e => !byteJustified deep all bs facts rest e
+    | some e => !byteJustifiedW deep domCs candsOf bs facts wits e
     | none => false)
 
-/-- The per-candidate check (address/multiplicity/payload of the pair, the between/before
-    region tests, the emitted checks' certificates, plus the byte justification of the dropped
-    receive's declared byte slots from the remaining interactions *including* the emitted
-    checks). The split equation `cs.busInteractions = A ++ S :: B ++ R :: C` is *not* checked
-    here — it is supplied separately (decided once for the chosen candidate) to avoid an O(n)
-    whole-list comparison per candidate. The justification scans are the last conjuncts, so
-    they only run for candidates that already match. -/
-def checkCancel (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (T : Thunk (TwoRootMap p all))
-    (M : Thunk (EqConstraintMap p all)) (shape : MemoryBusShape)
+/-- The per-candidate certificate: address/multiplicity/payload of the pair, the emitted
+    checks' certificates, plus the byte justification of the dropped receive's declared byte
+    slots through the witness lookup `wits`. The split equation, the between-region refutation
+    and the before-region shield are *not* re-checked here — the scan established them already
+    and supplies them to `checkCancel_sound` as hypotheses. The justification scan is the last
+    conjunct, so it only runs for candidates that already match. -/
+def checkCancel (deep : Bool) {all : List (Expression p)} (bs : BusSemantics p)
+    (facts : BusFacts p bs)
+    (M : Thunk (EqConstraintMap p all))
+    (domCs : List (Expression p)) (candsOf : Variable → List (Expression p))
+    (wits : Variable → List (BusInteraction (Expression p)))
     (busId : Nat) (slots : List Nat)
-    (A : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
-    (B : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
-    (C : List (BusInteraction (Expression p)))
+    (S R : BusInteraction (Expression p))
     (checks : List (BusInteraction (Expression p))) : Bool :=
   decide (S.busId = busId) && decide (R.busId = busId) &&
   decide (multConst S = some 1) && decide (multConst R = some (-1)) &&
   payloadEntailedEq M S.payload R.payload &&
-  B.all (midRefuted shape T busId S) &&
-  shieldOk shape T busId S A &&
   checks.all (emitOk bs facts busId slots R) &&
-  recvSlotsJustified deep all bs facts (A ++ B ++ C ++ checks) slots R
+  recvSlotsJustified deep domCs candsOf bs facts wits slots R
 
-/-- A passing `checkCancel` (with the split equation) yields `PassCorrect` via `dropPair_correct`. -/
+/-- A passing `checkCancel` — together with the split equation, the region hypotheses the scan
+    established, and the witness/index membership facts — yields `PassCorrect` via
+    `dropPair_correct`. -/
 theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (busId : Nat) (shape : MemoryBusShape)
@@ -1290,18 +1495,24 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
     (slots : List Nat)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
+    (domCs : List (Expression p)) (candsOf : Variable → List (Expression p))
+    (wits : Variable → List (BusInteraction (Expression p)))
     (A : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
     (B : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (C : List (BusInteraction (Expression p)))
     (hslots : facts.recvByteSlots busId (R.payload.map Expression.constValue?) = some slots)
     (checks : List (BusInteraction (Expression p)))
     (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C)
-    (h : checkCancel deep cs.algebraicConstraints bs facts T M shape busId slots A S B R C checks
-      = true) :
+    (hdomCs : ∀ c ∈ domCs, c ∈ cs.algebraicConstraints)
+    (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs.algebraicConstraints)
+    (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ A ++ B ++ C ++ checks)
+    (hmid : ∀ m0 ∈ B, midRefuted shape T busId S m0 = true)
+    (hshield : shieldOk shape T busId S A = true)
+    (h : checkCancel deep bs facts M domCs candsOf wits busId slots S R checks = true) :
     PassCorrect cs { cs with busInteractions := A ++ B ++ C ++ checks } [] bs := by
   unfold checkCancel at h
   simp only [Bool.and_eq_true] at h
-  obtain ⟨⟨⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hmid⟩, hpre⟩, hemit⟩, hjust⟩ := h
+  obtain ⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hemit⟩, hjust⟩ := h
   have hRmEv : ∀ env, (R.eval env).multiplicity = -1 :=
     fun env => R.multiplicity.constValue?_sound (-1) (of_decide_eq_true hRm) env
   refine dropPair_correct cs bs facts hp1 A B C S R busId shape hshape
@@ -1309,30 +1520,116 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
     (fun env => matches_evalPattern R.payload env) checks
     (fun ck hck => emitOk_sound bs facts busId slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
-    (fun env hall hbus => recvSlotsJustified_sound deep cs.algebraicConstraints bs facts
-      (A ++ B ++ C ++ checks) slots R hdeep hjust env hall hbus)
+    (fun env hall hbus => recvSlotsJustified_sound deep cs.algebraicConstraints domCs candsOf
+      bs facts (A ++ B ++ C ++ checks) wits slots R hdeep hdomCs hcands hwits hjust env hall hbus)
     hsplit
     (of_decide_eq_true hSb) (of_decide_eq_true hRb)
     (of_decide_eq_true hSm) (of_decide_eq_true hRm)
     (fun env hcon => payloadEntailedEq_sound M S.payload R.payload hpay env hcon) ?_ ?_
   · intro env hcon m0 hm0 hbid hmne hmaddr
-    exact midRefuted_sound shape T busId S m0 (List.all_eq_true.mp hmid m0 hm0) env hcon
+    exact midRefuted_sound shape T busId S m0 (hmid m0 hm0) env hcon
       hbid hmne hmaddr
   · intro env hcon A_pre m0 A_suf hAeq hbid hmne hmaddr hmult
     have hnp : preRefuted shape T busId S m0 = false := by
       by_contra hp'
       rw [Bool.not_eq_false] at hp'
       exact (preRefuted_sound shape T busId S m0 hp' env hcon hbid hmne hmaddr) hmult
-    obtain ⟨Rp, hRpmem, hRpprov⟩ := shieldOk_sound shape T busId S m0 A_suf A_pre (hAeq ▸ hpre) hnp
+    obtain ⟨Rp, hRpmem, hRpprov⟩ := shieldOk_sound shape T busId S m0 A_suf A_pre
+      (hAeq ▸ hshield) hnp
     exact ⟨Rp, hRpmem, provRecv_sound shape busId hp1 S Rp hRpprov env⟩
+
+/-- The scan behind `dropWits`: the first interaction of `arr` (positions ascending from `k`,
+    skipping any value equal to the dropped pair) that derives an `interactionBound` for `v` —
+    exactly the interaction `findVarBound` over the remaining region finds first, at the same
+    early-exit cost, with no region list materialized. (Fuel-structured for the easy induction;
+    called with `fuel := arr.size`, which reaches every position.) -/
+def dropWitsGo {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
+    (v : Variable) : Nat → Nat → Option (BusInteraction (Expression p))
+  | 0, _ => none
+  | fuel + 1, k =>
+    if h : k < arr.size then
+      if !decide (arr[k] = S) && !decide (arr[k] = R) then
+        match interactionBound bs facts arr[k] v with
+        | some _ => some arr[k]
+        | none => dropWitsGo facts arr S R v fuel (k + 1)
+      else dropWitsGo facts arr S R v fuel (k + 1)
+    else none
+
+/-- The witness lookup for a candidate drop: the first bound-deriving interaction other than
+    the dropped pair, then the emitted checks. Every returned interaction is a member of the
+    remaining region (`dropWits_mem`). -/
+def dropWits {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
+    (checks : List (BusInteraction (Expression p))) (v : Variable) :
+    List (BusInteraction (Expression p)) :=
+  match dropWitsGo facts arr S R v arr.size 0 with
+  | some bi => bi :: checks
+  | none => checks
+
+theorem dropWitsGo_mem {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p))) (S R : BusInteraction (Expression p))
+    (v : Variable) (fuel : Nat) :
+    ∀ (k : Nat) {bi : BusInteraction (Expression p)},
+      dropWitsGo facts arr S R v fuel k = some bi →
+      bi ∈ arr.toList ∧ bi ≠ S ∧ bi ≠ R := by
+  induction fuel with
+  | zero =>
+    intro k bi h
+    exact absurd h (by simp [dropWitsGo])
+  | succ fuel ih =>
+    intro k bi h
+    rw [dropWitsGo] at h
+    split_ifs at h with hk hne
+    · -- in range, not the dropped pair
+      revert h
+      cases hb : interactionBound bs facts arr[k] v with
+      | some b =>
+        intro h
+        obtain rfl := Option.some.inj h
+        rw [Bool.and_eq_true] at hne
+        exact ⟨by simpa using Array.getElem_mem hk,
+          fun he => by simp [he] at hne, fun he => by simp [he] at hne⟩
+      | none =>
+        intro h
+        exact ih (k + 1) h
+    · exact ih (k + 1) h
+
+theorem dropWits_mem {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p)))
+    (harr : arr = cs.busInteractions.toArray)
+    (S R : BusInteraction (Expression p)) (checks : List (BusInteraction (Expression p)))
+    {A B C : List (BusInteraction (Expression p))}
+    (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C) :
+    ∀ v, ∀ bi ∈ dropWits facts arr S R checks v, bi ∈ A ++ B ++ C ++ checks := by
+  intro v bi hbi
+  unfold dropWits at hbi
+  cases hgo : dropWitsGo facts arr S R v arr.size 0 with
+  | none =>
+    rw [hgo] at hbi
+    simp only [List.mem_append]
+    exact Or.inr hbi
+  | some bi' =>
+    rw [hgo] at hbi
+    rcases List.mem_cons.1 hbi with rfl | hbi
+    · obtain ⟨hmem, hne1, hne2⟩ := dropWitsGo_mem facts arr S R v arr.size 0 hgo
+      have hmem' : bi ∈ cs.busInteractions := by
+        rw [harr] at hmem
+        simpa using hmem
+      have := mem_core_of_ne hsplit hmem' hne1 hne2
+      simp only [List.mem_append] at this ⊢
+      tauto
+    · simp only [List.mem_append]
+      exact Or.inr hbi
 
 /-- Indexed left-to-right scan for the first droppable pair on `busId`, starting at position `i`:
     at each send `S` (position in `arr`), find its matching receive through the hash index (the
-    first position after it with an equal payload — exactly what the linear scan found) and run the
-    cheap region tests; the byte-justification scan and the O(n) split-equation decide run only for
-    candidates that already match. Stops at the first hit, returning the pass result together with
-    the send's position and whether a byte check was emitted (which the caller uses to decide where
-    to resume the enclosing fixpoint). -/
+    first position after it with an equal payload on the bus — exactly what the linear scan
+    found) and run the cheap region tests; the byte-justification lookup runs only for
+    candidates that already match, and the split equation holds by construction
+    (`split_of_extracts`) rather than by an O(n) whole-list comparison. Stops at the first hit,
+    returning the pass result together with the send's position and whether a byte check was
+    emitted (which the caller uses to decide where to resume the enclosing fixpoint). -/
 def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool)
@@ -1340,8 +1637,12 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     (hshape : facts.memShape busId = some shape)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
+    (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs.algebraicConstraints })
+    (candsT : Thunk (VarCsIdx p cs.algebraicConstraints))
     (bcBus? : Option Nat)
-    (arr : Array (BusInteraction (Expression p))) (idx : Std.HashMap UInt64 (List Nat))
+    (arr : Array (BusInteraction (Expression p)))
+    (harr : arr = cs.busInteractions.toArray)
+    (idx : Std.HashMap UInt64 (List Nat))
     (i : Nat) :
     Option ({ r : PassResult cs bs // r.out.algebraicConstraints = cs.algebraicConstraints }
       × Nat × Bool) :=
@@ -1349,70 +1650,79 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     let S := arr[i]
     -- (thunked: Lean is strict, and the continuation must not run once a pair is accepted)
     let next := fun (_ : Unit) => findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape
-      T M bcBus? arr idx (i + 1)
+      T M domCsT candsT bcBus? arr harr idx (i + 1)
     if decide (multConst S = some 1) && decide (S.busId = busId) then
-      match firstMatchAt M arr S i (idx.getD
-          (if aggressive then addrHash shape S.payload else payloadHash S.payload) []) with
+      match firstMatchAt M arr busId S i (idx.getD
+          (mixHash (hash busId)
+            (if aggressive then addrHash shape S.payload else payloadHash S.payload)) []) with
       | some j =>
-        match arr[j]? with
+        match hR : arr[j]? with
         | some R =>
-          -- Cheap region tests first, over the array index ranges (`Array.all` with
-          -- start/stop) — the A/B/C lists are materialized only for the few candidates the
-          -- tests accept, not for every payload match; only an otherwise-valid candidate pays
-          -- the byte justification scan (`checkCancel` re-verifies everything).
-          let A := (arr.extract 0 i).toList
-          if arr.all (midRefuted shape T busId S) (i + 1) j
-              && shieldOk shape T busId S A then
-          let B := (arr.extract (i + 1) j).toList
-          let C := (arr.extract (j + 1) arr.size).toList
-          -- The receive `R`'s byte obligation depends on its own constant pattern (e.g. a
-          -- memory receive whose address-space slot is a known constant ∉ {1,2} carries no
-          -- obligation), so `slots` is resolved per candidate, not per bus.
-          match hslots : facts.recvByteSlots busId (R.payload.map Expression.constValue?) with
-          | none => next ()
-          | some slots =>
-          -- Try the certificate with no emitted checks first: every non-justification conjunct
-          -- of `checkCancel` is guaranteed by the scan's own gates, so it passes iff every
-          -- declared byte slot is justified — the same predicate `unjustifiedSlots` decides —
-          -- and the common fully-justified drop pays the justification scan **once**.
-          if hchk0 : checkCancel deep cs.algebraicConstraints bs facts T M shape busId slots
-              A S B R C [] = true then
-            if hsplit : cs.busInteractions = A ++ S :: B ++ R :: C then
+          if hij : i < j then
+            -- Cheap region tests first — only an otherwise-valid candidate pays the byte
+            -- justification lookup.
+            let B := (arr.extract (i + 1) j).toList
+            if hmidB : B.all (midRefuted shape T busId S) = true then
+            let A := (arr.extract 0 i).toList
+            if hshieldA : shieldOk shape T busId S A = true then
+            let C := (arr.extract (j + 1) arr.size).toList
+            have hsplit : cs.busInteractions = A ++ S :: B ++ R :: C :=
+              split_of_extracts harr hij hi hR
+            have hmid : ∀ m0 ∈ B, midRefuted shape T busId S m0 = true :=
+              fun m0 hm0 => List.all_eq_true.mp hmidB m0 hm0
+            -- The receive `R`'s byte obligation depends on its own constant pattern (e.g. a
+            -- memory receive whose address-space slot is a known constant ∉ {1,2} carries no
+            -- obligation), so `slots` is resolved per candidate, not per bus.
+            match hslots : facts.recvByteSlots busId (R.payload.map Expression.constValue?) with
+            | none => next ()
+            | some slots =>
+            -- Try the certificate with no emitted checks first: it passes iff every declared
+            -- byte slot is justified — the same predicate `unjustifiedSlots` decides — and the
+            -- common fully-justified drop pays the justification lookup **once**.
+            if hchk0 : checkCancel deep bs facts M domCsT.get.val candsT.get.lookup
+                (dropWits facts arr S R []) busId slots S R [] = true then
               some (⟨⟨{ cs with busInteractions := A ++ B ++ C ++ [] }, [],
                     checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots
-                      T M A S B R C hslots [] hsplit hchk0⟩, rfl⟩, i, false)
+                      T M domCsT.get.val candsT.get.lookup (dropWits facts arr S R [])
+                      A S B R C hslots []
+                      hsplit domCsT.get.property (fun x => candsT.get.lookup_mem x)
+                      (dropWits_mem facts arr harr S R [] hsplit) hmid hshieldA hchk0⟩, rfl⟩,
+                i, false)
+            else
+            -- Some slot is unjustified. Such slots are materialized as a single explicit
+            -- self-check on the byte-check bus (more than one would not shrink the bus count and
+            -- would stall the cancellation loop); when the justification cannot pass (≥ 2
+            -- unjustified slots, or no byte-check bus), skip the certificate re-check — the
+            -- justification scan is the expensive part.
+            let unjust := unjustifiedSlots deep domCsT.get.val candsT.get.lookup bs facts
+              (dropWits facts arr S R []) slots R
+            let checks : List (BusInteraction (Expression p)) :=
+              match unjust, bcBus? with
+              | [slot], some bcBus => (R.payload[slot]?).elim [] (fun e =>
+                  [{ busId := bcBus, multiplicity := .const 1,
+                     payload := [e, e, .const 0, .const 1] }])
+              | _, _ => []
+            -- Emission-path drops are restricted to *syntactically* equal payloads unless
+            -- `aggressive`: an entailed-matched pair otherwise fires only when every byte slot
+            -- is already justified (`checks = []`). Measured (apc_005 class): mid-cycle entailed
+            -- drops on unjustified receives trade one emitted self-check per pair for
+            -- obligations the deferred syntactic cancellation discharges for free — a net bus
+            -- regression. The `aggressive` form runs once, in the coda, where the race is over:
+            -- each drop is then locally net −1 bus at worst (2 dropped, ≤1 emitted).
+            if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
+              if hchk : checkCancel deep bs facts M domCsT.get.val candsT.get.lookup
+                  (dropWits facts arr S R checks) busId slots S R checks = true then
+                some (⟨⟨{ cs with busInteractions := A ++ B ++ C ++ checks }, [],
+                      checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots
+                        T M domCsT.get.val candsT.get.lookup (dropWits facts arr S R checks)
+                        A S B R C hslots checks hsplit domCsT.get.property
+                        (fun x => candsT.get.lookup_mem x)
+                        (dropWits_mem facts arr harr S R checks hsplit) hmid hshieldA hchk⟩, rfl⟩,
+                  i, true)
+              else next ()
             else next ()
-          else
-          -- Some slot is unjustified. Such slots are materialized as a single explicit
-          -- self-check on the byte-check bus (more than one would not shrink the bus count and
-          -- would stall the cancellation loop); when the justification cannot pass (≥ 2
-          -- unjustified slots, or no byte-check bus), skip the certificate re-check — the
-          -- justification scan is the expensive part.
-          let unjust := unjustifiedSlots deep cs.algebraicConstraints bs facts (A ++ B ++ C)
-            slots R
-          let checks : List (BusInteraction (Expression p)) :=
-            match unjust, bcBus? with
-            | [slot], some bcBus => (R.payload[slot]?).elim [] (fun e =>
-                [{ busId := bcBus, multiplicity := .const 1,
-                   payload := [e, e, .const 0, .const 1] }])
-            | _, _ => []
-          -- Emission-path drops are restricted to *syntactically* equal payloads unless
-          -- `aggressive`: an entailed-matched pair otherwise fires only when every byte slot
-          -- is already justified (`checks = []`). Measured (apc_005 class): mid-cycle entailed
-          -- drops on unjustified receives trade one emitted self-check per pair for
-          -- obligations the deferred syntactic cancellation discharges for free — a net bus
-          -- regression. The `aggressive` form runs once, in the coda, where the race is over:
-          -- each drop is then locally net −1 bus at worst (2 dropped, ≤1 emitted).
-          if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
-          if hchk : checkCancel deep cs.algebraicConstraints bs facts T M shape busId slots
-              A S B R C checks = true then
-            if hsplit : cs.busInteractions = A ++ S :: B ++ R :: C then
-              some (⟨⟨{ cs with busInteractions := A ++ B ++ C ++ checks }, [],
-                    checkCancel_sound cs bs facts hp1 deep hdeep busId shape hshape slots
-                      T M A S B R C hslots checks hsplit hchk⟩, rfl⟩, i, true)
             else next ()
-          else next ()
-          else next ()
+            else next ()
           else next ()
         | none => next ()
       | none => next ()
@@ -1420,33 +1730,25 @@ def findCancelGoIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
   else none
   termination_by arr.size - i
 
-/-- Search one declared bus for a droppable pair starting at position `startPos` (index built once
-    per invocation). Returns the result together with the drop position and emitted flag. -/
-def findCancelForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
-    (aggressive : Bool)
-    (busId : Nat) (shape : MemoryBusShape)
-    (hshape : facts.memShape busId = some shape)
-    (T : Thunk (TwoRootMap p cs.algebraicConstraints))
-    (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
-    (bcBus? : Option Nat) (startPos : Nat) :
-    Option ({ r : PassResult cs bs // r.out.algebraicConstraints = cs.algebraicConstraints }
-      × Nat × Bool) :=
-  let arr := cs.busInteractions.toArray
-  findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape T M bcBus?
-    arr (recvIndex busId shape aggressive arr) startPos
-
 /-- Search declared buses from list index `curIdx` for a droppable pair, honouring a resume hint:
     buses before `resumeIdx` are skipped (they were exhausted on the previous sweep and — since a
     drop on one bus never re-enables a candidate on another, region tests refute cross-bus messages
     outright — stay exhausted), the bus at `resumeIdx` resumes at `resumePos`, and later buses start
-    from `0`. Returns the pass result together with the list index and position of the accepted
-    send and whether a byte check was emitted. -/
+    from `0`. The interaction array, the consolidated receive index and the byte-witness map are
+    built once per sweep by the caller and shared by every bus (the byte justification scans the
+    array directly, with the old early-exit cost but no region list materialized). Returns the
+    pass result together with the list index and position of the accepted send and whether a
+    byte check was emitted. -/
 def findCancel (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
+    (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs.algebraicConstraints })
+    (candsT : Thunk (VarCsIdx p cs.algebraicConstraints))
+    (arr : Array (BusInteraction (Expression p)))
+    (harr : arr = cs.busInteractions.toArray)
+    (idx : Std.HashMap UInt64 (List Nat))
     (bcBus? : Option Nat) (resumeIdx resumePos : Nat) :
     Nat → List Nat →
       Option ({ r : PassResult cs bs // r.out.algebraicConstraints = cs.algebraicConstraints }
@@ -1454,16 +1756,19 @@ def findCancel (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts
   | _, [] => none
   | curIdx, busId :: rest =>
     if curIdx < resumeIdx then
-      findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
+      findCancel cs bs facts hp1 deep hdeep aggressive T M domCsT candsT arr harr idx bcBus?
+        resumeIdx resumePos (curIdx + 1) rest
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
-        match findCancelForBus cs bs facts hp1 deep hdeep aggressive busId shape hshape
-            T M bcBus? startPos with
+        match findCancelGoIdx cs bs facts hp1 deep hdeep aggressive busId shape hshape
+            T M domCsT candsT bcBus? arr harr idx startPos with
         | some (r, pos, emitted) => some (r, curIdx, pos, emitted)
-        | none => findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
-      | none => findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos (curIdx + 1) rest
+        | none => findCancel cs bs facts hp1 deep hdeep aggressive T M domCsT candsT arr harr
+            idx bcBus? resumeIdx resumePos (curIdx + 1) rest
+      | none => findCancel cs bs facts hp1 deep hdeep aggressive T M domCsT candsT arr harr
+          idx bcBus? resumeIdx resumePos (curIdx + 1) rest
 
 /-- A `PassResult` is inhabited by the identity pass (its input, unchanged) — needed so the
     fixpoint loop below can be a `partial def`. -/
@@ -1477,22 +1782,31 @@ instance instInhabitedPassResult (cs : ConstraintSystem p) (bs : BusSemantics p)
     speedup: after a drop that emitted no byte check, the scan resumes at the drop's own bus/position
     (`resumeIdx`/`resumePos`) rather than rescanning the already-rejected prefix, which cannot
     contain a newly-droppable pair; a drop that *did* emit a byte check may make an earlier pair
-    justifiable (the check joins the remaining interactions), so the scan restarts from the top. -/
+    justifiable (the check joins the remaining interactions), so the scan restarts from the top.
+    The interaction array and the consolidated receive index are rebuilt once per sweep — the
+    interactions changed — while the constraint-derived thunks (`T`/`M`/`domCsT`/`candsT`)
+    transport across drops. -/
 partial def cancelLoop (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool)
     (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
+    (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs.algebraicConstraints })
+    (candsT : Thunk (VarCsIdx p cs.algebraicConstraints))
     (bcBus? : Option Nat) (busIds : List Nat) (resumeIdx resumePos : Nat) : PassResult cs bs :=
-  match findCancel cs bs facts hp1 deep hdeep aggressive T M bcBus? resumeIdx resumePos 0 busIds with
+  let arr := cs.busInteractions.toArray
+  let idx := recvIndexAll facts aggressive arr
+  match findCancel cs bs facts hp1 deep hdeep aggressive T M domCsT candsT arr rfl idx bcBus?
+      resumeIdx resumePos 0 busIds with
   | none => ⟨cs, [], PassCorrect.refl cs bs⟩
   | some (⟨r, hpres⟩, dropIdx, dropPos, emitted) =>
     let nextIdx := if emitted then 0 else dropIdx
     let nextPos := if emitted then 0 else dropPos
-    -- A drop changes only `busInteractions` (`hpres`), so the two maps — built once per pass
-    -- invocation — transport to the recursive call instead of being rebuilt per drop.
+    -- A drop changes only `busInteractions` (`hpres`), so the constraint-derived maps — built
+    -- once per pass invocation — transport to the recursive call instead of being rebuilt per
+    -- drop.
     let r2 := cancelLoop r.out bs facts hp1 deep hdeep aggressive (hpres.symm ▸ T) (hpres.symm ▸ M)
-      bcBus? busIds nextIdx nextPos
+      (hpres.symm ▸ domCsT) (hpres.symm ▸ candsT) bcBus? busIds nextIdx nextPos
     ⟨r2.out, r.derivs ++ r2.derivs, r.correct.andThen r2.correct⟩
 
 /-- Drop every matched consecutive send/receive pair on the declared memory buses with a
@@ -1505,16 +1819,22 @@ def busPairCancelPass (aggressive : Bool) : VerifiedPassW p := fun cs bs facts =
   if hp1 : (1 : ZMod p) ≠ 0 then
     let busIds := (cs.busInteractions.map (fun bi => bi.busId)).dedup
     let deep : Bool := decide p.Prime
-    -- Two-root decomposition data (address disequality) and normalized-constraint index
-    -- (entailed payload equality): `Thunk`s, so each map is built at most once per invocation —
-    -- on the first candidate that actually consults it — and reused across every drop (drops
-    -- leave `algebraicConstraints` untouched, so `cancelLoop` transports them).
+    -- Two-root decomposition data (address disequality), normalized-constraint index (entailed
+    -- payload equality), single-variable constraints and the variable→constraints index (deep
+    -- byte justification): `Thunk`s, so each is built at most once per invocation — on the
+    -- first candidate that actually consults it — and reused across every drop (drops leave
+    -- `algebraicConstraints` untouched, so `cancelLoop` transports them).
     let T : Thunk (TwoRootMap p cs.algebraicConstraints) :=
       Thunk.mk fun _ => TwoRootMap.build cs.algebraicConstraints
     let M : Thunk (EqConstraintMap p cs.algebraicConstraints) :=
       Thunk.mk fun _ =>
         if aggressive then EqConstraintMap.build cs.algebraicConstraints
         else EqConstraintMap.empty
-    cancelLoop cs bs facts hp1 deep (fun h => of_decide_eq_true h) aggressive T M
+    let domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs.algebraicConstraints } :=
+      Thunk.mk fun _ => ⟨cs.algebraicConstraints.filter Expression.isSingleVar,
+        fun _ hc => List.mem_of_mem_filter hc⟩
+    let candsT : Thunk (VarCsIdx p cs.algebraicConstraints) :=
+      Thunk.mk fun _ => VarCsIdx.build cs.algebraicConstraints
+    cancelLoop cs bs facts hp1 deep (fun h => of_decide_eq_true h) aggressive T M domCsT candsT
       (busIds.find? facts.byteCheck) busIds 0 0
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -886,13 +886,6 @@ structurally, so exactly the same first matching receive is found — the pass's
 unchanged, and its correctness never depended on the search (the accepted candidate is
 re-verified by `checkCancel` and the decided split equation). -/
 
-/-- Structural hash of an expression (order-sensitive), for the payload-match prefilter. -/
-def Expression.structHash : Expression p → UInt64
-  | .const n => mixHash 11 (UInt64.ofNat n.val)
-  | .var y => mixHash 13 (mixHash (hash y.name) (hash y.powdrId?))
-  | .add a b => mixHash 17 (mixHash a.structHash b.structHash)
-  | .mul a b => mixHash 19 (mixHash a.structHash b.structHash)
-
 /-- Structural hash of a payload (order-sensitive). -/
 def payloadHash (pl : List (Expression p)) : UInt64 :=
   pl.foldl (fun h e => mixHash h e.structHash) 7

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1581,7 +1581,7 @@ theorem dropWitsGo_mem {bs : BusSemantics p} (facts : BusFacts p bs)
         intro h
         obtain rfl := Option.some.inj h
         rw [Bool.and_eq_true] at hne
-        exact ⟨by simpa using Array.getElem_mem hk,
+        exact ⟨by simp [Array.getElem_mem hk],
           fun he => by simp [he] at hne, fun he => by simp [he] at hne⟩
       | none =>
         intro h

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -4,6 +4,18 @@ import ApcOptimizer.MemoryBus
 
 set_option autoImplicit false
 
+variable {p : ℕ}
+
+/-- Structural hash of an expression (order-sensitive) — the shared prefilter key for
+    "is this exact expression already present" tests (`busUnifyPass`'s already-present filter,
+    `busPairCancel`'s payload match, …). Hash inequality proves structural inequality; hits are
+    re-verified structurally, so a collision can only cost time. -/
+def Expression.structHash : Expression p → UInt64
+  | .const n => mixHash 11 (UInt64.ofNat n.val)
+  | .var y => mixHash 13 (mixHash (hash y.name) (hash y.powdrId?))
+  | .add a b => mixHash 17 (mixHash a.structHash b.structHash)
+  | .mul a b => mixHash 19 (mixHash a.structHash b.structHash)
+
 /-! # Unified consecutive-match bus unification (one pass for memory *and* the execution bridge)
 
 The abstract `admissible` spec — *consecutive same-address send→receive pairs match*
@@ -117,16 +129,16 @@ theorem consecutivePayloadEq (cs : ConstraintSystem p) (bs : BusSemantics p)
 
 /-! ## The checked pair and its entailment -/
 
-/-- A checked consecutive send→receive pair on bus `busId`: `L` splits as `pre ++ S :: mid ++ R
-    :: post`, `S` a constant send, `R` a constant receive, same constant address, and every `mid`
-    message is provably inactive or of a different address. -/
+/-- A checked consecutive send→receive pair on bus `busId`: `S` a constant send, `R` a constant
+    receive, same constant address, and every `mid` message provably inactive or of a different
+    address. The split equation `L = pre ++ S :: mid ++ R :: post` is *not* re-decided here —
+    the enumerator (`candidateSplits`) produces it by construction, and it reaches
+    `checkPair_sound` as a hypothesis (the old per-candidate O(#interactions) structural
+    comparison dominated this pass). -/
 def checkPair (shape : MemoryBusShape) {constraints : List (Expression p)}
     (T : TwoRootMap p constraints)
-    (L : List (BusInteraction (Expression p)))
-    (pre : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
-    (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
-    (post : List (BusInteraction (Expression p))) : Bool :=
-  decide (L = pre ++ S :: mid ++ R :: post) &&
+    (S : BusInteraction (Expression p))
+    (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p)) : Bool :=
   decide (multConst S = some 1) && decide (multConst R = some (-1)) &&
   addrConstsEq shape S R &&
   mid.all (fun m => addrConstsNeq shape S m || addrAffineNeq shape S m
@@ -139,16 +151,14 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (post : List (BusInteraction (Expression p)))
     (T : TwoRootMap p cs.algebraicConstraints)
-    (hchk : checkPair shape T
-      (cs.busInteractions.filter (fun bi => bi.busId = busId))
-      pre S mid R post = true)
+    (hsplit : cs.busInteractions.filter (fun bi => bi.busId = busId)
+      = pre ++ S :: mid ++ R :: post)
+    (hchk : checkPair shape T S mid R = true)
     (env : Variable → ZMod p) (hadm : cs.admissible bs env) (hsat : cs.satisfies bs env) :
     ∀ c ∈ memEqConstraints shape S R, c.eval env = 0 := by
   unfold checkPair at hchk
   simp only [Bool.and_eq_true] at hchk
-  obtain ⟨⟨⟨⟨hspl, hSm⟩, hRm⟩, haddrEq⟩, hmidall⟩ := hchk
-  have hsplit : cs.busInteractions.filter (fun bi => bi.busId = busId)
-      = pre ++ S :: mid ++ R :: post := of_decide_eq_true hspl
+  obtain ⟨⟨⟨hSm, hRm⟩, haddrEq⟩, hmidall⟩ := hchk
   have hSm : multConst S = some 1 := of_decide_eq_true hSm
   have hRm : multConst R = some (-1) := of_decide_eq_true hRm
   have hSev : (S.eval env).multiplicity = 1 := by
@@ -186,60 +196,75 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
 
 /-! ## The pass -/
 
+/-- One `(pre, S, mid, R, post)` candidate, carrying the split equation it was constructed
+    from. -/
+def SplitCand (p : ℕ) (L : List (BusInteraction (Expression p))) :=
+  { c : List (BusInteraction (Expression p)) × BusInteraction (Expression p)
+      × List (BusInteraction (Expression p)) × BusInteraction (Expression p)
+      × List (BusInteraction (Expression p)) //
+    L = c.1 ++ c.2.1 :: c.2.2.1 ++ c.2.2.2.1 :: c.2.2.2.2 }
+
 /-- Scan forward from a send `S` for its consumer: the first same-address receive, with every
     message before it excludable (different address, or inactive). Returns `(mid, R, post)` on
-    success; `none` if a possibly-same-address active non-receive blocks the window. -/
+    success — together with the recomposition proof `revMid.reverse ++ rest = mid ++ R :: post`
+    — or `none` if a possibly-same-address active non-receive blocks the window. -/
 def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
     (T : TwoRootMap p constraints) (S : BusInteraction (Expression p)) :
-    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
-    Option (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p)))
+    (revMid rest : List (BusInteraction (Expression p))) →
+    Option ({ mrp : List (BusInteraction (Expression p)) × BusInteraction (Expression p)
+      × List (BusInteraction (Expression p)) //
+      revMid.reverse ++ rest = mrp.1 ++ mrp.2.1 :: mrp.2.2 })
   | _, [] => none
   | revMid, r :: rest =>
       if decide (multConst r = some (-1)) && addrConstsEq shape S r then
-        some (revMid.reverse, r, rest)
+        some ⟨(revMid.reverse, r, rest), rfl⟩
       else if addrConstsNeq shape S r || addrAffineNeq shape S r || addrTwoRootNeq shape T S r
           || decide (multConst r = some 0) then
-        findConsumer shape T S (r :: revMid) rest
+        (findConsumer shape T S (r :: revMid) rest).map (fun ⟨mrp, hmrp⟩ =>
+          ⟨mrp, by
+            rw [← hmrp, List.reverse_cons, List.append_assoc]
+            rfl⟩)
       else none
 
-/-- One candidate `(pre, S, mid, R, post)` per active send `S`, pairing it with its consumer
-    receive (`findConsumer`). Linear in the number of sends × scan length, so no O(n²) blow-up
-    on large buses. `checkPair` re-verifies each candidate. -/
+/-- One candidate per active send `S`, pairing it with its consumer receive (`findConsumer`),
+    each carrying its split equation by construction. Linear in the number of sends × scan
+    length, so no O(n²) blow-up on large buses. `checkPair` re-verifies the pair conditions. -/
 def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints) :
-    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
-    List (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p)))
-  | _, [] => []
-  | revPre, S :: rest =>
+    (T : TwoRootMap p constraints) (L : List (BusInteraction (Expression p))) :
+    (revPre rest : List (BusInteraction (Expression p))) →
+    (hinv : L = revPre.reverse ++ rest) →
+    List (SplitCand p L)
+  | _, [], _ => []
+  | revPre, S :: rest, hinv =>
       (if decide (multConst S = some 1) then
         match findConsumer shape T S [] rest with
-        | some (mid, R, post) => [(revPre.reverse, S, mid, R, post)]
+        | some ⟨(mid, R, post), hmrp⟩ =>
+          [⟨(revPre.reverse, S, mid, R, post), by
+            rw [hinv]
+            have h : rest = mid ++ R :: post := hmrp
+            rw [h]
+            simp⟩]
         | none => []
-       else []) ++ candidateSplits shape T (S :: revPre) rest
+       else []) ++ candidateSplits shape T L (S :: revPre) rest
+        (by rw [hinv, List.reverse_cons, List.append_assoc]; rfl)
 
 /-- Collect the entailed equalities for one bus, with proof. -/
 def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape) :
-    List (List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p))) →
+    List (SplitCand p (cs.busInteractions.filter (fun bi => bi.busId = busId))) →
     { out : List (Expression p) //
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
-  | (pre, S, mid, R, post) :: rest =>
+  | ⟨(pre, S, mid, R, post), hsplit⟩ :: rest =>
     let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T busId shape hshape rest
-    if hchk : checkPair shape T
-        (cs.busInteractions.filter (fun bi => bi.busId = busId))
-        pre S mid R post = true then
+    if hchk : checkPair shape T S mid R = true then
       ⟨memEqConstraints shape S R ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
-        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T hchk env hadm hsat c h
+        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T hsplit
+            hchk env hadm hsat c h
         · exact hacc env hadm hsat c h⟩
     else ⟨acc, hacc⟩
 
@@ -255,8 +280,8 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     match hshape : facts.memShape busId with
     | some shape =>
       let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 T busId shape hshape
-        (candidateSplits shape T []
-          (cs.busInteractions.filter (fun bi => bi.busId = busId)))
+        (candidateSplits shape T _ []
+          (cs.busInteractions.filter (fun bi => bi.busId = busId)) rfl)
       ⟨eqs ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
@@ -282,8 +307,18 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
     -- `Std.HashSet` of it once and test membership in O(1); `Std.HashSet.contains_ofList` transports
     -- the check back to genuine list membership `z ∈ cs.vars` (all the correctness proof needs).
     let csVarSet := Std.HashSet.ofList cs.vars
+    -- The already-present test (`cs.algebraicConstraints.contains c`) is likewise a per-equality
+    -- O(#constraints) deep structural scan — most equalities *are* already present from the
+    -- previous cycle. Bucket the constraints by structural hash once and compare within the
+    -- bucket; the result is the identical Bool (hash inequality proves inequality).
+    let csHashes : Std.HashMap UInt64 (List (Expression p)) :=
+      cs.algebraicConstraints.foldl (fun m c =>
+        let h := c.structHash
+        m.insert h (c :: m.getD h [])) ∅
+    let containsC : Expression p → Bool := fun c =>
+      (csHashes.getD c.structHash []).any (fun c' => c' == c)
     let new := eqs.filter
-      (fun c => !c.normalize.fold.isConstZero && !cs.algebraicConstraints.contains c
+      (fun c => !c.normalize.fold.isConstZero && !containsC c
         && c.vars.all (fun z => csVarSet.contains z))
     if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else

--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -63,6 +63,15 @@ def coveredIdx (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : List Va
   (uniq.mergeSort (· ≤ ·)).filterMap (fun i =>
     if h : i < arr.size then (if Q arr[i] then some arr[i] else none) else none)
 
+/-- `coveredIdx` without the order-restoring sort — for consumers whose result is independent of
+    the covered list's *order* (`domainBatch`: the covered items only ever feed `all`/`any`
+    filters and length counts). Same membership soundness (`coveredIdxUnord_mem_of_eq`). -/
+def coveredIdxUnord (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : List Variable) :
+    List α :=
+  let uniq := ((candidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+  uniq.filterMap (fun i =>
+    if h : i < arr.size then (if Q arr[i] then some arr[i] else none) else none)
+
 /-- **Soundness.** Every item `coveredIdx` returns is a genuine item of `arr` (hence of the
     underlying list) that satisfies `Q`. This is all the enumeration proofs need; the index need
     not be complete for correctness (completeness only affects effectiveness, checked empirically). -/
@@ -79,6 +88,30 @@ theorem coveredIdx_mem (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs :
       exact ⟨i, h, hei, by rw [← hei]; exact hq⟩
     · rw [if_neg hq] at hfe; exact absurd hfe (by simp)
   · rw [dif_neg h] at hfe; exact absurd hfe (by simp)
+
+theorem coveredIdxUnord_mem (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : List Variable)
+    {e : α} (he : e ∈ coveredIdxUnord idx arr Q xs) :
+    ∃ i, ∃ _h : i < arr.size, arr[i] = e ∧ Q e = true := by
+  rw [coveredIdxUnord, List.mem_filterMap] at he
+  obtain ⟨i, _hi, hfe⟩ := he
+  by_cases h : i < arr.size
+  · rw [dif_pos h] at hfe
+    by_cases hq : Q arr[i]
+    · rw [if_pos hq] at hfe
+      have hei : arr[i] = e := Option.some.inj hfe
+      exact ⟨i, h, hei, by rw [← hei]; exact hq⟩
+    · rw [if_neg hq] at hfe; exact absurd hfe (by simp)
+  · rw [dif_neg h] at hfe; exact absurd hfe (by simp)
+
+/-- Soundness of the unordered variant for an array threaded with its list equation. -/
+theorem coveredIdxUnord_mem_of_eq (idx : CovIndex) (l : List α) (arr : Array α)
+    (harr : arr = l.toArray) (Q : α → Bool) (xs : List Variable)
+    {e : α} (he : e ∈ coveredIdxUnord idx arr Q xs) : e ∈ l ∧ Q e = true := by
+  subst harr
+  obtain ⟨i, hi, hei, hq⟩ := coveredIdxUnord_mem idx l.toArray Q xs he
+  subst hei
+  have hi' : i < l.length := by simpa using hi
+  exact ⟨by simp [l.getElem_mem hi'], hq⟩
 
 /-- Soundness, specialized to the array being a list's `toArray` (what the passes pass in): every
     returned item is a genuine member of the list and satisfies `Q`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1003,21 +1003,22 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts
       -- analogous drop for *obligations* is not worthwhile: an interaction's sub-box is large and
       -- its payload evaluation costly, and it is covered by few targets, so verifying its
       -- redundancy costs about what it would save.)
-      let esFull := CoveredIndex.coveredIdx fidx.csIdx fidx.arrCs (fun c => c.varsInF xs) xs
-      let bis := CoveredIndex.coveredIdx fidx.bisIdx fidx.arrBis
+      let esFull := CoveredIndex.coveredIdxUnord fidx.csIdx fidx.arrCs (fun c => c.varsInF xs) xs
+      let bis := CoveredIndex.coveredIdxUnord fidx.bisIdx fidx.arrBis
         (fun bi => bi.varsInF xs && !bs.isStateful bi.busId) xs
-      let es := CoveredIndex.coveredIdx fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs
+      let es := CoveredIndex.coveredIdxUnord fidx.activeIdx fidx.arrActive
+        (fun c => c.varsInF xs) xs
       let informative := !esFull.isEmpty || bis.any (biInformative bs facts)
       if informative && boxSize * (esFull.length + bis.length) ≤ maxEnumWork then
         have hes : ∀ e ∈ es, e ∈ cs.algebraicConstraints ∧ e.varsIn xs = true := by
           intro e he
-          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdx_mem_of_eq fidx.activeIdx activeCs
+          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdxUnord_mem_of_eq fidx.activeIdx activeCs
             fidx.arrActive fidx.harrActive (fun c => c.varsInF xs) xs he
           refine ⟨hactiveCs e hMem, ?_⟩
           rw [← Expression.varsInF_eq]; exact hQ
         have hbis : ∀ bi ∈ bis, bi ∈ cs.busInteractions ∧ bi.varsIn xs = true := by
           intro bi hbi
-          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdx_mem_of_eq fidx.bisIdx cs.busInteractions
+          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdxUnord_mem_of_eq fidx.bisIdx cs.busInteractions
             fidx.arrBis fidx.harrBis (fun bi => bi.varsInF xs && !bs.isStateful bi.busId) xs hbi
           simp only [Bool.and_eq_true] at hQ
           exact ⟨hMem, by rw [← BusInteraction.varsInF_eq]; exact hQ.1⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -396,6 +396,34 @@ def systemHasFoldable (cs : ConstraintSystem p) (xs : List Variable)
     cs.busInteractions.any (fun bi =>
       bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
 
+/-! ### The index-local gate
+
+`systemHasFoldable` is a full-system scan run once per target — the dominant cost of this pass.
+It decomposes exactly: an expression sharing **no** variable with the group `xs` can only have a
+foldable subexpression that is *variable-free* (`varsIn xs` is vacuous only for var-free nodes),
+and whether an expression has a var-free `add`/`mul` node is independent of `xs` and of the
+(nonempty) survivor set. So the gate equals: (a) any item *sharing a variable* with `xs` — found
+through the inverted indexes — passing the original per-item test, or (b) any item with a
+var-free compound node (precomputed once per invocation; empty after constant folding) sharing
+no variable with `xs`. Purely an efficiency gate, like `systemHasFoldable` itself. -/
+
+/-- Does the expression mention any variable of `xs`? (No allocation.) -/
+def Expression.anyVarIn (xs : List Variable) : Expression p → Bool
+  | .const _ => false
+  | .var y => containsFast xs y
+  | .add a b => a.anyVarIn xs || b.anyVarIn xs
+  | .mul a b => a.anyVarIn xs || b.anyVarIn xs
+
+/-- Does the expression contain a variable-free `add`/`mul` node? For an expression sharing no
+    variable with the group, `hasFoldable` holds iff this does (given a nonempty survivor set). -/
+def Expression.hasConstFoldableNode : Expression p → Bool
+  | .const _ => false
+  | .var _ => false
+  | .add a b =>
+      !(Expression.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+  | .mul a b =>
+      !(Expression.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+
 /-! ### Indexing the per-target covered-constraint scan
 
 `foldStep` gates every target on `groupDoms (coveredCsOf cs xs) xs`, whose `coveredCsOf` is a full
@@ -411,12 +439,18 @@ and rebuilt only on an accepted fold (`cs` changes), carrying the proofs tying i
 faster. -/
 
 /-- The prebuilt covered-constraint index for the current `cs`, with the proofs tying it to `cs` so
-    the covered set it yields is provably `coveredCsOf cs xs` (`coveredCsIdx_eq`). -/
+    the covered set it yields is provably `coveredCsOf cs xs` (`coveredCsIdx_eq`), plus the
+    proof-free data the index-local `systemHasFoldableIdx` gate consumes: the interaction-side
+    inverted index and the (normally empty) const-foldable item lists. -/
 structure FoldIdx (cs : ConstraintSystem p) where
   idx : CoveredIndex.CovIndex
   hidx : idx = CoveredIndex.build Expression.vars cs.algebraicConstraints
   arr : Array (Expression p)
   harr : arr = cs.algebraicConstraints.toArray
+  bisIdx : CoveredIndex.CovIndex
+  arrBis : Array (BusInteraction (Expression p))
+  cfCs : List (Expression p)
+  cfBis : List (BusInteraction (Expression p))
 
 /-- Build the index for a system (by construction the equalities hold `rfl`). -/
 def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
@@ -424,6 +458,35 @@ def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
   hidx := rfl
   arr := cs.algebraicConstraints.toArray
   harr := rfl
+  bisIdx := CoveredIndex.build BusInteraction.vars cs.busInteractions
+  arrBis := cs.busInteractions.toArray
+  cfCs := cs.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
+  cfBis := cs.busInteractions.filter (fun bi =>
+    bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
+
+/-- The index-local form of `systemHasFoldable` (see the section comment above): scan only the
+    items sharing a variable with `xs` (through the inverted indexes, candidate positions
+    deduplicated so an item sharing several variables is tested once — `hasFoldable` is the
+    expensive part), plus the precomputed const-foldable items when disjoint from `xs`. Requires
+    a nonempty survivor set (the caller's `1 ≤ survs.length` gate). Equal to
+    `systemHasFoldable cs xs survs`; purely an efficiency gate, so no proof is carried. -/
+def systemHasFoldableIdx {cs : ConstraintSystem p} (fidx : FoldIdx cs) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) : Bool :=
+  (((xs.flatMap (fun v => fidx.idx.buckets.getD v [])).foldl (·.insert ·)
+      (∅ : Std.HashSet Nat)).toList.any (fun i =>
+    if h : i < fidx.arr.size then
+      let c := fidx.arr[i]
+      !coveredBy xs c && c.hasFoldable xs survs
+    else false)) ||
+  (((xs.flatMap (fun v => fidx.bisIdx.buckets.getD v [])).foldl (·.insert ·)
+      (∅ : Std.HashSet Nat)).toList.any (fun i =>
+    if h : i < fidx.arrBis.size then
+      let bi := fidx.arrBis[i]
+      bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs)
+    else false)) ||
+  (fidx.cfCs.any (fun c => !c.anyVarIn xs)) ||
+  (fidx.cfBis.any (fun bi =>
+    !(bi.multiplicity.anyVarIn xs || bi.payload.any (fun e => e.anyVarIn xs))))
 
 /-- An expression with any variable has a nonempty variable list. -/
 theorem hasVar_vars_ne_nil (c : Expression p) (h : c.hasVar = true) : c.vars ≠ [] := by
@@ -464,8 +527,11 @@ theorem coveredCsIdx_eq (cs : ConstraintSystem p) (xs : List Variable) (fidx : F
 
 /-- One checked fold for a candidate group (identity unless the group has a bounded domain, at least
     one survivor, and some foldable subexpression). The per-target covered scan is served from the
-    prebuilt index (`coveredCsIdx_eq`), rebuilt only when a fold rewrites `cs`. Prime `p`; the
-    caller supplies `Fact p.Prime`. -/
+    prebuilt index (`coveredCsIdx_eq`) — and reused for the survivor filter
+    (`groupSurvivorsE es`, provably `groupSurvivors cs xs doms` via `hes`) and for the
+    index-local no-op gate (`systemHasFoldableIdx`), so no full-system scan remains on the
+    per-target path. The index is rebuilt only when a fold rewrites `cs`. Prime `p`; the caller
+    supplies `Fact p.Prime`. -/
 def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fidx : FoldIdx cs)
     (xs : List Variable) : Σ' (r : PassResult cs bs), FoldIdx r.out :=
   let es := CoveredIndex.coveredIdx fidx.idx fidx.arr (coveredBy xs) xs
@@ -474,9 +540,12 @@ def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fid
   | none => ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
   | some doms =>
     if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
-      let survs := groupSurvivors cs xs doms
-      if 1 ≤ survs.length && systemHasFoldable cs xs survs then
-        ⟨⟨foldOut cs xs survs, [], foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩,
+      let survs := groupSurvivorsE es doms
+      if 1 ≤ survs.length && systemHasFoldableIdx fidx xs survs then
+        have hsurv : groupSurvivors cs xs doms = survs := by
+          show groupSurvivors cs xs doms = groupSurvivorsE es doms
+          rw [hes]; rfl
+        ⟨⟨foldOut cs xs survs, [], hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩,
          FoldIdx.mk' (foldOut cs xs survs)⟩
       else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
@@ -493,29 +562,28 @@ def foldLoop [Fact p.Prime] (bs : BusSemantics p) :
 
 /-! ### Direct (unindexed) path for small systems
 
-The inverted index amortizes a full covered-set scan across many targets, but it pays a fixed
-per-invocation build (and a rebuild on each accepted fold) plus a per-target `HashSet`/`mergeSort`.
-On the *small* circuits (openvm-eth blocks, ≤ ~4.6k constraints) that overhead exceeds the saved
-scan — the plain `coveredCsOf` filter is cheaper — even though it wins decisively on the keccak
-stress case (~28.6k constraints). `domainFoldPass` therefore gates on system size: the direct loop
-below (recomputing `coveredCsOf` per target, as before this file's index change) runs on small
-systems, the indexed `foldLoop` on large ones. Both call the same `foldStepWith` core, so the fold
-semantics — hence effectiveness — are identical on every case; only the covered-set *lookup* differs. -/
+The inverted index amortizes the covered-set scan, but its per-target candidate gather
+(bucket flat-map + dedup + sort) *loses* on the openvm-eth blocks, whose variables are shared by
+hundreds of items each (huge buckets); the plain `coveredCsOf` filter is cheaper there, while
+the index wins decisively on the keccak stress case (~28.6k constraints, sparser sharing).
+`domainFoldPass` therefore gates on system size. Relative to the pre-index direct path, the
+covered set is computed **once** per target and reused for the survivor filter
+(`groupSurvivorsE es`, provably `groupSurvivors cs xs doms` — the old code paid the full filter
+a second time inside `groupSurvivors`). -/
 
-/-- One checked fold for a candidate group, given the covered set `es` (required to equal
-    `coveredCsOf cs xs`, so `foldOut_correct`'s `hdoms` transports). Used by the direct path with
-    `es := coveredCsOf cs xs`, `hes := rfl`; the indexed `foldStep` mirrors this same logic inline
-    (it additionally threads and rebuilds the covered-set index on each accepted fold, which the
-    dependent `Σ' r, FoldIdx r.out` return forces it to do branch-by-branch rather than delegate). -/
+/-- One checked fold for a candidate group, given the covered set `es = coveredCsOf cs xs`. -/
 def foldStepWith [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (xs : List Variable)
     (es : List (Expression p)) (hes : es = coveredCsOf cs xs) : PassResult cs bs :=
   match hdoms : groupDoms es xs with
   | none => ⟨cs, [], PassCorrect.refl cs bs⟩
   | some doms =>
     if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
-      let survs := groupSurvivors cs xs doms
+      let survs := groupSurvivorsE es doms
       if 1 ≤ survs.length && systemHasFoldable cs xs survs then
-        ⟨foldOut cs xs survs, [], foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩
+        have hsurv : groupSurvivors cs xs doms = survs := by
+          show groupSurvivors cs xs doms = groupSurvivorsE es doms
+          rw [hes]; rfl
+        ⟨foldOut cs xs survs, [], hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩
       else ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs, [], PassCorrect.refl cs bs⟩
 
@@ -528,9 +596,8 @@ def foldLoopDirect [Fact p.Prime] (bs : BusSemantics p) :
     let r2 := foldLoopDirect bs rest r1.out
     ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
-/-- Systems at least this many algebraic constraints use the inverted index; smaller ones use the
-    direct per-target `coveredCsOf` scan. openvm-eth's largest block is ~4.6k constraints (index is
-    net-slower there); the keccak stress case is ~28.6k (index wins ~13 %). Purely a runtime gate —
+/-- Systems with at least this many algebraic constraints use the inverted index; smaller ones use
+    the direct per-target `coveredCsOf` scan (see the section comment). Purely a runtime gate —
     both paths compute the identical fold. -/
 def domainFoldIndexThreshold : Nat := 8192
 
@@ -546,8 +613,6 @@ def domainFoldPass : VerifiedPass p := fun cs bsem =>
       let vs := c.vars.dedup
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    -- Runtime gate (effectiveness-identical): amortize the covered-set scan through the inverted
-    -- index only on large systems, where it wins; small systems use the cheaper direct filter.
     if domainFoldIndexThreshold ≤ cs.algebraicConstraints.length then
       foldLoop bsem targets cs (FoldIdx.mk' cs)
     else

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -60,11 +60,29 @@ theorem constOnSurvs_sound (survs : List (List (Variable × ZMod p))) (e : Expre
         rw [← Expression.evalFast_eq, hthis]; exact hc
     · next => exact absurd h (by simp)
 
+/-- Does the expression mention any variable of `xs`? (No allocation.) -/
+def Expression.anyVarIn (xs : List Variable) : Expression p → Bool
+  | .const _ => false
+  | .var y => containsFast xs y
+  | .add a b => a.anyVarIn xs || b.anyVarIn xs
+  | .mul a b => a.anyVarIn xs || b.anyVarIn xs
+
+/-- Does the expression contain a variable-free `add`/`mul` node? For an expression sharing no
+    variable with the group, `hasFoldable` holds iff this does (given a nonempty survivor set). -/
+def Expression.hasConstFoldableNode : Expression p → Bool
+  | .const _ => false
+  | .var _ => false
+  | .add a b =>
+      !(Expression.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+  | .mul a b =>
+      !(Expression.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+
 /-! ## The fold rewrite -/
 
-/-- Replace every maximal wholly-in-group subexpression that is constant on the survivors by that
-    constant; recurse otherwise. Leaves the group's variables in place where they are not folded. -/
-def foldRewrite (xs : List Variable) (survs : List (List (Variable × ZMod p))) :
+/-- The recursive fold core: replace every maximal wholly-in-group subexpression that is constant
+    on the survivors by that constant; recurse otherwise. Leaves the group's variables in place
+    where they are not folded. -/
+def foldRewriteGo (xs : List Variable) (survs : List (List (Variable × ZMod p))) :
     Expression p → Expression p
   | .const c => .const c
   | .var y => .var y
@@ -72,24 +90,33 @@ def foldRewrite (xs : List Variable) (survs : List (List (Variable × ZMod p))) 
       if (Expression.add a b).varsIn xs then
         match constOnSurvs survs (.add a b) with
         | some c => .const c
-        | none => .add (foldRewrite xs survs a) (foldRewrite xs survs b)
-      else .add (foldRewrite xs survs a) (foldRewrite xs survs b)
+        | none => .add (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
+      else .add (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
   | .mul a b =>
       if (Expression.mul a b).varsIn xs then
         match constOnSurvs survs (.mul a b) with
         | some c => .const c
-        | none => .mul (foldRewrite xs survs a) (foldRewrite xs survs b)
-      else .mul (foldRewrite xs survs a) (foldRewrite xs survs b)
+        | none => .mul (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
+      else .mul (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
+
+/-- The fold rewrite, gated: an expression sharing no variable with the group and containing no
+    variable-free compound node has no node the core could fold (a qualifying node is either
+    wholly-in-group with a variable — impossible — or variable-free), so it is returned untouched
+    without walking it node-by-node. `foldOut` maps this over the *whole* system per accepted
+    fold, and almost all expressions take the cheap branch. -/
+def foldRewrite (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (e : Expression p) : Expression p :=
+  if e.anyVarIn xs || e.hasConstFoldableNode then foldRewriteGo xs survs e else e
 
 /-! ## Agreement with the identity on any survivor-matching environment -/
 
 /-- On an environment that agrees on `xs` with some survivor `s`, `foldRewrite` is
     evaluation-preserving. The folded constants are exactly the survivor-constant values, and `s`'s
     membership pins them; unfolded nodes recurse. -/
-theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+theorem foldRewriteGo_agree (xs : List Variable) (survs : List (List (Variable × ZMod p)))
     (env : Variable → ZMod p) (s : List (Variable × ZMod p)) (hs : s ∈ survs)
     (hxs : ∀ x ∈ xs, env x = envOf s x) :
-    ∀ e : Expression p, (foldRewrite xs survs e).eval env = e.eval env := by
+    ∀ e : Expression p, (foldRewriteGo xs survs e).eval env = e.eval env := by
   -- For a wholly-in-`xs` expression, `env` and `envOf s` agree on its variables.
   have hcongr : ∀ e : Expression p, e.varsIn xs = true → e.eval env = e.eval (envOf s) := by
     intro e he
@@ -99,12 +126,12 @@ theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × 
   | const c => rfl
   | var y => rfl
   | add a b iha ihb =>
-      unfold foldRewrite
+      unfold foldRewriteGo
       by_cases hin : (Expression.add a b).varsIn xs = true
       · rw [if_pos hin]
         cases hc : constOnSurvs survs (.add a b) with
         | none =>
-            show (foldRewrite xs survs a).eval env + (foldRewrite xs survs b).eval env
+            show (foldRewriteGo xs survs a).eval env + (foldRewriteGo xs survs b).eval env
               = a.eval env + b.eval env
             rw [iha, ihb]
         | some c =>
@@ -115,16 +142,16 @@ theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × 
             have : (Expression.add a b).eval env = c := by rw [h1]; exact h2
             simpa [Expression.eval] using this.symm
       · rw [if_neg (by simpa using hin)]
-        show (foldRewrite xs survs a).eval env + (foldRewrite xs survs b).eval env
+        show (foldRewriteGo xs survs a).eval env + (foldRewriteGo xs survs b).eval env
           = a.eval env + b.eval env
         rw [iha, ihb]
   | mul a b iha ihb =>
-      unfold foldRewrite
+      unfold foldRewriteGo
       by_cases hin : (Expression.mul a b).varsIn xs = true
       · rw [if_pos hin]
         cases hc : constOnSurvs survs (.mul a b) with
         | none =>
-            show (foldRewrite xs survs a).eval env * (foldRewrite xs survs b).eval env
+            show (foldRewriteGo xs survs a).eval env * (foldRewriteGo xs survs b).eval env
               = a.eval env * b.eval env
             rw [iha, ihb]
         | some c =>
@@ -135,9 +162,21 @@ theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × 
             have : (Expression.mul a b).eval env = c := by rw [h1]; exact h2
             simpa [Expression.eval] using this.symm
       · rw [if_neg (by simpa using hin)]
-        show (foldRewrite xs survs a).eval env * (foldRewrite xs survs b).eval env
+        show (foldRewriteGo xs survs a).eval env * (foldRewriteGo xs survs b).eval env
           = a.eval env * b.eval env
         rw [iha, ihb]
+
+/-- On an environment that agrees on `xs` with some survivor, the (gated) fold rewrite is
+    evaluation-preserving. -/
+theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (env : Variable → ZMod p) (s : List (Variable × ZMod p)) (hs : s ∈ survs)
+    (hxs : ∀ x ∈ xs, env x = envOf s x) :
+    ∀ e : Expression p, (foldRewrite xs survs e).eval env = e.eval env := by
+  intro e
+  unfold foldRewrite
+  split
+  · exact foldRewriteGo_agree xs survs env s hs hxs e
+  · rfl
 
 /-- Bus-interaction-level agreement, from any expression-level agreement `hag`, applied to the
     multiplicity and every payload slot. -/
@@ -152,14 +191,14 @@ theorem mapExpr_eval_of_agree (g : Expression p → Expression p) (env : Variabl
 
 /-! ## Variables of the rewrite -/
 
-/-- Folding never introduces a variable: every variable of `foldRewrite … e` is a variable of `e`. -/
-theorem foldRewrite_vars (xs : List Variable) (survs : List (List (Variable × ZMod p)))
-    (e : Expression p) : ∀ v ∈ (foldRewrite xs survs e).vars, v ∈ e.vars := by
+/-- Folding never introduces a variable: every variable of `foldRewriteGo … e` is a variable of `e`. -/
+theorem foldRewriteGo_vars (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (e : Expression p) : ∀ v ∈ (foldRewriteGo xs survs e).vars, v ∈ e.vars := by
   induction e with
-  | const c => intro v hv; simp [foldRewrite, Expression.vars] at hv
+  | const c => intro v hv; simp [foldRewriteGo, Expression.vars] at hv
   | var y => intro v hv; exact hv
   | add a b iha ihb =>
-      unfold foldRewrite
+      unfold foldRewriteGo
       by_cases hin : (Expression.add a b).varsIn xs = true
       · rw [if_pos hin]
         cases constOnSurvs survs (.add a b) with
@@ -177,7 +216,7 @@ theorem foldRewrite_vars (xs : List Variable) (survs : List (List (Variable × Z
         · exact Or.inl (iha v hv)
         · exact Or.inr (ihb v hv)
   | mul a b iha ihb =>
-      unfold foldRewrite
+      unfold foldRewriteGo
       by_cases hin : (Expression.mul a b).varsIn xs = true
       · rw [if_pos hin]
         cases constOnSurvs survs (.mul a b) with
@@ -194,6 +233,15 @@ theorem foldRewrite_vars (xs : List Variable) (survs : List (List (Variable × Z
         rcases hv with hv | hv
         · exact Or.inl (iha v hv)
         · exact Or.inr (ihb v hv)
+
+/-- Folding never introduces a variable (gated form). -/
+theorem foldRewrite_vars (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (e : Expression p) : ∀ v ∈ (foldRewrite xs survs e).vars, v ∈ e.vars := by
+  intro v hv
+  unfold foldRewrite at hv
+  split at hv
+  · exact foldRewriteGo_vars xs survs e v hv
+  · exact hv
 
 /-! ## Agreement on any environment satisfying the covered constraints
 
@@ -407,23 +455,6 @@ through the inverted indexes — passing the original per-item test, or (b) any 
 var-free compound node (precomputed once per invocation; empty after constant folding) sharing
 no variable with `xs`. Purely an efficiency gate, like `systemHasFoldable` itself. -/
 
-/-- Does the expression mention any variable of `xs`? (No allocation.) -/
-def Expression.anyVarIn (xs : List Variable) : Expression p → Bool
-  | .const _ => false
-  | .var y => containsFast xs y
-  | .add a b => a.anyVarIn xs || b.anyVarIn xs
-  | .mul a b => a.anyVarIn xs || b.anyVarIn xs
-
-/-- Does the expression contain a variable-free `add`/`mul` node? For an expression sharing no
-    variable with the group, `hasFoldable` holds iff this does (given a nonempty survivor set). -/
-def Expression.hasConstFoldableNode : Expression p → Bool
-  | .const _ => false
-  | .var _ => false
-  | .add a b =>
-      !(Expression.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
-  | .mul a b =>
-      !(Expression.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
-
 /-! ### Indexing the per-target covered-constraint scan
 
 `foldStep` gates every target on `groupDoms (coveredCsOf cs xs) xs`, whose `coveredCsOf` is a full
@@ -629,9 +660,19 @@ def domainFoldIndexThreshold : Nat := 8192
 def domainFoldPass : VerifiedPass p := fun cs bsem =>
   if hpr : p.Prime then
     haveI : Fact p.Prime := ⟨hpr⟩
+    -- Domains come only from single-variable constraints (`findDomainAlg`/`rootsIn`), and a
+    -- single-variable constraint is covered by every group containing its variable — so a group
+    -- with a variable that has *no* single-variable constraint anywhere can never pass
+    -- `groupDoms`. Skipping those targets up front (one hash lookup per variable) avoids the
+    -- per-target covered-set scan for the ubiquitous byte-limb groups, exactly.
+    let svSet : Std.HashSet Variable := cs.algebraicConstraints.foldl (init := ∅) fun s c =>
+      match c.vars.dedup with
+      | [x] => s.insert x
+      | _ => s
     let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
       let vs := c.vars.dedup
-      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt))
+      if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
+        some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
     if domainFoldIndexThreshold ≤ cs.algebraicConstraints.length then
       foldLoop bsem targets cs (FoldIdx.mk' cs)

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -464,6 +464,26 @@ def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
   cfBis := cs.busInteractions.filter (fun bi =>
     bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
 
+/-- Refresh the index after an accepted fold. The constraint side is rebuilt — the fold reorders
+    constraints, and the covered-set equality (`coveredCsIdx_eq`) needs the exact tie — but the
+    interaction-side *buckets* are reused stale: `foldOut` maps interactions in place (same count
+    and order) and only ever shrinks an expression's variable set (subexpressions are replaced by
+    constants), so the stale buckets are a superset of freshly-built ones. The gate stays exact:
+    candidates are re-tested against the fresh array, and an over-included candidate that still
+    passes the per-item test would make the full scan true as well. This halves the dominant
+    rebuild-per-accepted-fold cost on fold-heavy circuits. -/
+def FoldIdx.refresh {cs : ConstraintSystem p} (old : FoldIdx cs) (ro : ConstraintSystem p) :
+    FoldIdx ro where
+  idx := CoveredIndex.build Expression.vars ro.algebraicConstraints
+  hidx := rfl
+  arr := ro.algebraicConstraints.toArray
+  harr := rfl
+  bisIdx := old.bisIdx
+  arrBis := ro.busInteractions.toArray
+  cfCs := ro.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
+  cfBis := ro.busInteractions.filter (fun bi =>
+    bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
+
 /-- The index-local form of `systemHasFoldable` (see the section comment above): scan only the
     items sharing a variable with `xs` (through the inverted indexes, candidate positions
     deduplicated so an item sharing several variables is tested once — `hasFoldable` is the
@@ -546,7 +566,7 @@ def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fid
           show groupSurvivors cs xs doms = groupSurvivorsE es doms
           rw [hes]; rfl
         ⟨⟨foldOut cs xs survs, [], hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩,
-         FoldIdx.mk' (foldOut cs xs survs)⟩
+         fidx.refresh (foldOut cs xs survs)⟩
       else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -439,25 +439,136 @@ theorem pdFirst_keep (bs : BusSemantics p) (singles : List (Expression p))
       rw [hcert] at hnc
       exact absurd hnc (by simp)
 
+/-! ### The fast duplicate analysis
+
+`pdKeep` per interaction pays an O(#interactions) `findIdx?` (with deep structural equality)
+plus a prefix scan of `msgEqCert`s — O(n²) certificate evaluations per invocation, the dominant
+cost of this pass on interaction-heavy circuits. The analysis below computes the *same* drop
+set in one left-to-right sweep: interactions are bucketed by the certificate's necessary
+invariants (bus id, constant multiplicity, payload length — `msgEqCert` fails outright across
+buckets), candidate pairs are prefiltered by per-slot structural hashes and variable Bloom
+masks (`slotEqCert` needs syntactic equality or a shared variable per slot), and the
+first-of-class check is memoized per bucket entry. The result is consumed as a *prefilter*
+only: `pointwiseDupDropPass` re-verifies every flagged drop through the original `pdKeep`, so
+the analysis carries no proof and a false flag can only cost time, never a wrong drop. -/
+
+/-- A 64-bit Bloom mask of the expression's variables (for the shared-variable prefilter). -/
+def Expression.pdVarBloom : Expression p → UInt64
+  | .const _ => 0
+  | .var y => (1 : UInt64) <<< (UInt64.ofNat ((mixHash (hash y.name) (hash y.powdrId?)).toNat % 64))
+  | .add a b => a.pdVarBloom ||| b.pdVarBloom
+  | .mul a b => a.pdVarBloom ||| b.pdVarBloom
+
+/-- Structural hash of an expression (order-sensitive), for the slot-equality prefilter. -/
+def Expression.pdStructHash : Expression p → UInt64
+  | .const n => mixHash 11 (UInt64.ofNat n.val)
+  | .var y => mixHash 13 (mixHash (hash y.name) (hash y.powdrId?))
+  | .add a b => mixHash 17 (mixHash a.pdStructHash b.pdStructHash)
+  | .mul a b => mixHash 19 (mixHash a.pdStructHash b.pdStructHash)
+
+/-- Necessary condition for `msgEqCert` on two payloads, from the precomputed per-slot
+    signatures: each slot pair is syntactically equal (hash) or shares a variable (Blooms). -/
+def pdSigsCompatible (a b : Array (UInt64 × UInt64)) : Bool :=
+  Array.isEqv a b (fun x y => x.1 == y.1 || (x.2 &&& y.2) != 0)
+
+/-- Full-value hash of an interaction, for the dropped-value buckets. -/
+def pdValHash (bi : BusInteraction (Expression p)) : UInt64 :=
+  mixHash (hash bi.busId) (mixHash bi.multiplicity.pdStructHash
+    (bi.payload.foldl (fun h e => mixHash h e.pdStructHash) 7))
+
+/-- One bucket entry of the sweep: position, the interaction, its slot signatures, and whether
+    it was kept. -/
+structure PdEntry (p : ℕ) where
+  pos : Nat
+  bi : BusInteraction (Expression p)
+  sigs : Array (UInt64 × UInt64)
+  kept : Bool
+
+/-- The value-keyed set of interactions the sweep decides to drop — exactly `pdKeep`'s drop set
+    (drops are value-based there too: `findIdx?` evaluates every duplicate at its first
+    occurrence). -/
+def pdDropSet (bs : BusSemantics p) (singles : List (Expression p))
+    (bis : List (BusInteraction (Expression p))) :
+    Std.HashMap UInt64 (List (BusInteraction (Expression p))) := Id.run do
+  let mut buckets : Std.HashMap UInt64 (List (PdEntry p)) := ∅
+  let mut firstMemo : Std.HashMap Nat Bool := ∅
+  let mut drops : Std.HashMap UInt64 (List (BusInteraction (Expression p))) := ∅
+  let mut pos := 0
+  for bi in bis do
+    if !bs.isStateful bi.busId then
+      match bi.multiplicity.constValue? with
+      | none => pure ()   -- can neither be dropped nor certify a drop
+      | some m =>
+        let key := mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length))
+        let sigs : Array (UInt64 × UInt64) :=
+          (bi.payload.map (fun e => (e.pdStructHash, e.pdVarBloom))).toArray
+        let entries := buckets.getD key []
+        -- an exact duplicate mirrors its first occurrence's decision (findIdx? semantics)
+        match entries.find? (fun e => decide (e.bi = bi)) with
+        | some e =>
+          if !e.kept then
+            let vk := pdValHash bi
+            drops := drops.insert vk (bi :: (drops.getD vk []))
+        | none =>
+          -- drop iff an earlier kept, first-of-class, certified twin exists
+          let mut dropped := false
+          for e in entries do
+            if !dropped && e.kept && pdSigsCompatible e.sigs sigs then
+              if msgEqCert singles e.bi bi then
+                -- lazily decide whether `e` is first of its class
+                let isFirst ← do
+                  match firstMemo[e.pos]? with
+                  | some b => pure b
+                  | none =>
+                    let b := entries.all (fun e' =>
+                      !(e'.pos < e.pos && pdSigsCompatible e'.sigs e.sigs
+                        && msgEqCert singles e'.bi e.bi))
+                    firstMemo := firstMemo.insert e.pos b
+                    pure b
+                if isFirst then
+                  dropped := true
+          if dropped then
+            let vk := pdValHash bi
+            drops := drops.insert vk (bi :: (drops.getD vk []))
+          buckets := buckets.insert key ({ pos, bi, sigs, kept := !dropped } :: entries)
+    pos := pos + 1
+  return drops
+
+/-- Was `bi` flagged by the sweep? (`false` = flagged as a drop candidate.) -/
+def pdFastKeep (drops : Std.HashMap UInt64 (List (BusInteraction (Expression p))))
+    (bi : BusInteraction (Expression p)) : Bool :=
+  match drops[pdValHash bi]? with
+  | some l => !(l.any (fun b => decide (b = bi)))
+  | none => true
+
 /-- Part C as a standalone (unguarded) pass: drop stateless interactions pointwise-equal to an
-    earlier first-of-class one. -/
+    earlier first-of-class one. Stated over an arbitrary *prefilter* `fast`: the kept set is
+    `fast bi || pdKeep … bi`, so a drop requires `pdKeep … = false` (the certified condition)
+    and keeping more is always sound. `pointwiseDupDropPass` instantiates `fast` with the sweep
+    above, which flags exactly `pdKeep`'s drop set — the expensive certified scan then runs only
+    on the few genuine drops. -/
 theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
-    (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (fast : BusInteraction (Expression p) → Bool) :
     PassCorrect cs
       (cs.filterBus
-        (pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions))
+        (fun bi => fast bi || pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions bi))
       [] bs :=
   cs.filterBusEntailed_correct bs _
        (by
          intro bi _ hkf
-         unfold pdKeep at hkf
          rw [Bool.or_eq_false_iff] at hkf
-         simpa using hkf.1)
+         have hkf' := hkf.2
+         unfold pdKeep at hkf'
+         rw [Bool.or_eq_false_iff] at hkf'
+         simpa using hkf'.1)
        (by
          intro bi hbimem hkf env hsat hm
-         unfold pdKeep at hkf
          rw [Bool.or_eq_false_iff] at hkf
-         obtain ⟨_hst, hmatch⟩ := hkf
+         have hkf' := hkf.2
+         unfold pdKeep at hkf'
+         rw [Bool.or_eq_false_iff] at hkf'
+         obtain ⟨_hst, hmatch⟩ := hkf'
          cases hidx : cs.busInteractions.findIdx? (fun x => x == bi) with
          | none => rw [hidx] at hmatch; simp at hmatch
          | some i =>
@@ -471,9 +582,9 @@ theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
                cs.busInteractions b = true :=
              pdFirst_keep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions b hfirst
            have hbout : b ∈ (cs.filterBus
-               (pdKeep bs (singleVarCs cs.algebraicConstraints)
-                 cs.busInteractions)).busInteractions :=
-             List.mem_filter.2 ⟨hbcs, hbkeep⟩
+               (fun bi => fast bi || pdKeep bs (singleVarCs cs.algebraicConstraints)
+                 cs.busInteractions bi)).busInteractions :=
+             List.mem_filter.2 ⟨hbcs, by simp [hbkeep]⟩
            have hdom : ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 := by
              intro c hc
              exact hsat.1 c (List.mem_of_mem_filter hc)
@@ -486,8 +597,12 @@ theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
 def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
   if hp : (decide p.Prime) = true then
     haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
-    ⟨cs.filterBus (pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions), [],
-     cs.pointwiseDupDrop_correct bs⟩
+    let singles := singleVarCs cs.algebraicConstraints
+    -- The fast sweep flags exactly `pdKeep`'s drop set; the certified `pdKeep` re-verifies each
+    -- flagged drop (short-circuited away for the unflagged rest by the `||`).
+    let drops := pdDropSet bs singles cs.busInteractions
+    ⟨cs.filterBus (fun bi => pdFastKeep drops bi || pdKeep bs singles cs.busInteractions bi), [],
+     cs.pointwiseDupDrop_correct bs (pdFastKeep drops)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-! ## Part A: the entailed nonlinear substitution -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/HintCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/HintCollapse.lean
@@ -759,10 +759,18 @@ theorem peel_sqReassign_eval (D : List Variable) (E : Expression p) (hnd : D.Nod
     expensive part of a collapse attempt — a full-system `occursOnlyInTarget` scan per candidate —
     so the scanner computes it once per constraint and shares it across the plain / sum-of-squares
     attempts. Kept as its own definition (not an inline `filter`) so that the `rfl` proofs at the
-    call sites are trivial rather than forcing the filter to reduce. -/
-def witnessesOf (cs : ConstraintSystem p) (busVars : Std.HashSet Variable) (E : Expression p) :
-    List Variable :=
-  E.vars.dedup.filter (fun v => !busVars.contains v && occursOnlyInTarget cs E v)
+    call sites are trivial rather than forcing the filter to reduce.
+
+    `cnt` is the once-per-invocation constraint-occurrence counter (how many constraints mention
+    each variable, see `constraintCountMap`): a variable mentioned by two or more *distinct*
+    constraints can never occur only in `E`, so the certified full-system scan runs only for the
+    rare `cnt = 1` candidates — the counter is a pure prefilter, and the proofs consume the
+    `occursOnlyInTarget` conjunct alone. (A variable whose ≥ 2 mentioning constraints are all
+    *duplicates* of `E` is conservatively rejected; `dedup` removes such duplicates anyway.) -/
+def witnessesOf (cs : ConstraintSystem p) (busVars : Std.HashSet Variable)
+    (cnt : Std.HashMap Variable Nat) (E : Expression p) : List Variable :=
+  E.vars.dedup.filter (fun v => !busVars.contains v && cnt.getD v 0 == 1
+    && occursOnlyInTarget cs E v)
 
 /-- Attempt the plain-sum collapse with target constraint `E` and its precomputed witness set `D`:
     peel the coefficients and — if all checks pass — return the verified `PassResult`.
@@ -773,8 +781,9 @@ def witnessesOf (cs : ConstraintSystem p) (busVars : Std.HashSet Variable) (E : 
     majority of) constraints with `D.length < 2` nothing else is evaluated. -/
 def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable)
+    (cnt : Std.HashMap Variable Nat)
     (E : Expression p) (hE : E ∈ cs.algebraicConstraints)
-    (D : List Variable) (hD : D = witnessesOf cs busVars E) : Option (PassResult cs bs) := by
+    (D : List Variable) (hD : D = witnessesOf cs busVars cnt E) : Option (PassResult cs bs) := by
   classical
   set inv : Variable := ⟨"hcinv#" ++ (D.headD ⟨"_", none⟩).name, none⟩ with hinvdef
   by_cases hchk : (decide (2 ≤ D.length) && (coeffsByteOK Bm.map D (peel D E).1 &&
@@ -860,8 +869,9 @@ def tryOne [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     square is `< 256²`, so the field sum does not wrap). -/
 def tryOneSq [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable)
+    (cnt : Std.HashMap Variable Nat)
     (E : Expression p) (hE : E ∈ cs.algebraicConstraints)
-    (D : List Variable) (hD : D = witnessesOf cs busVars E) : Option (PassResult cs bs) := by
+    (D : List Variable) (hD : D = witnessesOf cs busVars cnt E) : Option (PassResult cs bs) := by
   classical
   set inv : Variable := ⟨"hcsq#" ++ (D.headD ⟨"_", none⟩).name, none⟩ with hinvdef
   set denom : Expression p := sumExpr ((peel D E).1.map (fun c => Expression.mul c c)) with hden
@@ -969,18 +979,19 @@ def tryOneSq [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     both attempts short-circuit immediately, so the marginal cost of also offering the sum-of-squares
     shape is only the cheap coefficient re-check on the rare candidate constraints. -/
 def tryList [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable) :
+    (Bm : BoundsMap p cs bs) (busVars : Std.HashSet Variable)
+    (cnt : Std.HashMap Variable Nat) :
     (L : List (Expression p)) → (∀ E ∈ L, E ∈ cs.algebraicConstraints) → Option (PassResult cs bs)
   | [], _ => none
   | E :: rest, hmem =>
     let hE := hmem E (List.mem_cons_self ..)
-    let D := witnessesOf cs busVars E
-    match tryOne cs bs Bm busVars E hE D rfl with
+    let D := witnessesOf cs busVars cnt E
+    match tryOne cs bs Bm busVars cnt E hE D rfl with
     | some r => some r
     | none =>
-      match tryOneSq cs bs Bm busVars E hE D rfl with
+      match tryOneSq cs bs Bm busVars cnt E hE D rfl with
       | some r => some r
-      | none => tryList cs bs Bm busVars rest (fun E' h => hmem E' (List.mem_cons_of_mem _ h))
+      | none => tryList cs bs Bm busVars cnt rest (fun E' h => hmem E' (List.mem_cons_of_mem _ h))
 
 /-- The hint-collapse pass: replace the first bilinear reciprocal-witness constraint by a single
     derived inverse hint (needs prime `p` for the field inverse; identity otherwise, and identity
@@ -996,7 +1007,11 @@ def hintCollapsePass : VerifiedPassW p := fun cs bs facts =>
     let busVars : Std.HashSet Variable := cs.busInteractions.foldl (init := ∅) fun s bi =>
       bi.payload.foldl (fun s e => e.vars.foldl (·.insert ·) s)
         (bi.multiplicity.vars.foldl (·.insert ·) s)
-    (tryList cs bs Bm busVars cs.algebraicConstraints (fun _ h => h)).getD
+    -- Constraint-occurrence counter (see `witnessesOf`): built once per invocation, so the
+    -- certified full-system witness scan runs only for the rare single-occurrence candidates.
+    let cnt : Std.HashMap Variable Nat := cs.algebraicConstraints.foldl (init := ∅) fun m c =>
+      c.vars.dedup.foldl (fun m v => m.insert v (m.getD v 0 + 1)) m
+    (tryList cs bs Bm busVars cnt cs.algebraicConstraints (fun _ h => h)).getD
       ⟨cs, [], PassCorrect.refl cs bs⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1437,10 +1437,16 @@ def interpPoly (pz : List (List (Variable × ZMod p) × List (Variable × ZMod p
     exactly its constraint's root set), so the group is re-encodable only if
     `⌈log₂ box⌉ < |xs|` — decided without enumerating the box. This skips the enumeration for
     the ubiquitous pure-boolean-flag groups (box `2^|xs|` can never win). -/
-def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
+def buildReencode (useIdx : Bool) (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
     (xs : List Variable) (freshBase : String) :
     Option (List Variable × Std.HashMap Variable (Expression p)) :=
-  let es := CoveredIndex.coveredIdx csIdx arrCs (coveredBy xs) xs
+  -- The covered set: through the inverted index on large systems, by direct filter on small
+  -- ones — on small flag-heavy circuits the per-target bucket gather + sort of hyper-shared
+  -- variables costs more than the plain scan (same trade-off as `domainFoldIndexThreshold`).
+  -- Both produce `coveredCsOf` in its original order, which `checkReencode`'s certificate
+  -- recomputes exactly.
+  let es := if useIdx then CoveredIndex.coveredIdx csIdx arrCs (coveredBy xs) xs
+    else arrCs.foldr (fun c acc => if coveredBy xs c then c :: acc else acc) []
   match groupDoms es xs with
   | none => none
   | some doms =>
@@ -1477,7 +1483,7 @@ def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
     in the system is skipped before `buildReencode` — in the steady state the fresh-name
     counters repeat the previous cycle's accepted names, and `checkReencode`'s freshness
     conjunct would reject exactly these after a full scan. -/
-def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
+def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (useIdx : Bool)
     (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p)) (cs : ConstraintSystem p)
     (varSet : { s : Std.HashSet Variable // ∀ x, s.contains x = true → x ∈ cs.vars })
     (xs : List Variable) (freshBase : String) :
@@ -1488,7 +1494,7 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
     -- fresh-name collision: `checkReencode` would reject after the full freshness scan
     ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   else
-  match hb : buildReencode csIdx arrCs xs freshBase with
+  match hb : buildReencode useIdx csIdx arrCs xs freshBase with
   | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   | some (bits, hm) =>
     if hxsCs : xs.all (fun x => varSet.val.contains x) = true then
@@ -1507,7 +1513,8 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
            hchk⟩,
-         CoveredIndex.build Expression.vars ro.algebraicConstraints, ro.algebraicConstraints.toArray,
+         (if useIdx then CoveredIndex.build Expression.vars ro.algebraicConstraints else ⟨∅, []⟩),
+         ro.algebraicConstraints.toArray,
          ⟨Std.HashSet.ofList ro.vars, fun x hx => by
            rw [Std.HashSet.contains_ofList] at hx
            exact List.contains_iff_mem.mp hx⟩⟩
@@ -1521,15 +1528,15 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
 /-- Process the candidate groups sequentially (correctness composes; derivations concatenate). The
     inverted index and the proof-carrying variable set (valid for the current `cs`) are threaded
     through and rebuilt by `reencodeStep` whenever it rewrites `cs`. -/
-def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
+def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) (useIdx : Bool) :
     List (List Variable) → Nat → (cs : ConstraintSystem p) →
     CoveredIndex.CovIndex → Array (Expression p) →
     { s : Std.HashSet Variable // ∀ x, s.contains x = true → x ∈ cs.vars } → PassResult cs bsem
   | [], _, cs, _, _, _ => ⟨cs, [], PassCorrect.refl cs bsem⟩
   | xs :: rest, idx, cs, csIdx, arrCs, varSet =>
-    let r1 := reencodeStep bsem csIdx arrCs cs varSet xs
+    let r1 := reencodeStep bsem useIdx csIdx arrCs cs varSet xs
       (s!"rnc{cs.algebraicConstraints.length}_{cs.busInteractions.length}_{idx}")
-    let r2 := reencodeLoop bsem rest (idx + 1) r1.1.out r1.2.1 r1.2.2.1 r1.2.2.2
+    let r2 := reencodeLoop bsem useIdx rest (idx + 1) r1.1.out r1.2.1 r1.2.2.1 r1.2.2.2
     ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
 
 /-- `List.dedup` computed in linear time via a hash set, with the **identical** result: an element
@@ -1549,11 +1556,22 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
     haveI : Fact p.Prime := ⟨hpr⟩
     -- `dedupHash` replaces the quadratic `List.dedup` over the (up to thousands of) target
     -- variable-sets, producing the identical list in linear time.
+    -- Same single-variable-constraint prefilter as `domainFoldPass`: a group variable without
+    -- one can never obtain a domain, so `buildReencode`'s `groupDoms` would reject the target
+    -- after paying its covered-set lookup.
+    let svSet : Std.HashSet Variable := cs.algebraicConstraints.foldl (init := ∅) fun s c =>
+      match c.vars.dedup with
+      | [x] => s.insert x
+      | _ => s
     let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
       let vs := c.vars.dedup
-      if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none))
-    reencodeLoop bsem targets 0 cs
-      (CoveredIndex.build Expression.vars cs.algebraicConstraints) cs.algebraicConstraints.toArray
+      if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
+        some (vs.mergeSort (fun a b => compare a b != .gt))
+      else none))
+    let useIdx := 8192 ≤ cs.algebraicConstraints.length
+    reencodeLoop bsem useIdx targets 0 cs
+      (if useIdx then CoveredIndex.build Expression.vars cs.algebraicConstraints else ⟨∅, []⟩)
+      cs.algebraicConstraints.toArray
       ⟨Std.HashSet.ofList cs.vars, fun x hx => by
         rw [Std.HashSet.contains_ofList] at hx
         exact List.contains_iff_mem.mp hx⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -813,11 +813,6 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
     decide (2 ≤ survs.length) &&
     decide (bits.length < xs.length) &&
     decide (bits.Nodup) &&
-    -- freshness: no bit occurs anywhere in the system
-    bits.all (fun b =>
-      cs.algebraicConstraints.all (fun c => !c.mentionsF b) &&
-      cs.busInteractions.all (fun bi =>
-        !bi.multiplicity.mentionsF b && bi.payload.all (fun e => !e.mentionsF b))) &&
     -- the substituted group variables only mention bits
     xs.all (fun x =>
       ((Expression.var x).substF (groupSubst xs hm)).vars.all (fun v => bits.contains v)) &&
@@ -827,7 +822,14 @@ def checkReencode (cs : ConstraintSystem p) (xs bits : List Variable)
         decide (((Expression.var x).substF (groupSubst xs hm)).evalFast (envOf aβ) = envOf s x)))) &&
     -- soundness: every bit pattern's image satisfies the covered constraints
     patts.all (fun aβ => es.all (fun c =>
-      decide ((c.substF (groupSubst xs hm)).evalFast (envOf aβ) = 0)))
+      decide ((c.substF (groupSubst xs hm)).evalFast (envOf aβ) = 0))) &&
+    -- freshness: no bit occurs anywhere in the system. Deliberately the **last** conjunct: it is
+    -- the only O(bits × system) one, and short-circuiting puts it after the cheap per-candidate
+    -- rejections, so it effectively runs only for accepted groups.
+    bits.all (fun b =>
+      cs.algebraicConstraints.all (fun c => !c.mentionsF b) &&
+      cs.busInteractions.all (fun bi =>
+        !bi.multiplicity.mentionsF b && bi.payload.all (fun e => !e.mentionsF b)))
 
 /-! ## Derived-variable methods for the fresh bits
 
@@ -1111,7 +1113,7 @@ theorem checkReencode_sound_D [Fact p.Prime] (cs : ConstraintSystem p) (bsem : B
   · exact absurd hchk (by simp)
   rename_i doms hdoms
   simp only [Bool.and_eq_true] at hchk
-  obtain ⟨⟨⟨⟨⟨⟨⟨hbox, hm2⟩, hprofit⟩, hnodup⟩, hfreshB⟩, hvarsB⟩, hC5⟩, hC6⟩ := hchk
+  obtain ⟨⟨⟨⟨⟨⟨⟨hbox, hm2⟩, hprofit⟩, hnodup⟩, hvarsB⟩, hC5⟩, hC6⟩, hfreshB⟩ := hchk
   have hnodup' : bits.Nodup := of_decide_eq_true hnodup
   have hkeys := groupDoms_fst (coveredCsOf cs xs) xs doms hdoms
   have hbitKeys : (bitBox (p := p) bits).map Prod.fst = bits := by
@@ -1468,30 +1470,28 @@ def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
     checked for the few groups that are actually re-encodable. The output-variable frame is proven
     by construction (`reencodeOut_vars_subset`), so no per-variable scan is needed.
 
-    `varSet` is the (heuristic, threaded) set of `cs`'s variables: a candidate whose first fresh
-    bit already occurs in the system is skipped before `buildReencode` — in the steady state the
-    fresh-name counters repeat the previous cycle's accepted names, and `checkReencode`'s
-    freshness conjunct (an O(bits × system) scan paid per candidate) would reject exactly these.
-    The certificate still re-verifies freshness for candidates that pass, so a stale set can only
-    cost time, never a wrong rewrite. -/
+    `varSet` is the threaded, proof-carrying set of `cs`'s variables — `contains` implies
+    membership in `cs.vars`, so the group-membership side condition is decided by |xs| hash
+    lookups instead of materializing and scanning the ~10⁴-entry occurrence list per candidate.
+    It also prefilters fresh-name collisions: a candidate whose first fresh bit already occurs
+    in the system is skipped before `buildReencode` — in the steady state the fresh-name
+    counters repeat the previous cycle's accepted names, and `checkReencode`'s freshness
+    conjunct would reject exactly these after a full scan. -/
 def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
-    (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
-    (varSet : Std.HashSet Variable) (cs : ConstraintSystem p)
+    (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p)) (cs : ConstraintSystem p)
+    (varSet : { s : Std.HashSet Variable // ∀ x, s.contains x = true → x ∈ cs.vars })
     (xs : List Variable) (freshBase : String) :
-    PassResult cs bsem × CoveredIndex.CovIndex × Array (Expression p) × Std.HashSet Variable :=
+    Σ' (r : PassResult cs bsem), CoveredIndex.CovIndex × Array (Expression p) ×
+      { s : Std.HashSet Variable // ∀ x, s.contains x = true → x ∈ r.out.vars } :=
   if hxs : xs.all (fun x => x.powdrId?.isSome) = true then
-  if varSet.contains { name := freshBase ++ "_0" } then
+  if varSet.val.contains { name := freshBase ++ "_0" } then
     -- fresh-name collision: `checkReencode` would reject after the full freshness scan
     ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   else
   match hb : buildReencode csIdx arrCs xs freshBase with
   | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   | some (bits, hm) =>
-    -- The group-membership scan is checked only for the few groups `buildReencode` accepts, and
-    -- against a `cs.vars` bound once — the occurrence list is ~10⁴ entries, so materializing it
-    -- (×8) for every candidate group dominated this pass's runtime.
-    let csVars := cs.vars
-    if hxsCs : xs.all (fun x => decide (x ∈ csVars)) = true then
+    if hxsCs : xs.all (fun x => varSet.val.contains x) = true then
     if hxsB : xs.all (fun x => decide (x ∉ bits)) = true then
     if hbn : bits.all (fun b => decide (b.powdrId? = none)) = true then
     if hchk : checkReencode cs xs bits hm = true then
@@ -1503,12 +1503,14 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
          bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)),
          checkReencode_sound_D cs bsem xs bits hm
            (fun x hx => by simpa using List.all_eq_true.mp hxs x hx)
-           (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsCs x hx))
+           (fun x hx => varSet.property x (List.all_eq_true.mp hxsCs x hx))
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
            hchk⟩,
          CoveredIndex.build Expression.vars ro.algebraicConstraints, ro.algebraicConstraints.toArray,
-         ro.vars.foldl (·.insert ·) ∅⟩
+         ⟨Std.HashSet.ofList ro.vars, fun x hx => by
+           rw [Std.HashSet.contains_ofList] at hx
+           exact List.contains_iff_mem.mp hx⟩⟩
       else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
@@ -1517,14 +1519,15 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
   else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
 
 /-- Process the candidate groups sequentially (correctness composes; derivations concatenate). The
-    inverted index and the variable set (valid for the current `cs`) are threaded through and
-    rebuilt by `reencodeStep` whenever it rewrites `cs`. -/
+    inverted index and the proof-carrying variable set (valid for the current `cs`) are threaded
+    through and rebuilt by `reencodeStep` whenever it rewrites `cs`. -/
 def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
     List (List Variable) → Nat → (cs : ConstraintSystem p) →
-    CoveredIndex.CovIndex → Array (Expression p) → Std.HashSet Variable → PassResult cs bsem
+    CoveredIndex.CovIndex → Array (Expression p) →
+    { s : Std.HashSet Variable // ∀ x, s.contains x = true → x ∈ cs.vars } → PassResult cs bsem
   | [], _, cs, _, _, _ => ⟨cs, [], PassCorrect.refl cs bsem⟩
   | xs :: rest, idx, cs, csIdx, arrCs, varSet =>
-    let r1 := reencodeStep bsem csIdx arrCs varSet cs xs
+    let r1 := reencodeStep bsem csIdx arrCs cs varSet xs
       (s!"rnc{cs.algebraicConstraints.length}_{cs.busInteractions.length}_{idx}")
     let r2 := reencodeLoop bsem rest (idx + 1) r1.1.out r1.2.1 r1.2.2.1 r1.2.2.2
     ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
@@ -1551,5 +1554,7 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none))
     reencodeLoop bsem targets 0 cs
       (CoveredIndex.build Expression.vars cs.algebraicConstraints) cs.algebraicConstraints.toArray
-      (cs.vars.foldl (·.insert ·) ∅)
+      ⟨Std.HashSet.ofList cs.vars, fun x hx => by
+        rw [Std.HashSet.contains_ofList] at hx
+        exact List.contains_iff_mem.mp hx⟩
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1428,7 +1428,13 @@ def interpPoly (pz : List (List (Variable × ZMod p) × List (Variable × ZMod p
 /-- Construct the bits and the substitution map for a candidate group (proof-free — the
     checked certificate re-verifies everything). The covered constraints come from a prebuilt
     inverted index (`csIdx`/`arrCs`, built once per pass and rebuilt on each accepted rewrite)
-    instead of a full-system `filter` per candidate group — the dominant cost of this pass. -/
+    instead of a full-system `filter` per candidate group — the dominant cost of this pass.
+
+    Hopeless-target prefilter: when every covered constraint is single-variable and there is
+    exactly one per group variable, the survivors are the *entire* domain box (each domain is
+    exactly its constraint's root set), so the group is re-encodable only if
+    `⌈log₂ box⌉ < |xs|` — decided without enumerating the box. This skips the enumeration for
+    the ubiquitous pure-boolean-flag groups (box `2^|xs|` can never win). -/
 def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
     (xs : List Variable) (freshBase : String) :
     Option (List Variable × Std.HashMap Variable (Expression p)) :=
@@ -1436,7 +1442,13 @@ def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
   match groupDoms es xs with
   | none => none
   | some doms =>
-    if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
+    let boxSize := (doms.map (fun yd => yd.2.length)).prod
+    if boxSize ≤ 256 then
+      if es.length == xs.length && es.all (fun c => c.vars.eraseDups.length == 1)
+          && xs.length ≤ Nat.clog 2 boxSize then
+        -- single-var-only covered set (one per variable): survivors = box; unencodable
+        none
+      else
       let survs := groupSurvivorsE es doms
       if 2 ≤ survs.length then
         let k := Nat.clog 2 survs.length
@@ -1454,14 +1466,26 @@ def buildReencode (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
     filter — `buildReencode` — runs first, so the remaining side conditions (all cheap: the group
     is all input columns and disjoint from the fresh bits, the bits carry no powdr ID) are only
     checked for the few groups that are actually re-encodable. The output-variable frame is proven
-    by construction (`reencodeOut_vars_subset`), so no per-variable scan is needed. -/
+    by construction (`reencodeOut_vars_subset`), so no per-variable scan is needed.
+
+    `varSet` is the (heuristic, threaded) set of `cs`'s variables: a candidate whose first fresh
+    bit already occurs in the system is skipped before `buildReencode` — in the steady state the
+    fresh-name counters repeat the previous cycle's accepted names, and `checkReencode`'s
+    freshness conjunct (an O(bits × system) scan paid per candidate) would reject exactly these.
+    The certificate still re-verifies freshness for candidates that pass, so a stale set can only
+    cost time, never a wrong rewrite. -/
 def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
-    (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p)) (cs : ConstraintSystem p)
+    (csIdx : CoveredIndex.CovIndex) (arrCs : Array (Expression p))
+    (varSet : Std.HashSet Variable) (cs : ConstraintSystem p)
     (xs : List Variable) (freshBase : String) :
-    PassResult cs bsem × CoveredIndex.CovIndex × Array (Expression p) :=
+    PassResult cs bsem × CoveredIndex.CovIndex × Array (Expression p) × Std.HashSet Variable :=
   if hxs : xs.all (fun x => x.powdrId?.isSome) = true then
+  if varSet.contains { name := freshBase ++ "_0" } then
+    -- fresh-name collision: `checkReencode` would reject after the full freshness scan
+    ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+  else
   match hb : buildReencode csIdx arrCs xs freshBase with
-  | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+  | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   | some (bits, hm) =>
     -- The group-membership scan is checked only for the few groups `buildReencode` accepts, and
     -- against a `cs.vars` bound once — the occurrence list is ~10⁴ entries, so materializing it
@@ -1473,7 +1497,8 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
     if hchk : checkReencode cs xs bits hm = true then
       let ro := reencodeOut cs xs bits hm
       if ro.withinDegreeB bsem.degreeBound then
-        -- `cs` changed: rebuild the index for `ro` (accepts are rare, so this is cheap overall).
+        -- `cs` changed: rebuild the index and the variable set for `ro` (accepts are rare, so
+        -- this is cheap overall).
         ⟨⟨ro,
          bits.map (fun b => (b, bitCM (assignments (bitBox bits)) xs hm b)),
          checkReencode_sound_D cs bsem xs bits hm
@@ -1482,25 +1507,26 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p)
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
            hchk⟩,
-         CoveredIndex.build Expression.vars ro.algebraicConstraints, ro.algebraicConstraints.toArray⟩
-      else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
-    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
-    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
-    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
-    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
-  else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs⟩
+         CoveredIndex.build Expression.vars ro.algebraicConstraints, ro.algebraicConstraints.toArray,
+         ro.vars.foldl (·.insert ·) ∅⟩
+      else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+    else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+  else ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
 
 /-- Process the candidate groups sequentially (correctness composes; derivations concatenate). The
-    inverted index (`csIdx`/`arrCs`, valid for the current `cs`) is threaded through and rebuilt by
-    `reencodeStep` whenever it rewrites `cs`. -/
+    inverted index and the variable set (valid for the current `cs`) are threaded through and
+    rebuilt by `reencodeStep` whenever it rewrites `cs`. -/
 def reencodeLoop [Fact p.Prime] (bsem : BusSemantics p) :
     List (List Variable) → Nat → (cs : ConstraintSystem p) →
-    CoveredIndex.CovIndex → Array (Expression p) → PassResult cs bsem
-  | [], _, cs, _, _ => ⟨cs, [], PassCorrect.refl cs bsem⟩
-  | xs :: rest, idx, cs, csIdx, arrCs =>
-    let r1 := reencodeStep bsem csIdx arrCs cs xs
+    CoveredIndex.CovIndex → Array (Expression p) → Std.HashSet Variable → PassResult cs bsem
+  | [], _, cs, _, _, _ => ⟨cs, [], PassCorrect.refl cs bsem⟩
+  | xs :: rest, idx, cs, csIdx, arrCs, varSet =>
+    let r1 := reencodeStep bsem csIdx arrCs varSet cs xs
       (s!"rnc{cs.algebraicConstraints.length}_{cs.busInteractions.length}_{idx}")
-    let r2 := reencodeLoop bsem rest (idx + 1) r1.1.out r1.2.1 r1.2.2
+    let r2 := reencodeLoop bsem rest (idx + 1) r1.1.out r1.2.1 r1.2.2.1 r1.2.2.2
     ⟨r2.out, r1.1.derivs ++ r2.derivs, r1.1.correct.andThen r2.correct⟩
 
 /-- `List.dedup` computed in linear time via a hash set, with the **identical** result: an element
@@ -1525,4 +1551,5 @@ def reencodePass : VerifiedPass p := fun cs bsem =>
       if 2 ≤ vs.length && vs.length ≤ 8 then some (vs.mergeSort (fun a b => compare a b != .gt)) else none))
     reencodeLoop bsem targets 0 cs
       (CoveredIndex.build Expression.vars cs.algebraicConstraints) cs.algebraicConstraints.toArray
+      (cs.vars.foldl (·.insert ·) ∅)
   else ⟨cs, [], PassCorrect.refl cs bsem⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -365,3 +365,36 @@ and accepts both closer signs (mid-cycle the optimizer holds the negated `(1 −
 - **Measure per-case, not just aggregate**: `opt-export` + a canonical-form diff against
   `*.powdr_opt.json.gz` finds the mechanism; `benchmark.py` (+ keccak) confirms the totals. The
   geo metric moves with per-case wins — 67 small bus losses cost more than one big one.
+
+## Runtime leftovers (from the entry-90 runtime overhaul — see that log entry for the map)
+
+Levers identified but not taken, in rough value order (keccak profile shares at entry-87's end
+state; every item is output-preserving unless noted):
+
+- **domainBatch on keccak (~19 %)**: per-target work is now the unordered covered gather +
+  `assignments` box materialization + `DomainTable` rebuild per invocation. Candidates:
+  stream the box instead of materializing (`assignments` allocates the full product), and a
+  domainFold-style single-var prefilter for the *constraint-sourced* domain targets (bus-fact
+  domains make the general case harder). The user-suggested SAT-style propagation (prune the
+  box by evaluating constraints on partial assignments) fits `forcedOver`'s certificate shape —
+  the checked survivor scan visits every box point today; a DPLL-style search needs the skipped
+  subtrees refuted by a partially-determined covered item, which is provable but a real proof.
+- **reencode/domainFold accept-path on keccak**: `reencodeOut`/`foldOut` rewrite the whole
+  system per accept (inherent), but reencode also rebuilds its covered index + `cs.vars`
+  HashSet per accept; a stale-bucket refresh (the `FoldIdx.refresh` trick — buckets are
+  positional supersets when items are mapped in place) does not directly apply because
+  `reencodeOut` *removes* covered constraints (positions shift). A position-stable
+  `reencodeOut` variant would unlock it for both passes' constraint side.
+- **gauss (~6 % keccak)**: untouched this round.
+- **dedup (~4 % keccak)**: `List.dedup` over constraints and the `bi ∈ seen` scan are both
+  quadratic with deep equality. Hash-bucketed variants need `mem`-iff lemmas (the pass proof
+  consumes `List.mem_dedup`); ~100 lines of HashMap invariant proofs.
+- **rootPairUnify (~2-8 %)**: `scaledSlotBound`/`anyVarBound` rescan interactions per variable —
+  the `findVarBound`-per-candidate pattern that busPairCancel just shed.
+- **zeroWidthRange (~1.7 s/eth case)**: two `rangeEq?` scans per invocation (filterMap + keep);
+  fusing them into one tagged pass needs the `filterBus`-shaped proof reworked.
+- **Cross-cycle memoization (the big structural one)**: the cleanup cycle runs 5–9 times and the
+  enumeration passes rediscover the same negatives every cycle. A pass-state channel (e.g.
+  `VerifiedPassW` threading an opaque cache blob validated by cheap hashes) would cut the
+  steady-state tail of *every* pass at once; needs a framework change in
+  `Implementation/OptimizerPasses/Basic.lean`'s glue, so weigh against the audit-surface rule.

--- a/docs/log.md
+++ b/docs/log.md
@@ -3418,3 +3418,87 @@ unchanged** (2021 v / 186 c / 1752 bus). Build + `Scripts/check-proof-integrity.
 throughout ({propext, Classical.choice, Quot.sound} only). **Worked: yes — the wasm-eth variable
 gap that motivated the investigation (`../leanr-wasm/fable-wasm-1.md`) is closed; apc now leads
 powdr on variables and constraints, trails only slightly on bus.**
+
+### 90. Runtime overhaul: ~2.1× on keccak, ~1.2–1.3× on the heavy eth cases (effectiveness unchanged)
+
+Pure **performance** work across the six hottest passes, driven by gdb stack sampling (the
+container has no `perf`; ~250 samples per benchmark attribute time precisely). All changes are
+output-preserving by design — heuristic prefilters feed the existing certified checks, so a wrong
+prefilter can cost time but never change a drop/fold/collapse decision. Measured end-to-end on
+this container: **keccak 912 s → 432 s** (`run`; the baseline `profile` was 912 s and profile ≈
+run here), **apc_005 32.2 → 25.7 s, apc_006 26.6 → 23.7 s, apc_012 21.7 → 17.1 s** (profile
+totals; this machine has ±15 % run-to-run variance — the on-demand `Runtime Bench` workflow is
+the authoritative A/B). Effectiveness: `benchmark.py` over all 100 eth cases reproduces the
+documented aggregates exactly (vars 4.552×/3.887× geo, bus 3.543×/2.803×, W/L/T 31/7/62), and
+keccak's output is count-identical (2021 vars / 1752 bus / 186 constraints); spot checks
+apc_034 = 105/22/80, apc_066 = 49/10/37, apc_037 = 690 vars all match the documented sizes.
+
+**The shared disease, in six organs.** Almost all of the time went to per-candidate O(system)
+rescans and per-accept O(system) rebuilds inside passes that already had one layer of indexing:
+
+- **busPairCancel (keccak 117 s → ~55 s)**: the receive hash index was rebuilt per *bus* per
+  sweep — now one consolidated index (bus id mixed into the key) built once per sweep, with the
+  interaction array shared. The split equation `cs.busInteractions = A ++ S :: B ++ R :: C` was
+  *decided* per accepted drop (an O(n) deep structural comparison) — now proven by construction
+  from the array extracts (`split_of_extracts`/`list_split_two`). `checkCancel` re-ran the region
+  tests (`midRefuted` over B, `shieldOk` over A) the scan had just computed — they are hypotheses
+  of `checkCancel_sound` now. The byte justification materialized `A ++ B ++ C` and `findVarBound`-
+  scanned it per queried variable — `dropWits` scans the shared array directly with the same
+  early-exit, skipping the dropped pair by value. The deep justification's per-query constraint
+  filters (`all.filter isSingleVar`, `all.filter (containsVar x)`) are per-invocation thunks now
+  (`domCsT`, proof-carrying `VarCsIdx`), transported across drops like `TwoRootMap`. (A first
+  attempt eagerly built a per-sweep variable→bound witness map; it did ~30× the work of the old
+  early-exit scans on eth — reverted to the query-time scan. Lesson recorded below.)
+- **hintCollapse (keccak 48 s → 1.4 s)**: `witnessesOf` ran the full-system `occursOnlyInTarget`
+  scan per (constraint, variable). A per-invocation constraint-occurrence counter admits only
+  variables in exactly one constraint (a necessary condition); the certified scan runs just for
+  those — and they are the actual witnesses.
+- **flagFold/pointwiseDupDrop (keccak 109 s → ~27 s)**: `pdKeep` paid an O(n) `findIdx?` (deep
+  equality) plus a prefix `msgEqCert` scan per interaction — O(n²) certificates. `pdDropSet` now
+  computes the *same* drop set in one sweep (bucketed by the certificate's necessary invariants:
+  bus id, constant multiplicity, payload length; slot-hash + variable-Bloom pair prefilters;
+  memoized first-of-class), and the pass's predicate is `pdFastKeep drops bi || pdKeep … bi` — the
+  certified `pdKeep` re-verifies exactly the flagged drops, so `pointwiseDupDrop_correct` needed
+  only the `||`-weakening (keeping more is always sound).
+- **busUnify (keccak 45 s → ~12 s)**: `checkPair` decided the per-bus split equation per candidate
+  (O(n) deep comparison) — `candidateSplits`/`findConsumer` now carry the split by construction
+  (subtype invariants threaded through the accumulating recursion). The already-present filter
+  (`cs.algebraicConstraints.contains c` per candidate equality) compares within structural-hash
+  buckets (`Expression.structHash` moved to BusUnify for sharing).
+- **domainFold (keccak 156 s → ~100 s, apc_005 ~8 s → ~5 s)**: the covered set is computed once
+  per target and reused for the survivor filter — `groupSurvivors` re-ran the full `coveredCsOf`
+  filter per target even on the indexed path (`groupSurvivorsE es` + a `hes`-transport in
+  `foldStep`/`foldStepWith`). The no-op gate got an index-local form (`systemHasFoldableIdx`) on
+  the large-system path: an expression sharing no variable with the group can only fold at a
+  var-free compound node, so the gate = bucket-gathered sharing items + precomputed const-foldable
+  lists — exactly `systemHasFoldable`. `FoldIdx.refresh` reuses the interaction-side buckets stale
+  across accepted folds (folds map interactions in place and only shrink variable sets, so stale
+  buckets are positional supersets and the gate stays exact). `foldRewrite` is gated at expression
+  entry (`anyVarIn xs || hasConstFoldableNode` — otherwise no node qualifies), so `foldOut`'s
+  whole-system rewrite per accept skips the unrelated 95 % of expressions. And targets containing
+  a variable with *no* single-variable constraint anywhere are pruned before the covered-set scan
+  (`groupDoms` can only derive domains from single-variable constraints — exact).
+- **reencode (keccak 181 s → ~110 s, eth ≈ −20 %)**: same single-var-constraint target prefilter;
+  a hopeless-target skip in `buildReencode` (a single-var-only covered set with one constraint per
+  variable has survivors = the whole box, so `⌈log₂ box⌉ < |xs|` decides without enumerating — the
+  ubiquitous all-boolean flag groups); the freshness scan (the only O(bits × system) certificate
+  conjunct) moved to the last `&&` position so it runs only for near-accepts, plus a threaded
+  proof-carrying variable `HashSet` replaced the per-candidate `cs.vars` materialization + linear
+  membership scans (`Std.HashSet.contains_ofList` transports `contains` back to `∈ cs.vars`); and
+  the covered set uses a direct filter below the same size threshold as `domainFold` (per-target
+  bucket gather + sort of hyper-shared variables loses on flag-heavy eth blocks).
+- **domainBatch (keccak 142 s → ~105 s)**: `forcedOver`'s covered sets come from a new *unordered*
+  `coveredIdxUnord` (no per-target `mergeSort`) — every consumer is order-independent.
+
+**Working rules confirmed/added.** (1) The candidate-then-certified-recheck pattern keeps all of
+these proof-cheap: the only new proof surface is the split-by-construction lemmas, the
+`VarCsIdx`/`ByteWits`-style membership carriers, and `pointwiseDupDrop_correct`'s `||`-weakening.
+(2) *Measure early-exit behaviour before replacing a scan with an index*: the old `findVarBound`
+"O(n) rescan" was really O(first-hit) on eth; the eager witness map lost 3.7× there while the
+same map idea was right on keccak — the query-time array scan serves both. (3) This container's
+±15 % variance means per-pass eth deltas under ~1 s are noise; trust the same-runner CI A/B.
+
+Build green; `Scripts/check-proof-integrity.sh` green (the three correctness theorems still
+depend only on `{propext, Classical.choice, Quot.sound}`). Runtime leftovers (domainBatch box
+streaming / SAT-style pruning, gauss, dedup's quadratics, rootPairUnify's rescans, cross-cycle
+memoization) are recorded in `docs/ideas.md` under "Runtime leftovers". **Worked: yes.**


### PR DESCRIPTION
Cuts optimizer wall time on both benchmarks by removing per-candidate O(system) rescans and per-accept O(system) rebuilds from the six hottest passes, found by stack sampling. All changes are output-preserving by design: heuristic prefilters/indexes feed the existing certified checks, so a wrong index can cost time but never change a decision.

## Measured (this dev container; ±15 % run-to-run variance — please rely on the same-runner `Runtime Bench` CI for the authoritative A/B)

| benchmark | before | after |
|---|---|---|
| keccak (`profile`, 9 cleanup iterations) | 912 s | ~455 s (`run`: 432 s) |
| apc_005 (`profile`) | 32.2 s | 25.7 s |
| apc_006 (`profile`) | 26.6 s | 23.7 s |
| apc_012 (`profile`) | 21.7 s | 17.1 s |

**Effectiveness is unchanged**: `benchmark.py` over all 100 openvm-eth cases reproduces the documented aggregates exactly (variables 4.552×/3.887× geo, bus 3.543×/2.803× geo, per-case W/L/T 31/7/62), keccak's output is count-identical (2021 vars / 1752 bus / 186 constraints), and the documented per-case sizes (apc_034 105/22/80, apc_066 49/10/37, apc_037 690 vars) all match.

## What changed (per pass; details in `docs/log.md` entry 87)

- **busPairCancel** (keccak 117 s → ~55 s): one consolidated receive index per sweep (was per bus); split equation proven by construction from the array extracts instead of an O(n) structural decide per drop; `checkCancel` takes the scan's region tests as hypotheses instead of recomputing them; byte justification scans the shared array with the old early-exit cost instead of materializing `A ++ B ++ C` per candidate; deep-justification constraint filters hoisted to per-invocation thunks.
- **hintCollapse** (keccak 48 s → 1.4 s): per-invocation constraint-occurrence counter prefilters `witnessesOf`; the certified full-system scan runs only for single-occurrence candidates.
- **flagFold/pointwiseDupDrop** (keccak 109 s → ~27 s): one-sweep bucketed duplicate analysis (slot hashes + variable Bloom masks, memoized first-of-class) flags exactly `pdKeep`'s drop set; the pass predicate is `pdFastKeep … || pdKeep …`, so the certified check re-verifies only flagged drops.
- **busUnify** (keccak 45 s → ~12 s): candidate splits carry their split equation by construction; already-present equalities are compared within structural-hash buckets.
- **domainFold** (keccak 156 s → ~100 s; biggest eth item): covered set reused for the survivor filter (was recomputed per target); index-local no-op gate; stale-superset interaction buckets across accepted folds; `foldRewrite` gated at expression entry so per-accept whole-system rewrites skip unrelated expressions; targets with a domain-less variable pruned before any scan.
- **reencode** (keccak 181 s → ~110 s): same target prefilter; hopeless all-boolean groups decided without enumerating the box; freshness scan moved to the last certificate conjunct; threaded proof-carrying variable set replaces per-candidate `cs.vars` scans; direct covered-set filter below the size threshold.
- **domainBatch** (keccak 142 s → ~105 s): unordered covered-set variant, no per-target `mergeSort`.

No audited file is touched (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean` untouched); `lake build` and `Scripts/check-proof-integrity.sh` are green — the three correctness theorems still depend only on `{propext, Classical.choice, Quot.sound}`.

Remaining runtime levers (domainBatch box streaming / SAT-style pruning, gauss, dedup quadratics, rootPairUnify rescans, cross-cycle memoization) are recorded in `docs/ideas.md` under "Runtime leftovers".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkJ1skJ3TfyBWbGnaDzmcP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkJ1skJ3TfyBWbGnaDzmcP)_