### PR TITLE
CI: add the SP1 rsp and keccak effectiveness benchmarks

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -25,12 +25,12 @@ jobs:
           path: .lake/build/bin/apc-optimizer
           retention-days: 30
 
-  # Effectiveness over the full openvm-eth and wasm-eth sets and the keccak stress set. The matrix
-  # crosses side (this PR vs the latest main build) with a benchmark group, so each cell is its own
-  # runner: circuit sizes are deterministic, so the sides needn't share a runner, and splitting the
-  # 100-case wasm-eth set into its own group keeps it off the openvm-eth critical path. `report`
-  # merges every cell. benchmark.py also captures a rough total runtime, used for the report-only
-  # runtime row.
+  # Effectiveness over the full OpenVM (openvm-eth, wasm-eth) and SP1 (rsp) sets plus the keccak
+  # stress sets. The matrix crosses side (this PR vs the latest main build) with a benchmark group,
+  # so each cell is its own runner: circuit sizes are deterministic, so the sides needn't share a
+  # runner, and splitting the 100-case wasm-eth set into its own group keeps it off the openvm-eth
+  # critical path. `report` merges every cell. benchmark.py also captures a rough total runtime, used
+  # for the report-only runtime row.
   effectiveness:
     if: github.event_name == 'pull_request'
     needs: build
@@ -40,11 +40,15 @@ jobs:
       fail-fast: false
       matrix:
         side: [pr, main]
-        # `key` names the artifact; `sets` is the space-separated list this cell runs. keccak is tiny
-        # (2 cases), so it rides along with openvm-eth rather than paying for its own runner.
+        # `key` names the artifact; `sets` is the space-separated list of `<vm>:<set>` tokens this
+        # cell runs (vm picks the Benchmarks/<VM>/ dir + fact-aware backend: openvm -> BabyBear,
+        # sp1 -> KoalaBear). Tiny sets ride along with a full one rather than paying for their own
+        # runner: the OpenVM and SP1 keccak stress sets sit with openvm-eth; the full 200-case SP1
+        # rsp set pairs with wasm-eth. Per-cell JSON/MD are keyed by a unique label (sp1 sets get an
+        # `sp1-` prefix) so the two `keccak` sets don't collide.
         group:
-          - { key: openvm, sets: openvm-eth keccak }
-          - { key: wasm, sets: wasm-eth }
+          - { key: openvm, sets: "openvm:openvm-eth openvm:keccak sp1:keccak" }
+          - { key: wasm, sets: "openvm:wasm-eth sp1:rsp" }
     permissions:
       contents: read
       actions: read
@@ -71,9 +75,14 @@ jobs:
         run: |
           [ -f bin/apc-optimizer ] || { echo "no binary for side '${{ matrix.side }}'"; exit 0; }
           chmod +x bin/apc-optimizer
