### PR TITLE
domainFold: byte-identical per-cycle setup reduction (WS0/P1, step 1)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -665,16 +665,24 @@ def domainFoldPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bsem =>
     -- with a variable that has *no* single-variable constraint anywhere can never pass
     -- `groupDoms`. Skipping those targets up front (one hash lookup per variable) avoids the
     -- per-target covered-set scan for the ubiquitous byte-limb groups, exactly.
-    let svSet : Std.HashSet Variable := cs.algebraicConstraints.foldl (init := ∅) fun s c =>
-      match c.vars.dedup with
+    --
+    -- `svSet` and `targets` both need each constraint's deduped variable list, so compute it
+    -- **once** per constraint (`Expression.vars` is `++`-built, quadratic on skewed trees; the old
+    -- code paid `c.vars.dedup` twice per constraint per invocation, once per cleanup cycle).
+    let varsOf := cs.algebraicConstraints.map (fun c => c.vars.dedup)
+    let svSet : Std.HashSet Variable := varsOf.foldl (init := ∅) fun s vs =>
+      match vs with
       | [x] => s.insert x
       | _ => s
-    let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
-      let vs := c.vars.dedup
+    let targets := dedupHash (varsOf.filterMap (fun vs =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
         some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    if domainFoldIndexThreshold ≤ cs.algebraicConstraints.length then
+    -- No candidate group ⇒ every fold is a no-op; return the input without building the (full-system)
+    -- `FoldIdx` index. `foldLoop`/`foldLoopDirect` on `[]` already yield exactly this identity, so
+    -- the early exit is output-identical — it only skips the index build.
+    if targets.isEmpty then ⟨cs, [], PassCorrect.refl cs bsem⟩
+    else if domainFoldIndexThreshold ≤ cs.algebraicConstraints.length then
       foldLoop bsem targets cs (FoldIdx.mk' cs)
     else
       foldLoopDirect bsem targets cs


### PR DESCRIPTION
## What

Two **output-identical** reductions of `domainFoldPass`'s per-invocation setup, which is rebuilt on every cleanup cycle:

1. **Dedup constraint vars once.** `svSet` and `targets` each recomputed `c.vars.dedup` per constraint — two full scans of `algebraicConstraints`, and `Expression.vars` is `++`-built (quadratic on skewed trees). Now computed once per constraint (`varsOf`) and reused for both.
2. **Skip the index build when there are no candidate groups.** When `targets` is empty, every fold is a no-op, yet the code still eagerly built the full-system `FoldIdx` index before `foldLoop` returned the input unchanged. Now returns the identity `PassResult` up front.

Both are byte-identical by construction: `svSet`/`targets` are built from the same per-constraint values, and `foldLoop`/`foldLoopDirect` on `[]` already yield the same identity result the early exit returns. No proof changes (the pass's `PassCorrect` is untouched); `lake build` is clean, no warnings.

## Why

The WS0 runtime baseline (openvm-eth top-20 + keccak, profiled with per-pass invocation/change counters) flagged the finite-domain family (`domainFold`/`reencode`/`domainBatch`) as **47–56% of runtime on every hot case**, and `domainFold` in particular fires **0 times** on all three hot cases (openvm apc_005 0/6, wasm apc_006 0/10, keccak 0/10) while remaining a top-3 cost — i.e. it pays a large per-cycle setup cost to determine it has nothing to fold.

`domainFold` is already index-optimized (`systemHasFoldableIdx`, `FoldIdx`, the `svSet` target pre-skip), so this PR removes the residual redundant setup work rather than rewriting the algorithm. Skipping the pass **entirely across cycles** when its input is unchanged (cross-cycle memoization) is the larger structural follow-up.

## Effectiveness / risk

Effectiveness is unchanged by construction. Local spot-check: openvm apc_001 still optimizes to 117→18 constraints (6.5×), identical to `main`. Runtime effect is measured by CI's benchmark (didn't run the full suite locally).

Draft — opening for CI (effectiveness + runtime benchmark + proof integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)