### PR TITLE
Fix Lean tactic and document PR workflow guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,13 @@ for fewer distinct variables; break ties, and pursue variable-neutral wins, by r
 interactions and then constraints.
 
 When asked to improve the optimizer, use the `autoopt` skill.
+
+## Pushing work
+
+- All commits have to compile without warnings.
+- Changes should be committed in incremental commits if possible. Rebases are fine.
+- The agent can always open a draft PR.
+- Opening a PR triggers a CI run with benchmark results posted as a sticky comment. Agents may
+  use this to run benchmarks (e.g. when they are on constrained environments).
+- Agents should frequently check if there were any updates to main and rebase if needed, at least
+  before they open / update a PR.

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -222,7 +222,7 @@ private theorem memory_recv_nonByte_ok (busMap : Nat → Option OpenVmBusType)
     try rfl
   -- only the 6+-element case remains; `a0` is the address space, equal to `as`
   simp only [List.getElem?_cons_zero, Option.some.injEq] at has
-  push_neg at hasval
+  push Not at hasval
   obtain ⟨hne1, hne2⟩ := hasval
   have hmid : (a0.val == 1 || a0.val == 2) = false := by
     rw [has]


### PR DESCRIPTION
## Summary
This PR updates documentation for the development workflow and fixes a Lean tactic usage in the optimizer implementation.

## Changes
- **AGENTS.md**: Added "Pushing work" section documenting PR and commit guidelines for agents, including requirements for compilation without warnings, incremental commits, draft PR usage, CI/benchmark integration, and rebasing practices.
- **OpenVmFacts.lean**: Fixed deprecated `push_neg` tactic usage by replacing it with `push Not`, which is the correct modern Lean 4 syntax for negation manipulation.

## Implementation Details
The tactic change in `OpenVmFacts.lean` updates the proof in `memory_recv_nonByte_ok` to use the current Lean 4 standard library conventions. The `push Not` tactic properly handles the negation in the `hasval` hypothesis, maintaining the same logical behavior while using supported syntax.

https://claude.ai/code/session_01BNE6kCcGxQ8t4gQfZ9zaYQ