### PR TITLE
FactStore: thread a shared derived-data store through the cleanup cycle (+ range cache)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -93,7 +93,7 @@ def cleanupPasses : List (String × VerifiedPassS p) :=
     ("gauss", gaussElimPass.withFacts.guardDegree.toS),
     ("normalize1", normalizePass.withFacts.guardDegree.toS),
     ("constFold1", constantFoldPass.withFacts.guardDegree.toS),
-    ("domainBatch", (domainBatchPass pw).guardDegree.toS),
+    ("domainBatch", (domainBatchPass pw).guardDegree),
     ("normalize2", normalizePass.withFacts.guardDegree.toS),
     ("constFold2", constantFoldPass.withFacts.guardDegree.toS),
     ("zeroRegister", zeroRegisterPass.guardDegree.toS),
@@ -151,8 +151,11 @@ theorem cleanupCycle_respectsDeg : RespectsDegS (cleanupCycle (p := p)) := by
   unfold cleanupCycle
   refine chainPassesS_respectsDeg (fun f hf => ?_)
   simp only [cleanupPasses, List.map_cons, List.map_nil] at hf
+  -- Most entries are lifted fact-aware passes; the store-aware `domainBatch` uses the S-guard.
   fin_cases hf <;>
-    exact VerifiedPassW.toS_respectsDeg (VerifiedPassW.guardDegree_respectsDeg _)
+    first
+      | exact VerifiedPassW.toS_respectsDeg (VerifiedPassW.guardDegree_respectsDeg _)
+      | exact VerifiedPassS.guardDegree_respectsDeg _
 
 /-- The circuit optimizer as a store-threaded pass: fold the prelude, iterate the cleanup cycle to a
     fixpoint (`iterateToFixpointS`, no budget), then fold the coda, threading one shared `FactStore`

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Basic
 import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+import ApcOptimizer.Implementation.OptimizerPasses.FactStore
 import ApcOptimizer.Implementation.OptimizerPasses.Identity
 import ApcOptimizer.Implementation.OptimizerPasses.ConstantFold
 import ApcOptimizer.Implementation.OptimizerPasses.TrivialConstraint
@@ -64,8 +65,8 @@ follows automatically from the pass's own `PassCorrect`. -/
     command (`Main.lean`) times the same lists — so the optimizer and the profiler cannot drift
     apart. The prelude is a single constant-fold that canonicalizes the freshly-parsed system. The
     `String` labels name each pass in the profiler's timing report (irrelevant to behaviour). -/
-def preludePasses : List (String × VerifiedPassW p) :=
-  [ ("constFold0", constantFoldPass.withFacts.guardDegree) ]
+def preludePasses : List (String × VerifiedPassS p) :=
+  [ ("constFold0", constantFoldPass.withFacts.guardDegree.toS) ]
 
 /-- The cleanup-cycle passes as a **labelled list** (one of the three stages; see `preludePasses`).
 
@@ -82,117 +83,106 @@ def preludePasses : List (String × VerifiedPassW p) :=
     `(name, pass.….guardDegree)` entry to this list. That is the only edit needed here; the
     correctness proof follows automatically from the pass's own `PassCorrect`, and the profiler
     picks up the new label for free (it consumes this same list). -/
-def cleanupPasses : List (String × VerifiedPassW p) :=
+def cleanupPasses : List (String × VerifiedPassS p) :=
   -- One primality decision per optimizer run, threaded to every prime-gated pass below (they read
   -- the `Bool` in O(1) instead of re-running `decide (Nat.Prime p)` per invocation per iteration).
   let pw := PrimeWitness.of p
-  [ ("zeroWidthRange", (ZeroWidthRange.zeroWidthRangePass pw).guardDegree),
-    ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree),
-    ("carryBranch", (carryBranchPass pw).guardDegree),
-    ("gauss", gaussElimPass.withFacts.guardDegree),
-    ("normalize1", normalizePass.withFacts.guardDegree),
-    ("constFold1", constantFoldPass.withFacts.guardDegree),
-    ("domainBatch", (domainBatchPass pw).guardDegree),
-    ("normalize2", normalizePass.withFacts.guardDegree),
-    ("constFold2", constantFoldPass.withFacts.guardDegree),
-    ("zeroRegister", zeroRegisterPass.guardDegree),
-    ("digitFold", DigitFold.digitFoldPass.guardDegree),
-    ("oneHotAnnihilate", OneHotAnnihilate.oneHotAnnihilatePass.guardDegree),
-    ("hintCollapse", (hintCollapsePass pw).guardDegree),
-    ("rootPairUnify", (rootPairUnifyPass pw).guardDegree),
-    ("flagUnify", (flagUnifyPass pw).guardDegree),
-    ("flagFold", (flagFoldPass' pw).guardDegree),
-    ("dedup", dedupPass.withFacts.guardDegree),
-    ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree),
-    ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree),
-    ("tautoBus", tautoBusDropPass.withFacts.guardDegree),
-    ("domainFold", (domainFoldPass pw).withFacts.guardDegree),
-    ("busUnify", busUnifyPass.guardDegree),
-    ("busPairCancel", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw false))),
-    ("bytePack", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
-    ("disconnected", disconnectedComponentPass.withFacts.guardDegree),
-    ("reencode", reencodePass.withFacts.guardDegree) ]
+  [ ("zeroWidthRange", (ZeroWidthRange.zeroWidthRangePass pw).guardDegree.toS),
+    ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree.toS),
+    ("carryBranch", (carryBranchPass pw).guardDegree.toS),
+    ("gauss", gaussElimPass.withFacts.guardDegree.toS),
+    ("normalize1", normalizePass.withFacts.guardDegree.toS),
+    ("constFold1", constantFoldPass.withFacts.guardDegree.toS),
+    ("domainBatch", (domainBatchPass pw).guardDegree.toS),
+    ("normalize2", normalizePass.withFacts.guardDegree.toS),
+    ("constFold2", constantFoldPass.withFacts.guardDegree.toS),
+    ("zeroRegister", zeroRegisterPass.guardDegree.toS),
+    ("digitFold", DigitFold.digitFoldPass.guardDegree.toS),
+    ("oneHotAnnihilate", OneHotAnnihilate.oneHotAnnihilatePass.guardDegree.toS),
+    ("hintCollapse", (hintCollapsePass pw).guardDegree.toS),
+    ("rootPairUnify", (rootPairUnifyPass pw).guardDegree.toS),
+    ("flagUnify", (flagUnifyPass pw).guardDegree.toS),
+    ("flagFold", (flagFoldPass' pw).guardDegree.toS),
+    ("dedup", dedupPass.withFacts.guardDegree.toS),
+    ("trivialConstr", trivialConstraintDropPass.withFacts.guardDegree.toS),
+    ("zeroMultBus", zeroMultBusDropPass.withFacts.guardDegree.toS),
+    ("tautoBus", tautoBusDropPass.withFacts.guardDegree.toS),
+    ("domainFold", (domainFoldPass pw).withFacts.guardDegree.toS),
+    ("busUnify", busUnifyPass.guardDegree.toS),
+    ("busPairCancel", (VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw false))).toS),
+    ("bytePack", (VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)).toS),
+    ("disconnected", disconnectedComponentPass.withFacts.guardDegree.toS),
+    ("reencode", reencodePass.withFacts.guardDegree.toS) ]
 
 /-- The coda passes (one of the three stages; see `preludePasses`): run once after the cleanup loop
     reaches its fixpoint — drop bytes made redundant by the cleaned-up system, rescale carries to
     monic form, and one final constant-fold. -/
