### PR TITLE
Fix variable range checker spec

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -184,7 +184,7 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       bs.admissible (A ++ S :: B ++ R :: C) →
       bs.admissible (A ++ B ++ C)
   /-- Variable-range-checker style *stateless* bus: the 2-ary message `[x, b]` is accepted
-      **iff** the requested width is supported and `x` fits (`b.val ≤ 25 ∧ x.val < 2 ^ b.val`).
+      **iff** the requested width is supported and `x` fits (`b.val ≤ 17 ∧ x.val < 2 ^ b.val`).
       `trivial` sets it `false`; the OpenVM instance proves it for the variable range checker. -/
   varRangeBus : (busId : Nat) → Bool
   varRangeBus_sound :
@@ -192,7 +192,7 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       bs.isStateful busId = false ∧
       ∀ (x b mult : ZMod p),
         bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, b] }
-            = false ↔ (b.val ≤ 25 ∧ x.val < 2 ^ b.val)
+            = false ↔ (b.val ≤ 17 ∧ x.val < 2 ^ b.val)
   /-- Tuple-range-checker style *stateless* bus with fixed sizes: the 2-ary message `[x, y]` is
       accepted **iff** `x.val < s1 ∧ y.val < s2`, and at multiplicity `1` it never breaks an
       invariant. Lets a pass pack a byte obligation (`s1 = 256`) and an exact-width range check

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -34,7 +34,7 @@ private def slotBoundImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat) 
   -- XOR output be cancelled (`byteJustified`).
   | some .bitwiseLookup, [_, _, _, some op], 2 => if op.val ≤ 1 then some 256 else none
   | some .variableRangeChecker, [_, some bits], 0 =>
-      if bits.val ≤ 25 then some (2 ^ bits.val) else none
+      if bits.val ≤ 17 then some (2 ^ bits.val) else none
   | some (.tupleRangeChecker s1 _), [_, _], 0 => some s1
   | some (.tupleRangeChecker _ s2), [_, _], 1 => some s2
   -- Data limbs of a memory *receive* (multiplicity -1) from a known register / main-memory
@@ -621,13 +621,13 @@ def openVmFacts (p : ℕ) [NeZero p]
     · show (match busMap busId with | some t => t.isStateful | none => false) = false
       rw [hbus]; rfl
     · intro x
-      -- variableRangeChecker `[x, 0]`: `!(0 ≤ 25 ∧ x.val < 2^0) = false ↔ x.val < 1 ↔ x = 0`.
+      -- variableRangeChecker `[x, 0]`: `!(0 ≤ 17 ∧ x.val < 2^0) = false ↔ x.val < 1 ↔ x = 0`.
       have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
       show violates busMap { busId := busId, multiplicity := 1, payload := [x, 0] } = false ↔ x = 0
       unfold violates; rw [hbus]
       rw [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq,
         hv0, pow_zero, Nat.lt_one_iff, ZMod.val_eq_zero]
-      exact ⟨fun h => h.2, fun h => ⟨Nat.zero_le 25, h⟩⟩
+      exact ⟨fun h => h.2, fun h => ⟨Nat.zero_le 17, h⟩⟩
   varRangeBus busId := match busMap busId with
     | some .variableRangeChecker => true
     | _ => false
@@ -642,7 +642,7 @@ def openVmFacts (p : ℕ) [NeZero p]
       rw [hbus]; rfl
     · intro x b mult
       show violates busMap { busId := busId, multiplicity := mult, payload := [x, b] }
-          = false ↔ (b.val ≤ 25 ∧ x.val < 2 ^ b.val)
+          = false ↔ (b.val ≤ 17 ∧ x.val < 2 ^ b.val)
       unfold violates; rw [hbus]
       simp
   tupleRangeBus busId := match busMap busId with

