### PR TITLE
Runtime: tupleRange batch-drain with split-by-construction (effectiveness unchanged)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -123,11 +123,11 @@ def codaPasses : List (String × VerifiedPassW p) :=
     ("redundantByteDrop", RedundantByteDrop.redundantByteDropPass.guardDegree),
     ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
     -- Tuple/range packing is layout-only and does not unblock other optimizations (powdr likewise
-    -- runs global range packing once at the end), so it is deferred here out of the cleanup fixpoint
-    -- — where its own nested `iterateToFixpoint` re-ran on every cleanup cycle — to run once, after
-    -- `redundantByteDrop` has dropped droppable byte checks operand-granularly (packing a byte check
-    -- early would hide it from the drop, leaving more bus interactions).
-    ("tupleRange", VerifiedPassW.guardDegree (iterateToFixpoint tupleRangePass)),
+    -- runs global range packing once at the end), so it runs once here, out of the cleanup
+    -- fixpoint, after `redundantByteDrop` has dropped droppable byte checks operand-granularly
+    -- (packing a byte check early would hide it from the drop, leaving more bus interactions).
+    -- The pass drains every packable pair internally, so it needs no fixpoint wrapper.
+    ("tupleRange", tupleRangePass.guardDegree),
     ("bytePackLate", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
     ("monicScale", monicScalePass.withFacts.guardDegree),
     ("constFoldEnd", constantFoldPass.withFacts.guardDegree),

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.BusUnify
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+import ApcOptimizer.Implementation.OptimizerPasses.ListSplit
 import ApcOptimizer.Implementation.OptimizerPasses.SubstMap
 import ApcOptimizer.Implementation.MemoryBusDrop
 
@@ -1016,52 +1017,8 @@ theorem lookup_mem (I : VarCsIdx p constraints) (x : Variable) :
 
 end VarCsIdx
 
-/-! ### The split equation, by construction
-
-The scan walks the interaction *array*; a drop certificate needs the list-level split
-`cs.busInteractions = A ++ S :: B ++ R :: C`. Deciding that equation at runtime is an
-O(#interactions) deep structural comparison per accepted drop; instead it follows by
-construction from the way `A`/`B`/`C` are extracted. -/
-
-/-- A list splits at two positions into take/drop segments, nested-parenthesization form. -/
-theorem list_split_two_aux {α : Type _} {l : List α} {i j : Nat} (hij : i < j)
-    (hj : j < l.length) :
-    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
-      ((l.drop (i + 1)).take (j - (i + 1)) ++ (l[j]'hj :: l.drop (j + 1))) := by
-  have hi : i < l.length := Nat.lt_trans hij hj
-  conv_lhs => rw [← List.take_append_drop i l]
-  congr 1
-  rw [List.drop_eq_getElem_cons hi]
-  congr 1
-  conv_lhs => rw [← List.take_append_drop (j - (i + 1)) (l.drop (i + 1))]
-  congr 1
-  rw [List.drop_drop]
-  have hjj : i + 1 + (j - (i + 1)) = j := by omega
-  rw [hjj, List.drop_eq_getElem_cons hj]
-
-/-- A list splits at two positions into take/drop segments (the `A ++ S :: B ++ R :: C`
-    parenthesization the drop certificate uses). -/
-theorem list_split_two {α : Type _} {l : List α} {i j : Nat} (hij : i < j) (hj : j < l.length) :
-    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
-      (l.drop (i + 1)).take (j - (i + 1)) ++ l[j]'hj :: l.drop (j + 1) := by
-  conv_lhs => rw [list_split_two_aux hij hj]
-  simp [List.append_assoc, List.cons_append]
-
-/-- The array-extract form of `list_split_two`: the segments the scan materializes recompose to
-    the underlying list, so the split equation holds with no runtime comparison. -/
-theorem split_of_extracts {α : Type _} {l : List α} {arr : Array α}
-    (harr : arr = l.toArray) {i j : Nat} (hij : i < j) (hi : i < arr.size) {R : α}
-    (hR : arr[j]? = some R) :
-    l = (arr.extract 0 i).toList ++ arr[i] ::
-        (arr.extract (i + 1) j).toList ++ R :: (arr.extract (j + 1) arr.size).toList := by
-  subst harr
-  obtain ⟨hj, hRj⟩ := Array.getElem?_eq_some_iff.mp hR
-  have hjl : j < l.length := by simpa using hj
-  subst hRj
-  simp only [Array.toList_extract, List.extract_eq_take_drop, List.getElem_toArray,
-    List.size_toArray, List.drop_zero, Nat.sub_zero]
-  rw [List.take_of_length_le (l := l.drop (j + 1)) (by simp)]
-  exact list_split_two hij hjl
+/- The split-equation-by-construction lemmas (`list_split_two`, `split_of_extracts`) live in
+`ListSplit.lean`, shared with `TupleRange`. -/
 
 /-! ### Constraint-entailed payload matching
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
@@ -1,0 +1,51 @@
+import ApcOptimizer.Implementation.OptimizerPasses.Basic
+
+set_option autoImplicit false
+
+/-! # The split equation, by construction
+
+A pass that scans the interaction *array* and certifies a swap/drop needs the list-level split
+`cs.busInteractions = A ++ S :: B ++ R :: C`. Deciding that equation at runtime is an
+O(#interactions) deep structural comparison per accepted change; instead it follows by
+construction from the way `A`/`B`/`C` are extracted. Shared by `BusPairCancel` and
+`TupleRange`. -/
+
+/-- A list splits at two positions into take/drop segments, nested-parenthesization form. -/
+theorem list_split_two_aux {α : Type _} {l : List α} {i j : Nat} (hij : i < j)
+    (hj : j < l.length) :
+    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
+      ((l.drop (i + 1)).take (j - (i + 1)) ++ (l[j]'hj :: l.drop (j + 1))) := by
+  have hi : i < l.length := Nat.lt_trans hij hj
+  conv_lhs => rw [← List.take_append_drop i l]
+  congr 1
+  rw [List.drop_eq_getElem_cons hi]
+  congr 1
+  conv_lhs => rw [← List.take_append_drop (j - (i + 1)) (l.drop (i + 1))]
+  congr 1
+  rw [List.drop_drop]
+  have hjj : i + 1 + (j - (i + 1)) = j := by omega
+  rw [hjj, List.drop_eq_getElem_cons hj]
+
+/-- A list splits at two positions into take/drop segments (the `A ++ S :: B ++ R :: C`
+    parenthesization the drop certificate uses). -/
+theorem list_split_two {α : Type _} {l : List α} {i j : Nat} (hij : i < j) (hj : j < l.length) :
+    l = l.take i ++ l[i]'(Nat.lt_trans hij hj) ::
+      (l.drop (i + 1)).take (j - (i + 1)) ++ l[j]'hj :: l.drop (j + 1) := by
+  conv_lhs => rw [list_split_two_aux hij hj]
+  simp [List.append_assoc, List.cons_append]
+
+/-- The array-extract form of `list_split_two`: the segments the scan materializes recompose to
+    the underlying list, so the split equation holds with no runtime comparison. -/
+theorem split_of_extracts {α : Type _} {l : List α} {arr : Array α}
+    (harr : arr = l.toArray) {i j : Nat} (hij : i < j) (hi : i < arr.size) {R : α}
+    (hR : arr[j]? = some R) :
+    l = (arr.extract 0 i).toList ++ arr[i] ::
+        (arr.extract (i + 1) j).toList ++ R :: (arr.extract (j + 1) arr.size).toList := by
+  subst harr
+  obtain ⟨hj, hRj⟩ := Array.getElem?_eq_some_iff.mp hR
+  have hjl : j < l.length := by simpa using hj
+  subst hRj
+  simp only [Array.toList_extract, List.extract_eq_take_drop, List.getElem_toArray,
+    List.size_toArray, List.drop_zero, Nat.sub_zero]
+  rw [List.take_of_length_le (l := l.drop (j + 1)) (by simp)]
+  exact list_split_two hij hjl

--- a/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.BytePack
+import ApcOptimizer.Implementation.OptimizerPasses.ListSplit
 
 set_option autoImplicit false
 
@@ -15,8 +16,11 @@ All three table equivalences are proven `BusFacts` fields (`byteCheck`, `varRang
 `tupleRangeBus`, discharged for OpenVM in `ApcOptimizer/Implementation/OpenVmFacts.lean`); the pass is
 VM-agnostic and degrades to a no-op under `BusFacts.trivial`. The target tuple bus typically has
 *no* interactions in the input circuit, so its id cannot be read off `cs` — the pass probes the
-fact function over a bounded id range instead. One pair is packed per invocation;
-`iterateToFixpoint` drains them (the bus length strictly drops by one each time).
+fact function over a bounded id range instead. All packable pairs are drained in **one**
+invocation (the internal loop recurses on the strictly-dropping interaction count), and each
+accepted pack's split equation `cs.busInteractions = pre ++ D₁ :: mid ++ D₂ :: post` holds by
+construction from the array extracts (`split_of_extracts`, as in `BusPairCancel`) rather than by
+an O(#interactions) deep structural comparison per accept.
 
 The correctness core (`mergeStateless2_correct`) is stated for *any* stateless two-for-one swap
 whose replacement carries the conjunction of the replaced obligations — the byte-pair packing of
@@ -195,7 +199,7 @@ theorem tupleKey (bs : BusSemantics p) (facts : BusFacts p bs)
   · rintro ⟨hx, hy⟩; exact ⟨hx, hble, hy⟩
   · rintro ⟨hx, -, hy⟩; exact ⟨hx, hy⟩
 
-/-! ## The pass: find and pack one (byte, range) pair per invocation -/
+/-! ## The pass: find and pack every (byte, range) pair in one invocation -/
 
 /-- If `bi` is a single-value byte check `[e, e, 0, 1]` (multiplicity `1`) on a `byteCheck`
     bus, return the checked value. -/
@@ -231,147 +235,300 @@ def tupleBusCandidates {bs : BusSemantics p} (facts : BusFacts p bs) (maxId : Na
     | some (s1, s2) => if s1 = 256 then some (k, s1, s2) else none
     | none => none)
 
-/-- Scan for the complementary partner: given the first element's kind, find the second and
-    return `(mid, second, post)`-style data. `which = true` looks for a range check (the first
-    element was a byte check); `which = false` looks for a byte check. -/
-def findPartner {bs : BusSemantics p} (facts : BusFacts p bs) (s2 : Nat) (which : Bool) :
-    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p)) →
-    Option (List (BusInteraction (Expression p)) × BusInteraction (Expression p) ×
-      List (BusInteraction (Expression p)))
-  | _, [] => none
-  | revMid, b :: rest =>
-    if which then
-      match matchRangeCheck facts s2 b with
-      | some _ => some (revMid.reverse, b, rest)
-      | none => findPartner facts s2 which (b :: revMid) rest
-    else
-      match matchByteSingle facts b with
-      | some _ => some (revMid.reverse, b, rest)
-      | none => findPartner facts s2 which (b :: revMid) rest
+/-! ## Matcher soundness: a successful match pins the canonical shape by construction -/
 
-/-- Try to pack, for one tuple bus `(trBus, s1, s2)`, the first (byte, range) or (range, byte)
-    pair. The split equation and every fact are re-verified for the chosen candidate. -/
-def findTuplePackGo (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+/-- A `matchByteSingle` hit *is* the canonical single-value byte check — the accepted split
+    equation follows with no runtime comparison. -/
+theorem matchByteSingle_eq {bs : BusSemantics p} {facts : BusFacts p bs}
+    {bi : BusInteraction (Expression p)} {x : Expression p}
+    (h : matchByteSingle facts bi = some x) :
+    bi = byteCheck1 bi.busId x ∧ facts.byteCheck bi.busId = true := by
+  obtain ⟨busId, mult, payload⟩ := bi
+  simp only [matchByteSingle] at h
+  split at h
+  · rename_i hbc
+    split at h
+    · rename_i c e e' z op
+      split at h
+      · rename_i hcond
+        simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+        obtain ⟨⟨⟨rfl, rfl⟩, rfl⟩, rfl⟩ := hcond
+        cases h
+        exact ⟨rfl, hbc⟩
+      · cases h
+    · cases h
+  · cases h
+
+/-- A `matchRangeCheck` hit *is* the canonical range check, and carries the width facts the
+    packing key needs. -/
+theorem matchRangeCheck_eq {bs : BusSemantics p} {facts : BusFacts p bs} {s2 : Nat}
+    {bi : BusInteraction (Expression p)} {y : Expression p} {b : ZMod p}
+    (h : matchRangeCheck facts s2 bi = some (y, b)) :
+    bi = rangeCheck1 bi.busId y (.const b) ∧ facts.varRangeBus bi.busId = true ∧
+      b.val ≤ 25 ∧ 2 ^ b.val = s2 := by
+  obtain ⟨busId, mult, payload⟩ := bi
+  simp only [matchRangeCheck] at h
+  split at h
+  · rename_i hvr
+    split at h
+    · rename_i c y' b'
+      split at h
+      · rename_i hcond
+        simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+        obtain ⟨⟨rfl, hble⟩, hs2⟩ := hcond
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        obtain ⟨rfl, rfl⟩ := h
+        exact ⟨rfl, hvr, hble, hs2⟩
+      · cases h
+    · cases h
+  · cases h
+
+/-! ## Indexed partner scans -/
+
+/-- First position `≥ i` holding an exact-size range check, with its data and the matching
+    fact (the enclosing scan turns the position into a split equation by construction). -/
+def findRangeIdx {bs : BusSemantics p} (facts : BusFacts p bs) (s2 : Nat)
+    (arr : Array (BusInteraction (Expression p))) (i : Nat) :
+    Option ((j : Nat) ×' (y : Expression p) ×' (b : ZMod p) ×'
+      (i ≤ j ∧ ∃ hj : j < arr.size, matchRangeCheck facts s2 arr[j] = some (y, b))) :=
+  if hi : i < arr.size then
+    match hm : matchRangeCheck facts s2 arr[i] with
+    | some (y, b) => some ⟨i, y, b, Nat.le_refl i, hi, hm⟩
+    | none =>
+      match findRangeIdx facts s2 arr (i + 1) with
+      | some ⟨j, y, b, h⟩ => some ⟨j, y, b, Nat.le_of_succ_le h.1, h.2⟩
+      | none => none
+  else none
+  termination_by arr.size - i
+
+/-- First position `≥ i` holding a single-value byte check, with its data and the matching
+    fact. -/
+def findByteIdx {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p))) (i : Nat) :
+    Option ((j : Nat) ×' (x : Expression p) ×'
+      (i ≤ j ∧ ∃ hj : j < arr.size, matchByteSingle facts arr[j] = some x)) :=
+  if hi : i < arr.size then
+    match hm : matchByteSingle facts arr[i] with
+    | some x => some ⟨i, x, Nat.le_refl i, hi, hm⟩
+    | none =>
+      match findByteIdx facts arr (i + 1) with
+      | some ⟨j, x, h⟩ => some ⟨j, x, Nat.le_of_succ_le h.1, h.2⟩
+      | none => none
+  else none
+  termination_by arr.size - i
+
+/-! ## The accept certificates (one per pair orientation) -/
+
+/-- Packing a byte check (first) with a range check (second) into a tuple check is
+    `PassCorrect`, given the canonical split equation and the matched facts. -/
+theorem packByteFirst_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) (trBus s1 s2 bcBus vrBus : Nat)
+    (htr : facts.tupleRangeBus trBus = some (s1, s2)) (hs1 : s1 = 256)
+    (x y : Expression p) (b : ZMod p)
+    (hbc : facts.byteCheck bcBus = true) (hvr : facts.varRangeBus vrBus = true)
+    (hble : b.val ≤ 25) (hs2 : 2 ^ b.val = s2)
+    (pre mid post : List (BusInteraction (Expression p)))
+    (hsplit : cs.busInteractions
+      = pre ++ byteCheck1 bcBus x :: mid ++ rangeCheck1 vrBus y (.const b) :: post) :
+    PassCorrect cs
+      { cs with busInteractions := pre ++ tupleCheck trBus x y :: mid ++ post } [] bs := by
+  obtain ⟨hstT, hbrkT, -⟩ := facts.tupleRangeBus_sound trBus s1 s2 htr
+  obtain ⟨hstB, -, -⟩ := facts.byteCheck_sound bcBus hbc
+  obtain ⟨hstR, -⟩ := facts.varRangeBus_sound vrBus hvr
+  refine mergeStateless2_correct cs bs hp1
+    (byteCheck1 bcBus x) (rangeCheck1 vrBus y (.const b))
+    (tupleCheck trBus x y) hstB hstR hstT rfl rfl rfl
+    (tupleKey bs facts bcBus vrBus trBus s1 s2 hbc hvr htr hs1 b hble hs2 x y)
+    (fun env => by rw [tupleCheck_eval]; exact hbrkT (x.eval env) (y.eval env))
+    ?_ pre mid post hsplit
+  intro v hv
+  rw [BusInteraction.vars, List.mem_append] at hv
+  rcases hv with hm | he
+  · exact absurd hm (by
+      rw [show (tupleCheck trBus x y).multiplicity.vars = [] from rfl]; simp)
+  · obtain ⟨e, he', hve⟩ := List.mem_flatMap.1 he
+    have : e = x ∨ e = y := by simpa [tupleCheck] using he'
+    rcases this with rfl | rfl
+    · exact Or.inl (by
+        rw [BusInteraction.vars, List.mem_append]
+        exact Or.inr (List.mem_flatMap.2 ⟨e, by
+          show e ∈ [e, e, Expression.const 0, Expression.const 1]
+          exact List.mem_cons_self .., hve⟩))
+    · exact Or.inr (by
+        rw [BusInteraction.vars, List.mem_append]
+        exact Or.inr (List.mem_flatMap.2 ⟨e, by
+          show e ∈ [e, Expression.const b]
+          exact List.mem_cons_self .., hve⟩))
+
+/-- Packing a range check (first) with a byte check (second) into a tuple check is
+    `PassCorrect` — the mirrored orientation. -/
+theorem packRangeFirst_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) (trBus s1 s2 bcBus vrBus : Nat)
+    (htr : facts.tupleRangeBus trBus = some (s1, s2)) (hs1 : s1 = 256)
+    (x y : Expression p) (b : ZMod p)
+    (hbc : facts.byteCheck bcBus = true) (hvr : facts.varRangeBus vrBus = true)
+    (hble : b.val ≤ 25) (hs2 : 2 ^ b.val = s2)
+    (pre mid post : List (BusInteraction (Expression p)))
+    (hsplit : cs.busInteractions
+      = pre ++ rangeCheck1 vrBus y (.const b) :: mid ++ byteCheck1 bcBus x :: post) :
+    PassCorrect cs
+      { cs with busInteractions := pre ++ tupleCheck trBus x y :: mid ++ post } [] bs := by
+  obtain ⟨hstT, hbrkT, -⟩ := facts.tupleRangeBus_sound trBus s1 s2 htr
+  obtain ⟨hstB, -, -⟩ := facts.byteCheck_sound bcBus hbc
+  obtain ⟨hstR, -⟩ := facts.varRangeBus_sound vrBus hvr
+  refine mergeStateless2_correct cs bs hp1
+    (rangeCheck1 vrBus y (.const b)) (byteCheck1 bcBus x)
+    (tupleCheck trBus x y) hstR hstB hstT rfl rfl rfl
+    (fun env => by
+      rw [tupleKey bs facts bcBus vrBus trBus s1 s2 hbc hvr htr hs1 b hble hs2 x y env]
+      exact and_comm)
+    (fun env => by rw [tupleCheck_eval]; exact hbrkT (x.eval env) (y.eval env))
+    ?_ pre mid post hsplit
+  intro v hv
+  rw [BusInteraction.vars, List.mem_append] at hv
+  rcases hv with hm | he
+  · exact absurd hm (by
+      rw [show (tupleCheck trBus x y).multiplicity.vars = [] from rfl]; simp)
+  · obtain ⟨e, he', hve⟩ := List.mem_flatMap.1 he
+    have : e = x ∨ e = y := by simpa [tupleCheck] using he'
+    rcases this with rfl | rfl
+    · exact Or.inr (by
+        rw [BusInteraction.vars, List.mem_append]
+        exact Or.inr (List.mem_flatMap.2 ⟨e, by
+          show e ∈ [e, e, Expression.const 0, Expression.const 1]
+          exact List.mem_cons_self .., hve⟩))
+    · exact Or.inl (by
+        rw [BusInteraction.vars, List.mem_append]
+        exact Or.inr (List.mem_flatMap.2 ⟨e, by
+          show e ∈ [e, Expression.const b]
+          exact List.mem_cons_self .., hve⟩))
+
+/-- Indexed left-to-right scan for the first packable pair for tuple bus `trBus`, starting at
+    position `i`: at each position, a byte check looks right for the first exact-size range
+    check, a range check looks right for the first byte check. The split equation holds by
+    construction (`split_of_extracts`) rather than by an O(#interactions) whole-list
+    comparison, and the result carries the strict interaction-count decrease the drain loop
+    recurses on. -/
+def findTuplePackIdx (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (trBus s1 s2 : Nat)
-    (revPre : List (BusInteraction (Expression p))) :
-    List (BusInteraction (Expression p)) → Option (PassResult cs bs)
-  | [] => none
-  | a :: rest =>
-    let next := fun (_ : Unit) => findTuplePackGo cs bs facts hp1 trBus s1 s2 (a :: revPre) rest
-    match matchByteSingle facts a with
+    (htr : facts.tupleRangeBus trBus = some (s1, s2)) (hs1 : s1 = 256)
+    (arr : Array (BusInteraction (Expression p)))
+    (harr : arr = cs.busInteractions.toArray) (i : Nat) :
+    Option ((r : PassResult cs bs) ×'
+      r.out.busInteractions.length < cs.busInteractions.length) :=
+  if hi : i < arr.size then
+    let next := fun (_ : Unit) =>
+      findTuplePackIdx cs bs facts hp1 trBus s1 s2 htr hs1 arr harr (i + 1)
+    match hmb : matchByteSingle facts arr[i] with
     | some x =>
-      match findPartner facts s2 true [] rest with
-      | some (mid, second, post) =>
-        match matchRangeCheck facts s2 second with
-        | some (y, b) =>
-          if hfacts : facts.byteCheck a.busId = true ∧ facts.varRangeBus second.busId = true
-              ∧ facts.tupleRangeBus trBus = some (s1, s2) ∧ s1 = 256
-              ∧ (b.val ≤ 25) ∧ (2 ^ b.val = s2) then
-            if hsplit : cs.busInteractions = revPre.reverse ++ byteCheck1 a.busId x :: mid
-                ++ rangeCheck1 second.busId y (.const b) :: post then
-              some ⟨{ cs with busInteractions :=
-                        revPre.reverse ++ tupleCheck trBus x y :: mid ++ post }, [],
-                    by
-                      obtain ⟨hbc, hvr, htr, hs1, hble, hs2⟩ := hfacts
-                      obtain ⟨hstT, hbrkT, -⟩ := facts.tupleRangeBus_sound trBus s1 s2 htr
-                      obtain ⟨hstB, -, -⟩ := facts.byteCheck_sound a.busId hbc
-                      obtain ⟨hstR, -⟩ := facts.varRangeBus_sound second.busId hvr
-                      refine mergeStateless2_correct cs bs hp1
-                        (byteCheck1 a.busId x) (rangeCheck1 second.busId y (.const b))
-                        (tupleCheck trBus x y) hstB hstR hstT rfl rfl rfl
-                        (tupleKey bs facts a.busId second.busId trBus s1 s2 hbc hvr htr hs1 b
-                          hble hs2 x y)
-                        (fun env => by rw [tupleCheck_eval]; exact hbrkT (x.eval env) (y.eval env))
-                        ?_ revPre.reverse mid post hsplit
-                      intro v hv
-                      rw [BusInteraction.vars, List.mem_append] at hv
-                      rcases hv with hm | he
-                      · exact absurd hm (by
-                          rw [show (tupleCheck trBus x y).multiplicity.vars = [] from rfl]; simp)
-                      · obtain ⟨e, he', hve⟩ := List.mem_flatMap.1 he
-                        have : e = x ∨ e = y := by simpa [tupleCheck] using he'
-                        rcases this with rfl | rfl
-                        · exact Or.inl (by
-                            rw [BusInteraction.vars, List.mem_append]
-                            exact Or.inr (List.mem_flatMap.2 ⟨e, by
-                              show e ∈ [e, e, Expression.const 0, Expression.const 1]
-                              exact List.mem_cons_self .., hve⟩))
-                        · exact Or.inr (by
-                            rw [BusInteraction.vars, List.mem_append]
-                            exact Or.inr (List.mem_flatMap.2 ⟨e, by
-                              show e ∈ [e, Expression.const b]
-                              exact List.mem_cons_self .., hve⟩))⟩
-            else next ()
-          else next ()
+      match findRangeIdx facts s2 arr (i + 1) with
+      | some ⟨j, y, b, hj⟩ =>
+        match hR : arr[j]? with
+        | some R =>
+          have hij : i < j := Nat.lt_of_succ_le hj.1
+          have hmr : matchRangeCheck facts s2 R = some (y, b) := by
+            obtain ⟨hjs, hm⟩ := hj.2
+            rw [Array.getElem?_eq_getElem hjs, Option.some.injEq] at hR
+            exact hR ▸ hm
+          have hbe := matchByteSingle_eq (facts := facts) hmb
+          have hre := matchRangeCheck_eq (facts := facts) hmr
+          have hsplit : cs.busInteractions
+              = (arr.extract 0 i).toList ++ byteCheck1 (arr[i]).busId x ::
+                (arr.extract (i + 1) j).toList
+                ++ rangeCheck1 R.busId y (.const b) :: (arr.extract (j + 1) arr.size).toList := by
+            have h0 := split_of_extracts harr hij hi hR
+            rw [hbe.1, hre.1] at h0
+            exact h0
+          have hlt : ((arr.extract 0 i).toList ++ tupleCheck trBus x y ::
+              (arr.extract (i + 1) j).toList ++ (arr.extract (j + 1) arr.size).toList).length
+              < cs.busInteractions.length := by
+            rw [hsplit]
+            simp only [List.length_append, List.length_cons]
+            omega
+          some ⟨⟨{ cs with busInteractions :=
+                    (arr.extract 0 i).toList ++ tupleCheck trBus x y ::
+                    (arr.extract (i + 1) j).toList ++ (arr.extract (j + 1) arr.size).toList },
+                 [],
+                 packByteFirst_correct cs bs facts hp1 trBus s1 s2 (arr[i]).busId R.busId
+                   htr hs1 x y b hbe.2 hre.2.1 hre.2.2.1 hre.2.2.2 _ _ _ hsplit⟩,
+               hlt⟩
         | none => next ()
       | none => next ()
     | none =>
-      match matchRangeCheck facts s2 a with
+      match hmrf : matchRangeCheck facts s2 arr[i] with
       | some (y, b) =>
-        match findPartner facts s2 false [] rest with
-        | some (mid, second, post) =>
-          match matchByteSingle facts second with
-          | some x =>
-            if hfacts : facts.byteCheck second.busId = true ∧ facts.varRangeBus a.busId = true
-                ∧ facts.tupleRangeBus trBus = some (s1, s2) ∧ s1 = 256
-                ∧ (b.val ≤ 25) ∧ (2 ^ b.val = s2) then
-              if hsplit : cs.busInteractions = revPre.reverse
-                  ++ rangeCheck1 a.busId y (.const b) :: mid
-                  ++ byteCheck1 second.busId x :: post then
-                some ⟨{ cs with busInteractions :=
-                          revPre.reverse ++ tupleCheck trBus x y :: mid ++ post }, [],
-                      by
-                        obtain ⟨hbc, hvr, htr, hs1, hble, hs2⟩ := hfacts
-                        obtain ⟨hstT, hbrkT, -⟩ := facts.tupleRangeBus_sound trBus s1 s2 htr
-                        obtain ⟨hstB, -, -⟩ := facts.byteCheck_sound second.busId hbc
-                        obtain ⟨hstR, -⟩ := facts.varRangeBus_sound a.busId hvr
-                        refine mergeStateless2_correct cs bs hp1
-                          (rangeCheck1 a.busId y (.const b)) (byteCheck1 second.busId x)
-                          (tupleCheck trBus x y) hstR hstB hstT rfl rfl rfl
-                          (fun env => by
-                            rw [tupleKey bs facts second.busId a.busId trBus s1 s2 hbc hvr htr
-                              hs1 b hble hs2 x y env]
-                            exact and_comm)
-                          (fun env => by
-                            rw [tupleCheck_eval]; exact hbrkT (x.eval env) (y.eval env))
-                          ?_ revPre.reverse mid post hsplit
-                        intro v hv
-                        rw [BusInteraction.vars, List.mem_append] at hv
-                        rcases hv with hm | he
-                        · exact absurd hm (by
-                            rw [show (tupleCheck trBus x y).multiplicity.vars = [] from rfl]
-                            simp)
-                        · obtain ⟨e, he', hve⟩ := List.mem_flatMap.1 he
-                          have : e = x ∨ e = y := by simpa [tupleCheck] using he'
-                          rcases this with rfl | rfl
-                          · exact Or.inr (by
-                              rw [BusInteraction.vars, List.mem_append]
-                              exact Or.inr (List.mem_flatMap.2 ⟨e, by
-                                show e ∈ [e, e, Expression.const 0, Expression.const 1]
-                                exact List.mem_cons_self .., hve⟩))
-                          · exact Or.inl (by
-                              rw [BusInteraction.vars, List.mem_append]
-                              exact Or.inr (List.mem_flatMap.2 ⟨e, by
-                                show e ∈ [e, Expression.const b]
-                                exact List.mem_cons_self .., hve⟩))⟩
-              else next ()
-            else next ()
+        match findByteIdx facts arr (i + 1) with
+        | some ⟨j, x, hj⟩ =>
+          match hR : arr[j]? with
+          | some R =>
+            have hij : i < j := Nat.lt_of_succ_le hj.1
+            have hmb2 : matchByteSingle facts R = some x := by
+              obtain ⟨hjs, hm⟩ := hj.2
+              rw [Array.getElem?_eq_getElem hjs, Option.some.injEq] at hR
+              exact hR ▸ hm
+            have hre := matchRangeCheck_eq (facts := facts) hmrf
+            have hbe := matchByteSingle_eq (facts := facts) hmb2
+            have hsplit : cs.busInteractions
+                = (arr.extract 0 i).toList ++ rangeCheck1 (arr[i]).busId y (.const b) ::
+                  (arr.extract (i + 1) j).toList
+                  ++ byteCheck1 R.busId x :: (arr.extract (j + 1) arr.size).toList := by
+              have h0 := split_of_extracts harr hij hi hR
+              rw [hre.1, hbe.1] at h0
+              exact h0
+            have hlt : ((arr.extract 0 i).toList ++ tupleCheck trBus x y ::
+                (arr.extract (i + 1) j).toList ++ (arr.extract (j + 1) arr.size).toList).length
+                < cs.busInteractions.length := by
+              rw [hsplit]
+              simp only [List.length_append, List.length_cons]
+              omega
+            some ⟨⟨{ cs with busInteractions :=
+                      (arr.extract 0 i).toList ++ tupleCheck trBus x y ::
+                      (arr.extract (i + 1) j).toList ++ (arr.extract (j + 1) arr.size).toList },
+                   [],
+                   packRangeFirst_correct cs bs facts hp1 trBus s1 s2 R.busId (arr[i]).busId
+                     htr hs1 x y b hbe.2 hre.2.1 hre.2.2.1 hre.2.2.2 _ _ _ hsplit⟩,
+                 hlt⟩
           | none => next ()
         | none => next ()
       | none => next ()
+  else none
+  termination_by arr.size - i
 
-/-- Pack one byte check and one exact-width range check into a tuple check, for the first
-    declared tuple bus that fits. `iterateToFixpoint` drains all packable pairs. -/
+/-- Try each candidate tuple bus in order (the order the fixpoint-wrapped single-pack pass
+    observed): the first bus with a packable pair wins. The candidate facts are re-established
+    once per bus, so the packing scan itself carries no runtime fact decides. -/
+def tryTupleBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) (arr : Array (BusInteraction (Expression p)))
+    (harr : arr = cs.busInteractions.toArray) :
+    List (Nat × Nat × Nat) →
+    Option ((r : PassResult cs bs) ×'
+      r.out.busInteractions.length < cs.busInteractions.length)
+  | [] => none
+  | (trBus, s1, s2) :: rest =>
+    if h : facts.tupleRangeBus trBus = some (s1, s2) ∧ s1 = 256 then
+      match findTuplePackIdx cs bs facts hp1 trBus s1 s2 h.1 h.2 arr harr 0 with
+      | some r => some r
+      | none => tryTupleBuses cs bs facts hp1 arr harr rest
+    else tryTupleBuses cs bs facts hp1 arr harr rest
+
+/-- Drain every packable pair: pack the first (bus-major, then position-major) pair, recompute
+    the candidate buses on the shrunken system, repeat. One invocation replaces the enclosing
+    per-pair fixpoint — and its two full-system size recomputations per drained pair.
+    Terminates because every pack strictly drops the interaction count. -/
+def drainTuplePacks (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (hp1 : (1 : ZMod p) ≠ 0) : PassResult cs bs :=
+  let maxId := (cs.busInteractions.map (fun bi => bi.busId)).foldl max 0 + 65
+  match tryTupleBuses cs bs facts hp1 cs.busInteractions.toArray rfl
+      (tupleBusCandidates facts maxId) with
+  | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  | some ⟨r, _hlt⟩ =>
+    let r2 := drainTuplePacks r.out bs facts hp1
+    ⟨r2.out, r.derivs ++ r2.derivs, r.correct.andThen r2.correct⟩
+  termination_by cs.busInteractions.length
+  decreasing_by exact _hlt
+
+/-- Pack byte checks and exact-width range checks into tuple checks, draining every packable
+    pair in one invocation. -/
 def tupleRangePass : VerifiedPassW p := fun cs bs facts =>
-  if hp1 : (1 : ZMod p) ≠ 0 then
-    let maxId := (cs.busInteractions.map (fun bi => bi.busId)).foldl max 0 + 65
-    let rec tryBuses : List (Nat × Nat × Nat) → Option (PassResult cs bs)
-      | [] => none
-      | (trBus, s1, s2) :: rest =>
-        match findTuplePackGo cs bs facts hp1 trBus s1 s2 [] cs.busInteractions with
-        | some r => some r
-        | none => tryBuses rest
-    match tryBuses (tupleBusCandidates facts maxId) with
-    | some r => r
-    | none => ⟨cs, [], PassCorrect.refl cs bs⟩
+  if hp1 : (1 : ZMod p) ≠ 0 then drainTuplePacks cs bs facts hp1
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -398,3 +398,52 @@ state; every item is output-preserving unless noted):
   `VerifiedPassW` threading an opaque cache blob validated by cheap hashes) would cut the
   steady-state tail of *every* pass at once; needs a framework change in
   `Implementation/OptimizerPasses/Basic.lean`'s glue, so weigh against the audit-surface rule.
+
+## Runtime leftovers II (generated-C audit of the wasm-eth heavy cases)
+
+Reading the compiled C (`.lake/build/ir/`) plus a flat `perf` profile of wasm-eth `apc_012`
+(435 s at entry-90 state) shows ~40 % of big-case runtime is heap churn (`lean_dec_ref_cold`
+19.7 %, allocator 14.8 %, `List.reverseAux` copying 4.8 %), with `Variable` equality at 10.3 %.
+Pass ranking there: gauss 98 s, tupleRange 96 s (**taken — see the batch-drain entry**),
+busPairCancel 52 s, rootPairUnify 51 s, domainBatch 34 s. Levers not yet taken, in value order
+(all output-preserving unless noted):
+
+- **ZMod instance reconstruction per scalar op**: e.g. `addCoeff`'s merge branch compiles to
+  `ZMod.commRing p` → three structure projections → `lean_apply_2` **per field addition**; 400+
+  such construction sites across the pass C files. BabyBear values keep even products inside
+  Lean's tagged-scalar Nat range, so the arithmetic is nearly free — the whole cost is
+  dictionary building + dispatch. Fix: extend `IExpr.evalWith`'s hoisted-ops pattern
+  (DomainBatch) to `addCoeff`/`mergeTerms`/`linearize` and other hot arithmetic, or `@[csimp]`
+  fast ZMod ops compiling to direct `Nat` add/mod.
+- **gauss reduces every constraint unconditionally**: `pending = cs ++ cs` — each constraint
+  pays `substF` (full tree copy; shared nodes defeat ctor reuse) + `normalize` (quadratic
+  `addCoeff` merge) twice per invocation even when the solution map is empty or disjoint from
+  the constraint. Fix: solved-vars mention prefilter (HashSet), plus a var → dependent-solutions
+  index instead of `σ.map.toList.filter` per accepted pivot.
+- **rootPairUnify quadratic seen-join**: `rpLoop` probes `seen.findSome?` per candidate with
+  deep key comparison (`e.key == xk.2` compares full term lists); `seen` grows over the sweep.
+  Fix: hash-bucket `seen` by key hash (the `Expression.structHash` precedent from BusUnify).
+  Also `rpCandidates` runs `c.vars.eraseDups` (quadratic, string-compare equality) per
+  constraint, and a `ZMod` inverse per candidate.
+- **`sizeKey`/`varCount` ≈ 7.6 % of the run**: `Expression.vars` compiles to a per-node
+  `List.appendTR` (copies the whole left sublist — O(size × depth) cons allocations), then
+  `varCount` string-hashes every occurrence; `iterateToFixpoint` recomputes the key twice per
+  step (the previous step already computed it). Fix: fold the tree straight into the `HashSet`
+  and thread the computed key through the recursion.
+- **Variable identity ≈ 12 %**: the parser creates a fresh `String` per occurrence (~340 k
+  occurrences / ~17.5 k distinct on `apc_012`, names avg 24 chars with long shared prefixes),
+  so `lean_string_eq`'s pointer fast path never fires; every hash walks the full string; and
+  the derived `DecidableEq Variable` allocates a closure per names-equal comparison (generic
+  `Option Nat` dispatch — visible in `Spec.c`). Fix: intern variables in the parser
+  (`HashMap String Variable` pool; Implementation-only). A hand-written `DecidableEq Variable`
+  or a dense-id representation would also help but touches `Spec.lean` (audited).
+- **Runtime `decide p.Prime` per invocation** in flagFold (×3 entry points), flagUnify,
+  rootPairUnify, busPairCancel — trial division (`Nat.minFacAux`, ~22 k steps for babyBear);
+  in redundantByteDrop the decide sits **inside the per-element lambda**
+  (`ops.all (fun e => byteJustified (decide p.Prime) …)`). Dominates the small-APC tail. Fix:
+  hoist out of the lambda; longer-term decide once at pipeline entry and thread the result.
+- **flagFold derive-and-discard**: the box-constraint predicate recomputes `c.vars.eraseDups`
+  four times inside one expression; compute once per constraint, HashSet-dedup.
+- Lower priority: `withPtrEq`-shortcut structural equality for `Expression`/`BusInteraction`
+  (safe, Implementation-only; helps `dedup`'s quadratic `bi ∈ seen` and remaining split
+  decides); `substF` no-change signaling to preserve sharing; incremental lengths in `sizeKey`.

--- a/docs/log.md
+++ b/docs/log.md
@@ -3502,3 +3502,54 @@ Build green; `Scripts/check-proof-integrity.sh` green (the three correctness the
 depend only on `{propext, Classical.choice, Quot.sound}`). Runtime leftovers (domainBatch box
 streaming / SAT-style pruning, gauss, dedup's quadratics, rootPairUnify's rescans, cross-cycle
 memoization) are recorded in `docs/ideas.md` under "Runtime leftovers". **Worked: yes.**
+### 91. Runtime: tupleRange batch-drain with split-by-construction (effectiveness unchanged)
+
+Profiling the heaviest wasm-eth cases put `tupleRange` second (96.3 s of `apc_012`'s 435 s
+profile on a dev desktop) — yet the pass's useful work is tiny. The cost anatomy was exactly
+the disease entry 90 cured in `busPairCancel`/`busUnify`, left untreated here: the pass packed
+**one** (byte, range) pair per invocation and let `iterateToFixpoint` drain the rest, so every
+drained pair paid (a) a full pass re-entry, (b) two full-system `sizeKey` recomputations
+(`varCount` re-hashes every variable occurrence), and (c) an `O(#interactions)` *deep
+structural decide* of the split equation `cs.busInteractions = pre ++ D₁ :: mid ++ D₂ :: post`
+per accept — on `apc_012` a 12,949-interaction list compared expression-by-expression, with the
+whole bill paid once per drained pair, **1,877** times.
+
+**Treatment** (entry-90 pattern, `TupleRange.lean` rewritten below the matchers):
+
+- **Matcher soundness lemmas** (`matchByteSingle_eq`, `matchRangeCheck_eq`): a successful match
+  *is* the canonical `byteCheck1`/`rangeCheck1` — so the accepted split needs no runtime
+  re-verification of the interaction shapes, and the width facts (`b.val ≤ 25`, `2 ^ b.val = s2`)
+  ride along from the match.
+- **Split by construction**: the scan is array-indexed (`findRangeIdx`/`findByteIdx` carry
+  their position facts); an accept derives the split equation via `split_of_extracts` — moved,
+  with `list_split_two{,_aux}`, to a new shared `ListSplit.lean` (also imported by
+  `BusPairCancel`) — instead of deciding it.
+- **Batch drain** (`drainTuplePacks`): all packable pairs are drained in one invocation,
+  recursing on the strictly-dropping interaction count (each pack is 2-for-1), composing the
+  per-pack `PassCorrect`s with `andThen`; the pass-list entry drops its `iterateToFixpoint`
+  wrapper. Candidate buses are recomputed per round from the shrunken system, and the scan
+  order is position-major within bus-major — the exact pair sequence the fixpoint-wrapped
+  single-pack pass produced, so the transform is output-preserving by construction.
+
+Mid-flight, #140 moved `tupleRange` from the cleanup cycle to the coda (an effectiveness win:
+pack after `redundantByteDrop`). That removes the *re-run-every-cycle* component but keeps the
+whole per-pair bill (a)–(c) for the coda drain; this entry's rewrite composes with it — the
+coda entry is now the unwrapped `tupleRangePass.guardDegree`.
+
+**Measured** (dev desktop, single runs, not the CI container; both sides at the pre-#140 base,
+where the pass ran in the cleanup cycle): `apc_012` `profile` **434,984 ms → 325,986 ms**
+(−25 %), `tupleRange` **96,301 ms → 2,538 ms** (≈38×); cleanup iterations 9 → 9; every other
+pass's time within run-to-run variance. Outputs at that base: `opt-export` **byte-identical**
+on wasm-eth `apc_096`/`apc_058` (packs 8 tuple pairs)/`apc_084`/`apc_014`/`apc_012`
+(1,877 pairs) and openvm-eth `apc_001`/`apc_034`. Re-validated after rebasing onto #140:
+build and proof integrity green, the six fast cases again byte-identical against the post-#140
+baseline, and `benchmark.py` over all 100 openvm-eth cases matches that baseline's aggregates
+exactly (variables 4.552×/3.887× geo, bus 3.557×/2.812× geo, W/L/T 31/7/62). The same-runner
+CI benchmarks are the authoritative A/B for the post-#140 runtime.
+
+Build green; `Scripts/check-proof-integrity.sh` green (the three correctness theorems still
+depend only on `{propext, Classical.choice, Quot.sound}`). The generated-C audit that ranked
+this lever also recorded the remaining ones (ZMod dictionary reconstruction per scalar op,
+gauss's unconditional per-constraint renormalization, rootPairUnify's quadratic seen-join,
+`sizeKey`/`varCount` allocation, variable interning, runtime `p.Prime` decides) in
+`docs/ideas.md` under "Runtime leftovers II". **Worked: yes.**


### PR DESCRIPTION
Cuts `tupleRange` from the second-hottest pass on the heavy wasm-eth cases to noise, by giving it the same treatment #136 gave `busPairCancel`/`busUnify`: split equations by construction instead of decided, and all packable pairs drained in one invocation instead of one per enclosing fixpoint round. Output-preserving by construction — the scan visits the same positions in the same order the fixpoint-wrapped single-pack pass did, and every accept still goes through the unchanged `mergeStateless2_correct` certificate.

## Why it was slow

The pass packed **one** (byte, range) pair per invocation and relied on `iterateToFixpoint` to drain the rest, so every drained pair paid: a full pass re-entry, **two** full-system `sizeKey` recomputations (`varCount` re-hashes every variable occurrence in the system), and an O(#interactions) **deep structural decide** of the split equation `cs.busInteractions = pre ++ D₁ :: mid ++ D₂ :: post` — on wasm-eth `apc_012` that is a 12,949-interaction list compared expression-by-expression, and the case drains **1,877 pairs**, so the whole bill was paid 1,877 times.

## What changed (`TupleRange.lean` below the matchers; details in `docs/log.md` entry 91)

- **Matcher soundness lemmas** (`matchByteSingle_eq`, `matchRangeCheck_eq`): a successful match *is* the canonical `byteCheck1`/`rangeCheck1`, so accepts re-verify nothing about the interaction shapes and the width facts ride along from the match.
- **Split by construction**: the scan is array-indexed; accepts derive the split equation via `split_of_extracts` — moved with `list_split_two{,_aux}` into a new shared `ListSplit.lean` (imported by `BusPairCancel` and `TupleRange`) — instead of deciding it.
- **Batch drain** (`drainTuplePacks`): recurses on the strictly-dropping interaction count, composing per-pack `PassCorrect`s with `andThen`; the pass-list entry drops its `iterateToFixpoint` wrapper. Candidate buses are recomputed per round from the shrunken system, keeping the original bus-major, position-major pair order.

**Composition with #140**: mid-flight, #140 moved `tupleRange` to the coda, which removes the *re-run-every-cleanup-cycle* component but keeps the whole per-pair bill for the coda drain. This PR is rebased on top: the coda entry is now the unwrapped `tupleRangePass.guardDegree`.

## Measured (dev desktop, single runs, both sides at the pre-#140 base where the pass ran in the cleanup cycle — please rely on the same-runner CI benchmarks for the authoritative post-#140 A/B)

| wasm-eth `apc_012` (`profile`, 9 cleanup iterations before and after) | before | after |
|---|---|---|
| total | 434,984 ms | 325,986 ms (−25 %) |
| tupleRange | 96,301 ms | 2,538 ms (≈38×) |

**Effectiveness is unchanged**: at the pre-#140 base, `opt-export` output is **byte-identical** on wasm-eth `apc_096`, `apc_058` (packs 8 tuple pairs), `apc_084`, `apc_014`, `apc_012` (the heavy packer: 12,949 input interactions, 1,877 packed pairs) and openvm-eth `apc_001`, `apc_034`. Re-validated after the rebase onto #140: the six fast cases are again byte-identical against the post-#140 baseline, and `benchmark.py` over all 100 openvm-eth cases matches that baseline's aggregates exactly (variables 4.552×/3.887× geo, bus 3.557×/2.812× geo, constraints 10.845×/12.026×, per-case W/L/T 31/7/62).

No audited file is touched (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean` untouched); `lake build` and `Scripts/check-proof-integrity.sh` are green — the three correctness theorems still depend only on `{propext, Classical.choice, Quot.sound}`.

The generated-C/perf audit that ranked this lever also recorded the remaining runtime levers (ZMod dictionary reconstruction per scalar op, gauss's unconditional per-constraint renormalization, rootPairUnify's quadratic seen-join, `sizeKey`/`varCount` allocation, variable interning, runtime `p.Prime` decides) in `docs/ideas.md` under "Runtime leftovers II".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
