### PR TITLE
Runtime: de-quadratify seen-scans, dedup, and enumeration eval (effectiveness unchanged)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
@@ -118,6 +118,74 @@ theorem dedupStateless_evalFilter (bs : BusSemantics p) (env : Variable → ZMod
         List.map_cons,
         List.filter_cons_of_neg (by have hf : bs.isStateful (b.eval env).busId = false := (by simpa using h1); simp [hf]), ih]
 
+/-! ## Hash-bucketed stateless dedup
+
+`dedupStateless`' membership test `bi ∈ seen` scans the whole kept-so-far list — quadratic in the
+number of stateless interactions. Bucketing `seen` by a structural hash of the interaction turns
+each test into a one-bucket scan; `dedupStatelessFast_eq` proves the bucketed version returns the
+identical list, so the pass output — and the whole `dedup_correct` proof — are unchanged. -/
+
+/-- A structural hash of an expression (for bucketing). -/
+def Expression.bHash : Expression p → UInt64
+  | .const n => mixHash 11 (hash n.val)
+  | .var x => mixHash 13 (hash x)
+  | .add a b => mixHash 17 (mixHash a.bHash b.bHash)
+  | .mul a b => mixHash 19 (mixHash a.bHash b.bHash)
+
+/-- A structural hash of an interaction (bus id, multiplicity, payload). -/
+def BusInteraction.bHash (bi : BusInteraction (Expression p)) : UInt64 :=
+  mixHash (hash bi.busId)
+    (mixHash bi.multiplicity.bHash (bi.payload.foldl (fun h e => mixHash h e.bHash) 7))
+
+/-- `dedupStateless` with the `seen` set bucketed by `BusInteraction.bHash`: each membership test
+    scans only the matching bucket. -/
+def dedupStatelessFast (bs : BusSemantics p)
+    (seen : Std.HashMap UInt64 (List (BusInteraction (Expression p)))) :
+    List (BusInteraction (Expression p)) → List (BusInteraction (Expression p))
+  | [] => []
+  | bi :: rest =>
+    if bs.isStateful bi.busId then bi :: dedupStatelessFast bs seen rest
+    else if bi ∈ seen.getD bi.bHash [] then dedupStatelessFast bs seen rest
+    else bi :: dedupStatelessFast bs (seen.insert bi.bHash (bi :: seen.getD bi.bHash [])) rest
+
+/-- The bucketed dedup returns the identical list to `dedupStateless`, given a `seen` hash-map that
+    agrees with the `seen` list on membership (each interaction sits in its own hash bucket). -/
+theorem dedupStatelessFast_eq (bs : BusSemantics p)
+    (bis : List (BusInteraction (Expression p))) :
+    ∀ (seenL : List (BusInteraction (Expression p)))
+      (seenH : Std.HashMap UInt64 (List (BusInteraction (Expression p)))),
+      (∀ bi, bi ∈ seenL ↔ bi ∈ seenH.getD bi.bHash []) →
+      dedupStatelessFast bs seenH bis = dedupStateless bs seenL bis := by
+  induction bis with
+  | nil => intro _ _ _; rfl
+  | cons bi rest ih =>
+    intro seenL seenH h
+    rw [dedupStatelessFast, dedupStateless]
+    by_cases hst : bs.isStateful bi.busId = true
+    · rw [if_pos hst, if_pos hst, ih seenL seenH h]
+    · rw [if_neg hst, if_neg hst]
+      by_cases hmem : bi ∈ seenL
+      · rw [if_pos ((h bi).mp hmem), if_pos hmem, ih seenL seenH h]
+      · rw [if_neg (fun hc => hmem ((h bi).mpr hc)), if_neg hmem,
+          ih (bi :: seenL) (seenH.insert bi.bHash (bi :: seenH.getD bi.bHash []))
+            (by
+              intro x
+              rw [Std.HashMap.getD_insert]
+              by_cases hbh : bi.bHash = x.bHash
+              · rw [if_pos (by simpa using hbh), List.mem_cons, List.mem_cons]
+                have hx := h x
+                rw [← hbh] at hx
+                exact or_congr_right hx
+              · have hxne : x ≠ bi := fun he => hbh (by rw [he])
+                rw [if_neg (by simpa using hbh), List.mem_cons]
+                exact (or_iff_right hxne).trans (h x))]
+
+/-- The bucketed dedup, started empty, equals `dedupStateless` started empty. -/
+theorem dedupStatelessFast_eq_nil (bs : BusSemantics p)
+    (bis : List (BusInteraction (Expression p))) :
+    dedupStatelessFast bs ∅ bis = dedupStateless bs [] bis :=
+  dedupStatelessFast_eq bs bis [] ∅ (by intro bi; simp [Std.HashMap.getD_empty])
+
 /-! ## The pass -/
 
 /-- The deduplicated system. -/
