### PR TITLE
Runtime: hoist ZMod ring ops in Expression.fold (byte-identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/ConstantFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ConstantFold.lean
@@ -23,76 +23,98 @@ first pass, and is re-run after substitution passes to propagate freshly-exposed
 
 variable {p : ℕ}
 
-/-- Smart addition: fold two constants and drop `+ 0` on either side. -/
-def Expression.foldAdd (a b : Expression p) : Expression p :=
+/-- Smart addition with the field `add` supplied by the caller (so the `ZMod p` ring dictionary is
+    derived once, not per node): fold two constants (via `add`) and drop `+ 0` on either side. -/
+def Expression.foldAddWith (add : ZMod p → ZMod p → ZMod p) (a b : Expression p) : Expression p :=
   match a, b with
-  | .const m, .const n => .const (m + n)
+  | .const m, .const n => .const (add m n)
   | .const m, b => if m = 0 then b else .add (.const m) b
   | a, .const n => if n = 0 then a else .add a (.const n)
   | a, b => .add a b
 
-/-- Smart multiplication: fold two constants, absorb `* 0`, drop `* 1`. -/
-def Expression.foldMul (a b : Expression p) : Expression p :=
+/-- Smart multiplication with the field `mul` supplied by the caller: fold two constants, absorb
+    `* 0`, drop `* 1`. -/
+def Expression.foldMulWith (mul : ZMod p → ZMod p → ZMod p) (a b : Expression p) : Expression p :=
   match a, b with
-  | .const m, .const n => .const (m * n)
+  | .const m, .const n => .const (mul m n)
   | .const m, b => if m = 0 then .const 0 else if m = 1 then b else .mul (.const m) b
   | a, .const n => if n = 0 then .const 0 else if n = 1 then a else .mul a (.const n)
   | a, b => .mul a b
 
-theorem Expression.foldAdd_eval (a b : Expression p) (env : Variable → ZMod p) :
-    (a.foldAdd b).eval env = a.eval env + b.eval env := by
-  unfold Expression.foldAdd
+theorem Expression.foldAddWith_eval (add : ZMod p → ZMod p → ZMod p)
+    (hadd : ∀ x y, add x y = x + y) (a b : Expression p) (env : Variable → ZMod p) :
+    (a.foldAddWith add b).eval env = a.eval env + b.eval env := by
+  unfold Expression.foldAddWith
   split <;> (try split_ifs) <;> simp_all [Expression.eval]
 
-theorem Expression.foldMul_eval (a b : Expression p) (env : Variable → ZMod p) :
-    (a.foldMul b).eval env = a.eval env * b.eval env := by
-  unfold Expression.foldMul
+theorem Expression.foldMulWith_eval (mul : ZMod p → ZMod p → ZMod p)
+    (hmul : ∀ x y, mul x y = x * y) (a b : Expression p) (env : Variable → ZMod p) :
+    (a.foldMulWith mul b).eval env = a.eval env * b.eval env := by
+  unfold Expression.foldMulWith
   split <;> (try split_ifs) <;> simp_all [Expression.eval]
 
-/-- One bottom-up constant-folding / algebraic-normalization pass over an expression. Children are
-    normalized first, then the smart constructors fold the current node. -/
-def Expression.fold : Expression p → Expression p
+/-- One bottom-up constant-folding pass with the ring operations supplied by the caller. -/
+def Expression.foldWith (add mul : ZMod p → ZMod p → ZMod p) : Expression p → Expression p
   | .const n => .const n
   | .var x => .var x
-  | .add a b => a.fold.foldAdd b.fold
-  | .mul a b => a.fold.foldMul b.fold
+  | .add a b => Expression.foldAddWith add (a.foldWith add mul) (b.foldWith add mul)
+  | .mul a b => Expression.foldMulWith mul (a.foldWith add mul) (b.foldWith add mul)
 
-theorem Expression.fold_eval (e : Expression p) (env : Variable → ZMod p) :
-    e.fold.eval env = e.eval env := by
+theorem Expression.foldWith_eval (add mul : ZMod p → ZMod p → ZMod p)
+    (hadd : ∀ x y, add x y = x + y) (hmul : ∀ x y, mul x y = x * y)
+    (e : Expression p) (env : Variable → ZMod p) : (e.foldWith add mul).eval env = e.eval env := by
   induction e with
   | const n => rfl
   | var x => rfl
-  | add a b iha ihb => rw [Expression.fold, Expression.foldAdd_eval, iha, ihb]; rfl
-  | mul a b iha ihb => rw [Expression.fold, Expression.foldMul_eval, iha, ihb]; rfl
+  | add a b iha ihb =>
+      rw [Expression.foldWith, Expression.foldAddWith_eval add hadd, iha, ihb]; rfl
+  | mul a b iha ihb =>
+      rw [Expression.foldWith, Expression.foldMulWith_eval mul hmul, iha, ihb]; rfl
 
-theorem Expression.foldAdd_vars (a b : Expression p) :
-    ∀ x ∈ (a.foldAdd b).vars, x ∈ a.vars ++ b.vars := by
+/-- One bottom-up constant-folding / algebraic-normalization pass over an expression. The two ring
+    operations are derived from their instances **once per call** and threaded through the recursion:
+    the direct (un-hoisted) version reconstructs the `ZMod p` ring dictionary at every constant fold,
+    a measured hot cost on constant-heavy expressions (multiplicities, constant messages). It is the
+    same fold — `fold_eval`/`fold_vars` are all downstream consumers see. -/
+def Expression.fold (e : Expression p) : Expression p :=
+  e.foldWith (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul
+
+theorem Expression.fold_eval (e : Expression p) (env : Variable → ZMod p) :
+    e.fold.eval env = e.eval env :=
+  Expression.foldWith_eval _ _ (fun _ _ => rfl) (fun _ _ => rfl) e env
+
+theorem Expression.foldAddWith_vars (add : ZMod p → ZMod p → ZMod p) (a b : Expression p) :
+    ∀ x ∈ (a.foldAddWith add b).vars, x ∈ a.vars ++ b.vars := by
   intro x hx
-  unfold Expression.foldAdd at hx
+  unfold Expression.foldAddWith at hx
   split at hx <;> (try split_ifs at hx) <;> simp_all [Expression.vars]
 
-theorem Expression.foldMul_vars (a b : Expression p) :
-    ∀ x ∈ (a.foldMul b).vars, x ∈ a.vars ++ b.vars := by
+theorem Expression.foldMulWith_vars (mul : ZMod p → ZMod p → ZMod p) (a b : Expression p) :
+    ∀ x ∈ (a.foldMulWith mul b).vars, x ∈ a.vars ++ b.vars := by
   intro x hx
-  unfold Expression.foldMul at hx
+  unfold Expression.foldMulWith at hx
   split at hx <;> (try split_ifs at hx) <;> simp_all [Expression.vars]
 
-theorem Expression.fold_vars (e : Expression p) : ∀ x ∈ e.fold.vars, x ∈ e.vars := by
+theorem Expression.foldWith_vars (add mul : ZMod p → ZMod p → ZMod p) (e : Expression p) :
+    ∀ x ∈ (e.foldWith add mul).vars, x ∈ e.vars := by
   induction e with
-  | const n => intro x hx; simp [Expression.fold, Expression.vars] at hx
-  | var y => intro x hx; simpa [Expression.fold] using hx
+  | const n => intro x hx; simp [Expression.foldWith, Expression.vars] at hx
+  | var y => intro x hx; simpa [Expression.foldWith] using hx
   | add a b iha ihb =>
       intro x hx
-      rw [Expression.fold] at hx
-      rcases List.mem_append.1 (Expression.foldAdd_vars _ _ x hx) with h | h
+      rw [Expression.foldWith] at hx
+      rcases List.mem_append.1 (Expression.foldAddWith_vars add _ _ x hx) with h | h
       · exact List.mem_append.2 (Or.inl (iha x h))
       · exact List.mem_append.2 (Or.inr (ihb x h))
   | mul a b iha ihb =>
       intro x hx
-      rw [Expression.fold] at hx
-      rcases List.mem_append.1 (Expression.foldMul_vars _ _ x hx) with h | h
+      rw [Expression.foldWith] at hx
+      rcases List.mem_append.1 (Expression.foldMulWith_vars mul _ _ x hx) with h | h
       · exact List.mem_append.2 (Or.inl (iha x h))
       · exact List.mem_append.2 (Or.inr (ihb x h))
+
+theorem Expression.fold_vars (e : Expression p) : ∀ x ∈ e.fold.vars, x ∈ e.vars :=
+  Expression.foldWith_vars _ _ e
 
 /-- The constant-folding pass: normalize every expression. Correct via `mapExpr_correct`. -/
 def constantFoldPass : VerifiedPass p := fun cs bs =>


### PR DESCRIPTION
Two **universal, output-identical** primitive optimizations, found via a sampling profile (perf/LBR) of the optimizer on openvm-eth apc_005 and the keccak stress case. Unlike a per-pass fix, these target costs *every* pass pays.

## A. `Expression.fold`: derive the ZMod ring ops once per call
`fold` — and therefore `constValue?` and the 8 passes that call `fold` — reconstructed the `ZMod p` ring dictionary at **every** constant-fold node. The keccak profile showed `constValue? → foldAdd → …CommRing… → lean_alloc_object` as a top allocation source (ZMod dict reconstruction ~7.5% self, feeding the ~45% RC/alloc churn). `fold` now extracts `Add`/`Mul` **once** (`foldWith`, the `evalFast`/`evalWith` pattern already used in `DomainBatch`/`Reencode`) and threads them through the recursion. `fold`/`fold_eval`/`fold_vars` keep their signatures — no consumer changes — and are proved extensionally equal via `foldWith_eval`/`foldWith_vars`.

## B. `Variable` `Hashable`: id-first
Hash the powdr id first (a `Nat`), skipping the `String` hash when present. powdr ids are unique per variable (`next_free_id`), so this is a cheaper, well-distributed hash, consistent with `BEq` (equal variables share both fields). The profile showed `lean_string_hash` ~2% plus `instDecidableEqVariable_decEq` (String-first) driven partly by `HashSet` collisions.

## Correctness / scope
Byte-identical — same decisions, same output. No changes to any audited surface; no proof obligations altered (both are Implementation-only). `lake build` clean, no warnings. Local spot-check: openvm apc_001 117→18 constraints (6.5×), apc_005 1424/585/694, wasm apc_001 126→16 (7.875×) — all identical to `main`.

Draft — opening for CI's full runtime + effectiveness + proof-integrity run; the sticky comment gives the corpus-wide main-vs-branch runtime A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)