### PR TITLE
SP1: activate memory pair cancellation + op-6 range-check subsumption

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -256,6 +256,22 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
         (op = spec.pairOp →
            (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r = 0))
+  /-- A pure single-value range check at an arbitrary payload position, generalising the fixed
+      `[x, b]` layout: `rangeCheckAt busId pattern = some (valSlot, bound)` means every
+      multiplicity-`1` message on `busId` matching `pattern` breaks no invariant and is accepted
+      **iff** `payload[valSlot].val < bound`. Lets a subsumed-check dropper recognise a range check
+      whose value slot and bound live at bus-specific positions (SP1's op-6 `Range`, `[6, x, w, 0]`,
+      has `valSlot = 1`, `bound = 2 ^ w`). `trivial` declares none. -/
+  rangeCheckAt : (busId : Nat) → (pattern : List (Option (ZMod p))) → Option (Nat × Nat)
+  rangeCheckAt_sound :
+    ∀ (busId : Nat) (pattern : List (Option (ZMod p))) (valSlot bound : Nat),
+      rangeCheckAt busId pattern = some (valSlot, bound) →
+      bs.isStateful busId = false ∧
+      ∀ (m : BusInteraction (ZMod p)), m.busId = busId → m.multiplicity = 1 →
+        Matches m.payload pattern →
+        bs.breaksInvariant m = false ∧
+        ∀ (x : ZMod p), m.payload[valSlot]? = some x →
+          (bs.violatesConstraint m = false ↔ x.val < bound)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. Declares no memory
     shapes, so the memory/exec unify passes degrade to no-ops. -/
@@ -282,3 +298,5 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   zeroRangeEq_sound := by intro _ h; exact absurd h (by simp)
   byteXorSpec _ := none
   byteXorSpec_sound := by intro _ _ h; exact absurd h (by simp)
+  rangeCheckAt _ _ := none
+  rangeCheckAt_sound := by intro _ _ _ _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -745,5 +745,9 @@ def openVmFacts (p : ℕ) [NeZero p]
           ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
         unfold violates; rw [hbus]
         simp [isByte, ZMod.val_eq_zero, and_assoc]
+  -- OpenVM keeps `SubsumedRange` (its dedicated variable-range-checker bus); the layout-agnostic
+  -- `rangeCheckAt` is only needed for SP1's op-6 byte-bus range check.
+  rangeCheckAt _ _ := none
+  rangeCheckAt_sound := by intro _ _ _ _ h; exact absurd h (by simp)
 
 end ApcOptimizer.OpenVM

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -29,6 +29,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.BoxRewrite
 import ApcOptimizer.Implementation.OptimizerPasses.RedundantByteDrop
 import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
 import ApcOptimizer.Implementation.OptimizerPasses.SubsumedRange
+import ApcOptimizer.Implementation.OptimizerPasses.SubsumedCheck
 import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 import ApcOptimizer.Implementation.OptimizerPasses.SplitBytePair
@@ -127,6 +128,7 @@ def codaPasses : List (String × VerifiedPassW p) :=
     ("dedupLate", dedupPass.withFacts.guardDegree),
     ("redundantByteDrop", (RedundantByteDrop.redundantByteDropPass pw).guardDegree),
     ("subsumedRange", SubsumedRange.subsumedRangeDropPass.guardDegree),