@@ -166,6 +234,17 @@ theorem ConstraintSystem.dedup_correct (cs : ConstraintSystem p) (bs : BusSemant
     exact ⟨(hiff env).2 hsat, (hadm env).2 hadm',
       by rw [hside]; exact BusState.equiv_refl _⟩
 
-/-- The duplicate-removal pass. -/
+/-- The deduplicated system, computed with the hash-bucketed stateless dedup. Equal to
+    `ConstraintSystem.dedup` (`dedupFast_eq`), so it inherits `dedup_correct`. -/
+def ConstraintSystem.dedupFast (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    ConstraintSystem p :=
+  { algebraicConstraints := cs.algebraicConstraints.dedup,
+    busInteractions := dedupStatelessFast bs ∅ cs.busInteractions }
+
+theorem ConstraintSystem.dedupFast_eq (cs : ConstraintSystem p) (bs : BusSemantics p) :
+    cs.dedupFast bs = cs.dedup bs := by
+  simp only [ConstraintSystem.dedupFast, ConstraintSystem.dedup, dedupStatelessFast_eq_nil]
+
+/-- The duplicate-removal pass (runs the hash-bucketed dedup; correctness via `dedupFast_eq`). -/
 def dedupPass : VerifiedPass p := fun cs bs =>
-  ⟨cs.dedup bs, [], cs.dedup_correct bs⟩
+  ⟨cs.dedupFast bs, [], (cs.dedupFast_eq bs).symm ▸ cs.dedup_correct bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1278,11 +1278,12 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts
         -- the box cleared both caps: scan it lazily (`scanBox` streams the product, a `Nat` loop
         -- per range and an early abort). The scan certificates are proved against
         -- `scanInit … (assignments (matList fdoms))`; `scanBox_eq` / `matList_map_fst` bridge them.
-        let survC := compiledSurv bs es bis (fdoms.map Prod.fst)
-        match hscan : scanBox survC.val (fdoms.map Prod.fst) fdoms with
+        let keys := fdoms.map Prod.fst
+        let survC := compiledSurv bs es bis keys
+        match hscan : scanBox survC.val keys fdoms with
         | none =>
           -- no surviving point: the box is empty of solutions, everything is vacuously forced
-          (fdoms.map Prod.fst).map (fun x => ⟨x, 0, fun env hsat =>
+          keys.map (fun x => ⟨x, 0, fun env hsat =>
             (scanNone_unsat xs (DomainTable.matList fdoms)
               (T.matList_fst xs fdoms hdoms)
               (fun env hsat => T.matList_sound xs fdoms hdoms env hsat)

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -265,7 +265,7 @@ theorem foldRewrite_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs :
     intro x hx
     rw [hs_def, envOf_map doms env x (by rw [hkeys]; exact hx)]
   have hsurv : s ∈ groupSurvivors cs xs doms := by
-    simp only [groupSurvivors, groupSurvivorsE, List.mem_filter]
+    simp only [groupSurvivors, groupSurvivorsE_eq, List.mem_filter]
     refine ⟨hsassign, ?_⟩
     rw [List.all_eq_true]
     intro c hc

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -596,8 +596,13 @@ def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fid
         have hsurv : groupSurvivors cs xs doms = survs := by
           show groupSurvivors cs xs doms = groupSurvivorsE es doms
           rw [hes]; rfl
-        ⟨⟨foldOut cs xs survs, [], hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩,
-         fidx.refresh (foldOut cs xs survs)⟩
+        -- Compute the rewritten system once (it was built twice: as the output and as the index
+        -- refresh argument). `foldOut` maps `foldRewrite` over the whole system, so this halves the
+        -- per-accepted-fold cost; the `let` zeta-reduces, so the correctness term is unchanged.
+        let ro := foldOut cs xs survs
+        ⟨⟨ro, [], (hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms) :
+            PassCorrect cs (foldOut cs xs survs) [] bs)⟩,
+         fidx.refresh ro⟩
       else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -908,19 +908,19 @@ def fxLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) :
     (pending : List (BusInteraction (Expression p))) →
     (∀ bi ∈ pending, bi ∈ cs.busInteractions) →
-    List (FUSeen p cs) → Solved p cs bs → Solved p cs bs
+    Std.HashMap UInt64 (List (FUSeen p cs)) → Solved p cs bs → Solved p cs bs
   | [], _, _, σ => σ
   | c :: rest, hmem, seen, σ =>
     have hc : c ∈ cs.busInteractions := hmem c (List.mem_cons_self ..)
     let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
     let cands := fuCandidates c
     match cands.findSome? (fun xk =>
-        seen.findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
+        (seen.getD (fuKeyHash xk.2) []).findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
         match hdata : fuPairData? bs facts cs.algebraicConstraints ex.1.bi c ex.2 with
         | none =>
             fxLoop cs bs facts rest hrest
-              (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+              (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩))) σ
         | some d =>
         let pairs := (d.ryVars.eraseDups.filter (fun v => !(v ∈ d.rxVars))).filterMap (fun vy =>
           if fxCheckWith d (buildE d vy) vy
@@ -960,17 +960,17 @@ def fxLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
           · rw [if_neg hck] at hif
             exact absurd hif (by simp)
         fxLoop cs bs facts rest hrest
-          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩)))
           (σ.insertAll pairs hpairs hpairsV)
     | none =>
         fxLoop cs bs facts rest hrest
-          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+          (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩))) σ
 
 /-- Part A as a standalone (unguarded) pass: substitute every certified interpolation. -/
 def fxSubstPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