-def codaPasses : List (String × VerifiedPassW p) :=
+def codaPasses : List (String × VerifiedPassS p) :=
   -- One primality decision per optimizer run (see `cleanupPasses`), for the prime-gated coda passes.
   let pw := PrimeWitness.of p
-  [ ("busPairCancelLate", VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw true))),
+  [ ("busPairCancelLate", (VerifiedPassW.guardDegree (iterateToFixpoint (busPairCancelPass pw true))).toS),
     -- Explode packed pair byte checks into singles so `dedupLate` collapses the same value
     -- byte-checked in several pairs and `redundantByteDrop` becomes operand-granular; the
     -- survivors are re-packed by `bytePackLate` below (a pair with nothing to shed round-trips).
-    ("splitBytePair", SplitBytePair.splitBytePairPass.guardDegree),
-    ("dedupLate", dedupPass.withFacts.guardDegree),
-    ("redundantByteDrop", (RedundantByteDrop.redundantByteDropPass pw).guardDegree),
-    ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
+    ("splitBytePair", SplitBytePair.splitBytePairPass.guardDegree.toS),
+    ("dedupLate", dedupPass.withFacts.guardDegree.toS),
+    ("redundantByteDrop", (RedundantByteDrop.redundantByteDropPass pw).guardDegree.toS),
+    ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree.toS),
     -- Tuple/range packing is layout-only and does not unblock other optimizations (powdr likewise
     -- runs global range packing once at the end), so it runs once here, out of the cleanup
     -- fixpoint, after `redundantByteDrop` has dropped droppable byte checks operand-granularly
     -- (packing a byte check early would hide it from the drop, leaving more bus interactions).
     -- The pass drains every packable pair internally, so it needs no fixpoint wrapper.
-    ("tupleRange", tupleRangePass.guardDegree),
-    ("bytePackLate", VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
-    ("monicScale", monicScalePass.withFacts.guardDegree),
-    ("constFoldEnd", constantFoldPass.withFacts.guardDegree),
+    ("tupleRange", tupleRangePass.guardDegree.toS),
+    ("bytePackLate", (VerifiedPassW.guardDegree (iterateToFixpoint ByteCheckPack.byteCheckPackPass)).toS),
+    ("monicScale", monicScalePass.withFacts.guardDegree.toS),
+    ("constFoldEnd", constantFoldPass.withFacts.guardDegree.toS),
     -- Collapse recognised `sltu x, 1` (seqz) LessThan gadgets to the two-line is-zero gadget,
     -- dropping the four `diff_marker`s + `diff_val`. Runs after `monicScale`, where the cluster
     -- has reached the recognised form.
-    ("seqzCollapse", VerifiedPassW.guardDegree (iterateToFixpoint SeqzCollapse.seqzCollapsePass)) ]
+    ("seqzCollapse", (VerifiedPassW.guardDegree (iterateToFixpoint SeqzCollapse.seqzCollapsePass)).toS) ]
 
-/-- Fold a list of passes into one sequential pass (`andThen` left to right; identity on `[]`). -/
-def chainPasses (l : List (VerifiedPassW p)) : VerifiedPassW p :=
-  l.foldl VerifiedPassW.andThen (fun cs bs _ => ⟨cs, [], PassCorrect.refl cs bs⟩)
+/-- The optimizer's cleanup cycle: the `cleanupPasses` folded together in order, threading the shared
+    `FactStore`. See `cleanupPasses` for what each pass does and how to extend the cycle. -/
+def cleanupCycle : VerifiedPassS p :=
+  chainPassesS (cleanupPasses.map (·.2))
 
-/-- The optimizer's cleanup cycle: the `cleanupPasses` folded together in order. See `cleanupPasses`
-    for what each pass does and how to extend the cycle. -/
-def cleanupCycle : VerifiedPassW p :=
-  chainPasses (cleanupPasses.map (·.2))
-
-/-- Folding degree-respecting passes with `andThen` yields a degree-respecting pass. -/
-theorem foldl_andThen_respectsDeg :
-    ∀ (l : List (VerifiedPassW p)) (init : VerifiedPassW p),
-      RespectsDeg init → (∀ f ∈ l, RespectsDeg f) →
-      RespectsDeg (l.foldl VerifiedPassW.andThen init)
-  | [], _, hinit, _ => by simpa using hinit
-  | g :: rest, init, hinit, hall => by
-      rw [List.foldl_cons]
-      exact foldl_andThen_respectsDeg rest (init.andThen g)
-        (VerifiedPassW.andThen_respectsDeg hinit (hall g (List.mem_cons_self ..)))
-        (fun f hf => hall f (List.mem_cons_of_mem _ hf))
-
-/-- Any list of degree-respecting passes folds (`chainPasses`) to a degree-respecting pass. -/
-theorem chainPasses_respectsDeg {l : List (VerifiedPassW p)} (h : ∀ f ∈ l, RespectsDeg f) :
-    RespectsDeg (chainPasses l) := by
-  unfold chainPasses
-  exact foldl_andThen_respectsDeg _ _ (fun _ _ _ h => h) h
-
-theorem cleanupCycle_respectsDeg : RespectsDeg (cleanupCycle (p := p)) := by
+theorem cleanupCycle_respectsDeg : RespectsDegS (cleanupCycle (p := p)) := by
   unfold cleanupCycle
-  refine chainPasses_respectsDeg (fun f hf => ?_)
+  refine chainPassesS_respectsDeg (fun f hf => ?_)
   simp only [cleanupPasses, List.map_cons, List.map_nil] at hf
-  fin_cases hf <;> exact VerifiedPassW.guardDegree_respectsDeg _
+  fin_cases hf <;>
+    exact VerifiedPassW.toS_respectsDeg (VerifiedPassW.guardDegree_respectsDeg _)
 
