### PR TITLE
Runtime: remove the quadratic algebra cores in Gauss/normalize (output byte-identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -155,7 +155,249 @@ def pivotScore (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
   let base := (occ.getD xt.1 1 - 1) * (1 + xt.2.varCount)
   if prot.contains xt.1 && !xt.2.isVar then base + 1000000 else base
 
-/-! ## The elimination loop -/
+/-! ## Fast pivot selection (build only the winning candidate)
+
+`pm1PivotsOf`/`unitPivotsOf` build a full solution `Expression` (`toExpr`) for *every* solvable
+pivot of a constraint, then `argmin` keeps one and discards the rest — wasteful expression
+allocation, which dominates via reference-count churn on large systems. `fastBest` scans
+lightweight `(variable, score)` descriptors instead, computing each candidate's exact `pivotScore`
+from the linear form's coefficients and term counts *without materialising any solution*, then
+builds `toExpr` only for the winner. It is proven equal to the old `argmin` over
+`pm1PivotsOf ++ unitPivotsOf` (`fastBest_eq`), so `gaussLoop`'s decisions and output are unchanged.
+
+Remaining opportunity (not taken here): `pm1Desc`/`unitDesc` still build `l.others v` and rescan
+`l.coeff v` per candidate, so scoring is O(terms²) per constraint. On the measured corpora affine
+forms are short, so this is below the win; a single coefficient/others-count index pass would make
+scoring linear if longer forms ever dominate. -/
+
+/-- `argmin` commutes with a key-preserving map: when `g` carries the key (`kγ (g a) = kα a`), the
+    winner of the mapped list is the mapped winner. This lets us score cheap descriptors in place
+    of built candidates. -/
+theorem argmin_map_key {α γ : Type*} (g : α → γ) (kα : α → Nat) (kγ : γ → Nat)
+    (h : ∀ a, kγ (g a) = kα a) : ∀ l : List α, (l.map g).argmin kγ = (l.argmin kα).map g := by
+  intro l
+  induction l with
+  | nil => simp
+  | cons a t ih =>
+      rw [List.map_cons, List.argmin_cons, List.argmin_cons, ih]
+      cases t.argmin kα with
+      | none => simp
+      | some c =>
+          simp only [Option.map_some, h]
+          by_cases hlt : kα c < kα a <;> simp [hlt]
+
+theorem map_filterMap {α β γ : Type*} (f : α → Option β) (g : β → γ) (l : List α) :
+    (l.filterMap f).map g = l.filterMap (fun a => (f a).map g) := by
+  induction l with
+  | nil => simp
+  | cons a t ih =>
+      simp only [List.filterMap_cons]
+      cases f a with
+      | none => simpa using ih
+      | some b => simp [ih]
+
+/-! ### `toExpr` size facts (score a candidate without building it) -/
+
+theorem toExpr_foldl_varCount (terms : List (Variable × ZMod p)) :
+    ∀ init : Expression p,
+      (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).varCount
+        = init.varCount + terms.length := by
+  induction terms with
+  | nil => intro init; simp
+  | cons t rest ih =>
+      intro init
+      rw [List.foldl_cons, ih]
+      simp only [Expression.varCount, List.length_cons]
+      omega
+
+theorem LinExpr.toExpr_varCount (l : LinExpr p) : l.toExpr.varCount = l.terms.length := by
+  rw [LinExpr.toExpr, toExpr_foldl_varCount]
+  simp [Expression.varCount]
+
+theorem LinExpr.scale_terms_length (k : ZMod p) (l : LinExpr p) :
+    (l.scale k).terms.length = l.terms.length := by
+  simp [LinExpr.scale]
+
+theorem toExpr_foldl_isVar (terms : List (Variable × ZMod p)) :
+    ∀ init : Expression p, init.isVar = false →
+      (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).isVar = false := by
+  induction terms with
+  | nil => intro init h; simpa using h
+  | cons t rest ih => intro init _; exact ih _ rfl
+
+theorem LinExpr.toExpr_isVar (l : LinExpr p) : l.toExpr.isVar = false :=
+  toExpr_foldl_isVar l.terms _ rfl
+
+/-! ### Descriptors -/
+
+/-- Score of a pivot on `v` whose solution has `oc` variable occurrences. The `pivotScore`
+    protection penalty reduces to `prot.contains v`, since a `toExpr` solution is never a bare
+    variable. -/
+def gaussScore (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) (v : Variable)
+    (oc : Nat) : Nat :=
+  let base := (occ.getD v 1 - 1) * (1 + oc)
+  if prot.contains v then base + 1000000 else base
+
+theorem gaussScore_eq_pivotScore (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (v : Variable) (t : Expression p) (oc : Nat) (hiv : t.isVar = false) (hvc : t.varCount = oc) :
+    gaussScore occ prot v oc = pivotScore occ prot (v, t) := by
+  subst hvc
+  simp only [gaussScore, pivotScore, hiv, Bool.not_false, Bool.and_true]
+
+/-- `l.trySolve` in closed form (keeps the `Option (Variable × Expression p)` type, so rewriting
+    with it — unlike unfolding into `none` — never leaves the element type ambiguous). -/
+theorem LinExpr.trySolve_eq_of_one (l : LinExpr p) (v : Variable) (h : l.coeff v = 1) :
+    l.trySolve v = some (v, ((l.others v).scale (-1)).toExpr) := by
+  unfold LinExpr.trySolve; rw [if_pos h]
+
+theorem LinExpr.trySolve_eq_of_negOne (l : LinExpr p) (v : Variable) (h1 : l.coeff v ≠ 1)
+    (h2 : l.coeff v = -1) : l.trySolve v = some (v, (l.others v).toExpr) := by
+  unfold LinExpr.trySolve; rw [if_neg h1, if_pos h2]
+
+theorem LinExpr.trySolve_eq_none (l : LinExpr p) (v : Variable)
+    (h : ¬(l.coeff v = 1 ∨ l.coeff v = -1)) : l.trySolve v = none := by
+  unfold LinExpr.trySolve; rw [if_neg (fun hh => h (Or.inl hh)), if_neg (fun hh => h (Or.inr hh))]
+
+theorem LinExpr.trySolveUnit_eq_of (l : LinExpr p) (v : Variable)
+    (h : l.coeff v * (l.coeff v)⁻¹ = 1) :
+    l.trySolveUnit v = some (v, ((l.others v).scale (-(l.coeff v)⁻¹)).toExpr) := by
+  unfold LinExpr.trySolveUnit; rw [if_pos h]
+
+theorem LinExpr.trySolveUnit_eq_none (l : LinExpr p) (v : Variable)
+    (h : ¬l.coeff v * (l.coeff v)⁻¹ = 1) : l.trySolveUnit v = none := by
+  unfold LinExpr.trySolveUnit; rw [if_neg h]
+
+/-- `±1`-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` succeeds. -/
+def pm1Desc (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (v : Variable) : Option (Variable × Nat) :=
+  if l.coeff v = 1 ∨ l.coeff v = -1 then some (v, gaussScore occ prot v (l.others v).terms.length)
+  else none
+
+theorem pm1Desc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (v : Variable) :
+    pm1Desc l occ prot v = (l.trySolve v).map (fun xt => (xt.1, pivotScore occ prot xt)) := by
+  unfold pm1Desc
+  by_cases h1 : l.coeff v = 1
+  · rw [if_pos (Or.inl h1), LinExpr.trySolve_eq_of_one l v h1, Option.map_some,
+      gaussScore_eq_pivotScore occ prot v (((l.others v).scale (-1)).toExpr)
+        (l.others v).terms.length (LinExpr.toExpr_isVar _)
+        (by rw [LinExpr.toExpr_varCount, LinExpr.scale_terms_length])]
+  · by_cases h2 : l.coeff v = -1
+    · rw [if_pos (Or.inr h2), LinExpr.trySolve_eq_of_negOne l v h1 h2, Option.map_some,
+        gaussScore_eq_pivotScore occ prot v ((l.others v).toExpr)
+          (l.others v).terms.length (LinExpr.toExpr_isVar _) (LinExpr.toExpr_varCount _)]
+    · rw [if_neg (by rintro (h | h); exacts [h1 h, h2 h]),
+        LinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h]), Option.map_none]
+
+/-- Unit-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` fails but
+    `l.trySolveUnit v` succeeds. -/
+def unitDesc (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (v : Variable) : Option (Variable × Nat) :=
+  if ¬(l.coeff v = 1 ∨ l.coeff v = -1) ∧ l.coeff v * (l.coeff v)⁻¹ = 1 then
+    some (v, gaussScore occ prot v (l.others v).terms.length)
+  else none
+
+theorem unitDesc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
+    (v : Variable) :
+    unitDesc l occ prot v
+      = (match l.trySolve v with | some _ => none | none => l.trySolveUnit v).map
+          (fun xt : Variable × Expression p => (xt.1, pivotScore occ prot xt)) := by
+  unfold unitDesc
+  by_cases h1 : l.coeff v = 1
+  · rw [if_neg (fun hc => hc.1 (Or.inl h1)), LinExpr.trySolve_eq_of_one l v h1]; rfl
+  · by_cases h2 : l.coeff v = -1
+    · rw [if_neg (fun hc => hc.1 (Or.inr h2)), LinExpr.trySolve_eq_of_negOne l v h1 h2]; rfl
+    · rw [LinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h])]
+      by_cases h3 : l.coeff v * (l.coeff v)⁻¹ = 1
+      · rw [if_pos ⟨by rintro (h | h); exacts [h1 h, h2 h], h3⟩,
+          LinExpr.trySolveUnit_eq_of l v h3,
+          gaussScore_eq_pivotScore occ prot v (((l.others v).scale (-(l.coeff v)⁻¹)).toExpr)
+            (l.others v).terms.length (LinExpr.toExpr_isVar _)
+            (by rw [LinExpr.toExpr_varCount, LinExpr.scale_terms_length])]
+        rfl
+      · rw [if_neg (fun hc => h3 hc.2), LinExpr.trySolveUnit_eq_none l v h3]; rfl
+
+/-- All pivot descriptors, `±1` first (mirroring `pm1PivotsOf ++ unitPivotsOf`). -/
+def pivotDescs (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
+    List (Variable × Nat) :=
+  (l.terms.map Prod.fst).filterMap (pm1Desc l occ prot)
+    ++ (l.terms.map Prod.fst).filterMap (unitDesc l occ prot)
+
+theorem pivotDescs_eq (c : Expression p) (l : LinExpr p) (hlin : linearize c = some l)
+    (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
+    pivotDescs l occ prot
+      = (pm1PivotsOf c ++ unitPivotsOf c).map (fun xt => (xt.1, pivotScore occ prot xt)) := by
+  unfold pivotDescs pm1PivotsOf unitPivotsOf
+  rw [hlin, List.map_append, map_filterMap, map_filterMap]
+  congr 1
+  · exact List.filterMap_congr (fun v _ => pm1Desc_eq l occ prot v)
+  · exact List.filterMap_congr (fun v _ => unitDesc_eq l occ prot v)
+
+/-- The cheapest solvable pivot of a constraint, building the solution only for the winner. -/
+def fastBest (c : Expression p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
+    Option (Variable × Expression p) :=
+  match linearize c with
+  | none => none
+  | some l =>
+      match (pivotDescs l occ prot).argmin Prod.snd with
+      | none => none
+      | some (x, _) =>
+          match l.trySolve x with
+          | some xt => some xt
+          | none => l.trySolveUnit x
+
+theorem LinExpr.trySolve_fst (l : LinExpr p) (v : Variable) (w : Variable × Expression p)
+    (h : l.trySolve v = some w) : w.1 = v := by
+  unfold LinExpr.trySolve at h
+  split_ifs at h
+  all_goals simp_all [Prod.ext_iff]
+
+theorem LinExpr.trySolveUnit_fst (l : LinExpr p) (v : Variable) (w : Variable × Expression p)
+    (h : l.trySolveUnit v = some w) : w.1 = v := by
+  unfold LinExpr.trySolveUnit at h
+  split_ifs at h
+  all_goals simp_all [Prod.ext_iff]
+
+theorem mem_pm1_trySolve (c : Expression p) (l : LinExpr p) (hlin : linearize c = some l)
+    (w : Variable × Expression p) (h : w ∈ pm1PivotsOf c) : l.trySolve w.1 = some w := by
+  unfold pm1PivotsOf at h
+  rw [hlin] at h
+  obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
+  rw [LinExpr.trySolve_fst l v w hv]; exact hv
+
+theorem mem_unit_trySolveUnit (c : Expression p) (l : LinExpr p) (hlin : linearize c = some l)
+    (w : Variable × Expression p) (h : w ∈ unitPivotsOf c) :
+    l.trySolve w.1 = none ∧ l.trySolveUnit w.1 = some w := by
+  unfold unitPivotsOf at h
+  rw [hlin] at h
+  obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
+  cases hts : l.trySolve v with
+  | some r => rw [hts] at hv; simp at hv
+  | none =>
+      rw [hts] at hv
+      rw [LinExpr.trySolveUnit_fst l v w hv]
+      exact ⟨hts, hv⟩
+
+theorem fastBest_eq (c : Expression p) (occ : Std.HashMap Variable Nat)
+    (prot : Std.HashSet Variable) :
+    fastBest c occ prot = (pm1PivotsOf c ++ unitPivotsOf c).argmin (pivotScore occ prot) := by
+  unfold fastBest
+  split
+  · next hlin => simp [pm1PivotsOf, unitPivotsOf, hlin]
+  · next l hlin =>
+      rw [pivotDescs_eq c l hlin occ prot,
+        argmin_map_key (fun xt => (xt.1, pivotScore occ prot xt)) (pivotScore occ prot) Prod.snd
+          (fun _ => rfl)]
+      cases hA : (pm1PivotsOf c ++ unitPivotsOf c).argmin (pivotScore occ prot) with
+      | none => simp
+      | some w =>
+          simp only [Option.map_some]
+          have hmem : w ∈ pm1PivotsOf c ++ unitPivotsOf c :=
+            List.argmin_mem (by rw [hA]; exact Option.mem_some_self w)
+          rcases List.mem_append.1 hmem with hp | hu
+          · rw [mem_pm1_trySolve c l hlin w hp]
+          · obtain ⟨hn, hs⟩ := mem_unit_trySolveUnit c l hlin w hu
+            rw [hn, hs]
 
 /-- Process the pending constraints: reduce each by the current solutions, adopt the cheapest
     solvable pivot (if any), resolve it into the stored solutions, and continue. Structure of
@@ -171,16 +413,20 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
   | c :: rest, hmem, σ =>
     let hrest := fun c' hc' => hmem c' (List.mem_cons_of_mem _ hc')
     let c' := (c.substF σ.fn).normalize
-    match hbest : (pm1PivotsOf c' ++ unitPivotsOf c').argmin (pivotScore occ prot) with
+    match hbest : fastBest c' occ prot with
     | none => gaussLoop cs bs occ prot rest hrest σ
     | some (x, t) =>
+        -- `fastBest` picks exactly the old `argmin` pivot (`fastBest_eq`), so every downstream
+        -- soundness/vars proof is discharged against the original candidate-list membership.
+        have hbest' : (pm1PivotsOf c' ++ unitPivotsOf c').argmin (pivotScore occ prot) = some (x, t) :=
+          (fastBest_eq c' occ prot).symm.trans hbest
         have hx : ∀ env, cs.satisfies bs env → env x = t.eval env := by
           intro env hsat
           have hc0 : c.eval env = 0 := hsat.1 c (hmem c (List.mem_cons_self ..))
           have hc' : c'.eval env = 0 := by
             show ((c.substF σ.fn).normalize).eval env = 0
             rw [σ.eval_reduce c env hsat, hc0]
-          rcases List.mem_append.1 (List.argmin_mem hbest) with h | h
+          rcases List.mem_append.1 (List.argmin_mem hbest') with h | h
           · exact pm1PivotsOf_sound c' x t h env hc'
           · exact unitPivotsOf_sound c' x t h env hc'
         -- every variable of the reduced constraint (hence of any pivot solved from it) is a
@@ -193,7 +439,7 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
           · exact σ.varsIn y' t' hft' z hzt'
         have htvars : ∀ z ∈ t.vars, z ∈ cs.vars := by
           intro z hz
-          rcases List.mem_append.1 (List.argmin_mem hbest) with h | h
+          rcases List.mem_append.1 (List.argmin_mem hbest') with h | h
           · exact hc'vars z (pm1PivotsOf_vars c' x t h z hz)
           · exact hc'vars z (unitPivotsOf_vars c' x t h z hz)
         -- resolve `x` out of the stored solutions, then store `x := t`

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -267,16 +267,97 @@ theorem LinExpr.trySolveUnit_eq_none (l : LinExpr p) (v : Variable)
     (h : ¬l.coeff v * (l.coeff v)⁻¹ = 1) : l.trySolveUnit v = none := by
   unfold LinExpr.trySolveUnit; rw [if_neg h]
 
-/-- `±1`-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` succeeds. -/
-def pm1Desc (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
-    (v : Variable) : Option (Variable × Nat) :=
-  if l.coeff v = 1 ∨ l.coeff v = -1 then some (v, gaussScore occ prot v (l.others v).terms.length)
+/-! ### Coefficient/occurrence index (linear pivot scoring)
+
+Scoring a constraint's candidates needs, per variable, its total coefficient (`l.coeff v`, to
+classify `±1`/unit) and the size of its solution (`(l.others v).terms.length`, the pivot's
+`varCount`). Computed directly those are O(terms) each, so scoring is O(terms²) per constraint.
+`coeffIdx` folds the term list once into a `Std.HashMap Variable (ZMod p × Nat)` = (coefficient sum,
+occurrence count) per variable; then `coeff = idx[v].1` and `others-length = |terms| - idx[v].2` are
+O(1). Proven equal to `l.coeff`/`l.others` (`coeffIdx_coeff`/`coeffIdx_others`), so the descriptors
+below are unchanged in meaning. -/
+
+/-- Coefficient sum of the terms whose variable is `v`. `l.coeff v` unfolds to `csum l.terms v`. -/
+def csum (terms : List (Variable × ZMod p)) (v : Variable) : ZMod p :=
+  ((terms.filter (fun t => t.1 = v)).map Prod.snd).sum
+
+/-- Occurrence count of `v` among the terms. -/
+def ccnt (terms : List (Variable × ZMod p)) (v : Variable) : Nat :=
+  (terms.filter (fun t => t.1 = v)).length
+
+/-- One index step: add `t`'s coefficient and one occurrence to `t.1`'s entry (0 if absent). -/
+def idxStep (m : Std.HashMap Variable (ZMod p × Nat)) (t : Variable × ZMod p) :
+    Std.HashMap Variable (ZMod p × Nat) :=
+  m.insert t.1 (((m[t.1]?).getD (0, 0)).1 + t.2, ((m[t.1]?).getD (0, 0)).2 + 1)
+
+/-- The coefficient/occurrence index of a term list. -/
+def coeffIdx (terms : List (Variable × ZMod p)) : Std.HashMap Variable (ZMod p × Nat) :=
+  terms.foldl idxStep ∅
+
+theorem idxStep_fold (terms : List (Variable × ZMod p)) :
+    ∀ (m : Std.HashMap Variable (ZMod p × Nat)) (v : Variable),
+      ((terms.foldl idxStep m)[v]?).getD (0, 0)
+        = (((m[v]?).getD (0, 0)).1 + csum terms v, ((m[v]?).getD (0, 0)).2 + ccnt terms v) := by
+  induction terms with
+  | nil => intro m v; simp [csum, ccnt]
+  | cons t rest ih =>
+      intro m v
+      rw [List.foldl_cons, ih (idxStep m t) v]
+      have hstep : ((idxStep m t)[v]?).getD (0, 0)
+          = (((m[v]?).getD (0, 0)).1 + (if t.1 = v then t.2 else 0),
+             ((m[v]?).getD (0, 0)).2 + (if t.1 = v then 1 else 0)) := by
+        unfold idxStep
+        rw [Std.HashMap.getElem?_insert]
+        by_cases htv : t.1 = v
+        · subst htv; simp
+        · rw [if_neg (by simpa using htv), if_neg htv, if_neg htv]
+          simp
+      rw [hstep]
+      have hcsum : csum (t :: rest) v = (if t.1 = v then t.2 else 0) + csum rest v := by
+        unfold csum; by_cases htv : t.1 = v <;> simp [htv]
+      have hccnt : ccnt (t :: rest) v = ccnt rest v + (if t.1 = v then 1 else 0) := by
+        unfold ccnt; by_cases htv : t.1 = v <;> simp [htv]
+      rw [hcsum, hccnt]
+      refine Prod.ext ?_ ?_ <;> ring
+
+theorem coeffIdx_get (terms : List (Variable × ZMod p)) (v : Variable) :
+    ((coeffIdx terms)[v]?).getD (0, 0) = (csum terms v, ccnt terms v) := by
+  simp [coeffIdx, idxStep_fold terms ∅ v]
+
+theorem coeffIdx_coeff (l : LinExpr p) (v : Variable) :
+    (((coeffIdx l.terms)[v]?).getD (0, 0)).1 = l.coeff v := by
+  rw [coeffIdx_get]; rfl
+
+theorem filter_eq_ne_length (terms : List (Variable × ZMod p)) (v : Variable) :
+    (terms.filter (fun t => t.1 ≠ v)).length + (terms.filter (fun t => t.1 = v)).length
+      = terms.length := by
+  induction terms with
+  | nil => rfl
+  | cons t rest ih => by_cases htv : t.1 = v <;> simp_all <;> omega
+
+theorem coeffIdx_others (l : LinExpr p) (v : Variable) :
+    l.terms.length - (((coeffIdx l.terms)[v]?).getD (0, 0)).2 = (l.others v).terms.length := by
+  rw [coeffIdx_get]
+  simp only [LinExpr.others, ccnt]
+  have h := filter_eq_ne_length l.terms v
+  omega
+
+/-- `±1`-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` succeeds. The coefficient
+    and occurrence count come from the O(1) index (`total` = `|l.terms|`), so scanning all
+    candidates is O(terms) rather than O(terms²). -/
+def pm1Desc (idx : Std.HashMap Variable (ZMod p × Nat)) (total : Nat)
+    (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) (v : Variable) :
+    Option (Variable × Nat) :=
+  if ((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1 then
+    some (v, gaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
   else none
 
 theorem pm1Desc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
     (v : Variable) :
-    pm1Desc l occ prot v = (l.trySolve v).map (fun xt => (xt.1, pivotScore occ prot xt)) := by
+    pm1Desc (coeffIdx l.terms) l.terms.length occ prot v
+      = (l.trySolve v).map (fun xt => (xt.1, pivotScore occ prot xt)) := by
   unfold pm1Desc
+  rw [coeffIdx_coeff l v, coeffIdx_others l v]
   by_cases h1 : l.coeff v = 1
   · rw [if_pos (Or.inl h1), LinExpr.trySolve_eq_of_one l v h1, Option.map_some,
       gaussScore_eq_pivotScore occ prot v (((l.others v).scale (-1)).toExpr)
@@ -290,19 +371,22 @@ theorem pm1Desc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.
         LinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h]), Option.map_none]
 
 /-- Unit-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` fails but
-    `l.trySolveUnit v` succeeds. -/
-def unitDesc (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
-    (v : Variable) : Option (Variable × Nat) :=
-  if ¬(l.coeff v = 1 ∨ l.coeff v = -1) ∧ l.coeff v * (l.coeff v)⁻¹ = 1 then
-    some (v, gaussScore occ prot v (l.others v).terms.length)
+    `l.trySolveUnit v` succeeds. Index-driven, O(1), like `pm1Desc`. -/
+def unitDesc (idx : Std.HashMap Variable (ZMod p × Nat)) (total : Nat)
+    (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) (v : Variable) :
+    Option (Variable × Nat) :=
+  if ¬(((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1)
+      ∧ ((idx[v]?).getD (0, 0)).1 * (((idx[v]?).getD (0, 0)).1)⁻¹ = 1 then
+    some (v, gaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
   else none
 
 theorem unitDesc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable)
     (v : Variable) :
-    unitDesc l occ prot v
+    unitDesc (coeffIdx l.terms) l.terms.length occ prot v
       = (match l.trySolve v with | some _ => none | none => l.trySolveUnit v).map
           (fun xt : Variable × Expression p => (xt.1, pivotScore occ prot xt)) := by
   unfold unitDesc
+  rw [coeffIdx_coeff l v, coeffIdx_others l v]
   by_cases h1 : l.coeff v = 1
   · rw [if_neg (fun hc => hc.1 (Or.inl h1)), LinExpr.trySolve_eq_of_one l v h1]; rfl
   · by_cases h2 : l.coeff v = -1
@@ -317,17 +401,23 @@ theorem unitDesc_eq (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std
         rfl
       · rw [if_neg (fun hc => h3 hc.2), LinExpr.trySolveUnit_eq_none l v h3]; rfl
 
-/-- All pivot descriptors, `±1` first (mirroring `pm1PivotsOf ++ unitPivotsOf`). -/
+/-- All pivot descriptors, `±1` first (mirroring `pm1PivotsOf ++ unitPivotsOf`). The coefficient/
+    occurrence index is built once (O(terms)); each descriptor is then O(1). -/
 def pivotDescs (l : LinExpr p) (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
     List (Variable × Nat) :=
-  (l.terms.map Prod.fst).filterMap (pm1Desc l occ prot)
-    ++ (l.terms.map Prod.fst).filterMap (unitDesc l occ prot)
+  let idx := coeffIdx l.terms
+  let total := l.terms.length
+  (l.terms.map Prod.fst).filterMap (pm1Desc idx total occ prot)
+    ++ (l.terms.map Prod.fst).filterMap (unitDesc idx total occ prot)
 
 theorem pivotDescs_eq (c : Expression p) (l : LinExpr p) (hlin : linearize c = some l)
     (occ : Std.HashMap Variable Nat) (prot : Std.HashSet Variable) :
     pivotDescs l occ prot
       = (pm1PivotsOf c ++ unitPivotsOf c).map (fun xt => (xt.1, pivotScore occ prot xt)) := by
-  unfold pivotDescs pm1PivotsOf unitPivotsOf
+  show (l.terms.map Prod.fst).filterMap (pm1Desc (coeffIdx l.terms) l.terms.length occ prot)
+      ++ (l.terms.map Prod.fst).filterMap (unitDesc (coeffIdx l.terms) l.terms.length occ prot)
+      = (pm1PivotsOf c ++ unitPivotsOf c).map (fun xt => (xt.1, pivotScore occ prot xt))
+  unfold pm1PivotsOf unitPivotsOf
   rw [hlin, List.map_append, map_filterMap, map_filterMap]
   congr 1
   · exact List.filterMap_congr (fun v _ => pm1Desc_eq l occ prot v)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -61,6 +61,16 @@ def Expression.isVar : Expression p → Bool
     consumes. -/
 structure Solved (p : ℕ) (cs : ConstraintSystem p) (bs : BusSemantics p) where
   map : Std.HashMap Variable (Expression p)
+  /-- Reverse-dependency index: `revDeps[z]` is a *superset* of the solution keys `y` whose stored
+      right-hand side `map[y]` mentions `z`. Used to resolve a newly-adopted pivot `x := t` into
+      only the affected stored solutions (`revDeps[x]`) instead of scanning the whole map (which is
+      O(K²) over K pivots). It carries no proof field — a stale/superset entry only costs a
+      re-checked `mentions`, and soundness holds for whatever entailed pairs are produced; the
+      index's completeness (hence full resolution, hence byte-identical output) is verified by the
+      output tests, per the task's "retain the entailment proof + strong output comparison" option.
+      Buckets are `HashSet`s so re-posting a repeatedly-rewritten key is idempotent (a `List` bucket
+      would accumulate duplicates and blow up the re-insertion work). -/
+  revDeps : Std.HashMap Variable (Std.HashSet Variable)
   sound : ∀ env, cs.satisfies bs env → ∀ y t, map[y]? = some t → env y = t.eval env
   varsIn : ∀ (y : Variable) (t : Expression p), map[y]? = some t → ∀ z ∈ t.vars, z ∈ cs.vars
 
@@ -70,6 +80,7 @@ variable {cs : ConstraintSystem p} {bs : BusSemantics p}
 
 def empty : Solved p cs bs where
   map := ∅
+  revDeps := ∅
   sound := by
     intro _ _ y t h
     rw [Std.HashMap.getElem?_empty] at h
@@ -105,6 +116,9 @@ def insertAll (σ : Solved p cs bs) (pairs : List (Variable × Expression p))
   | (x, t) :: rest =>
       let σ' : Solved p cs bs :=
         { map := σ.map.insert x t,
+          -- post `x` into the reverse-dependency bucket of every variable `t` mentions (stale
+          -- entries from an overwritten `x` are harmless; the `HashSet` keeps re-posting idempotent).
+          revDeps := t.vars.foldl (fun rd z => rd.insert z (((rd[z]?).getD ∅).insert x)) σ.revDeps,
           sound := by
             intro env hsat y s hys
             rw [Std.HashMap.getElem?_insert] at hys
@@ -532,15 +546,25 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
           rcases List.mem_append.1 (List.argmin_mem hbest') with h | h
           · exact hc'vars z (pm1PivotsOf_vars c' x t h z hz)
           · exact hc'vars z (unitPivotsOf_vars c' x t h z hz)
-        -- resolve `x` out of the stored solutions, then store `x := t`
-        let touched := σ.map.toList.filter (fun ys => ys.2.mentions x)
+        -- resolve `x` out of the stored solutions, then store `x := t`. Only the keys in `x`'s
+        -- reverse-dependency bucket can mention `x`; re-check `mentions` (buckets may be stale).
+        let touched := ((σ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+          (σ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
+        have htouched : ∀ y s, (y, s) ∈ touched → σ.map[y]? = some s := by
+          intro y s hys
+          obtain ⟨y', _, hy'⟩ := List.mem_filterMap.1 hys
+          obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
+          by_cases hm : s'.mentions x
+          · rw [if_pos hm] at hif
+            simp only [Option.some.injEq, Prod.mk.injEq] at hif
+            obtain ⟨rfl, rfl⟩ := hif; exact hs'
+          · rw [if_neg hm] at hif; exact absurd hif (by simp)
         let pairs := touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
         have hpairs : ∀ env, cs.satisfies bs env → ∀ yt ∈ pairs, env yt.1 = yt.2.eval env := by
           intro env hsat yt hyt
           rcases List.mem_append.1 hyt with h | h
           · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 h
-            have hmemys : σ.map[y]? = some s :=
-              Std.HashMap.mem_toList_iff_getElem?_eq_some.1 (List.mem_of_mem_filter hys)
+            have hmemys : σ.map[y]? = some s := htouched y s hys
             have hy : env y = s.eval env := σ.sound env hsat y s hmemys
             have hxe : env x = t.eval env := hx env hsat
             show env y = ((s.subst x t).normalize).eval env
@@ -552,8 +576,7 @@ def gaussLoop (cs : ConstraintSystem p) (bs : BusSemantics p)
           intro yt hyt z hz
           rcases List.mem_append.1 hyt with h | h
           · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 h
-            have hmemys : σ.map[y]? = some s :=
-              Std.HashMap.mem_toList_iff_getElem?_eq_some.1 (List.mem_of_mem_filter hys)
+            have hmemys : σ.map[y]? = some s := htouched y s hys
             rcases Expression.subst_vars s x t z (Expression.normalize_vars _ z hz) with h2 | h2
             · exact σ.varsIn y s hmemys z h2
             · exact htvars z h2

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -58,6 +58,226 @@ theorem mergeTerms_eval (ts : List (Variable × ZMod p)) (env : Variable → ZMo
     = (ts.map (fun t => t.2 * env t.1)).sum := by
   simp [mergeTerms, foldl_addCoeff_eval]
 
+/-! ## Linear like-term merge (runtime `@[csimp]` replacement for `mergeTerms`)
+
+`mergeTerms`/`addCoeff` are O(terms²): every input term linearly scans the accumulated deduped
+list. For long affine forms (post-substitution reduced constraints; large blocks such as the sha256
+APC) this is the dominant cost. `mergeTermsFast` accumulates each variable's coefficient in a
+`Std.HashMap` while recording first-occurrence order in an `Array`, then rebuilds by walking the
+recorded order — O(terms) expected. Below a small constant threshold the list fold is faster (no
+hash setup), so a hybrid keeps the tiny-form path (asymptotically still linear: the bounded branch
+is O(1)). Proven `= mergeTerms` and installed via `@[csimp]`, so every call site (`LinExpr.norm`,
+hence `normalize`) uses it at runtime with **no proof churn** and the byte-identical result. -/
+
+/-- The coefficient the first-occurrence-ordered accumulator holds for `v` after merging (the
+    coefficient of the unique accumulator entry for `v`, if any). Mirrors `addCoeff`'s structure so
+    its update lemmas are one-line inductions. -/
+def assocCoeff : List (Variable × ZMod p) → Variable → Option (ZMod p)
+  | [], _ => none
+  | (v', c') :: rest, v => if v' = v then some c' else assocCoeff rest v
+
+theorem not_mem_of_assocCoeff_none (acc : List (Variable × ZMod p)) (v : Variable)
+    (h : assocCoeff acc v = none) : v ∉ acc.map Prod.fst := by
+  induction acc with
+  | nil => simp
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [assocCoeff] at h
+      split at h
+      · exact absurd h (by simp)
+      · next hne =>
+          simp only [List.map_cons, List.mem_cons, not_or]
+          exact ⟨fun hh => hne hh.symm, ih h⟩
+
+theorem mem_of_assocCoeff_some (acc : List (Variable × ZMod p)) (v : Variable) (c : ZMod p)
+    (h : assocCoeff acc v = some c) : v ∈ acc.map Prod.fst := by
+  induction acc with
+  | nil => simp [assocCoeff] at h
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [assocCoeff] at h
+      simp only [List.map_cons, List.mem_cons]
+      split at h
+      · next he => exact Or.inl he.symm
+      · next hne => exact Or.inr (ih h)
+
+/-- The effect of one `addCoeff` on `assocCoeff`: bump `v`'s coefficient (0 if absent), leave every
+    other variable untouched. -/
+theorem assocCoeff_addCoeff (v : Variable) (c : ZMod p) (acc : List (Variable × ZMod p))
+    (w : Variable) :
+    assocCoeff (addCoeff v c acc) w
+      = if w = v then some ((assocCoeff acc v).getD 0 + c) else assocCoeff acc w := by
+  induction acc with
+  | nil =>
+      simp only [addCoeff, assocCoeff, Option.getD_none, zero_add]
+      by_cases hwv : w = v
+      · subst hwv; simp
+      · rw [if_neg hwv, if_neg (fun he => hwv he.symm)]
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [addCoeff]
+      by_cases hv' : v' = v
+      · rw [if_pos hv']
+        subst hv'
+        simp only [assocCoeff]
+        by_cases hwv : w = v'
+        · subst hwv; simp
+        · have hwv' : ¬ v' = w := fun he => hwv he.symm
+          simp only [if_neg hwv, if_neg hwv']
+      · rw [if_neg hv']
+        simp only [assocCoeff, ih]
+        rw [if_neg hv']
+        by_cases hv'w : v' = w
+        · have hwv : ¬ w = v := fun he => hv' (hv'w.trans he)
+          rw [if_pos hv'w, if_neg hwv, if_pos hv'w]
+        · rw [if_neg hv'w, if_neg hv'w]
+
+theorem addCoeff_map_fst_of_mem (v : Variable) (c : ZMod p) (acc : List (Variable × ZMod p))
+    (h : v ∈ acc.map Prod.fst) : (addCoeff v c acc).map Prod.fst = acc.map Prod.fst := by
+  induction acc with
+  | nil => simp at h
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [addCoeff]
+      split
+      · next he => simp
+      · next hne =>
+          simp only [List.map_cons, List.mem_cons] at h
+          have hmem : v ∈ rest.map Prod.fst := by
+            rcases h with h | h
+            · exact absurd h.symm hne
+            · exact h
+          simp [ih hmem]
+
+theorem addCoeff_append_of_not_mem (v : Variable) (c : ZMod p) (acc : List (Variable × ZMod p))
+    (h : v ∉ acc.map Prod.fst) : addCoeff v c acc = acc ++ [(v, c)] := by
+  induction acc with
+  | nil => simp [addCoeff]
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [List.map_cons, List.mem_cons, not_or] at h
+      obtain ⟨hne, hrest⟩ := h
+      simp only [addCoeff]
+      rw [if_neg (fun he => hne he.symm)]
+      simp [ih hrest]
+
+/-- One step of the fast merge: bump `t.1`'s coefficient in the map, appending `t.1` to the order
+    array on first occurrence. -/
+def mtStep (st : Array Variable × Std.HashMap Variable (ZMod p)) (t : Variable × ZMod p) :
+    Array Variable × Std.HashMap Variable (ZMod p) :=
+  match st.2[t.1]? with
+  | some c0 => (st.1, st.2.insert t.1 (c0 + t.2))
+  | none => (st.1.push t.1, st.2.insert t.1 t.2)
+
+/-- Correspondence invariant tying the fast `(order, map)` state to the `addCoeff`-fold list. -/
+def MergeCorr (acc : List (Variable × ZMod p)) (order : Array Variable)
+    (m : Std.HashMap Variable (ZMod p)) : Prop :=
+  order.toList = acc.map Prod.fst ∧ (acc.map Prod.fst).Nodup ∧ ∀ v, m[v]? = assocCoeff acc v
+
+theorem mtStep_corr (acc : List (Variable × ZMod p)) (order : Array Variable)
+    (m : Std.HashMap Variable (ZMod p)) (t : Variable × ZMod p) (h : MergeCorr acc order m) :
+    MergeCorr (addCoeff t.1 t.2 acc) (mtStep (order, m) t).1 (mtStep (order, m) t).2 := by
+  obtain ⟨hord, hnod, hm⟩ := h
+  obtain ⟨tv, tc⟩ := t
+  have hmtv := hm tv
+  rcases hcase : (m[tv]? : Option (ZMod p)) with _ | c0
+  · have habs : assocCoeff acc tv = none := by rw [← hmtv, hcase]
+    have hnmem : tv ∉ acc.map Prod.fst := not_mem_of_assocCoeff_none acc tv habs
+    have hstep : mtStep (order, m) (tv, tc) = (order.push tv, m.insert tv tc) := by
+      simp only [mtStep, hcase]
+    have hfst : (addCoeff tv tc acc).map Prod.fst = acc.map Prod.fst ++ [tv] := by
+      rw [addCoeff_append_of_not_mem tv tc acc hnmem]; simp
+    rw [hstep]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [hfst, Array.toList_push, hord]
+    · rw [hfst]
+      exact hnod.append (List.nodup_singleton tv) (List.disjoint_singleton.2 hnmem)
+    · intro w
+      rw [Std.HashMap.getElem?_insert, assocCoeff_addCoeff, habs]
+      simp only [beq_iff_eq, Option.getD_none, zero_add]
+      by_cases hwv : tv = w
+      · subst hwv; simp
+      · rw [if_neg hwv, if_neg (fun he => hwv he.symm)]
+        exact hm w
+  · have hpres : assocCoeff acc tv = some c0 := by rw [← hmtv, hcase]
+    have hmem : tv ∈ acc.map Prod.fst := mem_of_assocCoeff_some acc tv c0 hpres
+    have hstep : mtStep (order, m) (tv, tc) = (order, m.insert tv (c0 + tc)) := by
+      simp only [mtStep, hcase]
+    have hfst : (addCoeff tv tc acc).map Prod.fst = acc.map Prod.fst :=
+      addCoeff_map_fst_of_mem tv tc acc hmem
+    rw [hstep]
+    refine ⟨?_, ?_, ?_⟩
+    · rw [hfst]; exact hord
+    · rw [hfst]; exact hnod
+    · intro w
+      rw [Std.HashMap.getElem?_insert, assocCoeff_addCoeff, hpres]
+      simp only [beq_iff_eq, Option.getD_some]
+      by_cases hwv : tv = w
+      · subst hwv; simp
+      · rw [if_neg hwv, if_neg (fun he => hwv he.symm)]
+        exact hm w
+
+theorem mtFold_corr (ts : List (Variable × ZMod p)) :
+    ∀ (acc : List (Variable × ZMod p)) (order : Array Variable)
+      (m : Std.HashMap Variable (ZMod p)), MergeCorr acc order m →
+      MergeCorr (ts.foldl (fun a t => addCoeff t.1 t.2 a) acc)
+        (ts.foldl mtStep (order, m)).1 (ts.foldl mtStep (order, m)).2 := by
+  induction ts with
+  | nil => intro acc order m h; simpa using h
+  | cons t rest ih =>
+      intro acc order m h
+      simp only [List.foldl_cons]
+      exact ih (addCoeff t.1 t.2 acc) (mtStep (order, m) t).1 (mtStep (order, m) t).2
+        (mtStep_corr acc order m t h)
+
+theorem recon_assoc (acc : List (Variable × ZMod p)) (hnod : (acc.map Prod.fst).Nodup) :
+    (acc.map Prod.fst).map (fun v => (v, (assocCoeff acc v).getD 0)) = acc := by
+  induction acc with
+  | nil => simp
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [List.map_cons] at hnod ⊢
+      rw [List.nodup_cons] at hnod
+      obtain ⟨hnotin, hnod'⟩ := hnod
+      have hhead : (assocCoeff ((v', c') :: rest) v').getD 0 = c' := by simp [assocCoeff]
+      have htail : (rest.map Prod.fst).map
+          (fun v => (v, (assocCoeff ((v', c') :: rest) v).getD 0))
+          = (rest.map Prod.fst).map (fun v => (v, (assocCoeff rest v).getD 0)) := by
+        apply List.map_congr_left
+        intro v hv
+        have hvne : ¬ v' = v := fun he => hnotin (he ▸ hv)
+        simp [assocCoeff, if_neg hvne]
+      rw [hhead, htail, ih hnod']
+
+theorem recon (acc : List (Variable × ZMod p)) (order : Array Variable)
+    (m : Std.HashMap Variable (ZMod p)) (h : MergeCorr acc order m) :
+    order.toList.map (fun v => (v, (m[v]?).getD 0)) = acc := by
+  obtain ⟨hord, hnod, hm⟩ := h
+  rw [hord]
+  rw [show (fun v => (v, (m[v]?).getD 0)) = (fun v => (v, (assocCoeff acc v).getD 0)) from
+    funext (fun v => by rw [hm v])]
+  exact recon_assoc acc hnod
+
+/-- The linear like-term merge. Proven `= mergeTerms` and installed via `@[csimp]`. -/
+def mergeTermsFast (ts : List (Variable × ZMod p)) : List (Variable × ZMod p) :=
+  if ts.length ≤ 32 then
+    ts.foldl (fun acc t => addCoeff t.1 t.2 acc) []
+  else
+    let st := ts.foldl mtStep (#[], ∅)
+    st.1.toList.map (fun v => (v, (st.2[v]?).getD 0))
+
+@[csimp] theorem mergeTerms_eq_fast : @mergeTerms = @mergeTermsFast := by
+  funext p ts
+  show mergeTerms ts = mergeTermsFast ts
+  unfold mergeTermsFast
+  split
+  · rfl
+  · have hbase : MergeCorr ([] : List (Variable × ZMod p)) (#[] : Array Variable)
+        (∅ : Std.HashMap Variable (ZMod p)) :=
+      ⟨by simp, by simp, fun v => by simp [assocCoeff]⟩
+    have hcorr := mtFold_corr ts [] #[] ∅ hbase
+    exact (recon _ _ _ hcorr).symm
+
 theorem dropZero_eval (ts : List (Variable × ZMod p)) (env : Variable → ZMod p) :
     ((ts.filter (fun t => t.2 ≠ 0)).map (fun t => t.2 * env t.1)).sum
     = (ts.map (fun t => t.2 * env t.1)).sum := by


### PR DESCRIPTION
## What

Removes the **asymptotic quadratic** behaviour in the affine / Gaussian-elimination algebra core. Short affine forms hide these costs, but a large enough block exercises them — e.g. the ~85 MB sha256 APC that currently takes hours — so the goal here is to remove the *complexity*, not just the hot constant.

Each disjoint change is its own commit, and **all are output byte-identical** (verified by the CI effectiveness check: exact per-case circuit sizes, identical to `main` on all three corpuses).

| commit | quadratic removed | how |
|---|---|---|
| build only the winning pivot | candidate `toExpr` construction, **O(#candidates·terms)** per constraint | `fastBest` scores lightweight `(variable, score)` descriptors and builds a solution `Expression` only for the `argmin` winner; proven equal to `(pm1PivotsOf ++ unitPivotsOf).argmin pivotScore` |
| linear like-term merge | `mergeTerms`/`addCoeff`, **O(terms²)** | `mergeTermsFast`: HashMap coefficient accumulation + first-occurrence order array, O(terms); proven `= mergeTerms`, installed via `@[csimp]` (no call-site churn) |
| linear pivot scoring | per-candidate `l.coeff`/`l.others` rescans, **O(terms²)** per constraint | one `(coeff, occurrence-count)` index (`coeffIdx`) built once per constraint, O(1) lookups → O(terms); proven equal to the coeff/others formulation |
| reverse-dependency index | per-pivot solution-map scan `σ.map.toList.filter (·.mentions x)`, **O(K²)** over K pivots | resolve a new pivot against only `x`'s reverse-dependency bucket (`HashSet` buckets, idempotent re-posting) instead of the whole map |

The **blind double sweep** (`constraints ++ constraints`) is deliberately left as-is: it is a 2× *constant* factor and is load-bearing — a single sweep *regresses* (it defers pivot discovery to later cleanup iterations over larger systems) — not an asymptotic quadratic.

## Scope & soundness

- Implementation only: `Gauss.lean` and `Normalize.lean`. No audited surface, benchmark, or pass schedule touched.
- Every pass remains a `VerifiedPass` with its machine-checked `PassCorrect`; the top-level correctness theorems depend only on the three standard axioms. `Scripts/check-proof-integrity.sh` passes — no `sorry`/`admit`/`native_decide`, no new axioms, no new `partial`.
- The first three commits prove the fast path *equals* its reference spec. The fourth adds `revDeps` as a **data-only** field: the pass stays sound via the same per-pivot entailment proof (a stale/incomplete bucket could only make the pass eliminate *fewer* variables, never emit a wrong circuit), and the index's completeness — hence full resolution, hence byte-identical output — is verified by the exact per-case size comparison, the "retain the entailment proof + strong output comparison in tests" option the task permits (as in the merged busPairCancel stable-array change).

## Effectiveness & runtime

- **Effectiveness: exact** — per-case circuit sizes identical to `main` on openvm-eth, wasm-eth, and keccak (+0.000× everywhere).
- On the current short-form corpus these are ~neutral (short affine forms don't trigger the O(terms²) cores), as expected; the payoff is asymptotic, for large blocks like the sha256 APC. The one visible signal is the `gauss` pass stage at ~0.87× (−13%, from the build-only-winner change). Aggregate runtime rows move within the ±7% single-run quick-bench noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)