### PR TITLE
Decide p.Prime once per run via PrimeWitness

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -83,29 +83,32 @@ def preludePasses : List (String × VerifiedPassW p) :=
     correctness proof follows automatically from the pass's own `PassCorrect`, and the profiler
     picks up the new label for free (it consumes this same list). -/
 def cleanupPasses : List (String × VerifiedPassW p) :=
-  [ ("zeroWidthRange", ZeroWidthRange.zeroWidthRangePass.guardDegree),
+  -- One primality decision per optimizer run, threaded to every prime-gated pass below (they read
+  -- the `Bool` in O(1) instead of re-running `decide (Nat.Prime p)` per invocation per iteration).
+  let pw := PrimeWitness.of p
+  [ ("zeroWidthRange", (ZeroWidthRange.zeroWidthRangePass pw).guardDegree),
     ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree),
-    ("carryBranch", carryBranchPass.guardDegree),
+    ("carryBranch", (carryBranchPass pw).guardDegree),
     ("gauss", gaussElimPass.withFacts.guardDegree),
     ("normalize1", normalizePass.withFacts.guardDegree),
     ("constFold1", constantFoldPass.withFacts.guardDegree),
-    ("domainBatch", domainBatchPass.guardDegree),
+    ("domainBatch", (domainBatchPass pw).guardDegree),
     ("normalize2", normalizePass.withFacts.guardDegree),
     ("constFold2", constantFoldPass.withFacts.guardDegree),
     ("zeroRegister", zeroRegisterPass.guardDegree),
     ("digitFold", DigitFold.digitFoldPass.guardDegree),
     ("oneHotAnnihilate", OneHotAnnihilate.oneHotAnnihilatePass.guardDegree),
-    ("hintCollapse", hintCollapsePass.guardDegree),
-    ("rootPairUnify", rootPairUnifyPass.guardDegree),
-    ("flagUnify", flagUnifyPass.guardDegree),
-    ("flagFold", flagFoldPass'.guardDegree),
+    ("hintCollapse", (hintCollapsePass pw).guardDegree),
+    ("rootPairUnify", (rootPairUnifyPass pw).guardDegree),
+    ("flagUnify", (flagUnifyPass pw).guardDegree),
+    ("flagFold", (flagFoldPass' pw).guardDegree),
     ("dedup", dedupPass.withFacts.guardDegree),
     ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
     ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
     ("tautoBus", tautoBusDropPass.withFacts.guardDegree),
-    ("domainFold", domainFoldPass.withFacts.guardDegree),
+    ("domainFold", (domainFoldPass pw).withFacts.guardDegree),
     ("busUnify", busUnifyPass.guardDegree),
-    ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass false))),
+    ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw false))),
     ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
     ("reencode", reencodePass.withFacts.guardDegree) ]
@@ -114,13 +117,15 @@ def cleanupPasses : List (String × VerifiedPassW p) :=
     reaches its fixpoint — drop bytes made redundant by the cleaned-up system, rescale carries to
     monic form, and one final constant-fold. -/
 def codaPasses : List (String × VerifiedPassW p) :=
-  [ ("busPairCancelLate", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass true))),
+  -- One primality decision per optimizer run (see `cleanupPasses`), for the prime-gated coda passes.
+  let pw := PrimeWitness.of p
+  [ ("busPairCancelLate", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw true))),
     -- Explode packed pair byte checks into singles so `dedupLate` collapses the same value
     -- byte-checked in several pairs and `redundantByteDrop` becomes operand-granular; the
     -- survivors are re-packed by `bytePackLate` below (a pair with nothing to shed round-trips).
     ("splitBytePair", SplitBytePair.splitBytePairPass.guardDegree),
     ("dedupLate", dedupPass.withFacts.guardDegree),
-    ("redundantByteDrop", RedundantByteDrop.redundantByteDropPass.guardDegree),
+    ("redundantByteDrop", (RedundantByteDrop.redundantByteDropPass pw).guardDegree),
     ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
     -- Tuple/range packing is layout-only and does not unblock other optimizations (powdr likewise
     -- runs global range packing once at the end), so it runs once here, out of the cleanup