+    ("subsumedCheck", SubsumedCheck.subsumedCheckDropPass.guardDegree),
     -- Tuple/range packing is layout-only and does not unblock other optimizations (powdr likewise
     -- runs global range packing once at the end), so it runs once here, out of the cleanup
     -- fixpoint, after `redundantByteDrop` has dropped droppable byte checks operand-granularly

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -409,42 +409,42 @@ theorem domainByteJustified_sound [Fact p.Prime] (domCs : List (Expression p)) (
     `wits` (see `deepByteVars`), the single-variable constraints `domCs` and the per-variable
     candidate constraints `candsOf` are precomputed by the caller (once per pass invocation,
     instead of two full filters of the constraint list per query). -/
-def byteJustifiedW (deep : Bool) (domCs : List (Expression p))
+def byteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (Expression p))
     (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
     (e : Expression p) : Bool :=
   match e.constValue? with
-  | some c => decide (c.val < 256)
+  | some c => decide (c.val < bound)
   | none =>
     (match e with
      | .var x =>
        (match findVarBound bs facts (wits x) x with
-        | some bound => decide (bound ≤ 256)
+        | some b => decide (b ≤ bound)
         | none => false) ||
-       (deep && deepByteJustified domCs (candsOf x) bs facts wits x)
+       (deep && decide (256 ≤ bound) && deepByteJustified domCs (candsOf x) bs facts wits x)
      | _ => false) ||
-    (deep && domainByteJustified domCs e)
+    (deep && decide (256 ≤ bound) && domainByteJustified domCs e)
 
 /-- The plain full-scan form (used by the coda's `RedundantByteDrop`): witness lookup and
     precomputed constraint lists instantiated with the naive per-query filters. -/
-def byteJustified (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
+def byteJustified (bound : Nat) (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
     (e : Expression p) : Bool :=
-  byteJustifiedW deep (all.filter Expression.isSingleVar)
+  byteJustifiedW bound deep (all.filter Expression.isSingleVar)
     (fun x => all.filter (Expression.containsVar x)) bs facts (fun _ => rest) e
 
-theorem byteJustifiedW_sound (deep : Bool) (all domCs : List (Expression p))
+theorem byteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List (Expression p))
     (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
     (wits : Variable → List (BusInteraction (Expression p))) (e : Expression p)
     (hdeep : deep = true → p.Prime)
     (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
-    (h : byteJustifiedW deep domCs candsOf bs facts wits e = true) (env : Variable → ZMod p)
+    (h : byteJustifiedW bound deep domCs candsOf bs facts wits e = true) (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
-    (e.eval env).val < 256 := by
+    (e.eval env).val < bound := by
   have hbusW : ∀ v, ∀ bi ∈ wits v, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false :=
     fun v bi hbi => hbus bi (hwits v bi hbi)
@@ -464,66 +464,70 @@ theorem byteJustifiedW_sound (deep : Bool) (all domCs : List (Expression p))
       cases e with
       | var x =>
         dsimp only at h
-        show (env x).val < 256
+        show (env x).val < bound
         rcases Bool.or_eq_true _ _ |>.mp h with h' | h'
         · cases hb : findVarBound bs facts (wits x) x with
-          | some bound =>
+          | some b =>
             rw [hb] at h'
             dsimp only at h'
-            exact lt_of_lt_of_le (findVarBound_sound bs facts (wits x) x bound hb env (hbusW x))
+            exact lt_of_lt_of_le (findVarBound_sound bs facts (wits x) x b hb env (hbusW x))
               (of_decide_eq_true h')
           | none => rw [hb] at h'; simp at h'
-        · rw [Bool.and_eq_true] at h'
-          haveI : Fact p.Prime := ⟨hdeep h'.1⟩
-          haveI : NeZero p := ⟨(hdeep h'.1).ne_zero⟩
-          exact deepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
-            h'.2 env hall hbusW
+        · rw [Bool.and_eq_true, Bool.and_eq_true] at h'
+          haveI : Fact p.Prime := ⟨hdeep h'.1.1⟩
+          haveI : NeZero p := ⟨(hdeep h'.1.1).ne_zero⟩
+          exact lt_of_lt_of_le
+            (deepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
+              h'.2 env hall hbusW)
+            (of_decide_eq_true h'.1.2)
       | const n => simp at h
       | add a b => simp at h
       | mul a b => simp at h
     · -- single-variable finite-domain expression path
-      rw [Bool.and_eq_true] at h
-      haveI : Fact p.Prime := ⟨hdeep h.1⟩
-      exact domainByteJustified_sound domCs e h.2 env
-        (fun c' hc' => hall c' (hdomCs c' hc'))
+      rw [Bool.and_eq_true, Bool.and_eq_true] at h
+      haveI : Fact p.Prime := ⟨hdeep h.1.1⟩
+      exact lt_of_lt_of_le
+        (domainByteJustified_sound domCs e h.2 env (fun c' hc' => hall c' (hdomCs c' hc')))
+        (of_decide_eq_true h.1.2)
 
-theorem byteJustified_sound (deep : Bool) (all : List (Expression p)) (bs : BusSemantics p)
+theorem byteJustified_sound (bound : Nat) (deep : Bool) (all : List (Expression p))
+    (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p))) (e : Expression p)
     (hdeep : deep = true → p.Prime)
-    (h : byteJustified deep all bs facts rest e = true) (env : Variable → ZMod p)
+    (h : byteJustified bound deep all bs facts rest e = true) (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
-    (e.eval env).val < 256 :=
-  byteJustifiedW_sound deep all (all.filter Expression.isSingleVar)
+    (e.eval env).val < bound :=
+  byteJustifiedW_sound bound deep all (all.filter Expression.isSingleVar)
     (fun x => all.filter (Expression.containsVar x)) bs facts rest (fun _ => rest) e hdeep
     (fun _ hc => List.mem_of_mem_filter hc) (fun _ _ hc => List.mem_of_mem_filter hc)
     (fun _ _ hbi => hbi) h env hall hbus
 
 /-- Are all of `R`'s payload entries at the declared byte slots justified (through the witness
     lookup `wits` and precomputed `domCs`/`candsOf`, see `byteJustifiedW`)? -/
-def recvSlotsJustified (deep : Bool) (domCs : List (Expression p))
+def recvSlotsJustified (bound : Nat) (deep : Bool) (domCs : List (Expression p))
     (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
     (slots : List Nat) (R : BusInteraction (Expression p)) : Bool :=
   slots.all (fun slot =>
     match R.payload[slot]? with
-    | some e => byteJustifiedW deep domCs candsOf bs facts wits e
+    | some e => byteJustifiedW bound deep domCs candsOf bs facts wits e
     | none => true)
 
-theorem recvSlotsJustified_sound (deep : Bool) (all domCs : List (Expression p))
+theorem recvSlotsJustified_sound (bound : Nat) (deep : Bool) (all domCs : List (Expression p))
     (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (Expression p)))
     (wits : Variable → List (BusInteraction (Expression p))) (slots : List Nat)
     (R : BusInteraction (Expression p)) (hdeep : deep = true → p.Prime)
     (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
-    (h : recvSlotsJustified deep domCs candsOf bs facts wits slots R = true)
+    (h : recvSlotsJustified bound deep domCs candsOf bs facts wits slots R = true)
     (env : Variable → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval env = 0)
     (hbus : ∀ bi ∈ rest, (bi.eval env).multiplicity ≠ 0 →
       bs.violatesConstraint (bi.eval env) = false) :
-    ∀ slot ∈ slots, ∀ x : ZMod p, (R.eval env).payload[slot]? = some x → x.val < 256 := by
+    ∀ slot ∈ slots, ∀ x : ZMod p, (R.eval env).payload[slot]? = some x → x.val < bound := by
   intro slot hslot x hget
   have hcheck := List.all_eq_true.mp h slot hslot
   -- the evaluated payload entry is the evaluation of the syntactic entry
@@ -536,7 +540,7 @@ theorem recvSlotsJustified_sound (deep : Bool) (all domCs : List (Expression p))
     rw [he] at hget' hcheck
     simp only [Option.map_some, Option.some.injEq] at hget'
     subst hget'
-    exact byteJustifiedW_sound deep all domCs candsOf bs facts rest wits e hdeep
+    exact byteJustifiedW_sound bound deep all domCs candsOf bs facts rest wits e hdeep
       hdomCs hcands hwits hcheck env hall hbus
 
 /-! ## Net-multiplicity bookkeeping -/
@@ -682,7 +686,6 @@ theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts 
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
     (pattern : List (Option (ZMod p))) (slots : List Nat) (bound : Nat)
     (hslots : facts.recvByteSlots busId pattern = some (slots, bound))
-    (hbound : 256 ≤ bound)
     (hRmatch : ∀ env, Matches (R.eval env).payload pattern)
     (checks : List (BusInteraction (Expression p)))
     (hchecks : ∀ ck ∈ checks,
@@ -695,7 +698,7 @@ theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts 
       (∀ c ∈ cs.algebraicConstraints, c.eval env = 0) →
       (∀ bi ∈ A ++ B ++ C ++ checks, (bi.eval env).multiplicity ≠ 0 →
         bs.violatesConstraint (bi.eval env) = false) →
-      ∀ slot ∈ slots, ∀ x : ZMod p, (R.eval env).payload[slot]? = some x → x.val < 256)
+      ∀ slot ∈ slots, ∀ x : ZMod p, (R.eval env).payload[slot]? = some x → x.val < bound)
     (hsplit : cs.busInteractions = A ++ S :: B ++ R :: C)
     (hSbus : S.busId = busId) (hRbus : R.busId = busId)
     (hSm : S.multiplicity.constValue? = some shape.setNewMult)
@@ -753,13 +756,12 @@ theorem dropPair_correct (cs : ConstraintSystem p) (bs : BusSemantics p) (facts 
   have hnvR : ∀ env, out.satisfies bs env → bs.violatesConstraint (R.eval env) = false := by
     intro env hsat
     have hbyteEnv : ∀ slot ∈ slots, ∀ x : ZMod p, (R.eval env).payload[slot]? = some x →
-        x.val < 256 := by
+        x.val < bound := by
       refine hbyte env (fun c hc => hsat.1 c hc) ?_
       intro bi hbi hne
       exact hsat.2 bi (by rw [houtb]; exact hbi) hne
     refine (facts.recvByteSlots_sound busId shape hshape pattern slots bound hslots (R.eval env)
-      (show (R.eval env).busId = busId from hRbus)).2 (hRmEv env) (hRmatch env)
-      (fun slot hs x hx => Nat.lt_of_lt_of_le (hbyteEnv slot hs x hx) hbound)
+      (show (R.eval env).busId = busId from hRbus)).2 (hRmEv env) (hRmatch env) hbyteEnv
   -- Side effects are `≈`-equal (the pair contributes `0` net; the checks are stateless). The
   -- evaluated-payload equality is discharged from the constraints, which hold in **both**
   -- refinement directions — a drop leaves `algebraicConstraints` untouched.
@@ -905,9 +907,12 @@ def payloadHash (pl : List (Expression p)) : UInt64 :=
 def addrHash (shape : MemoryBusShape) (pl : List (Expression p)) : UInt64 :=
   shape.addressFields.foldl (fun h slot => mixHash h ((pl[slot]?).elim 5 Expression.structHash)) 7
 
-/-- Positions (ascending) of the candidate receives (constant `-1` multiplicity) on **every**
-    memory-shaped bus, keyed by the bus id mixed with the payload hash — one build serves the
-    whole sweep, instead of one O(#interactions) rebuild per bus. In the cycle
+/-- Positions (ascending) of the candidate receives (the `getPrevious`, multiplicity
+    `-shape.setNewMult`) on **every** memory-shaped bus, keyed by the bus id mixed with the payload
+    hash — one build serves the whole sweep, instead of one O(#interactions) rebuild per bus. The
+    receive multiplicity is read from each bus's own declared shape (`-shape.setNewMult`), so a bus
+    that sets-new with `-1` (SP1's memory, whose reads carry `+1`) is indexed correctly, not just
+    the `-1` convention of OpenVM memory / every VM's execution bridge. In the cycle
     (`aggressive = false`) the payload part of the key is the exact payload hash — tiny buckets,
     cheap syntactic probes. In the coda (`aggressive = true`) it is the *address-slot* hash
     (`addrHash`, computed against the bus's own declared shape), a coarsening under which
@@ -918,14 +923,14 @@ def recvIndexAll {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Boo
     (arr : Array (BusInteraction (Expression p))) :
     Std.HashMap UInt64 (List Nat) :=
   (arr.toList.zipIdx).foldr (fun bij m =>
-    if decide (multConst bij.1 = some (-1)) then
-      match facts.memShape bij.1.busId with
-      | some shape =>
+    match facts.memShape bij.1.busId with
+    | some shape =>
+      if decide (multConst bij.1 = some (-shape.setNewMult)) then
         let h := mixHash (hash bij.1.busId)
           (if aggressive then addrHash shape bij.1.payload else payloadHash bij.1.payload)
         m.insert h (bij.2 :: m.getD h [])
-      | none => m
-    else m) ∅
+      else m
+    | none => m) ∅
 
 /-- Every element of a two-point split other than the two distinguished ones lies in the
     remaining region. -/
@@ -1685,13 +1690,13 @@ theorem emitOk_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat)
     · exact absurd hrest (by simp)
 
 /-- The declared byte slots of `R` whose payload entries the witnesses do not justify. -/
-def unjustifiedSlots (deep : Bool) (domCs : List (Expression p))
+def unjustifiedSlots (bound : Nat) (deep : Bool) (domCs : List (Expression p))
     (candsOf : Variable → List (Expression p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits : Variable → List (BusInteraction (Expression p)))
     (slots : List Nat) (R : BusInteraction (Expression p)) : List Nat :=
   slots.filter (fun slot =>
     match R.payload[slot]? with
-    | some e => !byteJustifiedW deep domCs candsOf bs facts wits e
+    | some e => !byteJustifiedW bound deep domCs candsOf bs facts wits e
     | none => false)
 
 /-- The per-candidate certificate: address/multiplicity/payload of the pair, the emitted
@@ -1710,10 +1715,9 @@ def checkCancel (deep : Bool) {all : List (Expression p)} (bs : BusSemantics p)
     (checks : List (BusInteraction (Expression p))) : Bool :=
   decide (S.busId = busId) && decide (R.busId = busId) &&
   decide (multConst S = some shape.setNewMult) && decide (multConst R = some (-shape.setNewMult)) &&
-  decide (256 ≤ bound) &&
   payloadEntailedEq M S.payload R.payload &&
   checks.all (emitOk bs facts busId shape slots R) &&
-  recvSlotsJustified deep domCs candsOf bs facts wits slots R
+  recvSlotsJustified bound deep domCs candsOf bs facts wits slots R
 
 /-- A passing `checkCancel` — together with the split equation, the region hypotheses the scan
     established, and the witness/index membership facts — yields `PassCorrect` via
@@ -1742,15 +1746,15 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
     PassCorrect cs { cs with busInteractions := A ++ B ++ C ++ checks } [] bs := by
   unfold checkCancel at h
   simp only [Bool.and_eq_true] at h
-  obtain ⟨⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hbnd⟩, hpay⟩, hemit⟩, hjust⟩ := h
+  obtain ⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hemit⟩, hjust⟩ := h
   have hRmEv : ∀ env, (R.eval env).multiplicity = -shape.setNewMult :=
     fun env => R.multiplicity.constValue?_sound (-shape.setNewMult) (of_decide_eq_true hRm) env
   refine dropPair_correct cs bs facts hp1 A B C S R busId shape hshape
-    (R.payload.map Expression.constValue?) slots bound hslots (of_decide_eq_true hbnd)
+    (R.payload.map Expression.constValue?) slots bound hslots
     (fun env => matches_evalPattern R.payload env) checks
     (fun ck hck => emitOk_sound bs facts busId shape slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
-    (fun env hall hbus => recvSlotsJustified_sound deep cs.algebraicConstraints domCs candsOf
+    (fun env hall hbus => recvSlotsJustified_sound bound deep cs.algebraicConstraints domCs candsOf
       bs facts (A ++ B ++ C ++ checks) wits slots R hdeep hdomCs hcands hwits hjust env hall hbus)
     hsplit
     (of_decide_eq_true hSb) (of_decide_eq_true hRb)
@@ -2060,7 +2064,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
           -- `facts.memShape … = some shape`, hence is stateful (`facts.memShape_stateful`) — a
           -- check is therefore never a send/receive candidate. It lives only in the threaded
           -- `checks` list (consulted by `dropWits` for byte justification), at the logical tail.
-          let unjust := unjustifiedSlots deep domCsT.get.val candsT.get.lookup bs facts
+          let unjust := unjustifiedSlots bound deep domCsT.get.val candsT.get.lookup bs facts
             (dropWits facts arr alive S R checksOld []) slots R
           let checks : List (BusInteraction (Expression p)) :=
             match unjust, bcBus? with

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -215,7 +215,7 @@ def byteDropKeep (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p
     (all : List (Expression p))
     (rest : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
   match byteCheckOperands? bs facts bi with
-  | some ops => !(ops.all (fun e => byteJustified pw.isPrime all bs facts rest e))
+  | some ops => !(ops.all (fun e => byteJustified 256 pw.isPrime all bs facts rest e))
   | none => true
 
 /-- Drop every stateless byte-check interaction whose operands are all byte-justified from the
@@ -236,11 +236,11 @@ def redundantByteDropPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs f
        | none => rw [hro] at hkf; exact absurd hkf (by simp)
        | some ops =>
          rw [hro] at hkf
-         have hjust : ops.all (fun e => byteJustified pw.isPrime
+         have hjust : ops.all (fun e => byteJustified 256 pw.isPrime
              cs.algebraicConstraints bs facts (byteDropBase bs facts cs) e) = true := by
            simpa using hkf
          refine byteCheckOperands?_accepted bs facts bi ops hro env (fun e he => ?_)
-         refine byteJustified_sound pw.isPrime cs.algebraicConstraints bs facts
+         refine byteJustified_sound 256 pw.isPrime cs.algebraicConstraints bs facts
            (byteDropBase bs facts cs) e (fun h => pw.correct h)
            (List.all_eq_true.mp hjust e he) env
            (fun c hc => hsat.1 c hc) (fun bi' hbi' hmult => ?_)

--- a/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
@@ -1,0 +1,137 @@
+import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+import ApcOptimizer.Implementation.OptimizerPasses.FlagFold
+
+set_option autoImplicit false
+
+/-! # Subsumed pure-range-check removal (the `rangeCheckAt` generalisation of `SubsumedRange`)
+
+`SubsumedRange` drops a variable range check `[x, w]` on OpenVM's dedicated variable-range-checker
+bus. SP1 has no such bus: its range checks ride the multi-op byte bus as `[6, x, w, 0]` (op 6,
+`Range`). This pass generalises the same idea through the layout-agnostic `rangeCheckAt` fact:
+`rangeCheckAt busId pattern = some (valSlot, bound)` says a mult-1 message matching `pattern` is
+accepted **iff** `payload[valSlot] < bound`. A recognised check whose value variable is *already*
+bounded `< bound` by the non-circular justification base (interactions this pass never drops) is
+entailed, so dropping it is sound, variable-neutral, and removes one bus interaction.
+
+Same two proven ingredients as `SubsumedRange`: `filterBusEntailed_correct` (drop a stateless
+interaction accepted under every assignment satisfying the filtered system) and a non-circular
+base via `findVarBound`. `trivial`/OpenVM declare no `rangeCheckAt`, so this pass is a no-op there
+(OpenVM keeps using `SubsumedRange`); SP1 uses it to shed the op-6 checks whose result is a
+16-bit memory limb already bounded by the surviving read. -/
+
+namespace SubsumedCheck
+
+variable {p : ℕ}
+
+/-- Recognise a pure single-value range check (`facts.rangeCheckAt`) at multiplicity `1` whose
+    value slot holds a bare variable: returns the checked variable, its slot, and its bound. -/
+def checkOf (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Variable × Nat × Nat) :=
+  match facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?) with
+  | some (valSlot, bound) =>
+    if bi.multiplicity = Expression.const 1 then
+      match bi.payload[valSlot]? with
+      | some (Expression.var x) => some (x, valSlot, bound)
+      | _ => none
+    else none
+  | none => none
+
+theorem checkOf_spec (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (valSlot bound : Nat)
+    (h : checkOf bs facts bi = some (x, valSlot, bound)) :
+    facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?) = some (valSlot, bound) ∧
+      bi.multiplicity = Expression.const 1 ∧ bi.payload[valSlot]? = some (Expression.var x) := by
+  unfold checkOf at h
+  split at h
+  · rename_i vs bd hrc
+    split_ifs at h with hmc
+    split at h
+    · rename_i x' hxp
+      simp only [Option.some.injEq, Prod.mk.injEq] at h
+      obtain ⟨rfl, rfl, rfl⟩ := h
+      exact ⟨hrc, hmc, hxp⟩
+    · exact absurd h (by simp)
+  · exact absurd h (by simp)
+
+/-- A recognised check lives on a stateless bus. -/
+theorem checkOf_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (valSlot bound : Nat)
+    (h : checkOf bs facts bi = some (x, valSlot, bound)) : bs.isStateful bi.busId = false :=
+  (facts.rangeCheckAt_sound bi.busId (bi.payload.map Expression.constValue?) valSlot bound
+    (checkOf_spec bs facts bi x valSlot bound h).1).1
+
+/-- If the checked variable is in range (`< bound`), the recognised message is accepted. -/
+theorem checkOf_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) (valSlot bound : Nat)
+    (h : checkOf bs facts bi = some (x, valSlot, bound)) (env : Variable → ZMod p)
+    (hlt : (env x).val < bound) : bs.violatesConstraint (bi.eval env) = false := by
+  obtain ⟨hrc, hmc, hxp⟩ := checkOf_spec bs facts bi x valSlot bound h
+  obtain ⟨_, hm⟩ := facts.rangeCheckAt_sound bi.busId (bi.payload.map Expression.constValue?)
+    valSlot bound hrc
+  have hmult : (bi.eval env).multiplicity = 1 := by
+    show bi.multiplicity.eval env = 1
+    rw [hmc]; rfl
+  have hmatch : Matches (bi.eval env).payload (bi.payload.map Expression.constValue?) :=
+    matches_evalPattern bi.payload env
+  obtain ⟨_, hiff⟩ := hm (bi.eval env) rfl hmult hmatch
+  have hget : (bi.eval env).payload[valSlot]? = some (env x) := by
+    show (bi.payload.map (fun e => e.eval env))[valSlot]? = some (env x)
+    rw [List.getElem?_map, hxp]; rfl
+  exact (hiff (env x) hget).mpr hlt
+
+/-! ## The pass -/
+
+/-- The justification base: interactions this pass never drops (not recognised as pure checks). -/
+def dropBase (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (BusInteraction (Expression p)) :=
+  cs.busInteractions.filter (fun bi => (checkOf bs facts bi).isNone)
+
+/-- Keep `bi` unless it is a recognised pure check whose variable is already bounded `< bound` by a
+    retained (base) interaction. -/
+def dropKeep (bs : BusSemantics p) (facts : BusFacts p bs)
+    (base : List (BusInteraction (Expression p))) (bi : BusInteraction (Expression p)) : Bool :=
+  match checkOf bs facts bi with
+  | some (x, _, bound) =>
+    match findVarBound bs facts base x with
+    | some b' => !decide (b' ≤ bound)
+    | none => true
+  | none => true
+
+/-- Drop every pure single-value range check whose bound is already entailed by a stronger-or-equal
+    retained stateless check on the same variable. -/
+def subsumedCheckDropPass : VerifiedPassW p := fun cs bs facts =>
+  ⟨cs.filterBus (dropKeep bs facts (dropBase bs facts cs)), [],
+   cs.filterBusEntailed_correct bs _
+     (by
+       intro bi _ hkf
+       cases hr : checkOf bs facts bi with
+       | none => exact absurd hkf (by simp [dropKeep, hr])
+       | some xvb =>
+         obtain ⟨x, valSlot, bound⟩ := xvb
+         exact checkOf_stateless bs facts bi x valSlot bound hr)
+     (by
+       intro bi hbimem hkf env hsat _
+       cases hr : checkOf bs facts bi with
+       | none => exact absurd hkf (by simp [dropKeep, hr])
+       | some xvb =>
+         obtain ⟨x, valSlot, bound⟩ := xvb
+         cases hb : findVarBound bs facts (dropBase bs facts cs) x with
+         | none => exact absurd hkf (by simp [dropKeep, hr, hb])
+         | some b' =>
+           have hble : b' ≤ bound := by
+             simp only [dropKeep, hr, hb, Bool.not_eq_false', decide_eq_true_eq] at hkf
+             exact hkf
+           have hbase : (env x).val < b' := by
+             refine findVarBound_sound bs facts (dropBase bs facts cs) x b' hb env
+               (fun bi' hbi' hmult => ?_)
+             have hbimem' : bi' ∈ cs.busInteractions := (List.mem_filter.1 hbi').1
+             have hnone : checkOf bs facts bi' = none := by
+               have := (List.mem_filter.1 hbi').2
+               simpa using this
+             have hkeep : dropKeep bs facts (dropBase bs facts cs) bi' = true := by
+               simp only [dropKeep, hnone]
+             exact hsat.2 bi' (List.mem_filter.2 ⟨hbimem', hkeep⟩) hmult
+           exact checkOf_accepted bs facts bi x valSlot bound hr env
+             (lt_of_lt_of_le hbase hble))⟩
+
+end SubsumedCheck

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -45,12 +45,26 @@ private def slotFunImpl (busMap : Nat → Option Sp1BusType) (busId : Nat)
       else none
   | _, _, _ => none
 
-private def slotBoundImpl (busMap : Nat → Option Sp1BusType) (busId : Nat) (slot : Nat) :
-    Option Nat :=
+private def slotBoundImpl (busMap : Nat → Option Sp1BusType) (busId : Nat) (mult : ZMod p)
+    (pattern : List (Option (ZMod p))) (slot : Nat) : Option Nat :=
   match busMap busId, slot with
   -- The byte bus operands `b` (slot 2) and `c` (slot 3) are always bytes.
   | some .byteLookup, 2 => some 256
   | some .byteLookup, 3 => some 256
+  -- An op-6 (`Range`) byte-bus message `[6, a, b, 0]` range-checks its result `a` (slot 1) to
+  -- `a < 2^b`. When the op selector (slot 0) and width `b` (slot 2) are constant in the pattern,
+  -- that bounds slot 1 by `2^b` — the fact that lets `busPairCancel` justify SP1's 16-bit memory
+  -- data limbs (each carried by an op-6 width-16 range check) when telescoping.
+  | some .byteLookup, 1 =>
+    match pattern[0]?, pattern[2]? with
+    | some (some op), some (some w) => if op.val = 6 then some (2 ^ w.val) else none
+    | _, _ => none
+  -- The four data limbs (slots 5–8) of a memory `getPrevious` (multiplicity `1`, full ≥9-slot
+  -- record) are 16-bit; a surviving read thus justifies the telescoped same-register pairs' data.
+  | some .memory, 5 => if mult = 1 ∧ 9 ≤ pattern.length then some (2 ^ 16) else none
+  | some .memory, 6 => if mult = 1 ∧ 9 ≤ pattern.length then some (2 ^ 16) else none
+  | some .memory, 7 => if mult = 1 ∧ 9 ≤ pattern.length then some (2 ^ 16) else none
+  | some .memory, 8 => if mult = 1 ∧ 9 ≤ pattern.length then some (2 ^ 16) else none
   | _, _ => none
 
 /-- A payload matching a 4-entry pattern is a 4-entry list. -/
@@ -85,6 +99,50 @@ private theorem byte_operands (busMap : Nat → Option Sp1BusType)
              omega)
           | simp_all)
   · exact absurd hok (by simp)
+
+/-- An accepted op-6 (`Range`) byte-bus message `[6, a, b, c]` range-checks `a` to `a < 2^b`. -/
+private theorem byte_op6_bound (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .byteLookup)
+    (hok : violates busMap m = false)
+    (op a b c : ZMod p) (hpay : m.payload = [op, a, b, c]) (hop : op.val = 6) :
+    a.val < 2 ^ b.val := by
+  obtain ⟨bid, mult, payload⟩ := m
+  simp only at hbus hpay
+  subst hpay
+  unfold violates at hok
+  rw [hbus] at hok
+  dsimp only at hok
+  simp only [hop] at hok
+  rw [Bool.not_eq_false', Bool.and_eq_true] at hok
+  exact of_decide_eq_true hok.2
+
+/-- An op-6 `[6, a, b, c]` message with a supported width (`b ≤ 16`) and `c = 0` is accepted **iff**
+    its result is in range (`a < 2^b`). -/
+private theorem byte_op6_iff (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .byteLookup)
+    (op a b c : ZMod p) (hpay : m.payload = [op, a, b, c]) (hop : op.val = 6)
+    (hw : b.val ≤ 16) (hc : c.val = 0) :
+    violates busMap m = false ↔ a.val < 2 ^ b.val := by
+  obtain ⟨bid, mult, payload⟩ := m
+  simp only at hbus hpay
+  subst hpay
+  unfold violates
+  rw [hbus]
+  dsimp only
+  simp only [hop, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq]
+  constructor
+  · intro h; exact h.2
+  · intro h; exact ⟨⟨hw, hc⟩, h⟩
+
+/-- Recognise SP1's op-6 (`Range`) byte-bus check as a pure single-value range check: a message
+    matching `[6, _, w, 0]` with a supported width `w ≤ 16` is accepted iff its result (slot 1) is
+    `< 2^w`. -/
+private def rangeCheckAtImpl (busMap : Nat → Option Sp1BusType) (busId : Nat)
+    (pattern : List (Option (ZMod p))) : Option (Nat × Nat) :=
+  match busMap busId, pattern with
+  | some .byteLookup, [some op, _, some w, some c] =>
+    if op.val = 6 ∧ w.val ≤ 16 ∧ c.val = 0 then some (1, 2 ^ w.val) else none
+  | _, _ => none
 
 /-- The fixed-zero cell of the SP1 memory bus: register `x0` = address `(0, 0, 0)` (the three
     address limbs at payload slots 2, 3 and 4), with the four data limbs at payload slots 5–8.
@@ -207,6 +265,22 @@ private theorem memory_getPrev_ok (busMap : Nat → Option Sp1BusType)
   have h3 : d3.val < 65536 := hslots 8 (by simp) d3 rfl
   simp [is16Bit, hm, h0, h1, h2, h3]
 
+/-- The four data limbs (payload slots 5–8) of an accepted memory `getPrevious` (multiplicity `1`,
+    full ≥9-slot record) are 16-bit — the converse of `memory_getPrev_ok`, used by `slotBound` so a
+    surviving read bounds the telescoped chain's data. -/
+private theorem memory_read_data (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
+    (hm : m.multiplicity = 1) (hok : violates busMap m = false) (hlen : 9 ≤ m.payload.length)
+    (slot : Nat) (hs : slot = 5 ∨ slot = 6 ∨ slot = 7 ∨ slot = 8)
+    (x : ZMod p) (hget : m.payload[slot]? = some x) : x.val < 2 ^ 16 := by
+  obtain ⟨bid, mult, payload⟩ := m
+  simp only at hbus hm hget hlen
+  unfold violates at hok
+  rw [hbus, hm] at hok
+  rcases hs with rfl | rfl | rfl | rfl <;>
+    (rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
+      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp_all [is16Bit, List.all_cons, List.all_nil])
+
 /-- A memory `setNew` (multiplicity -1) never violates: either the characteristic is > 2 and a
     `setNew` is not a `getPrevious`, or `p ∣ 2` and every value is trivially 16-bit. -/
 private theorem memory_setNew_ok [NeZero p] (busMap : Nat → Option Sp1BusType)
@@ -234,7 +308,7 @@ def sp1Facts (p : ℕ) [NeZero p]
     (busMap : Nat → Option Sp1BusType := defaultBusMap) :
     BusFacts p (sp1BusSemantics p busMap) :=
   { BusFacts.trivial (sp1BusSemantics p busMap) with
-    slotBound := fun busId _ _ slot => slotBoundImpl busMap busId slot
+    slotBound := fun busId mult pattern slot => slotBoundImpl busMap busId mult pattern slot
     slotBound_sound := by
       intro m pattern slot bound x hfact hmatch hok hget
       have hok' : violates busMap m = false := hok
@@ -252,6 +326,57 @@ def sp1Facts (p : ℕ) [NeZero p]
         obtain ⟨op, a, b, c, hpay, hb, hc⟩ := byte_operands busMap m hbus hok'
         have hxc : c = x := by rw [hpay] at hget; simpa using hget
         rw [← hxc]; exact hc
+      · -- slot 1: an op-6 range check `[6, a, w, 0]` bounds `a` by `2^w`.
+        rename_i hbus
+        obtain ⟨op, a, b, c, hpay, _, _⟩ := byte_operands busMap m hbus hok'
+        rcases hp0 : pattern[0]? with _ | o0
+        · rw [hp0] at hfact; simp at hfact
+        · rcases o0 with _ | pop
+          · rw [hp0] at hfact; simp at hfact
+          · rcases hp2 : pattern[2]? with _ | o2
+            · rw [hp0, hp2] at hfact; simp at hfact
+            · rcases o2 with _ | pw
+              · rw [hp0, hp2] at hfact; simp at hfact
+              · rw [hp0, hp2] at hfact
+                dsimp only at hfact
+                split_ifs at hfact with hop6
+                · simp only [Option.some.injEq] at hfact; subst hfact
+                  have hpop : op = pop := by
+                    have := hmatch.2 0 pop (by rw [hp0]); rw [hpay] at this; simpa using this
+                  have hpw : b = pw := by
+                    have := hmatch.2 2 pw (by rw [hp2]); rw [hpay] at this; simpa using this
+                  have hax : a = x := by rw [hpay] at hget; simpa using hget
+                  have hopval : op.val = 6 := by rw [hpop]; exact hop6
+                  have hb6 := byte_op6_bound busMap m hbus hok' op a b c hpay hopval
+                  rw [hpw, hax] at hb6; exact hb6
+      · -- memory data slot 5: a full-record read has 16-bit data
+        rename_i hbus
+        split_ifs at hfact with hm1
+        obtain ⟨hm1', hlen⟩ := hm1
+        simp only [Option.some.injEq] at hfact; subst hfact
+        exact memory_read_data busMap m hbus hm1' hok' (by have h := hmatch.1; omega) 5
+          (by tauto) x hget
+      · -- memory data slot 6
+        rename_i hbus
+        split_ifs at hfact with hm1
+        obtain ⟨hm1', hlen⟩ := hm1
+        simp only [Option.some.injEq] at hfact; subst hfact
+        exact memory_read_data busMap m hbus hm1' hok' (by have h := hmatch.1; omega) 6
+          (by tauto) x hget
+      · -- memory data slot 7
+        rename_i hbus
+        split_ifs at hfact with hm1
+        obtain ⟨hm1', hlen⟩ := hm1
+        simp only [Option.some.injEq] at hfact; subst hfact
+        exact memory_read_data busMap m hbus hm1' hok' (by have h := hmatch.1; omega) 7
+          (by tauto) x hget
+      · -- memory data slot 8
+        rename_i hbus
+        split_ifs at hfact with hm1
+        obtain ⟨hm1', hlen⟩ := hm1
+        simp only [Option.some.injEq] at hfact; subst hfact
+        exact memory_read_data busMap m hbus hm1' hok' (by have h := hmatch.1; omega) 8
+          (by tauto) x hget
       · exact absurd hfact (by simp)
     slotFun := slotFunImpl busMap
     slotFun_sound := by
@@ -462,6 +587,37 @@ def sp1Facts (p : ℕ) [NeZero p]
                 = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
             unfold violates; rw [hbus]
             simp [hp3, isByte, ZMod.val_eq_zero, and_assoc]
-      · rw [if_neg hp] at hspec; exact absurd hspec (by simp) }
+      · rw [if_neg hp] at hspec; exact absurd hspec (by simp)
+    -- SP1's op-6 (`Range`) byte-bus check `[6, a, w, 0]` (w ≤ 16) is a pure range check on `a`
+    -- (`a < 2^w`), so a subsumed-check dropper can remove it when `a` is already bounded.
+    rangeCheckAt := fun busId pattern => rangeCheckAtImpl busMap busId pattern
+    rangeCheckAt_sound := by
+      intro busId pattern valSlot bound hfact
+      unfold rangeCheckAtImpl at hfact
+      split at hfact
+      · rename_i op e1 w c hbus
+        split_ifs at hfact with hcond
+        obtain ⟨hop, hw, hc⟩ := hcond
+        simp only [Option.some.injEq, Prod.mk.injEq] at hfact
+        obtain ⟨rfl, rfl⟩ := hfact
+        refine ⟨?_, fun m hbusId hmult hmatch => ?_⟩
+        · show (match busMap busId with | some t => t.isStateful | none => false) = false
+          rw [hbus]; rfl
+        · have hmbus : busMap m.busId = some .byteLookup := by rw [hbusId]; exact hbus
+          obtain ⟨q0, q1, q2, q3, hpe⟩ := payload_four hmatch
+          have hq0 : q0 = op := by
+            have := hmatch.2 0 op (by simp); rw [hpe] at this; simpa using this
+          have hq2 : q2 = w := by
+            have := hmatch.2 2 w (by simp); rw [hpe] at this; simpa using this
+          have hq3 : q3 = c := by
+            have := hmatch.2 3 c (by simp); rw [hpe] at this; simpa using this
+          rw [hq0, hq2, hq3] at hpe
+          have hbreak : breaksInvariant busMap m = false := by
+            unfold breaksInvariant; simp [hmbus, hmult]
+          refine ⟨hbreak, fun x hx => ?_⟩
+          have hxq : q1 = x := by rw [hpe] at hx; simpa using hx
+          rw [← hxq]
+          exact byte_op6_iff busMap m hmbus op q1 w c hpe hop hw hc
+      · exact absurd hfact (by simp) }
 
 end ApcOptimizer.SP1

--- a/docs/log.md
+++ b/docs/log.md
@@ -3553,3 +3553,36 @@ this lever also recorded the remaining ones (ZMod dictionary reconstruction per 
 gauss's unconditional per-constraint renormalization, rootPairUnify's quadratic seen-join,
 `sizeKey`/`varCount` allocation, variable interning, runtime `p.Prime` decides) in
 `docs/ideas.md` under "Runtime leftovers II". **Worked: yes.**
+
+### 92. Activate SP1 memory pair cancellation + op-6 range-check subsumption (bus 1.494× → 1.957×, vars 2.652× → 2.938×)
+
+Builds on the VM-neutral bus-fact refactor (execution-bridge `direction` fix, `recvByteSlots` bound,
+`byteXorSpec` byte hygiene). Those set SP1 up but left memory cancellation inert: the receive index
+hard-coded the `-1` receive multiplicity and the byte justification hard-coded `< 256`, neither of
+which fits SP1's memory (reads carry `+1`, data is 16-bit). Three `Implementation/`-only changes
+close that (no audit surface, OpenVM a no-op throughout):
+
+- **`recvIndexAll`** now indexes the `getPrevious` at each bus's own `-shape.setNewMult` (was a
+  hard-coded `-1`), so SP1 memory reads (`+1`) are found as cancellation candidates. Purely
+  heuristic; every hit is still re-verified by `checkCancel`. OpenVM's `-1` is unchanged.
+- **`byteJustifiedW` / `recvSlotsJustified` / `dropPair_correct` / `checkCancel` gained a `bound`
+  parameter** (proving `payload[slot] < bound`, not a fixed `< 256`); the byte-specific deep/domain
+  paths stay sound behind a `256 ≤ bound` gate. This lets the 16-bit memory obligation
+  (`bound = 2^16`) be discharged directly instead of via the old `256 ≤ bound` bridge (now removed).
+- **SP1 `slotBound` gained op-6 and memory-read arms**: an op-6 `[6, a, w, 0]` bounds slot 1 by
+  `2^w`, and a full-record memory read (mult 1) bounds its four data limbs (slots 5–8) by `2^16`. So
+  a *surviving* register read justifies the 16-bit data of the telescoped same-register pairs.
+
+Plus a new **`SubsumedCheck`** coda pass + layout-agnostic **`BusFacts.rangeCheckAt`** fact
+(`some (valSlot, bound)` = accepted iff `payload[valSlot] < bound`): SP1's op-6 `[6, a, w, 0]`
+range check is dropped when `a` is already bounded `< 2^w` by the non-circular base (e.g. `a` is a
+16-bit memory limb bounded by its surviving read). Generalises `SubsumedRange` to SP1's byte-bus
+layout; OpenVM declares no `rangeCheckAt` and keeps `SubsumedRange`, so it is a no-op there.
+
+**Impact (`benchmark.py --vm sp1`, 100 rsp cases):** variables **2.652× → 2.938×**, bus
+**1.494× → 1.957×** (per-case-by-variables W/L/T 0/99/1 → 0/69/31); apc_001 mem 36 → 26, op-6
+43 → 34, bus 112 → 84. **No regression:** OpenVM's `setNewMult = 1` makes `recvIndexAll` and the
+`256`-bound path no-ops; OpenVM keccak byte-identical (2021 v / 186 c / 1752 bus); proof integrity
+green ({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. Remaining SP1
+gap = ALU-intermediate variables (free witnesses powdr inlines) and register-vs-RAM address
+disequality (powdr's sort-based memory argument) — see `docs/ideas.md`. **Worked: yes.**


### PR DESCRIPTION
## Summary

Builds on the VM-neutral bus-fact refactor now in `main` (merged via #143 / #139), which already
carries the execution-bridge `direction` fix, the `recvByteSlots` per-bus bound, and `byteXorSpec`
byte hygiene. Those set SP1 up but left memory pair cancellation **inert** — the receive index
hard-coded the `-1` receive multiplicity and the byte justification hard-coded `< 256`, neither of
which fits SP1's memory (reads carry `+1`, data limbs are 16-bit). This PR closes that gap and adds
op-6 range-check subsumption. Everything is under `Implementation/` (no audited-surface / spec
change); OpenVM is a no-op throughout.

## Key changes

**BusPairCancel.lean:**
- `recvIndexAll` now indexes the `getPrevious` at each bus's own `-shape.setNewMult` (was a hard-coded
  `-1`), so SP1 memory reads (`+1`) are found as cancellation candidates. Purely heuristic — every hit
  is re-verified by `checkCancel`; OpenVM's `-1` (setNewMult `1`) is unchanged.
- `byteJustifiedW` / `recvSlotsJustified` / `dropPair_correct` / `checkCancel` gained a `bound`
  parameter (proving `payload[slot] < bound`, not a fixed `< 256`); the byte-specific deep/domain
  paths stay sound behind a `256 ≤ bound` gate. The 16-bit memory obligation (`bound = 2^16`) is now
  discharged directly, and the old `256 ≤ bound` bridge is removed.

**Sp1Facts.lean:**
- `slotBound` gained two arms: an op-6 `[6, a, w, 0]` bounds slot 1 (`a`) by `2^w`; a full-record
  memory read (mult 1) bounds its four data limbs (slots 5–8) by `2^16`. So a *surviving* register
  read justifies the 16-bit data of the telescoped same-register send/receive pairs.
- Added `byte_op6_bound`, `byte_op6_iff`, `memory_read_data`, `rangeCheckAtImpl` and the
  `rangeCheckAt` fact instance (op-6 recognized as a pure single-value range check).

**BusFacts.lean / OpenVmFacts.lean:**
- New layout-agnostic `rangeCheckAt` fact (`some (valSlot, bound)` = a mult-1 message is accepted iff
  `payload[valSlot] < bound`). `trivial` and OpenVM declare none.

**SubsumedCheck.lean (new pass, coda):**
- `subsumedCheckDropPass` drops a pure range check recognized via `rangeCheckAt` when its value is
  already bounded `< bound` by the non-circular base (`findVarBound`), via `filterBusEntailed_correct`.
  Generalizes `SubsumedRange` to SP1's op-6 byte-bus layout; OpenVM keeps `SubsumedRange`, so this is a
  no-op there.

**RedundantByteDrop.lean / Optimizer.lean:**
- Pass `256` as the `bound` to `byteJustified`; import + wire `subsumedCheck` into the coda after
  `subsumedRange`.

## Impact

`benchmark.py --vm sp1` over the 100 rsp cases, this branch vs its `main` base (effectiveness =
size before / size after; larger is better):

| measure | main | this PR | powdr |
|---|---|---|---|
| variables | 2.652× | **2.938×** | 3.980× |
| bus interactions | 1.494× | **1.957×** | 2.822× |
| constraints | 8.380× | 9.202× | 9.810× |

Per-case-by-variables W/L/T vs powdr: 0/99/1 → **0/69/31**. Representative case apc_001: memory
36 → 26, op-6 range checks 43 → 34, total bus 112 → 84.

## No regression elsewhere

OpenVM memory/exec use `setNewMult = 1`, so `recvIndexAll`'s receive multiplicity and the `256`-bound
justification path are unchanged there, and OpenVM declares no `rangeCheckAt` (keeps `SubsumedRange`).
OpenVM keccak is byte-identical (2021 vars / 186 constraints / 1752 bus interactions). Proof integrity
green (`optimizerWithBusFacts_maintainsCorrectness` et al. depend only on `{propext, Classical.choice,
Quot.sound}`); no `sorry` / `axiom` / `native_decide`; clean build with no warnings.

## Remaining SP1 gap (future work)

- ALU-intermediate variables (`address_operation__value`, `bitwise_result`) that powdr inlines but that
  are free witnesses here (no defining constraint to substitute).
- Register-vs-RAM address disequality that blocks fuller register telescoping (powdr uses a sort-based
  memory argument; apc's discipline is list-consecutive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)