-          for set in ${{ matrix.group.sets }}; do
-            python3 Benchmarks/benchmark.py "$set" --binary bin/apc-optimizer \
-              --json "$set.json" --md "$set.md"
+          for token in ${{ matrix.group.sets }}; do
+            vm=${token%%:*}; bset=${token#*:}
+            # Non-openvm sets get a `<vm>-` label prefix so SP1 keccak doesn't overwrite OpenVM's;
+            # openvm keeps the bare label the report assembler expects.
+            label=$bset
+            if [ "$vm" != openvm ]; then label="$vm-$bset"; fi
+            python3 Benchmarks/benchmark.py "$bset" --vm "$vm" --binary bin/apc-optimizer \
+              --json "$label.json" --md "$label.md"
           done
       - uses: actions/upload-artifact@v4
         with:
@@ -159,7 +168,8 @@ jobs:
       - name: Assemble comment
         run: |
           : > bench.md
-          for set in openvm-eth wasm-eth keccak; do
+          # Labels match the per-cell JSON/MD written by the effectiveness job (sp1 sets prefixed).
+          for set in openvm-eth wasm-eth keccak sp1-rsp sp1-keccak; do
             if [ -f "main/$set.json" ]; then
               python3 Benchmarks/benchmark.py --compare "main/$set.json" "pr/$set.json" \
                 --md "$set.md"
@@ -184,7 +194,7 @@ jobs:
           pr: ${{ github.event.pull_request.head.repo.full_name == github.repository
                   && github.event.number || '' }}
           note: >-
-            openvm-eth + wasm-eth + keccak, PR `${{ steps.base.outputs.psha }}`
+            openvm-eth + wasm-eth + keccak + sp1/rsp + sp1/keccak, PR `${{ steps.base.outputs.psha }}`
             ${{ steps.base.outputs.sha && format('vs main `{0}`', steps.base.outputs.sha)
                  || '(no main baseline binary)' }}.
             Effectiveness is exact; the runtime row and detail are report-only. Full runtime detail:

--- a/Benchmarks/benchmark.py
+++ b/Benchmarks/benchmark.py
@@ -209,9 +209,16 @@ def summarize(results):
     return summary
 
 
-def emit_summary_md(benchmark, summary, skipped):
+def _bench_label(benchmark, vm):
+    """Report label for a set: bare for openvm (the unmarked default), else `vm/set`, so
+    same-named sets across VMs (e.g. OpenVM `keccak` vs SP1 `keccak`) stay distinguishable."""
+    return benchmark if vm == "openvm" else f"{vm}/{benchmark}"
+
+
+def emit_summary_md(benchmark, summary, skipped, vm="openvm"):
     """Markdown summary of one benchmark run (apc-optimizer vs powdr)."""
-    lines = [f"### Effectiveness — {benchmark}, {summary['n']} cases, apc-optimizer vs powdr", "",
+    lines = [f"### Effectiveness — {_bench_label(benchmark, vm)}, {summary['n']} cases, "
+             "apc-optimizer vs powdr", "",
              "Effectiveness = size before / size after (larger is better); "
              "priority: variables > bus interactions > constraints. "
              "agg = Σbefore ⁄ Σafter, geo = geomean of per-case factors.", "",
@@ -246,8 +253,8 @@ def emit_compare_md(base, target):
     b_results = [(name, base["results"][name]) for name in common]
     ts, bs = summarize(t_results), summarize(b_results)
 
-    lines = [f"### Effectiveness — {target['benchmark']}, {len(common)} cases, "
-             "this branch vs main", "",
+    lines = [f"### Effectiveness — {_bench_label(target['benchmark'], target.get('vm', 'openvm'))}, "
+             f"{len(common)} cases, this branch vs main", "",
              "| measure | main | this branch | Δ | powdr |",
              "|---|---|---|---|---|"]
     for mt in METRICS:
@@ -406,7 +413,7 @@ def main():
                                          "skipped": skipped}))
         print(f"wrote {args.json}", file=sys.stderr)
     if args.md is not None:
-        args.md.write_text(emit_summary_md(benchmark, summary, skipped))
+        args.md.write_text(emit_summary_md(benchmark, summary, skipped, args.vm))
         print(f"wrote {args.md}", file=sys.stderr)
 
     if want_report:


### PR DESCRIPTION
Adds the two SP1 benchmark sets (`rsp` and `keccak`, added in #143) to the PR effectiveness CI, reusing the existing `openvm-eth` and `wasm-eth` runner jobs rather than spinning up new ones.

## What changed

- **`.github/workflows/lean_action_ci.yml`** — the `effectiveness` matrix now encodes each cell's sets as `<vm>:<set>` tokens (the `vm` picks the `Benchmarks/<VM>/` directory and the fact-aware backend: `openvm` → BabyBear, `sp1` → KoalaBear):
  - `openvm` group: `openvm:openvm-eth openvm:keccak sp1:keccak` — the tiny SP1 keccak stress set (2 cases) rides along next to the OpenVM keccak set, matching the file's existing "tiny sets ride along rather than paying for their own runner" rationale.
  - `wasm` group: `openvm:wasm-eth sp1:rsp` — the full 200-case SP1 `rsp` set pairs with `wasm-eth`.
  - SP1 cells run with `--vm sp1` and write per-cell JSON/MD under an `sp1-` label (`sp1-rsp`, `sp1-keccak`) so the two `keccak` sets never overwrite each other in the merged artifacts.
  - The `report` assembler loop and its sticky-comment note pick up the new labels.

- **`Benchmarks/benchmark.py`** — the report header keyed on the bare set name, so OpenVM `keccak` and SP1 `keccak` would render identical table titles. The header is now VM-qualified (`sp1/keccak`) for any non-openvm set; `openvm` stays bare, matching the tool's convention where openvm is the unmarked default. Applies to both the single-run summary and the branch-vs-main comparison.

No changes to the audited surface, the optimizer, or any Lean source — this is CI plumbing plus a benchmark-report label fix. The SP1 backend the benchmarks exercise is already in `main` (#139/#143/#152).

## Verification

Ran both SP1 cells end-to-end against a local binary with the exact invocations CI uses — `benchmark.py keccak --vm sp1` and `benchmark.py rsp --vm sp1` both produce results and write to the `sp1-` labels. Confirmed the `--compare` path (used by the report assembler) renders the disambiguated `sp1/keccak` and `sp1/rsp` headers, and that OpenVM sets still render bare. Validated the workflow YAML and the `<vm>:<set>` token parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLioE9o2e3gjL4vw5di8a9)_