--- a/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
@@ -76,6 +76,29 @@ theorem ConstraintSystem.implies_trans {a b c : ConstraintSystem p} {busSemantic
     let ⟨env'', hc, hbc⟩ := h2 env' hb
     ⟨env'', hc, BusState.equiv_trans hab hbc⟩
 
+/-! ## Precomputed primality witness
+
+`decide (Nat.Prime p)` is an expensive trial division (≈ √p steps for the field modulus). Every
+prime-gated pass needs to know whether `p` is prime, but re-deciding it once per pass invocation —
+and again on every cleanup iteration — repeats that cost dozens of times per optimizer run.
+`PrimeWitness p` computes the decision **once** (`PrimeWitness.of`) and carries the `Bool` together
+with a proof that `true` entails `Nat.Prime p`; the pipeline builds one and threads it to each
+prime-gated pass, which then branches on the `Bool` in O(1) instead of re-deciding. Purely a runtime
+optimization — the soundness proof a pass gets from `pw.correct` is the same `Nat.Prime p` it
+previously obtained from `of_decide_eq_true`. -/
+
+/-- A once-computed decision of `p`'s primality: the `Bool` result of `decide (Nat.Prime p)`
+    together with the proof that `true` entails primality. -/
+structure PrimeWitness (p : ℕ) where
+  /-- Whether `p` is prime (the result of the one expensive `decide`). -/
+  isPrime : Bool
+  /-- `isPrime = true` entails `Nat.Prime p` — the fact prime-gated passes consume. -/
+  correct : isPrime = true → Nat.Prime p
+
+/-- Compute the witness. This is the single `decide (Nat.Prime p)` per optimizer run. -/
+def PrimeWitness.of (p : ℕ) : PrimeWitness p :=
+  ⟨decide (Nat.Prime p), fun h => of_decide_eq_true h⟩
+
 /-! ## Verified passes
 
 A single optimization step, packaged with its correctness proof. `VerifiedPass` is a function

--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -381,15 +381,15 @@ theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
       exact BusState.equiv_refl _
 
 /-- The rewriter as a standalone (unguarded) pass; prime `p` re-checked at runtime. -/
-def boxRewritePass : VerifiedPass p := fun cs bs =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def boxRewritePass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     ⟨cs.boxRewrite bs, [], cs.boxRewrite_correct bs⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-- The completed composite (supersedes the `FlagFold.lean` version): substitute the XOR
     component, rewrite the over-bound survivors multilinearly, then collect the tautologies and
     pointwise duplicates. Wired under a single degree guard. -/
-def flagFoldPass' : VerifiedPassW p :=
-  fxSubstPass.andThen boxRewritePass.withFacts |>.andThen boxTautoDropPass.withFacts
-    |>.andThen pointwiseDupDropPass.withFacts
+def flagFoldPass' (pw : PrimeWitness p) : VerifiedPassW p :=
+  (fxSubstPass pw).andThen (boxRewritePass pw).withFacts |>.andThen (boxTautoDropPass pw).withFacts
+    |>.andThen (pointwiseDupDropPass pw).withFacts

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1765,10 +1765,10 @@ partial def cancelLoop (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : 
     prime `p`), or materializing it as one explicit byte check on a `byteCheck` bus already
     present in the system. Runs its own cancellation fixpoint (`cancelLoop`), so a whole access
     chain is cancelled in a single invocation. -/
-def busPairCancelPass (aggressive : Bool) : VerifiedPassW p := fun cs bs facts =>
+def busPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : VerifiedPassW p := fun cs bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
     let busIds := (cs.busInteractions.map (fun bi => bi.busId)).dedup
-    let deep : Bool := decide p.Prime
+    let deep : Bool := pw.isPrime
     -- Two-root decomposition data (address disequality), normalized-constraint index (entailed
     -- payload equality), single-variable constraints and the variable→constraints index (deep
     -- byte justification): `Thunk`s, so each is built at most once per invocation — on the
@@ -1785,6 +1785,6 @@ def busPairCancelPass (aggressive : Bool) : VerifiedPassW p := fun cs bs facts =
         fun _ hc => List.mem_of_mem_filter hc⟩
     let candsT : Thunk (VarCsIdx p cs.algebraicConstraints) :=
       Thunk.mk fun _ => VarCsIdx.build cs.algebraicConstraints
-    cancelLoop cs bs facts hp1 deep (fun h => of_decide_eq_true h) aggressive T M domCsT candsT
+    cancelLoop cs bs facts hp1 deep (fun h => pw.correct h) aggressive T M domCsT candsT
       (busIds.find? facts.byteCheck) busIds 0 0
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
@@ -268,9 +268,9 @@ theorem resolveMap_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSem
     never-vanishing factor to its other factor. Needs prime `p` (zero divisors would break the
     factoring); identity otherwise, and identity with `BusFacts.trivial` (no bounds ⇒ no
     certificate ever fires). -/
-def carryBranchPass : VerifiedPassW p := fun cs bs facts =>
-  if hp : p.Prime then
-    haveI : Fact p.Prime := ⟨hp⟩
+def carryBranchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let Bm : BoundsMap p cs bs := BoundsMap.build facts
     ⟨{ cs with algebraicConstraints := cs.algebraicConstraints.map (resolveExpr Bm.map) }, [],
       resolveMap_correct cs bs Bm⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1071,8 +1071,9 @@ def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFa
 /-- The batch finite-domain propagation pass: build the domain table once, collect every
     checked forced constant from constraints and bus obligations, substitute them all in one
     traversal. Prime `p` only (runtime-decided); identity otherwise. -/
-def domainBatchPass : VerifiedPassW p := fun cs bs facts =>
-  if hp : p.Prime then
+def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    have hp : p.Prime := pw.correct hpB
     haveI : Fact p.Prime := ⟨hp⟩
     haveI : NeZero p := ⟨hp.ne_zero⟩
     let T : DomainTable p cs bs :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -657,9 +657,9 @@ def domainFoldIndexThreshold : Nat := 8192
     the group's variables. Recovers the address-constant folding that unblocks memory chaining
     (which the re-encoder currently achieves only as a side effect). Prime `p` only; identity
     otherwise. -/
-def domainFoldPass : VerifiedPass p := fun cs bsem =>
-  if hpr : p.Prime then
-    haveI : Fact p.Prime := ⟨hpr⟩
+def domainFoldPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bsem =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     -- Domains come only from single-variable constraints (`findDomainAlg`/`rootsIn`), and a
     -- single-variable constraint is covered by every group containing its variable — so a group
     -- with a variable that has *no* single-variable constraint anywhere can never pass

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -172,9 +172,9 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
     exact ⟨(hiff env).2 hsat, hadm, BusState.equiv_refl _⟩
 
 /-- Part B as a standalone (unguarded) verified pass; prime `p` re-checked at runtime. -/
-def boxTautoDropPass : VerifiedPass p := fun cs bs =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def boxTautoDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let singles := singleVarCs cs.algebraicConstraints
     let cache : Std.HashMap Variable (Option (List (ZMod p))) :=
       (cs.algebraicConstraints.flatMap Expression.vars).eraseDups.foldl
@@ -594,9 +594,9 @@ theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
            rw [heq] at hob
            exact hob hm)
 
