### PR TITLE
Defer tupleRange packing to the coda (fewer bus interactions)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -106,7 +106,6 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
     ("domainFold", domainFoldPass.withFacts.guardDegree),
     ("busUnify", busUnifyPass.guardDegree),
     ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass false))),
-    ("tupleRange", VerifiedPassW.guardDegree (iterateToFixpoint tupleRangePass)),
     ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
     ("reencode", reencodePass.withFacts.guardDegree) ]
@@ -123,6 +122,12 @@ def codaPasses : List (String × VerifiedPassW p) :=
     ("dedupLate", dedupPass.withFacts.guardDegree),
     ("redundantByteDrop", RedundantByteDrop.redundantByteDropPass.guardDegree),
     ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
+    -- Tuple/range packing is layout-only and does not unblock other optimizations (powdr likewise
+    -- runs global range packing once at the end), so it is deferred here out of the cleanup fixpoint
+    -- — where its own nested `iterateToFixpoint` re-ran on every cleanup cycle — to run once, after
+    -- `redundantByteDrop` has dropped droppable byte checks operand-granularly (packing a byte check
+    -- early would hide it from the drop, leaving more bus interactions).
+    ("tupleRange", VerifiedPassW.guardDegree (iterateToFixpoint tupleRangePass)),
     ("bytePackLate", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("monicScale", monicScalePass.withFacts.guardDegree),
     ("constFoldEnd", constantFoldPass.withFacts.guardDegree),


### PR DESCRIPTION
## What

Move the `tupleRange` pass out of the cleanup fixpoint and into the coda (run once), placed after `redundantByteDrop`/`subsumedRange`.

## Why

`tupleRange` packs a `(byte check, range check)` pair into one tuple-range bus interaction. Running it *inside* the cleanup fixpoint packed byte checks early — hiding them from `redundantByteDrop`, so checks that were actually droppable survived as tuple-range packs. Deferring it (mirroring powdr's "run global range packing once at the end" — layout packing does not unblock other optimizations) lets `redundantByteDrop` drop those checks operand-granularly first, and only the survivors are packed.

## Effect (wasm-eth)

**Effectiveness improves, strictly:** variables and constraints unchanged, **bus interactions down** on every affected case, **no case regresses on any axis**. Local spot-check vs this branch's merge-base:

| case | main (v, c, bus) | this PR | Δ bus |
|---|---|---|---|
| apc_007 | (258, 6, 272) | (258, 6, 174) | −98 |
| apc_004 | (238, 118, 176) | (238, 118, 146) | −30 |
| apc_005 | (184, 94, 106) | (184, 94, 92) | −14 |
| apc_019 | (53, 1, 38) | (53, 1, 36) | −2 (= powdr's bus count) |

In my full-corpus measurement on the pre-#136 base the effect was bus 13,535 → 11,661 (−13.8%), 0 regressions across all 100 cases. It also removes `tupleRange`'s nested `iterateToFixpoint` from every cleanup cycle, so the optimizer is faster on the memory-heavy blocks. The **Effectiveness Bench** / **Runtime Bench** CI will confirm the full corpus here.

## Correctness

Only the *schedule* changes — the `tupleRange` pass and its `PassCorrect` proof are untouched, so this is correct by construction. `lake build` and `Scripts/check-proof-integrity.sh` pass unchanged (the correctness theorems still depend only on `propext, Classical.choice, Quot.sound`). No change to the audited spec or the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)