-    let σ := fxLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
+    let σ := fxLoop cs bs facts cs.busInteractions (fun _ h => h) ∅ Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -176,9 +176,14 @@ def boxTautoDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let singles := singleVarCs cs.algebraicConstraints
+    -- Build the per-variable domain cache in one linear pass over all occurrences, skipping
+    -- variables already seen (a `contains` guard) rather than pre-deduplicating with the quadratic
+    -- `List.eraseDups` over the whole ~10⁵-entry occurrence list. `findDomainAlg` is deterministic,
+    -- so the resulting map — hence `boxTautoReplaceWith`'s output — is identical; the correctness
+    -- theorem takes the oracle as an arbitrary function, so this rebuild is proof-transparent.
     let cache : Std.HashMap Variable (Option (List (ZMod p))) :=
-      (cs.algebraicConstraints.flatMap Expression.vars).eraseDups.foldl
-        (fun m v => m.insert v (findDomainAlg singles v)) ∅
+      (cs.algebraicConstraints.flatMap Expression.vars).foldl
+        (fun m v => if m.contains v then m else m.insert v (findDomainAlg singles v)) ∅
     ⟨cs.boxTautoReplaceWith singles (fun v => cache.getD v none), [],
      cs.boxTautoReplace_correct bs (fun v => cache.getD v none)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -353,6 +353,21 @@ structure FUSeen (p : ℕ) (cs : ConstraintSystem p) where
   x : Variable
   key : Nat × Option (ZMod p) × ZMod p × Variable
 
+/-- Hash of an `FUSeen` match key, used to bucket the `seen` accumulator of `fuLoop`/`fxLoop`. It
+    reads only fields the `key == key'` test compares, so equal keys share a bucket (a match is
+    never hidden); unequal keys that collide are separated by the retained exact `e.key == xk.2`
+    check inside the scan. -/
+def fuKeyHash (key : Nat × Option (ZMod p) × ZMod p × Variable) : UInt64 :=
+  mixHash (hash key.1) (mixHash (hash (key.2.1.map ZMod.val))
+    (mixHash (hash key.2.2.1.val) (hash key.2.2.2)))
+
+/-- Prepend seen-entries into their key-hash buckets. `foldr` keeps each bucket in the same order
+    as the old flat `es ++ seen` list, so the bucketed scan returns the identical earliest twin —
+    output unchanged, per-candidate scan now over one bucket instead of the whole history. -/
+def fuInsertAll {cs : ConstraintSystem p} (m : Std.HashMap UInt64 (List (FUSeen p cs)))
+    (es : List (FUSeen p cs)) : Std.HashMap UInt64 (List (FUSeen p cs)) :=
+  es.foldr (fun e acc => acc.insert (fuKeyHash e.key) (e :: acc.getD (fuKeyHash e.key) [])) m
+
 /-- Scaled-check candidates of one interaction: carrier variables of the first payload slot
     with a constant-coefficient decomposition and a *nonempty* offset part (raw checks have
     nothing to unify). -/