-def pointwiseDupDropPass : VerifiedPass p := fun cs bs =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def pointwiseDupDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let singles := singleVarCs cs.algebraicConstraints
     -- The fast sweep flags exactly `pdKeep`'s drop set; the certified `pdKeep` re-verifies each
     -- flagged drop (short-circuited away for the unflagged rest by the `||`).
@@ -962,9 +962,9 @@ def fxLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
           (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
 
 /-- Part A as a standalone (unguarded) pass: substitute every certified interpolation. -/
-def fxSubstPass : VerifiedPassW p := fun cs bs facts =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def fxSubstPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let σ := fxLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
@@ -976,5 +976,6 @@ def fxSubstPass : VerifiedPassW p := fun cs bs facts =>
     substitution creates — the boxed-out booleanity (part B) and the pointwise-duplicate scaled
     check (part C). Intermediate states exceed the degree bound by design; the composite is
     wired under a single `guardDegree`. -/
-def flagFoldPass : VerifiedPassW p :=
-  fxSubstPass.andThen boxTautoDropPass.withFacts |>.andThen pointwiseDupDropPass.withFacts
+def flagFoldPass (pw : PrimeWitness p) : VerifiedPassW p :=
+  (fxSubstPass pw).andThen (boxTautoDropPass pw).withFacts
+    |>.andThen (pointwiseDupDropPass pw).withFacts

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -446,9 +446,9 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
 /-- Flag unification across duplicate scaled range checks. Prime `p` only (re-checked at
     runtime). Runs after `rootPairUnifyPass` — the carrier limbs must already be shared — and
     before `dedupPass`, which collects the checks this pass makes syntactically identical. -/
-def flagUnifyPass : VerifiedPassW p := fun cs bs facts =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def flagUnifyPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let σ := fuLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],

