### PR TITLE
Stream constraintRedundant's box enumeration (foldAll)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -741,8 +741,8 @@ def constraintRedundant {cs : ConstraintSystem p} {bs : BusSemantics p} (T : Dom
         let dec : DecidableEq (ZMod p) := inferInstance
         let add := addI.add
         let mul := mulI.mul
-        (assignments d).all (fun a => @decide (ic.evalWith add mul a = 0) (dec _ 0))
-      | none => (assignments d).all (fun a => decide (c.eval (envOfFast a) = 0))
+        foldAll d (fun a => @decide (ic.evalWith add mul a = 0) (dec _ 0))
+      | none => foldAll d (fun a => decide (c.eval (envOfFast a) = 0))
 
 /-- The single-pass box scan, after the first survivor: walk the remaining points, intersecting
     the list of `(x, c)` candidates on which every survivor seen so far agrees. The moment no

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
@@ -730,6 +730,25 @@ def assignments : List (Variable × List (ZMod p)) → List (List (Variable × Z
   | [] => [[]]
   | (x, d) :: rest => (assignments rest).flatMap (fun a => d.map (fun v => (x, v) :: a))
 
+/-- Streaming conjunction over the cartesian product: apply `P` to each assignment generated on the
+    fly (same order as `assignments`), short-circuiting on the first `false` and **never
+    materializing the product list**. Provably equal to `(assignments doms).all P` (`foldAll_eq`),
+    so it is a drop-in that only changes runtime: on a box that is quickly refuted the generation
+    stops early, and even a fully-scanned box pays no list allocation. -/
+def foldAll : List (Variable × List (ZMod p)) → (List (Variable × ZMod p) → Bool) → Bool
+  | [], P => P []
+  | (x, d) :: rest, P => foldAll rest (fun a => d.all (fun v => P ((x, v) :: a)))
+
+/-- `foldAll` computes exactly `(assignments doms).all P`. -/
+theorem foldAll_eq (doms : List (Variable × List (ZMod p)))
+    (P : List (Variable × ZMod p) → Bool) : foldAll doms P = (assignments doms).all P := by
+  induction doms generalizing P with
+  | nil => simp [foldAll, assignments]
+  | cons xd rest ih =>
+    obtain ⟨x, d⟩ := xd
+    rw [foldAll]
+    simp only [assignments, List.all_flatMap, List.all_map, Function.comp_def, ih]
+
 /-- Read an assignment as an environment (`0` for unassigned variables). -/
 def envOf : List (Variable × ZMod p) → Variable → ZMod p
   | [], _ => 0


### PR DESCRIPTION
## What

`domainBatch`'s `constraintRedundant` materialized the whole cartesian product `assignments d` (up to `maxEnumSize` = 65,536 points) before scanning it with `.all` — so a box refuted at the first point still paid the full list allocation, once per constraint, per invocation, per cleanup cycle.

This adds `foldAll` (in `DomainProp.lean`): a streaming conjunction over the product that generates each assignment on the fly, short-circuits on the first `false`, and **never builds the list**, with `foldAll_eq : foldAll doms P = (assignments doms).all P`. `constraintRedundant` now uses it.

## Correctness / effectiveness

The value is unchanged by `foldAll_eq`, so `activeCs` — and every downstream decision — is identical: purely a runtime change, **effectiveness-neutral**. Verified against main on a sample — identical `(vars, constraints, bus)` on every case. `lake build` and `Scripts/check-proof-integrity.sh` pass (correctness theorems still depend only on `propext, Classical.choice, Quot.sound`); no change to the audited spec or the benchmark.

## Runtime

Removes the wasted materialization + generates only up to the abort point. Spot-check vs main on domain-heavy blocks: apc_007 −12.7%, apc_004 −10.9%, apc_005 −8.0%, apc_010 −9.4%. On the pre-#136 baseline the full corpus was −2.5% with medium cases −10..−20%. The **Runtime Bench** CI will confirm the full corpus here.

## Independence

Independent of the `PrimeWitness` PR (#141) — touches only `DomainProp.lean` and a different part of `DomainBatch.lean`, no shared hunks, so the two merge cleanly in either order. Rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)