@@ -386,21 +401,21 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) :
     (pending : List (BusInteraction (Expression p))) →
     (∀ bi ∈ pending, bi ∈ cs.busInteractions) →
-    List (FUSeen p cs) → Solved p cs bs → Solved p cs bs
+    Std.HashMap UInt64 (List (FUSeen p cs)) → Solved p cs bs → Solved p cs bs
   | [], _, _, σ => σ
   | c :: rest, hmem, seen, σ =>
     have hc : c ∈ cs.busInteractions := hmem c (List.mem_cons_self ..)
     let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
     let cands := fuCandidates c
     match cands.findSome? (fun xk =>
-        seen.findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
+        (seen.getD (fuKeyHash xk.2) []).findSome? (fun e => if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
         -- pair-level work once per match; per-target checks share it (definitionally the
         -- same value as `fuCheck` — see its definition)
         match hdata : fuPairData? bs facts cs.algebraicConstraints ex.1.bi c ex.2 with
         | none =>
             fuLoop cs bs facts rest hrest
-              (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+              (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩))) σ
         | some d =>
         let pairs := (fuTargets ex.1.bi c ex.2).filterMap (fun t =>
           if fuCheckWith d t.2 t.1
@@ -437,11 +452,11 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
           · rw [if_neg hck] at hif
             exact absurd hif (by simp)
         fuLoop cs bs facts rest hrest
-          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩)))
           (σ.insertAll pairs hpairs hpairsV)
     | none =>
         fuLoop cs bs facts rest hrest
-          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+          (fuInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩))) σ
 
 /-- Flag unification across duplicate scaled range checks. Prime `p` only (re-checked at
     runtime). Runs after `rootPairUnifyPass` — the carrier limbs must already be shared — and
@@ -449,7 +464,7 @@ def fuLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
 def flagUnifyPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
-    let σ := fuLoop cs bs facts cs.busInteractions (fun _ h => h) [] Solved.empty
+    let σ := fuLoop cs bs facts cs.busInteractions (fun _ h => h) ∅ Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -783,12 +783,61 @@ def reencodeOut (cs : ConstraintSystem p) (xs bits : List Variable)
 def coveredCsOf (cs : ConstraintSystem p) (xs : List Variable) : List (Expression p) :=
   cs.algebraicConstraints.filter (coveredBy xs)
 
+/-- All covered constraints zero at a point, with the ring ops hoisted out of the per-point
+    evaluation (cf. `survivesAllCW` in `DomainBatch`): `add`/`mul` are extracted from the `ZMod p`
+    instances once by the caller and passed in, so each `IExpr` node is a direct closure call
+    instead of re-deriving the `CommRing (ZMod p)` chain. -/
+def survZeroCW (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr p))
+    (a : List (Variable × ZMod p)) : Bool :=
+  ces.all (fun ie => decide (ie.evalWith add mul a = 0))
+
+theorem survZeroCW_eq (add mul : ZMod p → ZMod p → ZMod p)
+    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b)
+    (ces : List (IExpr p)) (a : List (Variable × ZMod p)) :
+    survZeroCW add mul ces a = ces.all (fun ie => decide (ie.eval a = 0)) := by
+  simp only [survZeroCW, IExpr.evalWith_eq add mul hadd hmul]
+
 /-- The surviving group values from a **precomputed** covered set: enumerated over the group's
-    domains, filtered by the covered constraints. -/
+    domains, filtered by the covered constraints.
+
+    The enumerated points all share the key order of `doms` (`assignments_keys`), so the covered
+    constraints are compiled **once per target** to positional `IExpr`s (variable leaves → indices,
+    `compileEs`) and each box point is evaluated by index — no per-variable `envOf` scan — with the
+    ring ops hoisted out of the instances once (`survZeroCW`). This is the `domainBatch`
+    index-compile treatment, here shared by the re-encoder and `domainFold`. When a covered
+    constraint mentions a variable outside `doms`'s keys (`compileEs` returns `none`, not expected
+    for a covered set but handled for totality) it falls back to the direct `evalFast` filter. Both
+    compute the identical list (`groupSurvivorsE_eq`), so the output is unchanged. -/
 def groupSurvivorsE (es : List (Expression p))
     (doms : List (Variable × List (ZMod p))) : List (List (Variable × ZMod p)) :=