-/-- The circuit optimizer: fold the prelude, iterate the cleanup cycle to a fixpoint
-    (`iterateToFixpoint`, no budget), then fold the coda. `pipeline` and the profiler both consume
-    `preludePasses` / `cleanupPasses` / `codaPasses`, so they stay in lockstep. -/
+/-- The circuit optimizer as a store-threaded pass: fold the prelude, iterate the cleanup cycle to a
+    fixpoint (`iterateToFixpointS`, no budget), then fold the coda, threading one shared `FactStore`
+    throughout. `pipelineS` and the profiler both consume `preludePasses` / `cleanupPasses` /
+    `codaPasses`, so they stay in lockstep. -/
+def pipelineS : VerifiedPassS p :=
+  ((chainPassesS (preludePasses.map (·.2))).andThen (iterateToFixpointS cleanupCycle)).andThen
+    (chainPassesS (codaPasses.map (·.2)))
+
+/-- The circuit optimizer (fact-aware, store-free interface): run `pipelineS` from an empty store and
+    discard the final store. Keeping this `VerifiedPassW` type leaves `optimizerWithBusFacts` and the
+    audited `ApcOptimizer/Optimizer.lean` unchanged. -/
 def pipeline : VerifiedPassW p :=
-  chainPasses (preludePasses.map (·.2))
-    |>.andThen (iterateToFixpoint cleanupCycle)
-    |>.andThen (chainPasses (codaPasses.map (·.2)))
+  fun cs bs facts => (pipelineS cs bs facts FactStore.empty).1
 
-theorem pipeline_respectsDeg : RespectsDeg (pipeline (p := p)) := by
-  unfold pipeline
-  refine VerifiedPassW.andThen_respectsDeg (VerifiedPassW.andThen_respectsDeg
-    (chainPasses_respectsDeg (fun f hf => ?_))
-    (iterateToFixpoint_respectsDeg cleanupCycle_respectsDeg))
-    (chainPasses_respectsDeg (fun f hf => ?_))
+theorem pipelineS_respectsDeg : RespectsDegS (pipelineS (p := p)) := by
+  unfold pipelineS
+  refine VerifiedPassS.andThen_respectsDeg (VerifiedPassS.andThen_respectsDeg
+    (chainPassesS_respectsDeg (fun f hf => ?_))
+    (iterateToFixpointS_respectsDeg cleanupCycle_respectsDeg))
+    (chainPassesS_respectsDeg (fun f hf => ?_))
   · simp only [preludePasses, List.map_cons, List.map_nil] at hf
     fin_cases hf
-    exact VerifiedPassW.guardDegree_respectsDeg _
+    exact VerifiedPassW.toS_respectsDeg (VerifiedPassW.guardDegree_respectsDeg _)
   · simp only [codaPasses, List.map_cons, List.map_nil] at hf
-    fin_cases hf <;> exact VerifiedPassW.guardDegree_respectsDeg _
+    fin_cases hf <;>
+      exact VerifiedPassW.toS_respectsDeg (VerifiedPassW.guardDegree_respectsDeg _)
+
+theorem pipeline_respectsDeg : RespectsDeg (pipeline (p := p)) :=
+  fun cs bs facts h => pipelineS_respectsDeg cs bs facts FactStore.empty h
 
 /-- The fact-aware circuit optimizer: given proven `BusFacts` about a bus semantics (which fixes the
     implicit `bs`), run the pipeline and return the resulting constraint system together with the

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1,6 +1,7 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
 import ApcOptimizer.Implementation.OptimizerPasses.Gauss
 import ApcOptimizer.Implementation.OptimizerPasses.CoveredIndex
+import ApcOptimizer.Implementation.OptimizerPasses.FactStore
 
 set_option autoImplicit false
 
@@ -148,38 +149,8 @@ with a `% p` per element — for **every** `(interaction, variable)` hit, though
 of distinct bounds (`2^16`, `2^8`, …) ever occur. The cache shares one materialization per
 bound; its entries provably equal the uncached list, so the built table is identical. -/
 