--- a/ApcOptimizer/Implementation/OptimizerPasses/SubsumedRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SubsumedRange.lean
@@ -24,7 +24,7 @@ The drop reuses two proven ingredients, exactly as `RedundantByteDrop`:
    variable could each justify the other and both would be dropped unsoundly.
 
 A recognized check `[x, w]` is dropped when the base bounds `x` by some `b' ≤ 2^w`: the retained
-source forces `x.val < b' ≤ 2^w`, and `w ≤ 25` (a wider check always violates and is never
+source forces `x.val < b' ≤ 2^w`, and `w ≤ 17` (a wider check always violates and is never
 recognized), so the message `[x, w]` is accepted. No new `BusFacts`; the bound comparison is a
 plain `Nat` `≤`, so the direction is exactly "the retained check is at least as strong".
 
@@ -36,8 +36,8 @@ namespace SubsumedRange
 variable {p : ℕ}
 
 /-- Recognize a single-variable range check `[x, width]` (multiplicity `1`) on a `varRangeBus`
-    bus whose width is a *satisfiable* constant (`width.val ≤ 25`), returning the checked variable
-    and the width constant. A width `> 25` check always violates, so dropping it would be unsound;
+    bus whose width is a *satisfiable* constant (`width.val ≤ 17`), returning the checked variable
+    and the width constant. A width `> 17` check always violates, so dropping it would be unsound;
     it is deliberately not recognized. -/
 def rangeCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Option (Variable × ZMod p) :=
@@ -48,7 +48,7 @@ def rangeCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
       match c.constValue? with
       | some cv =>
         if facts.varRangeBus bi.busId = true ∧ bi.multiplicity = Expression.const 1
-            ∧ cv.val ≤ 25 then some (x, cv) else none
+            ∧ cv.val ≤ 17 then some (x, cv) else none
       | none => none
     | _ => none
   | _ => none
@@ -58,7 +58,7 @@ def rangeCheck? (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem rangeCheck?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) (x : Variable) (cv : ZMod p)
     (h : rangeCheck? bs facts bi = some (x, cv)) :
-    facts.varRangeBus bi.busId = true ∧ bi.multiplicity = Expression.const 1 ∧ cv.val ≤ 25 ∧
+    facts.varRangeBus bi.busId = true ∧ bi.multiplicity = Expression.const 1 ∧ cv.val ≤ 17 ∧
       ∃ c, bi.payload = [Expression.var x, c] ∧ c.constValue? = some cv := by
   unfold rangeCheck? at h
   split at h

--- a/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
@@ -179,7 +179,7 @@ theorem tupleKey (bs : BusSemantics p) (facts : BusFacts p bs)
     (hspec : facts.byteXorSpec bcBus = some spec) (hbound : spec.bound = 256)
     (hvr : facts.varRangeBus vrBus = true)
     (htr : facts.tupleRangeBus trBus = some (s1, s2))
-    (hs1 : s1 = 256) (b : ZMod p) (hble : b.val ≤ 25) (hs2 : 2 ^ b.val = s2)
+    (hs1 : s1 = 256) (b : ZMod p) (hble : b.val ≤ 17) (hs2 : 2 ^ b.val = s2)
     (x y : Expression p) :
     ∀ env, bs.violatesConstraint ((tupleCheck trBus x y).eval env) = false ↔
       bs.violatesConstraint ((mkByteCheck spec bcBus x).eval env) = false ∧
@@ -193,7 +193,7 @@ theorem tupleKey (bs : BusSemantics p) (facts : BusFacts p bs)
   have hB : bs.violatesConstraint
       { busId := vrBus, multiplicity := 1,
         payload := [y.eval env, (Expression.const b).eval env] } = false ↔
-      (b.val ≤ 25 ∧ (y.eval env).val < 2 ^ b.val) :=
+      (b.val ≤ 17 ∧ (y.eval env).val < 2 ^ b.val) :=
     hvriff (y.eval env) b 1
   rw [hB, hs1, ← hs2]
   constructor
@@ -224,7 +224,7 @@ def matchRangeCheck {bs : BusSemantics p} (facts : BusFacts p bs) (s2 : Nat)
   if facts.varRangeBus bi.busId then
     match bi.multiplicity, bi.payload with
     | .const c, [y, .const b] =>
-        if decide (c = 1) && decide (b.val ≤ 25) && decide (2 ^ b.val = s2)
+        if decide (c = 1) && decide (b.val ≤ 17) && decide (2 ^ b.val = s2)
         then some (y, b) else none
     | _, _ => none
   else none
@@ -279,7 +279,7 @@ theorem matchRangeCheck_eq {bs : BusSemantics p} {facts : BusFacts p bs} {s2 : N
     {bi : BusInteraction (Expression p)} {y : Expression p} {b : ZMod p}
     (h : matchRangeCheck facts s2 bi = some (y, b)) :
     bi = rangeCheck1 bi.busId y (.const b) ∧ facts.varRangeBus bi.busId = true ∧
-      b.val ≤ 25 ∧ 2 ^ b.val = s2 := by
+      b.val ≤ 17 ∧ 2 ^ b.val = s2 := by
   obtain ⟨busId, mult, payload⟩ := bi
   simp only [matchRangeCheck] at h
   split at h
@@ -340,7 +340,7 @@ theorem packByteFirst_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (htr : facts.tupleRangeBus trBus = some (s1, s2)) (hs1 : s1 = 256)
     (x y : Expression p) (b : ZMod p) (spec : ByteXorSpec p)
     (hspec : facts.byteXorSpec bcBus = some spec) (hbound : spec.bound = 256)
-    (hvr : facts.varRangeBus vrBus = true) (hble : b.val ≤ 25) (hs2 : 2 ^ b.val = s2)
+    (hvr : facts.varRangeBus vrBus = true) (hble : b.val ≤ 17) (hs2 : 2 ^ b.val = s2)
     (pre mid post : List (BusInteraction (Expression p)))
     (hsplit : cs.busInteractions
       = pre ++ mkByteCheck spec bcBus x :: mid ++ rangeCheck1 vrBus y (.const b) :: post) :
@@ -379,7 +379,7 @@ theorem packRangeFirst_correct (cs : ConstraintSystem p) (bs : BusSemantics p)
     (htr : facts.tupleRangeBus trBus = some (s1, s2)) (hs1 : s1 = 256)
     (x y : Expression p) (b : ZMod p) (spec : ByteXorSpec p)
     (hspec : facts.byteXorSpec bcBus = some spec) (hbound : spec.bound = 256)
-    (hvr : facts.varRangeBus vrBus = true) (hble : b.val ≤ 25) (hs2 : 2 ^ b.val = s2)
+    (hvr : facts.varRangeBus vrBus = true) (hble : b.val ≤ 17) (hs2 : 2 ^ b.val = s2)
     (pre mid post : List (BusInteraction (Expression p)))
     (hsplit : cs.busInteractions
       = pre ++ rangeCheck1 vrBus y (.const b) :: mid ++ mkByteCheck spec bcBus x :: post) :

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -89,8 +89,10 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
 
   | some .variableRangeChecker, [x, bits] =>
     -- Check that x < 2^bits, and that the number of bits requested is one the checker
-    -- supports: OpenVM's variable range checker rejects any lookup of more than 25 bits.
-    !(decide (bits.val ≤ 25) && decide (x.val < 2 ^ bits.val))
+    -- supports: OpenVM's variable range checker rejects any lookup of more than 17 bits.
+    -- TODO: The maximum number of bits is configurable, but the default is 17 and the
+    -- OpenVM chips assume that it is at least 17, so we're being conservative here.
+    !(decide (bits.val ≤ 17) && decide (x.val < 2 ^ bits.val))
 
   | some (.tupleRangeChecker s1 s2), [x, y] =>
     -- Range check that x < s1 and y < s2.


### PR DESCRIPTION
The up to 25-Bit range check was to generous. While OpenVM *can* be configured that way, it is not by default and in practice. #147 exploited this!