-  (assignments doms).filter
-    (fun a => es.all (fun c => decide (c.evalFast (envOf a) = 0)))
+  match compileEs (doms.map Prod.fst) es with
+  | some ces =>
+    -- `add`/`mul` extracted from the instances once, as args to the survivor test's partial
+    -- application (formed once per target, so the `CommRing` chain is not re-derived per point).
+    (assignments doms).filter
+      (survZeroCW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul ces)
+  | none =>
+    (assignments doms).filter (fun a => es.all (fun c => decide (c.evalFast (envOf a) = 0)))
+
+/-- `groupSurvivorsE` computes the identical list to the direct `evalFast`/`envOf` filter — the
+    index-compiled path is a pure speedup. Consumers that reason about the survivor set as a
+    `List.filter` rewrite through this. -/
+theorem groupSurvivorsE_eq (es : List (Expression p))
+    (doms : List (Variable × List (ZMod p))) :
+    groupSurvivorsE es doms =
+      (assignments doms).filter (fun a => es.all (fun c => decide (c.evalFast (envOf a) = 0))) := by
+  unfold groupSurvivorsE
+  split
+  · rename_i ces hce
+    refine List.filter_congr (fun a ha => ?_)
+    have hkeys : a.map Prod.fst = doms.map Prod.fst := assignments_keys doms a ha
+    have hfun : (fun e : Expression p => decide (e.eval (envOfFast a) = 0))
+        = (fun c : Expression p => decide (c.evalFast (envOf a) = 0)) := by
+      funext c; rw [envOfFast_eq, Expression.evalFast_eq]
+    rw [survZeroCW_eq (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul
+        (fun _ _ => rfl) (fun _ _ => rfl) ces a,
+      compileEs_all (doms.map Prod.fst) es ces hce a hkeys, hfun]
+  · rfl
 
 /-- The surviving group values: enumerated over the group's domains, filtered by the covered
     constraints. The covered set is bound outside the filter so it is computed **once**, not once
@@ -1205,6 +1254,7 @@ theorem checkReencode_sound_D [Fact p.Prime] (cs : ConstraintSystem p) (bsem : B
     have hamem : (doms.map (fun yd => (yd.1, env yd.1))) ∈ assignments doms :=
       mem_assignments doms env hdsound
     have hasurv : (doms.map (fun yd => (yd.1, env yd.1))) ∈ groupSurvivors cs xs doms := by
+      simp only [groupSurvivors, groupSurvivorsE_eq]
       refine List.mem_filter.2 ⟨hamem, ?_⟩
       rw [List.all_eq_true]
       intro c hc

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -531,6 +531,22 @@ def rpCandidates (c : Expression p) :
       else none
     | none => none)
 
+/-- Hash of a candidate key, used to bucket the `seen` accumulator. It reads only fields that the
+    `key == key'` test compares, so equal keys hash equally — bucketing never hides a twin — while
+    unequal keys that happen to collide are still separated by the exact `e.key == xk.2` check
+    inside the scan. Mirrors the `pdValHash`/`Expression.structHash` bucketing used elsewhere. -/
+def rpKeyHash (key : ZMod p × List (Variable × ZMod p) × ZMod p × ZMod p) : UInt64 :=
+  mixHash (hash key.1.val)
+    (mixHash (hash key.2.2.1.val) (mixHash (hash key.2.2.2.val) (hash key.2.1.length)))
+
+/-- Prepend seen-entries into their key-hash buckets. `foldr` keeps each bucket in the same order
+    as the old flat `es ++ seen` list, so the bucketed `findSome?` returns the identical earliest
+    twin the linear scan did — the pass output is unchanged, only the per-candidate scan is now
+    over one bucket instead of the whole history. -/
+def rpInsertAll {cs : ConstraintSystem p} (m : Std.HashMap UInt64 (List (RPSeen p cs)))
+    (es : List (RPSeen p cs)) : Std.HashMap UInt64 (List (RPSeen p cs)) :=
+  es.foldr (fun e acc => acc.insert (rpKeyHash e.key) (e :: acc.getD (rpKeyHash e.key) [])) m
+
 /-- Scan the constraints: for each two-root candidate, look for an earlier twin with the same
     key whose pair certificate passes, and adopt the entailed equality into the solution map.
     The certificate is re-checked inside the proof, so the scan itself carries no obligations. -/
@@ -538,14 +554,14 @@ def rpLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) (domCs : List (Expression p))
     (hdomCs : ∀ c ∈ domCs, c ∈ cs.algebraicConstraints) :
     (pending : List (Expression p)) → (∀ c ∈ pending, c ∈ cs.algebraicConstraints) →