-/-- Proof-carrying cache of materialized `[0, bound)` domains, keyed by bound. -/
-structure RangeCache (p : ℕ) where
-  map : Std.HashMap Nat (List (ZMod p))
-  sound : ∀ b l, map[b]? = some l → l = (List.range b).map (Nat.cast : Nat → ZMod p)
-
-def RangeCache.empty : RangeCache p where
-  map := ∅
-  sound := by
-    intro _ _ h
-    rw [Std.HashMap.getElem?_empty] at h
-    exact absurd h (by simp)
-
-/-- The materialized `[0, b)` domain, from the cache when present. -/
-def RangeCache.get (C : RangeCache p) (b : Nat) :
-    { l : List (ZMod p) // l = (List.range b).map (Nat.cast : Nat → ZMod p) } × RangeCache p :=
-  match h : C.map[b]? with
-  | some l => (⟨l, C.sound b l h⟩, C)
-  | none =>
-    let l := (List.range b).map (Nat.cast : Nat → ZMod p)
-    (⟨l, rfl⟩,
-     { map := C.map.insert b l,
-       sound := by
-         intro b' l' h'
-         rw [Std.HashMap.getElem?_insert] at h'
-         by_cases hb : (b == b') = true
-         · rw [if_pos hb] at h'
-           have hbb : b = b' := by simpa using hb
-           have hll : l = l' := by simpa using h'
-           subst hbb; subst hll
-           rfl
-         · rw [if_neg hb] at h'
-           exact C.sound b' l' h' })
+-- `RangeCache` (the materialized-`[0, bound)` cache) now lives in `FactStore.lean` so it can be a
+-- shared store member threaded across `domainBatch` invocations; `interactionDomainC` below reads it.
 
 /-- `interactionDomain` through the cache: the same domain (`interactionDomainC_fst`), one
     materialization per distinct bound. -/
@@ -213,8 +184,8 @@ def addBusDoms [NeZero p] {cs : ConstraintSystem p} {bs : BusSemantics p}
     (facts : BusFacts p bs) :
     (pending : List (BusInteraction (Expression p))) →
     (∀ bi ∈ pending, bi ∈ cs.busInteractions) →
-    RangeCache p → DomainTable p cs bs → DomainTable p cs bs
-  | [], _, _, T => T
+    RangeCache p → DomainTable p cs bs → RangeCache p × DomainTable p cs bs
+  | [], _, C, T => (C, T)
   | bi :: rest, hmem, C, T =>
     let hbi := hmem bi (List.mem_cons_self ..)
     let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
@@ -1070,15 +1041,21 @@ def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFa
 
 /-- The batch finite-domain propagation pass: build the domain table once, collect every
     checked forced constant from constraints and bus obligations, substitute them all in one
-    traversal. Prime `p` only (runtime-decided); identity otherwise. -/
-def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+    traversal. Prime `p` only (decided once via `pw`); identity otherwise.
+
+    Store-threaded: the input `store.rangeCache` seeds the range materialization, and the cache
+    grown during the domain-table build is written back so later invocations reuse the (input-
+    independent) `[0, bound)` lists instead of rematerializing them. The cache never changes the
+    table (`interactionDomainC_fst`), so the output is unaffected. -/
+def domainBatchPass (pw : PrimeWitness p) : VerifiedPassS p := fun cs bs facts store =>
   if hpB : pw.isPrime = true then
     have hp : p.Prime := pw.correct hpB
     haveI : Fact p.Prime := ⟨hp⟩
     haveI : NeZero p := ⟨hp.ne_zero⟩
-    let T : DomainTable p cs bs :=
-      addBusDoms facts cs.busInteractions (fun _ h => h) RangeCache.empty
-        (addConstraintDoms cs.algebraicConstraints (fun _ h => h) DomainTable.empty)
+    let CT := addBusDoms facts cs.busInteractions (fun _ h => h) store.rangeCache
+      (addConstraintDoms cs.algebraicConstraints (fun _ h => h) DomainTable.empty)
+    let T : DomainTable p cs bs := CT.2
+    let store' : FactStore p := { store with rangeCache := CT.1 }
     let targets := cs.algebraicConstraints.map (fun e => e.vars.dedup) ++
       cs.busInteractions.map (fun bi => bi.vars.dedup)
     let activeCs := cs.algebraicConstraints.filter (fun c => !constraintRedundant T c)
@@ -1091,8 +1068,8 @@ def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =
         arrActive := activeCs.toArray, harrActive := rfl }
     let σ := collectForced facts T activeCs (fun _ h => (List.mem_filter.1 h).1) fidx targets ∅
       Solved.empty
-    if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
-    else ⟨cs.substF σ.fn, [],
+    if σ.map.isEmpty then (⟨cs, [], PassCorrect.refl cs bs⟩, store')
+    else (⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)
-        (fun y t hyt => σ.varsIn y t hyt)⟩
-  else ⟨cs, [], PassCorrect.refl cs bs⟩
+        (fun y t hyt => σ.varsIn y t hyt)⟩, store')
+  else (⟨cs, [], PassCorrect.refl cs bs⟩, store)

--- a/ApcOptimizer/Implementation/OptimizerPasses/FactStore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FactStore.lean
@@ -28,15 +28,63 @@ machinery mirrors `FactPass.lean` one-for-one. The top-level `pipeline` seeds th
 
 variable {p : ℕ}
 
-/-- The shared derived-data store threaded through the cleanup cycle. `Prop`-free: only raw data,
-    no soundness proof — consumers re-validate against the current system. Starts empty
-    (`FactStore.empty`); members are added incrementally. -/
+/-! ## Store members
+
+### Materialized range cache (input-independent)
+
+`RangeCache` memoizes the materialized `[0, bound)` finite domains that `domainBatch` builds when
+turning a range-check bound into an explicit value list — a `bound`-element list (`2^16 = 65 536`
+for a 16-bit check) with a `% p` per element. It is **input-independent**: `C.map[b]?` is always the
+list `(List.range b).map Nat.cast`, so the cache is sound for *every* constraint system and needs no
+re-validation. Making it a store member built once and threaded across every `domainBatch` invocation
+(rather than rebuilt from empty each cycle) removes the repeated 65 536-element materializations.
+Moved here from `DomainBatch.lean` so the store can own it. -/
+
+/-- Proof-carrying cache of materialized `[0, bound)` domains, keyed by bound. Input-independent:
+    every entry equals the canonical list, so it is sound for any system. -/
+structure RangeCache (p : ℕ) where
+  map : Std.HashMap Nat (List (ZMod p))
+  sound : ∀ b l, map[b]? = some l → l = (List.range b).map (Nat.cast : Nat → ZMod p)
+
+def RangeCache.empty : RangeCache p where
+  map := ∅
+  sound := by
+    intro _ _ h
+    rw [Std.HashMap.getElem?_empty] at h
+    exact absurd h (by simp)
+
+/-- The materialized `[0, b)` domain, from the cache when present (inserting it on a miss). -/
+def RangeCache.get (C : RangeCache p) (b : Nat) :
+    { l : List (ZMod p) // l = (List.range b).map (Nat.cast : Nat → ZMod p) } × RangeCache p :=
+  match h : C.map[b]? with
+  | some l => (⟨l, C.sound b l h⟩, C)
+  | none =>
+    let l := (List.range b).map (Nat.cast : Nat → ZMod p)
+    (⟨l, rfl⟩,
+     { map := C.map.insert b l,
+       sound := by
+         intro b' l' h'
+         rw [Std.HashMap.getElem?_insert] at h'
+         by_cases hb : (b == b') = true
+         · rw [if_pos hb] at h'
+           have hbb : b = b' := by simpa using hb
+           have hll : l = l' := by simpa using h'
+           subst hbb; subst hll
+           rfl
+         · rw [if_neg hb] at h'
+           exact C.sound b' l' h' })
+
+/-- The shared derived-data store threaded through the cleanup cycle. Beyond the input-independent
+    `rangeCache`, members are raw data with no soundness proof — consumers re-validate against the
+    current system. Starts empty (`FactStore.empty`); members are added incrementally. -/
 structure FactStore (p : ℕ) where
-  -- members added in later phases
-  deriving Inhabited
+  /-- Materialized `[0, bound)` range domains, shared across `domainBatch` invocations. -/
+  rangeCache : RangeCache p
 
 /-- The empty store: no cached facts. -/
-def FactStore.empty : FactStore p := {}
+def FactStore.empty : FactStore p := { rangeCache := RangeCache.empty }
+
+instance : Inhabited (FactStore p) := ⟨FactStore.empty⟩
 
 /-- A proof-carrying pass that additionally threads the shared `FactStore`: given the current
     system, semantics, proven facts, and the incoming store, it returns the usual proof-carrying

--- a/ApcOptimizer/Implementation/OptimizerPasses/FactStore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FactStore.lean
@@ -1,0 +1,157 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+
+set_option autoImplicit false
+
+/-! # A shared, threaded fact store (implementation)
+
+The optimizer's passes each derive the same kinds of data — variable→item occurrence indices,
+value-bound maps, two-root decompositions, entailed finite domains, materialized range lists — and
+today each pass rebuilds its own from scratch on every cleanup cycle, then discards it. This module
+adds a **`FactStore`**: one value threaded through the whole cleanup cycle (prelude → cleanup
+fixpoint → coda) so those derived structures can be built once and reused across passes and cycles.
+
+The store is deliberately **`Prop`-free**: it carries only raw data (hash maps / lists over the
+spec-level types `Variable`, `Expression`, `ZMod p`, `Nat`), never a soundness proof. Every consumer
+**re-validates what it reads against the current system** — exactly the candidate-then-reverify
+pattern already used by `CoveredIndex` (`coveredIdx_mem`), `busPairCancel`'s `recvIndex`, and the
+`VarCsIdx`. So a store entry that has gone stale (a cached position that now names a different item,
+a bound whose witnessing interaction was dropped) can at most cause a consumer to *miss* an
+optimization; it can never license an unsound one. This is the "untrusted candidate generator"
+discipline: correctness never depends on the store being fresh or even correct.
+
+Because the store carries no proof, threading it needs no proof either: a `VerifiedPassS` returns
+the same proof-carrying `PassResult` as a `VerifiedPassW` (so `PassCorrect` composes exactly as
+before, via `PassCorrect.andThen`) plus an updated store on the side. The degree-respecting
+machinery mirrors `FactPass.lean` one-for-one. The top-level `pipeline` seeds the store with
+`FactStore.empty`, threads it, and discards it — so `optimizerWithBusFacts` and the audited
+`ApcOptimizer/Optimizer.lean` are unchanged. -/
+
+variable {p : ℕ}
+
+/-- The shared derived-data store threaded through the cleanup cycle. `Prop`-free: only raw data,
+    no soundness proof — consumers re-validate against the current system. Starts empty
+    (`FactStore.empty`); members are added incrementally. -/
+structure FactStore (p : ℕ) where
+  -- members added in later phases
+  deriving Inhabited
+
+/-- The empty store: no cached facts. -/
+def FactStore.empty : FactStore p := {}
+
+/-- A proof-carrying pass that additionally threads the shared `FactStore`: given the current
+    system, semantics, proven facts, and the incoming store, it returns the usual proof-carrying
+    `PassResult` **plus** an updated store. The store is data only; the `PassResult` is exactly the
+    obligation a `VerifiedPassW` discharges, so correctness composes unchanged. -/
+abbrev VerifiedPassS (p : ℕ) :=
+  (cs : ConstraintSystem p) → (bs : BusSemantics p) → (facts : BusFacts p bs) →
+    FactStore p → PassResult cs bs × FactStore p
+
+/-- Any fact-aware (non-store) pass is a store pass that passes the store through untouched. Safe
+    because consumers re-validate: passing a store across a pass that changed the system can at most
+    make a later reuse miss. -/
+def VerifiedPassW.toS (f : VerifiedPassW p) : VerifiedPassS p :=
+  fun cs bs facts s => (f cs bs facts, s)
+
+/-- Sequential composition (same proof shape as `VerifiedPassW.andThen`): the `PassResult`s compose
+    via `PassCorrect.andThen`, derivations concatenate, and the store threads through. -/
+def VerifiedPassS.andThen (f g : VerifiedPassS p) : VerifiedPassS p :=
+  fun cs bs facts s =>
+    let r1 := f cs bs facts s
+    let r2 := g r1.1.out bs facts r1.2
+    (⟨r2.1.out, r1.1.derivs ++ r2.1.derivs, r1.1.correct.andThen r2.1.correct⟩, r2.2)
+
+/-- Wrap a store pass with a degree guard: if the output would exceed the bound, keep the input
+    system (correct by reflexivity) but retain the pass's store work (sound regardless of which
+    system we keep). -/
+def VerifiedPassS.guardDegree (f : VerifiedPassS p) : VerifiedPassS p :=
+  fun cs bs facts s =>
+    let r := f cs bs facts s
+    if r.1.out.withinDegreeB bs.degreeBound then r
+    else (⟨cs, [], PassCorrect.refl cs bs⟩, r.2)
+
+/-! ## Degree guarding for store passes
+
+Mirrors `FactPass.lean`'s `RespectsDeg` machinery: the store output is irrelevant to the degree
+bound, so every lemma is the fact-aware one with the extra store argument threaded through. -/
+
+/-- A store pass never pushes a within-bound system past the semantics' degree bound. Identical to
+    `RespectsDeg` up to the extra (ignored, for degree purposes) store argument. -/
+def RespectsDegS (f : VerifiedPassS p) : Prop :=
+  ∀ (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs) (s : FactStore p),
+    cs.withinDegree bs.degreeBound → (f cs bs facts s).1.out.withinDegree bs.degreeBound
+
+/-- A degree-respecting fact-aware pass lifts to a degree-respecting store pass. -/
+theorem VerifiedPassW.toS_respectsDeg {f : VerifiedPassW p} (hf : RespectsDeg f) :
+    RespectsDegS f.toS :=
+  fun cs bs facts _ h => hf cs bs facts h
+
+theorem VerifiedPassS.guardDegree_respectsDeg (f : VerifiedPassS p) :
+    RespectsDegS f.guardDegree := by
+  intro cs bs facts s h
+  by_cases hok : (f cs bs facts s).1.out.withinDegreeB bs.degreeBound = true
+  · simp only [VerifiedPassS.guardDegree, hok, if_true]
+    exact (ConstraintSystem.withinDegreeB_iff _ _).1 hok
+  · simp only [VerifiedPassS.guardDegree, hok]
+    exact h
+
+theorem VerifiedPassS.andThen_respectsDeg {f g : VerifiedPassS p}
+    (hf : RespectsDegS f) (hg : RespectsDegS g) : RespectsDegS (f.andThen g) := by
+  intro cs bs facts s h
+  exact hg _ bs facts _ (hf cs bs facts s h)
+
+/-! ## Chaining and the store-threaded fixpoint -/
+
+/-- The identity store pass: system unchanged, store unchanged, correct by reflexivity. -/
+def VerifiedPassS.id : VerifiedPassS p :=
+  fun cs bs _ s => (⟨cs, [], PassCorrect.refl cs bs⟩, s)
+
+theorem VerifiedPassS.id_respectsDeg : RespectsDegS (VerifiedPassS.id (p := p)) :=
+  fun _ _ _ _ h => h
+
+/-- Fold a list of store passes into one sequential store pass (identity on `[]`). -/
+def chainPassesS (l : List (VerifiedPassS p)) : VerifiedPassS p :=
+  l.foldl VerifiedPassS.andThen VerifiedPassS.id
+
+theorem foldl_andThenS_respectsDeg :
+    ∀ (l : List (VerifiedPassS p)) (init : VerifiedPassS p),
+      RespectsDegS init → (∀ f ∈ l, RespectsDegS f) →
+      RespectsDegS (l.foldl VerifiedPassS.andThen init)
+  | [], _, hinit, _ => by simpa using hinit
+  | g :: rest, init, hinit, hall => by
+      rw [List.foldl_cons]
+      exact foldl_andThenS_respectsDeg rest (init.andThen g)
+        (VerifiedPassS.andThen_respectsDeg hinit (hall g (List.mem_cons_self ..)))
+        (fun f hf => hall f (List.mem_cons_of_mem _ hf))
+
+theorem chainPassesS_respectsDeg {l : List (VerifiedPassS p)} (h : ∀ f ∈ l, RespectsDegS f) :
+    RespectsDegS (chainPassesS l) := by
+  unfold chainPassesS
+  exact foldl_andThenS_respectsDeg _ _ VerifiedPassS.id_respectsDeg h
+
+/-- Iterate a store pass to a fixpoint, threading the store, with **no** iteration budget — the exact
+    recursion of `iterateToFixpoint`, on the same well-founded `sizeKey` measure (the store does not
+    enter the measure). Correct by construction: each kept step is `PassCorrect`, derivations
+    concatenate, and the stopping case returns the input system unchanged (keeping the store work,
+    which is sound regardless of which system we keep). -/
+def iterateToFixpointS (f : VerifiedPassS p) (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (s : FactStore p) : PassResult cs bs × FactStore p :=
+  let r := f cs bs facts s
+  if _h : r.1.out.sizeKey < cs.sizeKey then
+    let r2 := iterateToFixpointS f r.1.out bs facts r.2
+    (⟨r2.1.out, r.1.derivs ++ r2.1.derivs, r.1.correct.andThen r2.1.correct⟩, r2.2)
+  else
+    (⟨cs, [], PassCorrect.refl cs bs⟩, r.2)
+  termination_by cs.sizeKey
+  decreasing_by exact _h
+
+theorem iterateToFixpointS_respectsDeg {f : VerifiedPassS p} (hf : RespectsDegS f) :
+    RespectsDegS (iterateToFixpointS f) := by
+  intro cs
+  induction cs using sizeKey_wf.induction with
+  | _ cs ih =>
+    intro bs facts s hcs
+    rw [iterateToFixpointS]
+    split
+    · rename_i h
+      exact ih _ h bs facts _ (hf cs bs facts s hcs)
+    · exact hcs

--- a/Main.lean
+++ b/Main.lean
@@ -216,44 +216,52 @@ def cmdReport (unoptFile optFile : String) : IO Unit := do
     ",\"apc-optimizer\":" ++ circuitJson optimized ++ "}")
 
 open ApcOptimizer.OpenVM in
-/-- Profiling helper: apply one fact-aware pass, forcing full evaluation, and return the new
-    system plus the elapsed milliseconds. -/
-def applyTimed (pass : VerifiedPassW babyBear) (cs : ConstraintSystem babyBear)
-    (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs) :
-    IO (ConstraintSystem babyBear × Nat) := do
+/-- Profiling helper: apply one store-threaded pass, forcing full evaluation, and return the new
+    system, the threaded store, and the elapsed milliseconds. Mirrors the store threading of
+    `iterateToFixpointS` so the profiler measures the shared `FactStore` exactly as the pipeline uses
+    it. -/
+def applyTimed (pass : VerifiedPassS babyBear) (cs : ConstraintSystem babyBear)
+    (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs) (store : FactStore babyBear) :
+    IO (ConstraintSystem babyBear × FactStore babyBear × Nat) := do
   let t0 ← IO.monoMsNow
-  let out ← IO.lazyPure (fun _ => (pass cs bs facts).out)
-  -- Force the whole output structure (varCount traverses every expression node).
+  let res ← IO.lazyPure (fun _ => pass cs bs facts store)
+  let out := res.1.out
+  let store' := res.2
+  -- Force the whole output structure (varCount traverses every expression node) and the store.
   let _ ← IO.lazyPure (fun _ =>
     out.varCount + out.algebraicConstraints.length + out.busInteractions.length)
+  let _ ← IO.lazyPure (fun _ => store')
   let t1 ← IO.monoMsNow
-  pure (out, t1 - t0)
+  pure (out, store', t1 - t0)
 
 open ApcOptimizer.OpenVM in
-/-- Run one cleanup cycle's passes in order, accumulating per-pass elapsed time. -/
-partial def runCycleTimed (passes : List (String × VerifiedPassW babyBear))
+/-- Run one cleanup cycle's passes in order, threading the store and accumulating per-pass time. -/
+partial def runCycleTimed (passes : List (String × VerifiedPassS babyBear))
     (cs : ConstraintSystem babyBear) (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs)
-    (acc : Std.HashMap String Nat) : IO (ConstraintSystem babyBear × Std.HashMap String Nat) := do
+    (store : FactStore babyBear) (acc : Std.HashMap String Nat) :
+    IO (ConstraintSystem babyBear × FactStore babyBear × Std.HashMap String Nat) := do
   let mut c := cs
+  let mut st := store
   let mut a := acc
   for (name, pass) in passes do
-    let (c', dt) ← applyTimed pass c bs facts
+    let (c', st', dt) ← applyTimed pass c bs facts st
     c := c'
+    st := st'
     a := a.insert name (a.getD name 0 + dt)
-  pure (c, a)
+  pure (c, st, a)
 
 open ApcOptimizer.OpenVM in
-/-- Iterate the cleanup cycle to a fixpoint (mirroring `iterateToFixpoint`), accumulating per-pass
-    time and counting iterations. -/
-partial def profileLoop (passes : List (String × VerifiedPassW babyBear))
+/-- Iterate the cleanup cycle to a fixpoint (mirroring `iterateToFixpointS`), threading the store,
+    accumulating per-pass time and counting iterations. -/
+partial def profileLoop (passes : List (String × VerifiedPassS babyBear))
     (cs : ConstraintSystem babyBear) (bs : BusSemantics babyBear) (facts : BusFacts babyBear bs)
-    (acc : Std.HashMap String Nat) (iter : Nat) :
-    IO (ConstraintSystem babyBear × Std.HashMap String Nat × Nat) := do
-  let (cs', acc') ← runCycleTimed passes cs bs facts acc
+    (store : FactStore babyBear) (acc : Std.HashMap String Nat) (iter : Nat) :
+    IO (ConstraintSystem babyBear × FactStore babyBear × Std.HashMap String Nat × Nat) := do
+  let (cs', store', acc') ← runCycleTimed passes cs bs facts store acc
   if cs'.sizeKey < cs.sizeKey then
-    profileLoop passes cs' bs facts acc' (iter + 1)
+    profileLoop passes cs' bs facts store' acc' (iter + 1)
   else
-    pure (cs, acc', iter)
+    pure (cs, store', acc', iter)
 
 open ApcOptimizer.OpenVM in
 /-- `profile <file>`: run the OpenVM pipeline with per-pass timing, reporting the cumulative time
@@ -267,9 +275,9 @@ def cmdProfile (fileName : String) : IO Unit := do
   -- profiler steps the passes here instead of calling the pure `pipeline`; but it reads those same
   -- three lists, so it cannot time a pass the optimizer does not run, nor drift out of sync.
   let t0 ← IO.monoMsNow
-  let (cs, acc) ← runCycleTimed (preludePasses (p := babyBear)) cs bs facts ∅
-  let (cs, acc, iters) ← profileLoop (cleanupPasses (p := babyBear)) cs bs facts acc 0
-  let (_, acc) ← runCycleTimed (codaPasses (p := babyBear)) cs bs facts acc
+  let (cs, s, acc) ← runCycleTimed (preludePasses (p := babyBear)) cs bs facts FactStore.empty ∅
+  let (cs, s, acc, iters) ← profileLoop (cleanupPasses (p := babyBear)) cs bs facts s acc 0
+  let (_, _, acc) ← runCycleTimed (codaPasses (p := babyBear)) cs bs facts s acc
   let t1 ← IO.monoMsNow
   IO.println s!"profile {fileName}: {iters} cleanup iterations, {t1 - t0} ms total"
   let sorted := acc.toList.toArray.qsort (fun a b => a.2 > b.2)

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -393,11 +393,20 @@ state; every item is output-preserving unless noted):
   the `findVarBound`-per-candidate pattern that busPairCancel just shed.
 - **zeroWidthRange (~1.7 s/eth case)**: two `rangeEq?` scans per invocation (filterMap + keep);
   fusing them into one tagged pass needs the `filterBus`-shaped proof reworked.
-- **Cross-cycle memoization (the big structural one)**: the cleanup cycle runs 5–9 times and the
-  enumeration passes rediscover the same negatives every cycle. A pass-state channel (e.g.
-  `VerifiedPassW` threading an opaque cache blob validated by cheap hashes) would cut the
-  steady-state tail of *every* pass at once; needs a framework change in
-  `Implementation/OptimizerPasses/Basic.lean`'s glue, so weigh against the audit-surface rule.
+- **Cross-cycle memoization / shared `FactStore` (the big structural one)**: the cleanup cycle runs
+  5–9 times and the passes rediscover the same derived data (occurrence indices, bound maps, two-root
+  decompositions, domains) every cycle. The **substrate now exists** — entry 92 added a `FactStore`
+  threaded through the whole pipeline by `VerifiedPassS` (`OptimizerPasses/FactStore.lean`, no glue in
+  `Basic.lean` touched), carrying `Prop`-free data that consumers re-validate at use, and the
+  input-independent range cache is shared through it. What remains is the part that pays for the
+  *input-dependent* members: they can only be reused byte-identically when their source list is
+  unchanged, and the O(system) freshness check to detect that costs about as much as their (cheap)
+  rebuild — so a real win needs **incremental maintenance**: update the store's occurrence
+  index / bound map / two-root map *through* `substF` and the drop primitives (a dirty-worklist over
+  stable-position arrays / tombstones), so members stay fresh without a rebuild or a whole-list check.
+  That is the step that lets `busPairCancel`/`domainFold`/`reencode`/the bound consumers reuse instead
+  of rebuild. Measured caveat (entry 92): these builds are individually cheap (a `BoundsMap.build` is
+  0–6 ms), so the win comes from the *aggregate* across ~27 passes × ~9 cycles, not any single pass.
 
 ## Runtime leftovers II (generated-C audit of the wasm-eth heavy cases)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -3502,6 +3502,7 @@ Build green; `Scripts/check-proof-integrity.sh` green (the three correctness the
 depend only on `{propext, Classical.choice, Quot.sound}`). Runtime leftovers (domainBatch box
 streaming / SAT-style pruning, gauss, dedup's quadratics, rootPairUnify's rescans, cross-cycle
 memoization) are recorded in `docs/ideas.md` under "Runtime leftovers". **Worked: yes.**
+
 ### 91. Runtime: tupleRange batch-drain with split-by-construction (effectiveness unchanged)
 
 Profiling the heaviest wasm-eth cases put `tupleRange` second (96.3 s of `apc_012`'s 435 s
@@ -3553,3 +3554,60 @@ this lever also recorded the remaining ones (ZMod dictionary reconstruction per 
 gauss's unconditional per-constraint renormalization, rootPairUnify's quadratic seen-join,
 `sizeKey`/`varCount` allocation, variable interning, runtime `p.Prime` decides) in
 `docs/ideas.md` under "Runtime leftovers II". **Worked: yes.**
+
+### 92. Shared `FactStore`: thread derived data through the cleanup cycle + share the materialized range cache (runtime; effectiveness unchanged)
+
+Infrastructure plus a first member for reusing per-pass derived data across the cleanup cycle
+instead of rebuilding it in every pass on every cycle. **Effectiveness is unchanged — output is
+byte-identical to the previous pipeline** by construction (the range cache never affects the domain
+table; the framework is a pure store-threading refactor), locally confirmed by `opt-export` diff on
+95 wasm-eth cases (the 5 giant cases identical by the same argument), with the CI effectiveness bench
+confirming the openvm-eth corpus is unchanged. Audited surface untouched; the three correctness
+theorems still depend only on `{propext, Classical.choice, Quot.sound}`.
+
+**The framework (`OptimizerPasses/FactStore.lean`).** A `FactStore p` is threaded through the whole
+pipeline (prelude → cleanup fixpoint → coda) by a store-aware pass type `VerifiedPassS` — a
+`VerifiedPassW` that additionally takes and returns the store. `VerifiedPassS.andThen`/`.guardDegree`,
+`chainPassesS`, and the store-threaded fixpoint `iterateToFixpointS` mirror `FactPass.lean`
+one-for-one, and the degree-respecting lemmas carry over unchanged (the store never enters the degree
+argument, and the `PassResult` a store pass returns is exactly the obligation a `VerifiedPassW`
+discharges, so `PassCorrect` composes as before). The store carries **no soundness proof for its data
+members**: consumers re-validate what they read against the current system (the
+`CoveredIndex.coveredIdx_mem` / `recvIndex` candidate-then-reverify discipline), so a stale or wrong
+entry can only miss an optimization, never license an unsound one. `pipeline` runs the store-threaded
+`pipelineS` from `FactStore.empty` and discards the final store, so `optimizerWithBusFacts` and the
+audited `ApcOptimizer/Optimizer.lean` are unchanged; the `profile` CLI threads the store identically,
+keeping the profiler in lockstep with the three pass lists.
+
+**First member — the range cache (input-independent).** `RangeCache` (the memo of materialized
+`[0, bound)` finite-domain lists — a 65 536-element list for a 16-bit range check) moves from
+`DomainBatch.lean` into the store. It is input-independent (every entry is the canonical
+`(List.range b).map Nat.cast`, sound for *any* system), so it threads globally with zero staleness
+and zero re-validation: materialized once and reused across every `domainBatch` invocation instead of
+rebuilt from empty each cleanup cycle. `addBusDoms` now returns the grown cache; by
+`interactionDomainC_fst` the cache never changes the domain table, so the pass output is byte-identical.
+
+**Measured (profile, same runner, vs `origin/main`).** The win is on the small APCs whose cost is
+dominated by re-materializing the 16-bit range list across cleanup cycles:
+- wasm-eth apc_019: 329 → 226 ms total (domainBatch 265 → 161)   **−31 %**
+- wasm-eth apc_079: 314 → 213 ms total (domainBatch 258 → 157)   **−32 %**
+- other small wasm-eth cases: −2 % to −6 %; mid/large cases neutral (enumeration-bound).
+
+The gain is confined to circuits that re-materialize a wide range list (16-bit) across cleanup
+cycles; elsewhere it is neutral. This container has large run-to-run variance and concurrent load, so
+the on-demand `Runtime Bench` workflow (same-runner A/B) is the authoritative corpus-wide measurement.
+
+**Other candidate members measured but not shipped.** The remaining derived structures (the value
+`BoundsMap`, the variable→item occurrence index, `TwoRootMap`, `EqConstraintMap`, `DomainTable`) are
+all *input-dependent* — their soundness is keyed to the current constraint/interaction lists — so
+reusing them across passes needs an O(system) freshness check to stay byte-identical (a stale reuse
+would silently drop derived facts and *regress* effectiveness). But their builds are **cheap**: a
+direct measurement put one `BoundsMap.build` at 0–6 ms even on a 10 s case (`probeCandidatesOf` keeps
+the 256-value probes rare), at a ~42 % byte-identical reuse hit rate — so sharing them would save
+under ~0.5 % while the freshness check costs about as much. A real win from these needs incremental
+maintenance of the store through `substF`/drops (a dirty-worklist architecture over stable-position
+arrays), recorded under `docs/ideas.md`; an unsafe pointer-identity freshness check was rejected as
+incompatible with the fully-machine-checked, three-axioms-only guarantee.
+
+Build green; `Scripts/check-proof-integrity.sh` green. **Worked: yes** (framework + range cache; the
+other members are a deliberate no-op pending incremental maintenance).


### PR DESCRIPTION
## What

Adds a shared **`FactStore`** threaded through the whole optimizer pipeline (prelude → cleanup fixpoint → coda), so derived data can be built once and reused across passes and cycles instead of rebuilt every pass, every cycle. This is the substrate for the "cross-cycle memoization / derive-and-discard" idea in `docs/ideas.md`. Ships the framework plus its first, cleanest member (the materialized range cache). See **log entry 91** for the full write-up.

**Effectiveness is unchanged — output is byte-identical to `main`** (this is a pure runtime change).

## The framework (`ApcOptimizer/Implementation/OptimizerPasses/FactStore.lean`)

- A `FactStore p` threaded by a store-aware pass type `VerifiedPassS` (a `VerifiedPassW` that also takes/returns the store). `andThen`/`guardDegree`/`chainPassesS`/`iterateToFixpointS` and the degree-respecting lemmas mirror `FactPass.lean` one-for-one.
- The store carries **no soundness proof for its data members** — consumers re-validate what they read against the current system (the `CoveredIndex.coveredIdx_mem` candidate-then-reverify discipline). A stale/wrong entry can only *miss* an optimization, never license an unsound one.
- `pipeline` runs the store-threaded `pipelineS` from `FactStore.empty` and discards the final store, so **`optimizerWithBusFacts` and the audited `ApcOptimizer/Optimizer.lean` are unchanged**, and `Basic.lean` is untouched. The `profile` CLI threads the store identically.

## First member: the range cache (input-independent)

`RangeCache` (the memo of materialized `[0, bound)` finite-domain lists — a 65 536-element list for a 16-bit range check) moves into the store. It is input-independent (every entry is the canonical `(List.range b).map Nat.cast`, sound for any system), so it threads globally with zero staleness: materialized once, reused across every `domainBatch` invocation instead of rebuilt from empty each cycle. By `interactionDomainC_fst` the cache never affects the domain table, so output is byte-identical.

**Measured (profile, same runner, vs `main`):**
| case | main | this PR | Δ |
|---|---:|---:|---:|
| wasm-eth apc_019 | 329 ms | 226 ms | **−31 %** |
| wasm-eth apc_079 | 314 ms | 213 ms | **−32 %** |
| other small wasm-eth | | | −2 % to −6 % |
| mid / large cases | | | neutral (enumeration-bound) |

The gain lands on the ~small-APC class whose cost is dominated by re-materializing the 16-bit range list across cleanup cycles. Local timings are noisy on this shared box — the **Runtime Bench** workflow is the authoritative A/B.

## Other members: measured, not shipped

The remaining candidate members (`BoundsMap`, occurrence index, `TwoRootMap`, `EqConstraintMap`, `DomainTable`) are all *input-dependent*, so reusing them across passes needs an O(system) freshness check to stay byte-identical (a stale reuse would silently drop derived facts and regress effectiveness). But their builds are **cheap** — a direct measurement put one `BoundsMap.build` at **0–6 ms** even on a 10 s case, at a ~42 % byte-identical reuse hit rate — so sharing them saves under ~0.5 % while the freshness check costs about as much. A real win from them needs **incremental maintenance** of the store through `substF`/drops (a dirty-worklist over stable-position arrays), now recorded in `docs/ideas.md`. An unsafe pointer-identity freshness check was rejected as incompatible with the fully-machine-checked, three-axioms-only guarantee.

## Integrity

- Audited surface (`Spec.lean`, `OpenVmSemantics.lean`, `MemoryBus.lean`, `ApcOptimizer/Optimizer.lean`) and `Basic.lean` glue untouched.
- `lake build` green, no warnings; `Scripts/check-proof-integrity.sh` green (three standard axioms only).
- Byte-identity confirmed locally by `opt-export` diff on 95 wasm-eth cases; CI effectiveness bench confirms the openvm-eth corpus is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)