--- a/ApcOptimizer/Implementation/OptimizerPasses/HintCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/HintCollapse.lean
@@ -1000,9 +1000,9 @@ def tryList [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     and the sum-of-squares (byte-bounded *difference* coefficients, `is-equal`) — sharing the
     per-constraint witness-set computation. The bounds map and the set of bus-occurring variables are
     built once here, not once per scanned constraint. -/
-def hintCollapsePass : VerifiedPassW p := fun cs bs facts =>
-  if hp : p.Prime then
-    haveI : Fact p.Prime := ⟨hp⟩
+def hintCollapsePass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let Bm : BoundsMap p cs bs := BoundsMap.build facts
     let busVars : Std.HashSet Variable := cs.busInteractions.foldl (init := ∅) fun s bi =>
       bi.payload.foldl (fun s e => e.vars.foldl (·.insert ·) s)

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -228,16 +228,17 @@ def byteDropBase (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintS
 
 /-- Keep `bi` unless it is a recognized byte check whose operands are all byte-justified from
     the constraints and the justification base. -/
-def byteDropKeep (bs : BusSemantics p) (facts : BusFacts p bs) (all : List (Expression p))
+def byteDropKeep (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (all : List (Expression p))
     (rest : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
   match byteCheckOperands? bs facts bi with
-  | some ops => !(ops.all (fun e => byteJustified (decide p.Prime) all bs facts rest e))
+  | some ops => !(ops.all (fun e => byteJustified pw.isPrime all bs facts rest e))
   | none => true
 
 /-- Drop every stateless byte-check interaction whose operands are all byte-justified from the
     parts of the system this pass can never remove. -/
-def redundantByteDropPass : VerifiedPassW p := fun cs bs facts =>
-  ⟨cs.filterBus (byteDropKeep bs facts cs.algebraicConstraints (byteDropBase bs facts cs)), [],
+def redundantByteDropPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  ⟨cs.filterBus (byteDropKeep pw bs facts cs.algebraicConstraints (byteDropBase bs facts cs)), [],
    cs.filterBusEntailed_correct bs _
      (by
        intro bi _ hkf
@@ -252,19 +253,19 @@ def redundantByteDropPass : VerifiedPassW p := fun cs bs facts =>
        | none => rw [hro] at hkf; exact absurd hkf (by simp)
        | some ops =>
          rw [hro] at hkf
-         have hjust : ops.all (fun e => byteJustified (decide p.Prime)
+         have hjust : ops.all (fun e => byteJustified pw.isPrime
              cs.algebraicConstraints bs facts (byteDropBase bs facts cs) e) = true := by
            simpa using hkf
          refine byteCheckOperands?_accepted bs facts bi ops hro env (fun e he => ?_)
-         refine byteJustified_sound (decide p.Prime) cs.algebraicConstraints bs facts
-           (byteDropBase bs facts cs) e (fun h => of_decide_eq_true h)
+         refine byteJustified_sound pw.isPrime cs.algebraicConstraints bs facts
+           (byteDropBase bs facts cs) e (fun h => pw.correct h)
            (List.all_eq_true.mp hjust e he) env
            (fun c hc => hsat.1 c hc) (fun bi' hbi' hmult => ?_)
          -- every justification-base interaction survives the filter, so `hsat` accepts it
          have hnone : byteCheckOperands? bs facts bi' = none := by
            have := (List.mem_filter.1 hbi').2
            simpa using this
-         have hkeep : byteDropKeep bs facts cs.algebraicConstraints
+         have hkeep : byteDropKeep pw bs facts cs.algebraicConstraints
              (byteDropBase bs facts cs) bi' = true := by
            unfold byteDropKeep
            rw [hnone]

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -589,9 +589,9 @@ def rpLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     `busPairCancelPass`). One sweep; the cleanup fixpoint iterates the pass, so chains resolve
     across cycles (the high limbs' root expressions become equal only after the low limbs
     unify). Solutions are bare variables, so substitution can never grow a degree. -/
-def rootPairUnifyPass : VerifiedPassW p := fun cs bs facts =>
-  if hp : (decide p.Prime) = true then
-    haveI : Fact p.Prime := ⟨of_decide_eq_true hp⟩
+def rootPairUnifyPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if hpB : pw.isPrime = true then
+    haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let σ := rpLoop cs bs facts cs.algebraicConstraints (fun _ h => h)
       cs.algebraicConstraints (fun _ h => h) [] Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ZeroWidthRange.lean
@@ -141,10 +141,10 @@ theorem rangeEq?_violates_iff (one : Bool) (hone : one = true → Nat.Prime p)
 /-- Convert every width-0 range check into the equality `value = 0`, and — on a prime field —
     every width-1 range check into the booleanity `value·(value−1) = 0`, dropping the
     interactions. -/
-def zeroWidthRangePass : VerifiedPassW p := fun cs bs facts =>
+def zeroWidthRangePass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
   if h1ne : (1 : ZMod p) ≠ 0 then
-    let one : Bool := decide (Nat.Prime p)
-    have hone : one = true → Nat.Prime p := fun h => of_decide_eq_true h
+    let one : Bool := pw.isPrime
+    have hone : one = true → Nat.Prime p := fun h => pw.correct h
     let newC := cs.busInteractions.filterMap (rangeEq? one bs facts)
     let out1 : ConstraintSystem p :=
       { cs with algebraicConstraints := cs.algebraicConstraints ++ newC }


### PR DESCRIPTION
## What

Prime-gated passes each ran `decide (Nat.Prime p)` — a trial division (~√p steps on the field modulus) — once per invocation and again on every cleanup iteration, dozens of times per optimizer run. `RedundantByteDrop` decided it per byte-check operand (super-linear).

This adds `PrimeWitness p` (the `Bool` result of the decision plus its soundness proof) to `Basic.lean`, computed **once per run** via `PrimeWitness.of`, and threads it to every prime-gated pass so each branches on an O(1) `Bool` read instead of re-deciding.

## Correctness / effectiveness

Semantically identity: `pw.isPrime ≡ decide (Nat.Prime p)` and the branches are unchanged, so **outputs are unchanged** (effectiveness-neutral). Verified on a sample against main — every case produces identical `(vars, constraints, bus)`. `lake build` and `Scripts/check-proof-integrity.sh` pass (the correctness theorems still depend only on `propext, Classical.choice, Quot.sound`); no change to the audited spec or the benchmark. The soundness a pass gets from `pw.correct` is the same `Nat.Prime p` it previously obtained from `of_decide_eq_true`.

## Runtime

Removes the repeated trial divisions. Spot-check vs main on small cases (where the fixed per-invocation cost is proportionally largest): apc_019 319→294 ms, apc_005 1056→968 ms, apc_003 248→210 ms — roughly −8..−20% on the small blocks; the big blocks (dominated by real work) are ~flat. The **Runtime Bench** CI will confirm the full corpus here.

## Note

Rebased onto current main (post-#136); the three files #136 rewrote (FlagFold/DomainFold/BusPairCancel) were resolved by keeping #136's bodies and adding only the prime gate — the two changes are orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)