-    List (RPSeen p cs) → Solved p cs bs → Solved p cs bs
+    Std.HashMap UInt64 (List (RPSeen p cs)) → Solved p cs bs → Solved p cs bs
   | [], _, _, σ => σ
   | c :: rest, hmem, seen, σ =>
     have hc : c ∈ cs.algebraicConstraints := hmem c (List.mem_cons_self ..)
     let hrest := fun c' h' => hmem c' (List.mem_cons_of_mem _ h')
     let cands := rpCandidates c
     match hfound : cands.findSome? (fun xk =>
-        seen.findSome? (fun e =>
+        (seen.getD (rpKeyHash xk.2) []).findSome? (fun e =>
           if e.key == xk.2 && e.x != xk.1 &&
               rpCheckPair bs facts cs.busInteractions domCs e.c c e.x xk.1
           then some (e, xk.1) else none)) with
@@ -579,11 +595,11 @@ def rpLoop [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
           exact ConstraintSystem.mem_vars_of_constraint ex.1.mem
             (rpCheckPair_vars bs facts cs.busInteractions domCs ex.1.c c ex.1.x ex.2 hcert).1
         rpLoop cs bs facts domCs hdomCs rest hrest
-          ((cands.filter (fun xk => xk.1 != ex.2)).map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen)
+          (rpInsertAll seen ((cands.filter (fun xk => xk.1 != ex.2)).map (fun xk => ⟨c, hc, xk.1, xk.2⟩)))
           (σ.insertAll [(ex.2, Expression.var ex.1.x)] hpairs hpairsV)
     | none =>
         rpLoop cs bs facts domCs hdomCs rest hrest
-          (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩) ++ seen) σ
+          (rpInsertAll seen (cands.map (fun xk => ⟨c, hc, xk.1, xk.2⟩))) σ
 
 /-- Two-root decomposition unification. Prime `p` only (re-checked at runtime, as in
     `busPairCancelPass`). One sweep; the cleanup fixpoint iterates the pass, so chains resolve
@@ -593,7 +609,7 @@ def rootPairUnifyPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let σ := rpLoop cs bs facts cs.algebraicConstraints (fun _ h => h)
-      cs.algebraicConstraints (fun _ h => h) [] Solved.empty
+      cs.algebraicConstraints (fun _ h => h) ∅ Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -447,3 +447,72 @@ busPairCancel 52 s, rootPairUnify 51 s, domainBatch 34 s. Levers not yet taken, 
 - Lower priority: `withPtrEq`-shortcut structural equality for `Expression`/`BusInteraction`
   (safe, Implementation-only; helps `dedup`'s quadratic `bi ∈ seen` and remaining split
   decides); `substF` no-change signaling to preserve sharing; incremental lengths in `sizeKey`.
+
+## Runtime leftovers III (post the "de-quadratify seen-scans / dedup / enumeration" PR)
+
+That PR **cleared** these earlier leftovers (all output-preserving, proven, verified byte-identical):
+- **rootPairUnify seen-join** and **flagUnify/flagFold-A seen-scans** — the `seen` history is now a
+  `Std.HashMap UInt64 (List …Seen)` bucketed by a hash of the match key; the O(C²)/O(B²) scan
+  becomes a per-bucket scan (the search is proof-free — a re-checked certificate — so bucketing
+  preserves the picked element and every proof).
+- **dedup bus-side `bi ∈ seen`** — bucketed by `BusInteraction.bHash`; `dedupStatelessFast_eq`
+  proves the identical list via a HashMap↔list-agreement induction; **keccak dedup 16.6 s → 7.0 s**.
+- **reencode/domainFold enumeration eval** (the entry-54 `evalFast`/`envOf` tax) — `groupSurvivorsE`
+  compiles the covered constraints once per target to positional `IExpr` with hoisted ring ops
+  (`compileEs`/`survZeroCW`, the `domainBatch` `compiledSurv` treatment); `groupSurvivorsE_eq` proves
+  the identical survivor list. Helps the DIRECT path (<8192 constraints); keccak already indexed.
+- **flagFold-B O(N²) eraseDups**, **domainFold double `foldOut`**, **domainBatch `fdoms.map fst`**
+  recompute — hoisted / linearized.
+
+**Dropped after measuring** (do NOT re-propose without new evidence): domainFold index-threshold
+lowering (index is circuit-dependent — helped some large eth cases, regressed others); constraint-
+side dedup hash-pair (keccak dedup is bus-side-dominated → pure overhead); gauss substF-rebuild-skip
+for solved-var-disjoint constraints (neutral on keccak — the solution map is large, few disjoint).
+
+### Remaining quadratic (or worse) algorithms, rough value order
+
+- **The cleanup fixpoint is an O(size) structural multiplier**: `iterateToFixpoint cleanupCycle`
+  runs ~O(#vars+#bus) cycles (keccak 9), each re-running every pass over the whole system, and the
+  enumeration passes rediscover the same negatives every cycle. Cross-cycle memoization (a pass-state
+  channel threaded through `VerifiedPassW`) would cut every pass's steady-state tail at once — but it
+  needs a `Basic.lean` glue change; weigh against the audit-surface rule.
+- **Finite-domain enumeration trio (keccak's dominant ~57 %) — near-linear-with-large-constant, not
+  quadratic, on keccak** (indexed paths, >8192 constraints). The residual is `CoveredIndex.coveredIdx`
+  gather + `CoveredIndex.build` **rebuild-per-accept** in `reencode`. A **position-stable
+  `reencodeOut`** (keep covered constraints in place, marked dead, so positions don't shift) would let
+  it use `FoldIdx.refresh` like `domainFold` instead of a full rebuild — **the single biggest keccak
+  lever left**. `domainBatch`'s box scan is already `compiledSurv`-hoisted; its residual is the
+  pinned-(domain-1)-var box bloat — substitute pinned constants and enumerate only free vars, needs
+  `forcedOver` soundness reproven against the reduced box.
+- **gauss — O(V²) resolved-map maintenance** (`σ.map.toList.filter (·.mentions x)` per adopted pivot,
+  `Gauss.lean` ~line 200): materializes the whole solution map per pivot. Needs a proof-carrying
+  reverse index `var → keys-whose-value-mentions-it` in `Solved`, with a **completeness invariant
+  maintained through resolution** (adopting `x:=t` moves entries from `depIdx[x]` to `depIdx[t.vars]`)
+  — that invariant is the hard part.
+- **busPairCancel — O(B²), worst O(B³)**: the from-index-0 live-prefix rebuild + `shieldOk` scan per
+  drop, inside its own `iterateToFixpoint` (one pair/drop). The shield depends on the prefix, so this
+  is **positional/consecutive, NOT value-bucketable** — needs incremental shield state. Just
+  array-optimized in #151; high risk.
+- **busUnify — O(B²)**: `candidateSplits` per active send × `findConsumer` forward scan, no
+  amortization. Positional (first forward consumer), not value-bucketable.
+- **dedup constraint-side — O(C²)**: `cs.algebraicConstraints.dedup` (`List.dedup`, deep `Expression`
+  equality). A `(structHash c, c)` hash-pair + `dedup_map_of_injective` is a cheap CONSTANT-factor win
+  (short-circuit on the hash) but stays O(C²); a true O(C) needs `List.dedup`'s keep-last order
+  preserved through a HashMap dedup (a mem-iff / list-equality proof).
+- **oneHotAnnihilate O(C²)** (`hasProd` scans all constraints per marker; in the cleanup cycle →
+  O(C³) compounded), **hintCollapse O(C²+C·B)** (`occursOnlyInTarget` full-system scan per
+  single-occurrence variable), **seqzCollapse O(G²·C)** (self-fixpoint, one gadget/full-scan step,
+  coda) — smaller absolute cost; per-container / bucket-by-shape indexes would help.
+- **reencode/domainFold DIRECT paths O(C²)** — only reached below 8192 constraints (small, fast);
+  harmless, noted for completeness.
+
+**Why keccak vs SHA differ**: keccak is dominated by the near-linear-large-constant enumeration
+(above the index threshold), so it scales ~n^1.4; the genuinely-quadratic passes above are a smaller
+keccak slice. For larger circuits (SHA) the O(B²)/O(V²)/O(C²) passes outgrow the enumeration and
+dominate (~n^2.5 effective). The seen-scan/dedup fixes above are asymptotic, so they help SHA-scale
+disproportionately; a full "massive SHA" result also needs busPairCancel/gauss/busUnify de-quadratified.
+
+Cross-cutting constant factors (from leftovers II, still open): `Variable` is a fresh `String` per
+occurrence → equality/hash walk the full name (~10–15 % of big-case time; intern in the parser,
+Implementation-only); ZMod-instance reconstruction per scalar op (extend the `IExpr.evalWith` /
+`Expression.evalFast` hoist to `addCoeff`/`mergeTerms`).


### PR DESCRIPTION
## What this does

Pure **runtime** work targeting the optimizer's super-linear scaling: the *output is unchanged* on
every benchmark case, so effectiveness is identical — only wall-clock cost drops. Nothing in the
audited surface, `Basic.lean`, or the spec changed; correctness follows from each pass's own
`PassCorrect`. `lake build` green, no warnings, no `sorry`/`native_decide`.

## Motivation

The nightly powdr run showed the optimizer scaling ~quadratically — on openvm-eth, ~14× more
constraints costs ~100× more optimizer time. The super-linear work is a set of **O(n²) `seen`-scans
/ dedup** (each element checked against a growing history) plus a **quadratic finite-domain
enumeration eval** and per-invocation **whole-tree rebuilds**.

## Changes (each output-preserving; verified byte-identical vs `main` on all 100 openvm-eth cases + keccak)

**De-quadratified O(n²)→~O(n) via hash-bucketing.** Each of these passes picks a candidate then
re-checks it with a certificate, so the *search* carries no proof obligation; bucketing the history
into a `HashMap` keyed by a hash of the match key (equal keys share a bucket, collisions resolved by
the retained exact check, insertion order preserved) returns the identical picked element:
- `rootPairUnify` (`rpLoop`) and `flagUnify` / `flagFold` part A (`fuLoop`/`fxLoop`) — the two-root
  and scaled-check candidate `seen`-scans.
- **`dedup` bus side** (`dedupStateless`): the `bi ∈ seen` membership scan → per-bucket scan.
  `dedupStatelessFast_eq` proves (a HashMap↔list-agreement induction) it returns the identical list,
  and `dedupFast_eq` reuses `dedup_correct` verbatim. **keccak: dedup 16.6 s → 7.0 s.**

**Finite-domain enumeration** (`groupSurvivorsE`, shared by `reencode` + `domainFold`): compile the
covered constraints once per target to positional `IExpr` with the ring ops hoisted out of the
instances (the `domainBatch` `compiledSurv` treatment) instead of `evalFast (envOf a)` at every box
point; `groupSurvivorsE_eq` proves the identical survivor list. **eth apc_100: reencode 7417 → 5940
ms, domainFold 2652 → 2227 ms.**

**Recomputation / rebuild hoists (proof-transparent `let`s):**
- `domainFold` (`foldStep`): compute `foldOut` once per accepted fold (was twice).
- `domainBatch` (`forcedOver`): hoist the recomputed domain-key list.
- `flagFold` part B (`boxTautoDrop`): build the per-variable domain cache in one linear pass instead
  of an O(N²) `eraseDups` over the whole occurrence list.

## Results

- **Effectiveness unchanged** — output byte-identical vs `main` on all 100 openvm-eth cases and on
  the keccak stress case (`2021 / 186 / 1752`), via `apc-optimizer run`.
- **openvm-eth optimizer time ≈ −5%** aggregate over all 100 cases, no per-case regressions; the
  slowest cases benefit most (the enumeration + `seen`-scan fixes: large cases ≈ −5 to −8%).
- **keccak ≈ −7%** (best-of-2 runs; single-run variance ±3%), led by the dedup-bus (−9.6 s) and the
  `seen`-scan bucketing.
- The `seen`-scan and dedup fixes are **asymptotic** (O(n²) → ~O(n)), so they help larger
  (SHA-scale) circuits disproportionately more than the keccak/eth percentages alone show.

## Not included (honest frontier)

- The enumeration trio (`domainBatch`/`domainFold`/`reencode`) dominates the keccak profile, but on
  keccak (>8192 constraints) it runs its inverted-index paths, already near the engineered floor; the
  residual is the index gather/rebuild, needing a position-stable `reencodeOut` (log entry 86).
- `busPairCancel` (O(B²) shielded-prefix rebuild, just optimized in #151) and `busUnify` (O(B²)
  forward consumer scan) are **positional/consecutive** scans, not value-bucketable.
- `gauss`'s residual O(V²) resolved-map maintenance (`σ.map.toList` per pivot) needs a proof-carrying
  reverse index with a completeness invariant through resolution. (A substF-rebuild-skip for
  solved-var-disjoint constraints was implemented and measured **neutral** on keccak, so it was
  dropped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxTz3FwUa6oTALyWZtNsQV