### PR TITLE
SP1: close ~65% of the memory-telescoping gap to powdr (vars 2.94×→3.54×, bus 1.96×→2.46×)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -320,3 +320,243 @@ theorem addrAffineNeq_sound (shape : MemoryBusShape) (S bi : BusInteraction (Exp
           simp only [hL, hL'] at hcond
           exact constDiffNZ_sound L L' hcond env
             (by rw [← linearize_eval e L hL env, ← linearize_eval e' L' hL' env]; exact key)
+
+/-! ## The nonzero-witness (register-vs-RAM) address-disequality certificate
+
+The `addrAffineNeq`/`addrTwoRootNeq` certificates refute an address match only when *some single*
+address slot differs by a provable constant (or two-root gap). But SP1 (and any VM with a flat
+multi-limb address space) distinguishes a **register** access — a small constant address `(c, 0, 0)`
+whose high limbs are literally `0` — from a **RAM** access `(e₂, e₃, e₄)` by a *reciprocal*
+constraint `inv · (e₃ + e₄) − 1 = 0`, which pins the high-limb *sum* nonzero (`e₃ + e₄ ≠ 0`). No
+single slot is provably nonzero (`e₃` or `e₄` alone may be `0`), so neither existing certificate
+fires, and register accesses never telescope across the interleaved RAM ones.
+
+This certificate closes that. It reads reciprocal constraints `a · b + k = 0` (`k ≠ 0`) as
+**nonzero witnesses** — each factor `a`, `b` is nonzero, since `a·b = −k ≠ 0` — and refutes an
+address match when some *subset* `T` of the address slots has its limb-difference sum
+`Σ_{i∈T}(mᵢ − Sᵢ)` equal (up to sign) to a nonzero witness `g`: were the addresses equal, that sum
+would be `0`, contradicting `g ≠ 0`. Purely linear arithmetic plus one reciprocal constraint — no
+bounds, and (unlike two-root) no primality. It strictly extends `addrAffineNeq` (a nonzero *constant*
+difference is the `T`-singleton, witness-free case, still handled there) to nonzero *symbolic*
+differences. Corpus-agnostic: any flat address space that pins "not a register" (or any two accesses
+separated by a proved-nonzero limb combination) benefits. -/
+
+/-- A linear form is identically zero (empty terms and zero constant after normalization). -/
+def isZeroLin (l : LinExpr p) : Bool :=
+  l.norm.terms.isEmpty && decide (l.norm.const = 0)
+
+theorem isZeroLin_sound (l : LinExpr p) (h : isZeroLin l = true) (env : Variable → ZMod p) :
+    l.eval env = 0 := by
+  unfold isZeroLin at h
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+  obtain ⟨hterms, hconst⟩ := h
+  have hz : l.norm.eval env = l.norm.const := by
+    simp only [LinExpr.eval, List.isEmpty_iff.1 hterms, List.map_nil, List.sum_nil, add_zero]
+  rw [← LinExpr.norm_eval, hz, hconst]
+
+/-- Nonzero linear factors of a single reciprocal product `a * b + r` with `r` a nonzero constant:
+    `a·b = −r ≠ 0`, so each factor that linearizes is a nonzero witness. -/
+def reciprocalWitsProd (a b r : Expression p) : List (LinExpr p) :=
+  match linearize r with
+  | some lr =>
+    if lr.terms.isEmpty && decide (lr.const ≠ 0) then
+      (match linearize a with | some la => [la] | none => []) ++
+      (match linearize b with | some lb => [lb] | none => [])
+    else []
+  | none => []
+
+theorem reciprocalWitsProd_sound (a b r : Expression p) (g : LinExpr p)
+    (h : g ∈ reciprocalWitsProd a b r) (env : Variable → ZMod p)
+    (hc : a.eval env * b.eval env + r.eval env = 0) : g.eval env ≠ 0 := by
+  unfold reciprocalWitsProd at h
+  cases hr : linearize r with
+  | none => simp [hr] at h
+  | some lr =>
+    simp only [hr] at h
+    split_ifs at h with hcond
+    · simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+      obtain ⟨hterms, hne⟩ := hcond
+      have hrconst : r.eval env = lr.const := by
+        rw [linearize_eval r lr hr env]
+        simp only [LinExpr.eval, List.isEmpty_iff.1 hterms, List.map_nil, List.sum_nil, add_zero]
+      have hrne : r.eval env ≠ 0 := by rw [hrconst]; exact hne
+      have hprodne : a.eval env * b.eval env ≠ 0 := by
+        intro hp0; rw [hp0] at hc; exact hrne (by linear_combination hc)
+      have hane : a.eval env ≠ 0 := fun ha => hprodne (by rw [ha, zero_mul])
+      have hbne : b.eval env ≠ 0 := fun hb => hprodne (by rw [hb, mul_zero])
+      rw [List.mem_append] at h
+      rcases h with hla | hlb
+      · cases ha : linearize a with
+        | none => rw [ha] at hla; simp at hla
+        | some la =>
+          rw [ha] at hla; simp only [List.mem_singleton] at hla
+          rw [hla, ← linearize_eval a la ha env]; exact hane
+      · cases hb : linearize b with
+        | none => rw [hb] at hlb; simp at hlb
+        | some lb =>
+          rw [hb] at hlb; simp only [List.mem_singleton] at hlb
+          rw [hlb, ← linearize_eval b lb hb env]; exact hbne
+    · simp at h
+
+/-- Nonzero linear witnesses recognized from a constraint of the form `a·b + r = 0` (in either
+    additive order), with `r` a nonzero constant. -/
+def reciprocalWits? (c : Expression p) : List (LinExpr p) :=
+  match c with
+  | .add e1 e2 =>
+    match e1 with
+    | .mul a b => reciprocalWitsProd a b e2
+    | _ => match e2 with
+           | .mul a b => reciprocalWitsProd a b e1
+           | _ => []
+  | _ => []
+
+theorem reciprocalWits?_sound (c : Expression p) (g : LinExpr p) (h : g ∈ reciprocalWits? c)
+    (env : Variable → ZMod p) (hc : c.eval env = 0) : g.eval env ≠ 0 := by
+  unfold reciprocalWits? at h
+  split at h
+  · rename_i e1 e2
+    split at h
+    · rename_i a b
+      exact reciprocalWitsProd_sound a b e2 g h env (by rw [← hc]; simp [Expression.eval])
+    · split at h
+      · rename_i a b
+        exact reciprocalWitsProd_sound a b e1 g h env
+          (by rw [← hc]; simp only [Expression.eval]; ring)
+      · simp at h
+  · simp at h
+
+/-- Linear forms provably nonzero under `constraints` (each backed by a reciprocal constraint). -/
+structure NonzeroWits (p : ℕ) (constraints : List (Expression p)) where
+  wits : List (LinExpr p)
+  sound : ∀ g ∈ wits, ∀ env : Variable → ZMod p,
+    (∀ c ∈ constraints, c.eval env = 0) → g.eval env ≠ 0
+
+/-- Collect every reciprocal-witness linear form from the constraint list. -/
+def NonzeroWits.build (constraints : List (Expression p)) : NonzeroWits p constraints where
+  wits := constraints.flatMap reciprocalWits?
+  sound := by
+    intro g hg env hcon
+    rw [List.mem_flatMap] at hg
+    obtain ⟨c, hc, hgc⟩ := hg
+    exact reciprocalWits?_sound c g hgc env (hcon c hc)
+
+/-- Equal addresses agree at every declared address slot (the per-slot half of `addrAffineNeq`). -/
+theorem addr_eq_slot (shape : MemoryBusShape) (S m : BusInteraction (Expression p))
+    (env : Variable → ZMod p) (heq : shape.address (S.eval env) = shape.address (m.eval env))
+    (f : Nat) (hf : f ∈ shape.addressFields) :
+    (S.eval env).payload[f]? = (m.eval env).payload[f]? := by
+  obtain ⟨j, hj⟩ : ∃ j, shape.addressFields[j]? = some f := List.getElem?_of_mem hf
+  have e1 : (shape.address (S.eval env))[j]? = some ((S.eval env).payload[f]?) := by
+    simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+  have e2 : (shape.address (m.eval env))[j]? = some ((m.eval env).payload[f]?) := by
+    simp only [MemoryBusShape.address, List.getElem?_map, hj, Option.map_some]
+  rw [heq, e2] at e1
+  exact (Option.some.inj e1).symm
+
+/-- `Σ_{f ∈ fields} (m.payload[f] − S.payload[f])` as a linear form; `none` if any listed slot is
+    absent from either payload or is nonlinear. -/
+def diffSumOver (S m : BusInteraction (Expression p)) : List Nat → Option (LinExpr p)
+  | [] => some ⟨0, []⟩
+  | f :: fs =>
+    match diffSumOver S m fs with
+    | none => none
+    | some acc =>
+      match S.payload[f]?, m.payload[f]? with
+      | some eS, some eM =>
+        match linearize eS, linearize eM with
+        | some lS, some lM => some ((lM.add (lS.scale (-1))).add acc)
+        | _, _ => none
+      | _, _ => none
+
+/-- If the two interactions agree at every listed slot (under `env`), the difference sum is `0`. -/
+theorem diffSumOver_eval_zero (S m : BusInteraction (Expression p)) (fields : List Nat)
+    (D : LinExpr p) (h : diffSumOver S m fields = some D) (env : Variable → ZMod p)
+    (hslots : ∀ f ∈ fields, (S.eval env).payload[f]? = (m.eval env).payload[f]?) :
+    D.eval env = 0 := by
+  induction fields generalizing D with
+  | nil =>
+    simp only [diffSumOver, Option.some.injEq] at h; subst h
+    simp [LinExpr.eval]
+  | cons f fs ih =>
+    simp only [diffSumOver] at h
+    cases hacc : diffSumOver S m fs with
+    | none => simp [hacc] at h
+    | some acc =>
+      cases hSp : S.payload[f]? with
+      | none => simp [hacc, hSp] at h
+      | some eS =>
+        cases hmp : m.payload[f]? with
+        | none => simp [hacc, hSp, hmp] at h
+        | some eM =>
+          cases hlS : linearize eS with
+          | none => simp [hacc, hSp, hmp, hlS] at h
+          | some lS =>
+            cases hlM : linearize eM with
+            | none => simp [hacc, hSp, hmp, hlS, hlM] at h
+            | some lM =>
+              simp only [hacc, hSp, hmp, hlS, hlM, Option.some.injEq] at h
+              subst h
+              have haccz : acc.eval env = 0 :=
+                ih acc hacc (fun f' hf' => hslots f' (List.mem_cons_of_mem _ hf'))
+              have hkey : (S.eval env).payload[f]? = (m.eval env).payload[f]? :=
+                hslots f (List.mem_cons_self ..)
+              have hSev : (S.eval env).payload[f]? = some (eS.eval env) := by
+                show (S.payload.map (fun e => e.eval env))[f]? = _
+                rw [List.getElem?_map, hSp]; rfl
+              have hMev : (m.eval env).payload[f]? = some (eM.eval env) := by
+                show (m.payload.map (fun e => e.eval env))[f]? = _
+                rw [List.getElem?_map, hmp]; rfl
+              rw [hSev, hMev] at hkey
+              have hval : eS.eval env = eM.eval env := (Option.some.inj hkey)
+              have hlMe := linearize_eval eM lM hlM env
+              have hlSe := linearize_eval eS lS hlS env
+              rw [LinExpr.add_eval, LinExpr.add_eval, LinExpr.scale_eval]
+              linear_combination -hlMe + hlSe - hval + haccz
+
+/-- The address slots of `S` and `m` provably differ: some subset `T` of the shape's address fields
+    has limb-difference sum `Σ_{i∈T}(mᵢ − Sᵢ)` equal (up to sign) to a nonzero witness `g`.  Were
+    the addresses equal every difference would vanish, contradicting `g ≠ 0`. -/
+def addrNonzeroNeq (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (nw : NonzeroWits p constraints) (S m : BusInteraction (Expression p)) : Bool :=
+  shape.addressFields.sublists.any (fun T =>
+    match diffSumOver S m T with
+    | some D => nw.wits.any (fun g => isZeroLin (D.add (g.scale (-1))) || isZeroLin (D.add g))
+    | none => false)
+
+theorem addrNonzeroNeq_sound (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (nw : NonzeroWits p constraints) (S m : BusInteraction (Expression p))
+    (h : addrNonzeroNeq shape nw S m = true) (env : Variable → ZMod p)
+    (hcon : ∀ c ∈ constraints, c.eval env = 0) :
+    shape.address (S.eval env) ≠ shape.address (m.eval env) := by
+  intro heq
+  unfold addrNonzeroNeq at h
+  rw [List.any_eq_true] at h
+  obtain ⟨T, hT, hcond⟩ := h
+  have hTsub : List.Sublist T shape.addressFields := List.mem_sublists.mp hT
+  cases hD : diffSumOver S m T with
+  | none => rw [hD] at hcond; simp at hcond
+  | some D =>
+    rw [hD] at hcond
+    rw [List.any_eq_true] at hcond
+    obtain ⟨g, hg, hzero⟩ := hcond
+    have hDzero : D.eval env = 0 :=
+      diffSumOver_eval_zero S m T D hD env (fun f hf =>
+        addr_eq_slot shape S m env heq f (hTsub.subset hf))
+    have hgne : g.eval env ≠ 0 := nw.sound g hg env hcon
+    rcases (Bool.or_eq_true _ _).mp hzero with hz | hz
+    · have hzz := isZeroLin_sound _ hz env
+      rw [LinExpr.add_eval, LinExpr.scale_eval, hDzero] at hzz
+      exact hgne (by linear_combination -hzz)
+    · have hzz := isZeroLin_sound _ hz env
+      rw [LinExpr.add_eval, hDzero] at hzz
+      exact hgne (by linear_combination hzz)
+
+/-- The address-disequality certificates a memory-telescoping pass consults, bundled so both the
+    two-root and the reciprocal-nonzero data thread through the pass as one memoized value. -/
+structure AddrCerts (p : ℕ) (constraints : List (Expression p)) where
+  tworoot : TwoRootMap p constraints
+  nonzero : NonzeroWits p constraints
+
+/-- Build both certificate tables from the constraint list. -/
+def AddrCerts.build (constraints : List (Expression p)) : AddrCerts p constraints :=
+  ⟨TwoRootMap.build constraints, NonzeroWits.build constraints⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1452,33 +1452,35 @@ theorem firstMatchAt_spec {constraints : List (Expression p)}
     for interior-pair telescoping on the heap. Sound under the constraints `T` was built from
     (`midRefuted_sound` takes their satisfaction). -/
 def midRefuted (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
   decide (m.busId ≠ busId) || decide (multConst m = some 0) || addrConstsNeq shape S m
-    || addrAffineNeq shape S m || addrTwoRootNeq shape T.get S m
+    || addrAffineNeq shape S m || addrTwoRootNeq shape T.get.tworoot S m
+    || addrNonzeroNeq shape T.get.nonzero S m
 
 /-- Refute `m` as an active same-address *send* on `busId` (the "before" region test: earliest-send). -/
 def preRefuted (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S m : BusInteraction (Expression p)) : Bool :=
   midRefuted shape T busId S m ||
     (match multConst m with | some c => decide (c ≠ shape.setNewMult) | none => false)
 
 theorem midRefuted_sound (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S m : BusInteraction (Expression p))
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S m : BusInteraction (Expression p))
     (h : midRefuted shape T busId S m = true) (env : Variable → ZMod p)
     (hcon : ∀ c ∈ constraints, c.eval env = 0)
     (hbid : (m.eval env).busId = busId) (hmne : (m.eval env).multiplicity ≠ 0)
     (hmaddr : shape.address (m.eval env) = shape.address (S.eval env)) : False := by
   unfold midRefuted at h
-  rw [Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true] at h
-  rcases h with (((h | h) | h) | h) | h
+  rw [Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true] at h
+  rcases h with ((((h | h) | h) | h) | h) | h
   · exact absurd hbid (of_decide_eq_true h)
   · exact hmne (m.multiplicity.constValue?_sound 0 (of_decide_eq_true h) env)
   · exact addrConstsNeq_sound shape S m h env hmaddr.symm
   · exact addrAffineNeq_sound shape S m h env hmaddr.symm
-  · exact addrTwoRootNeq_sound shape T.get S m h env hcon hmaddr.symm
+  · exact addrTwoRootNeq_sound shape T.get.tworoot S m h env hcon hmaddr.symm
+  · exact addrNonzeroNeq_sound shape T.get.nonzero S m h env hcon hmaddr.symm
 
 theorem preRefuted_sound (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S m : BusInteraction (Expression p))
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S m : BusInteraction (Expression p))
     (h : preRefuted shape T busId S m = true) (env : Variable → ZMod p)
     (hcon : ∀ c ∈ constraints, c.eval env = 0)
     (hbid : (m.eval env).busId = busId) (hmne : (m.eval env).multiplicity ≠ 0)
@@ -1519,7 +1521,7 @@ theorem provRecv_sound (shape : MemoryBusShape) (busId : Nat) (hp1 : (1 : ZMod p
     processed so far (everything to the right) contains a provable active same-address receive; `ok`
     is whether every not-`preRefuted` message so far is followed by such a receive. O(n). -/
 def shieldScan (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S : BusInteraction (Expression p)) :
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S : BusInteraction (Expression p)) :
     List (BusInteraction (Expression p)) → Bool × Bool
   | [] => (false, true)
   | m0 :: rest =>
@@ -1532,13 +1534,13 @@ def shieldScan (shape : MemoryBusShape) {constraints : List (Expression p)}
     same-address receive after it" — the relaxed completeness side condition that admits chains led
     by a boundary store. Computed in one O(n) pass (`shieldScan`). -/
 def shieldOk (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat) (S : BusInteraction (Expression p))
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat) (S : BusInteraction (Expression p))
     (l : List (BusInteraction (Expression p))) : Bool :=
   (shieldScan shape T busId S l).2
 
 /-- If the scan's `hasRecv` flag is set, the list contains a provable receive. -/
 theorem shieldScan_hasRecv (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat)
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat)
     (S : BusInteraction (Expression p)) :
     ∀ (l : List (BusInteraction (Expression p))), (shieldScan shape T busId S l).1 = true →
       ∃ Rp ∈ l, provRecv shape busId S Rp = true
@@ -1555,7 +1557,7 @@ theorem shieldScan_hasRecv (shape : MemoryBusShape) {constraints : List (Express
     provably excluded (`¬preRefuted`), the suffix `A_suf` carries a provable active same-address
     receive. -/
 theorem shieldOk_sound (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : Thunk (TwoRootMap p constraints)) (busId : Nat)
+    (T : Thunk (AddrCerts p constraints)) (busId : Nat)
     (S m0 : BusInteraction (Expression p)) (A_suf : List (BusInteraction (Expression p))) :
     ∀ (A_pre : List (BusInteraction (Expression p))),
       shieldOk shape T busId S (A_pre ++ m0 :: A_suf) = true →
@@ -1727,7 +1729,7 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
     (slots : List Nat) (bound : Nat)
-    (T : Thunk (TwoRootMap p cs.algebraicConstraints))
+    (T : Thunk (AddrCerts p cs.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs.algebraicConstraints))
     (domCs : List (Expression p)) (candsOf : Variable → List (Expression p))
     (wits : Variable → List (BusInteraction (Expression p)))
@@ -1925,7 +1927,7 @@ structure DropResult {p : ℕ} (cs0 : ConstraintSystem p) (bs : BusSemantics p)
 def mkDropResult (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
-    (T : Thunk (TwoRootMap p cs0.algebraicConstraints))
+    (T : Thunk (AddrCerts p cs0.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs0.algebraicConstraints))
     (domCs : List (Expression p)) (hdomCs : ∀ c ∈ domCs, c ∈ cs0.algebraicConstraints)
     (candsOf : Variable → List (Expression p))
@@ -2007,7 +2009,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
     (aggressive : Bool)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
-    (T : Thunk (TwoRootMap p cs0.algebraicConstraints))
+    (T : Thunk (AddrCerts p cs0.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs0.algebraicConstraints))
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
@@ -2096,7 +2098,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
 def findCancel (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool)
-    (T : Thunk (TwoRootMap p cs0.algebraicConstraints))
+    (T : Thunk (AddrCerts p cs0.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs0.algebraicConstraints))
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
@@ -2134,7 +2136,7 @@ def findCancel (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFact
 def cancelLoop (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool)
-    (T : Thunk (TwoRootMap p cs0.algebraicConstraints))
+    (T : Thunk (AddrCerts p cs0.algebraicConstraints))
     (M : Thunk (EqConstraintMap p cs0.algebraicConstraints))
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
@@ -2178,8 +2180,8 @@ def busPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : VerifiedPassW 
     -- Constraint-derived thunks (address disequality, entailed-payload equality, single-variable
     -- constraints, variable→constraints index): built at most once per invocation and reused
     -- across every drop (drops leave `algebraicConstraints` untouched, so they stay valid).
-    let T : Thunk (TwoRootMap p cs.algebraicConstraints) :=
-      Thunk.mk fun _ => TwoRootMap.build cs.algebraicConstraints
+    let T : Thunk (AddrCerts p cs.algebraicConstraints) :=
+      Thunk.mk fun _ => AddrCerts.build cs.algebraicConstraints
     let M : Thunk (EqConstraintMap p cs.algebraicConstraints) :=
       Thunk.mk fun _ =>
         if aggressive then EqConstraintMap.build cs.algebraicConstraints

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -397,13 +397,119 @@ theorem domainByteJustified_sound [Fact p.Prime] (domCs : List (Expression p)) (
           rw [Expression.fold_eval, hsubeval] at hfoldeval
           rw [hfoldeval]; exact hbyte
 
+/-! ## Affine bound propagation (multi-limb recomposition slots)
+
+A memory data slot is often an affine recomposition of byte limbs — `256·hi + lo`, or
+`result₀ + 256·result₁` — which is `< 2¹⁶` whenever each limb is a byte, but is neither a constant,
+a single variable, nor a single-variable domain expression, so the justifications above miss it and a
+telescoped register access cannot shed its (genuinely 16-bit) data. This propagates a per-variable
+value bound through a linearized form: with `(env v).val < bᵥ` for each variable, the field value of
+`const + Σ cᵥ·v` is at most `const.val + Σ cᵥ.val·(bᵥ − 1)` **provided that natural bound is below
+`p`** (no wraparound), and equals it exactly there. Purely arithmetic; needs no primality. -/
+
+/-- Natural upper bound of a term list `Σ cᵥ·v` under per-variable value bounds `bnd` (`bnd v` bounds
+    `(env v).val` strictly): `Σ cᵥ.val·(bnd v − 1)`; `none` if any variable is unbounded. -/
+def linTermsNatBound (bnd : Variable → Option Nat) : List (Variable × ZMod p) → Option Nat
+  | [] => some 0
+  | (v, c) :: rest =>
+    match bnd v, linTermsNatBound bnd rest with
+    | some b, some acc => some (c.val * (b - 1) + acc)
+    | _, _ => none
+
+/-- Natural upper bound of `L.eval`: `L.const.val + Σ cᵥ.val·(bnd v − 1)`. -/
+def LinExpr.natBound (bnd : Variable → Option Nat) (L : LinExpr p) : Option Nat :=
+  (linTermsNatBound bnd L.terms).map (fun s => L.const.val + s)
+
+/-- Over `ZMod p` a term-list sum equals the cast of its natural (`.val`-wise) sum. -/
+theorem terms_eval_eq_cast [NeZero p] (terms : List (Variable × ZMod p)) (env : Variable → ZMod p) :
+    (terms.map (fun t => t.2 * env t.1)).sum
+      = (((terms.map (fun t => t.2.val * (env t.1).val)).sum : ℕ) : ZMod p) := by
+  induction terms with
+  | nil => simp
+  | cons t rest ih =>
+    simp only [List.map_cons, List.sum_cons, ih, Nat.cast_add, Nat.cast_mul]
+    congr 1
+    rw [ZMod.natCast_val, ZMod.natCast_val, ZMod.cast_id, ZMod.cast_id]
+
+/-- The natural term-sum is bounded by `linTermsNatBound` when every variable is bounded. -/
+theorem linTermsNatBound_le (bnd : Variable → Option Nat) (env : Variable → ZMod p)
+    (terms : List (Variable × ZMod p)) (M : Nat) (h : linTermsNatBound bnd terms = some M)
+    (hbnd : ∀ v ∈ terms.map Prod.fst, ∀ b, bnd v = some b → (env v).val < b) :
+    (terms.map (fun t => t.2.val * (env t.1).val)).sum ≤ M := by
+  induction terms generalizing M with
+  | nil => simp only [linTermsNatBound, Option.some.injEq] at h; subst h; simp
+  | cons t rest ih =>
+    simp only [linTermsNatBound] at h
+    cases hb : bnd t.1 with
+    | none => rw [hb] at h; simp at h
+    | some b =>
+      cases hr : linTermsNatBound bnd rest with
+      | none => rw [hb, hr] at h; simp at h
+      | some Macc =>
+        rw [hb, hr] at h; simp only [Option.some.injEq] at h; subst h
+        have hvt : (env t.1).val < b := hbnd t.1 (by simp) b hb
+        have hacc : (rest.map (fun t => t.2.val * (env t.1).val)).sum ≤ Macc :=
+          ih Macc hr (fun v hv => hbnd v (by simp only [List.map_cons, List.mem_cons]; exact Or.inr hv))
+        simp only [List.map_cons, List.sum_cons]
+        have hmul : t.2.val * (env t.1).val ≤ t.2.val * (b - 1) :=
+          Nat.mul_le_mul_left _ (by omega)
+        omega
+
+/-- If `L`'s natural bound `M` is `< p`, then `L.eval` has value `≤ M` (in particular `< bound` when
+    `M < bound`): no wraparound, so the field value equals the natural value. -/
+theorem LinExpr.eval_val_lt (L : LinExpr p) (env : Variable → ZMod p) (bnd : Variable → Option Nat)
+    (hbnd : ∀ v ∈ L.terms.map Prod.fst, ∀ b, bnd v = some b → (env v).val < b)
+    (M : Nat) (hM : L.natBound bnd = some M) (bound : Nat) (hMb : M < bound) (hMp : M < p) :
+    (L.eval env).val < bound := by
+  have hNe : NeZero p := ⟨by omega⟩
+  unfold LinExpr.natBound at hM
+  cases hs : linTermsNatBound bnd L.terms with
+  | none => rw [hs] at hM; simp at hM
+  | some S =>
+    rw [hs] at hM
+    simp only [Option.map_some, Option.some.injEq] at hM
+    subst hM
+    have hsum := linTermsNatBound_le bnd env L.terms S hs hbnd
+    have hcast : L.eval env
+        = (((L.const.val + (L.terms.map (fun t => t.2.val * (env t.1).val)).sum : ℕ)) : ZMod p) := by
+      rw [LinExpr.eval, terms_eval_eq_cast, Nat.cast_add, ZMod.natCast_val, ZMod.cast_id]
+    have hlt : L.const.val + (L.terms.map (fun t => t.2.val * (env t.1).val)).sum < p := by omega
+    rw [hcast, ZMod.val_natCast, Nat.mod_eq_of_lt hlt]
+    omega
+
+/-- Affine byte/limb justification: `e` linearizes to a form whose per-variable-bounded natural value
+    is `< bound` (and `< p`, so it does not wrap). -/
+def affineJustified (bound : Nat) (bnd : Variable → Option Nat) (e : Expression p) : Bool :=
+  match linearize e with
+  | some L =>
+    match L.natBound bnd with
+    | some M => decide (M < bound) && decide (M < p)
+    | none => false
+  | none => false
+
+theorem affineJustified_sound (bound : Nat) (bnd : Variable → Option Nat) (e : Expression p)
+    (env : Variable → ZMod p)
+    (hbnd : ∀ v b, bnd v = some b → (env v).val < b)
+    (h : affineJustified bound bnd e = true) : (e.eval env).val < bound := by
+  unfold affineJustified at h
+  cases hL : linearize e with
+  | none => simp [hL] at h
+  | some L =>
+    cases hM : L.natBound bnd with
+    | none => simp [hL, hM] at h
+    | some M =>
+      simp only [hL, hM, Bool.and_eq_true, decide_eq_true_eq] at h
+      rw [linearize_eval e L hL env]
+      exact LinExpr.eval_val_lt L env bnd (fun v _ b hb => hbnd v b hb) M hM bound h.1 h.2
+
 /-- Is `e` provably a byte under every assignment satisfying the remaining system? Either a
     constant `< 256`, a variable with a proven bus-fact bound `≤ 256` derived from the remaining
     interactions (e.g. another receive of the same word, or an explicit byte-check
     lookup), or — when `deep` is set (prime `p` only) — a variable a constraint pins to a byte
     on every point of its selector flags' finite domains (`deepBoundOk`), or a single-variable
     expression whose variable's finite domain makes `e` a byte at every point
-    (`domainByteJustified`, e.g. the `255·b` sign-extension limbs).
+    (`domainByteJustified`, e.g. the `255·b` sign-extension limbs), or an affine recomposition of
+    bounded limbs (`affineJustified`, e.g. the `256·hi + lo` 16-bit memory slots).
 
     Parameterized form: the remaining interactions are consulted through the witness lookup
     `wits` (see `deepByteVars`), the single-variable constraints `domCs` and the per-variable
@@ -423,7 +529,8 @@ def byteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (Expression p))
         | none => false) ||
        (deep && decide (256 ≤ bound) && deepByteJustified domCs (candsOf x) bs facts wits x)
      | _ => false) ||
-    (deep && decide (256 ≤ bound) && domainByteJustified domCs e)
+    (deep && decide (256 ≤ bound) && domainByteJustified domCs e) ||
+    affineJustified bound (fun x => findVarBound bs facts (wits x) x) e
 
 /-- The plain full-scan form (used by the coda's `RedundantByteDrop`): witness lookup and
     precomputed constraint lists instantiated with the naive per-query filters. -/
@@ -458,8 +565,8 @@ theorem byteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List (Expr
   | none =>
     rw [hc] at h
     dsimp only at h
-    rw [Bool.or_eq_true] at h
-    rcases h with h | h
+    rw [Bool.or_eq_true, Bool.or_eq_true] at h
+    rcases h with (h | h) | h
     · -- variable path (bus-fact bound or deep selector-flag justification)
       cases e with
       | var x =>
@@ -489,6 +596,9 @@ theorem byteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List (Expr
       exact lt_of_lt_of_le
         (domainByteJustified_sound domCs e h.2 env (fun c' hc' => hall c' (hdomCs c' hc')))
         (of_decide_eq_true h.1.2)
+    · -- affine recomposition path (`256·hi + lo`, …)
+      exact affineJustified_sound bound (fun x => findVarBound bs facts (wits x) x) e env
+        (fun v b hb => findVarBound_sound bs facts (wits v) v b hb env (hbusW v)) h
 
 theorem byteJustified_sound (bound : Nat) (deep : Bool) (all : List (Expression p))
     (bs : BusSemantics p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -138,13 +138,13 @@ theorem consecutivePayloadEq (cs : ConstraintSystem p) (bs : BusSemantics p)
     `checkPair_sound` as a hypothesis (the old per-candidate O(#interactions) structural
     comparison dominated this pass). -/
 def checkPair (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints)
+    (T : TwoRootMap p constraints) (nw : NonzeroWits p constraints)
     (S : BusInteraction (Expression p))
     (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p)) : Bool :=
   decide (multConst S = some shape.setNewMult) && decide (multConst R = some (-shape.setNewMult)) &&
   addrConstsEq shape S R &&
   mid.all (fun m => addrConstsNeq shape S m || addrAffineNeq shape S m
-    || addrTwoRootNeq shape T S m || decide (multConst m = some 0))
+    || addrTwoRootNeq shape T S m || addrNonzeroNeq shape nw S m || decide (multConst m = some 0))
 
 theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0)
@@ -152,10 +152,10 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
     (pre : List (BusInteraction (Expression p))) (S : BusInteraction (Expression p))
     (mid : List (BusInteraction (Expression p))) (R : BusInteraction (Expression p))
     (post : List (BusInteraction (Expression p)))
-    (T : TwoRootMap p cs.algebraicConstraints)
+    (T : TwoRootMap p cs.algebraicConstraints) (nw : NonzeroWits p cs.algebraicConstraints)
     (hsplit : cs.busInteractions.filter (fun bi => bi.busId = busId)
       = pre ++ S :: mid ++ R :: post)
-    (hchk : checkPair shape T S mid R = true)
+    (hchk : checkPair shape T nw S mid R = true)
     (env : Variable → ZMod p) (hadm : cs.admissible bs env) (hsat : cs.satisfies bs env) :
     ∀ c ∈ memEqConstraints shape S R, c.eval env = 0 := by
   unfold checkPair at hchk
@@ -176,11 +176,13 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
       shape.address (m.eval env) = shape.address (S.eval env) → False := by
     intro m hm hmne hmaddr
     rcases (Bool.or_eq_true _ _).mp (List.all_eq_true.mp hmidall m hm) with hcond | hz
-    · rcases (Bool.or_eq_true _ _).mp hcond with hcond2 | h2r
-      · rcases (Bool.or_eq_true _ _).mp hcond2 with hneq | haff
-        · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
-        · exact addrAffineNeq_sound shape S m haff env (hmaddr.symm)
-      · exact addrTwoRootNeq_sound shape T S m h2r env hcon (hmaddr.symm)
+    · rcases (Bool.or_eq_true _ _).mp hcond with hcond_a | hnz
+      · rcases (Bool.or_eq_true _ _).mp hcond_a with hcond2 | h2r
+        · rcases (Bool.or_eq_true _ _).mp hcond2 with hneq | haff
+          · exact addrConstsNeq_sound shape S m hneq env (hmaddr.symm)
+          · exact addrAffineNeq_sound shape S m haff env (hmaddr.symm)
+        · exact addrTwoRootNeq_sound shape T S m h2r env hcon (hmaddr.symm)
+      · exact addrNonzeroNeq_sound shape nw S m hnz env hcon (hmaddr.symm)
     · have : (m.eval env).multiplicity = 0 := by
         show m.multiplicity.eval env = 0
         exact m.multiplicity.constValue?_sound 0 (of_decide_eq_true hz) env
@@ -213,7 +215,8 @@ def SplitCand (p : ℕ) (L : List (BusInteraction (Expression p))) :=
     success — together with the recomposition proof `revMid.reverse ++ rest = mid ++ R :: post`
     — or `none` if a possibly-same-address active non-receive blocks the window. -/
 def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints) (S : BusInteraction (Expression p)) :
+    (T : TwoRootMap p constraints) (nw : NonzeroWits p constraints)
+    (S : BusInteraction (Expression p)) :
     (revMid rest : List (BusInteraction (Expression p))) →
     Option ({ mrp : List (BusInteraction (Expression p)) × BusInteraction (Expression p)
       × List (BusInteraction (Expression p)) //
@@ -223,8 +226,8 @@ def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
       if decide (multConst r = some (-shape.setNewMult)) && addrConstsEq shape S r then
         some ⟨(revMid.reverse, r, rest), rfl⟩
       else if addrConstsNeq shape S r || addrAffineNeq shape S r || addrTwoRootNeq shape T S r
-          || decide (multConst r = some 0) then
-        (findConsumer shape T S (r :: revMid) rest).map (fun ⟨mrp, hmrp⟩ =>
+          || addrNonzeroNeq shape nw S r || decide (multConst r = some 0) then
+        (findConsumer shape T nw S (r :: revMid) rest).map (fun ⟨mrp, hmrp⟩ =>
           ⟨mrp, by
             rw [← hmrp, List.reverse_cons, List.append_assoc]
             rfl⟩)
@@ -234,14 +237,15 @@ def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
     each carrying its split equation by construction. Linear in the number of sends × scan
     length, so no O(n²) blow-up on large buses. `checkPair` re-verifies the pair conditions. -/
 def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints) (L : List (BusInteraction (Expression p))) :
+    (T : TwoRootMap p constraints) (nw : NonzeroWits p constraints)
+    (L : List (BusInteraction (Expression p))) :
     (revPre rest : List (BusInteraction (Expression p))) →
     (hinv : L = revPre.reverse ++ rest) →
     List (SplitCand p L)
   | _, [], _ => []
   | revPre, S :: rest, hinv =>
       (if decide (multConst S = some shape.setNewMult) then
-        match findConsumer shape T S [] rest with
+        match findConsumer shape T nw S [] rest with
         | some ⟨(mid, R, post), hmrp⟩ =>
           [⟨(revPre.reverse, S, mid, R, post), by
             rw [hinv]
@@ -249,12 +253,13 @@ def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
             rw [h]
             simp⟩]
         | none => []
-       else []) ++ candidateSplits shape T L (S :: revPre) rest
+       else []) ++ candidateSplits shape T nw L (S :: revPre) rest
         (by rw [hinv, List.reverse_cons, List.append_assoc]; rfl)
 
 /-- Collect the entailed equalities for one bus, with proof. -/
 def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
+    (nw : NonzeroWits p cs.algebraicConstraints)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape) :
     List (SplitCand p (cs.busInteractions.filter (fun bi => bi.busId = busId))) →
@@ -262,29 +267,30 @@ def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
   | ⟨(pre, S, mid, R, post), hsplit⟩ :: rest =>
-    let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T busId shape hshape rest
-    if hchk : checkPair shape T S mid R = true then
+    let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T nw busId shape hshape rest
+    if hchk : checkPair shape T nw S mid R = true then
       ⟨memEqConstraints shape S R ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
-        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T hsplit
+        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T nw hsplit
             hchk env hadm hsat c h
         · exact hacc env hadm hsat c h⟩
     else ⟨acc, hacc⟩
 
 /-- Collect over every declared bus, with proof. -/
 def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints) :
+    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
+    (nw : NonzeroWits p cs.algebraicConstraints) :
     List Nat →
     { out : List (Expression p) //
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
   | busId :: rest =>
-    let ⟨acc, hacc⟩ := collectAllBuses cs bs facts hp1 T rest
+    let ⟨acc, hacc⟩ := collectAllBuses cs bs facts hp1 T nw rest
     match hshape : facts.memShape busId with
     | some shape =>
-      let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 T busId shape hshape
-        (candidateSplits shape T _ []
+      let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 T nw busId shape hshape
+        (candidateSplits shape T nw _ []
           (cs.busInteractions.filter (fun bi => bi.busId = busId)) rfl)
       ⟨eqs ++ acc, by
         intro env hadm hsat c hc
@@ -301,7 +307,9 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
     -- precompute the per-variable two-root data once (memoized `twoRootOf?`), so the
     -- address-disequality certificate is a constant-time hash lookup per candidate pair
     let T := TwoRootMap.build cs.algebraicConstraints
-    let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1 T
+    -- reciprocal (nonzero-witness) forms, for the register-vs-RAM address-disequality certificate
+    let nw := NonzeroWits.build cs.algebraicConstraints
+    let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1 T nw
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
     -- keep only equalities over existing columns, so the pass introduces no new variable
     -- (the real slot equalities are built from `cs`'s payloads, so none are dropped).

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -56,9 +56,14 @@ private def slotBoundImpl (busMap : Nat → Option Sp1BusType) (busId : Nat) (mu
   -- that bounds slot 1 by `2^b` — the fact that lets `busPairCancel` justify SP1's 16-bit memory
   -- data limbs (each carried by an op-6 width-16 range check) when telescoping.
   | some .byteLookup, 1 =>
-    match pattern[0]?, pattern[2]? with
-    | some (some op), some (some w) => if op.val = 6 then some (2 ^ w.val) else none
-    | _, _ => none
+    match pattern[0]? with
+    | some (some op) =>
+      -- Non-range byte ops (`op ≤ 5`) return a byte; op-6 (`Range`) returns `< 2^w` (needs `w`).
+      if op.val ≤ 5 then some 256
+      else match pattern[2]? with
+        | some (some w) => if op.val = 6 then some (2 ^ w.val) else none
+        | _ => none
+    | _ => none
   -- The four data limbs (slots 5–8) of a memory `getPrevious` (multiplicity `1`, full ≥9-slot
   -- record) are 16-bit; a surviving read thus justifies the telescoped same-register pairs' data.
   | some .memory, 5 => if mult = 1 ∧ 9 ≤ pattern.length then some (2 ^ 16) else none
@@ -115,6 +120,50 @@ private theorem byte_op6_bound (busMap : Nat → Option Sp1BusType)
   simp only [hop] at hok
   rw [Bool.not_eq_false', Bool.and_eq_true] at hok
   exact of_decide_eq_true hok.2
+
+/-- An accepted byte-bus message `[op, a, b, c]` whose op is a non-range operation (`op ≤ 5`) has a
+    **byte result**: AND/OR/XOR of bytes are bytes (`≤ b` / `< 2⁸`), U8Range forces `a = 0`, LTU
+    yields a comparison bit, MSB a single bit — so `a < 256` in every case. This lets a surviving
+    byte-op interaction bound the affine limb recompositions its result feeds (`256·hi + lo`). -/
+private theorem byte_result_lt256 (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .byteLookup)
+    (hok : violates busMap m = false)
+    (op a b c : ZMod p) (hpay : m.payload = [op, a, b, c]) (hop : op.val ≤ 5) :
+    a.val < 256 := by
+  obtain ⟨bid, mult, payload⟩ := m
+  simp only at hbus hpay
+  subst hpay
+  unfold violates at hok
+  rw [hbus] at hok
+  dsimp only at hok
+  rcases (show op.val = 0 ∨ op.val = 1 ∨ op.val = 2 ∨ op.val = 3 ∨ op.val = 4 ∨ op.val = 5 by omega)
+    with h | h | h | h | h | h
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨⟨hb, _⟩, ha⟩ := hok
+    rw [ha]; exact lt_of_le_of_lt Nat.and_le_left hb
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨⟨hb, hc⟩, ha⟩ := hok
+    rw [ha]; exact Nat.or_lt_two_pow (n := 8) hb hc
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨⟨hb, hc⟩, ha⟩ := hok
+    rw [ha]; exact Nat.xor_lt_two_pow (n := 8) hb hc
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨_, ha⟩ := hok
+    rw [ha]; omega
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨_, ha⟩ := hok
+    rw [ha]; split <;> omega
+  · rw [h] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    obtain ⟨⟨hb, _⟩, ha⟩ := hok
+    rw [ha, Nat.shiftRight_eq_div_pow]
+    have h128 : (2 : ℕ) ^ 7 = 128 := rfl
+    rw [h128]; omega
 
 /-- An op-6 `[6, a, b, c]` message with a supported width (`b ≤ 16`) and `c = 0` is accepted **iff**
     its result is in range (`a < 2^b`). -/
@@ -326,29 +375,37 @@ def sp1Facts (p : ℕ) [NeZero p]
         obtain ⟨op, a, b, c, hpay, hb, hc⟩ := byte_operands busMap m hbus hok'
         have hxc : c = x := by rw [hpay] at hget; simpa using hget
         rw [← hxc]; exact hc
-      · -- slot 1: an op-6 range check `[6, a, w, 0]` bounds `a` by `2^w`.
+      · -- slot 1: a non-range byte op bounds its result `a` by `256`; op-6 by `2^w`.
         rename_i hbus
         obtain ⟨op, a, b, c, hpay, _, _⟩ := byte_operands busMap m hbus hok'
+        have hax : a = x := by rw [hpay] at hget; simpa using hget
         rcases hp0 : pattern[0]? with _ | o0
         · rw [hp0] at hfact; simp at hfact
         · rcases o0 with _ | pop
           · rw [hp0] at hfact; simp at hfact
-          · rcases hp2 : pattern[2]? with _ | o2
-            · rw [hp0, hp2] at hfact; simp at hfact
-            · rcases o2 with _ | pw
-              · rw [hp0, hp2] at hfact; simp at hfact
-              · rw [hp0, hp2] at hfact
-                dsimp only at hfact
-                split_ifs at hfact with hop6
-                · simp only [Option.some.injEq] at hfact; subst hfact
-                  have hpop : op = pop := by
-                    have := hmatch.2 0 pop (by rw [hp0]); rw [hpay] at this; simpa using this
-                  have hpw : b = pw := by
-                    have := hmatch.2 2 pw (by rw [hp2]); rw [hpay] at this; simpa using this
-                  have hax : a = x := by rw [hpay] at hget; simpa using hget
-                  have hopval : op.val = 6 := by rw [hpop]; exact hop6
-                  have hb6 := byte_op6_bound busMap m hbus hok' op a b c hpay hopval
-                  rw [hpw, hax] at hb6; exact hb6
+          · rw [hp0] at hfact
+            dsimp only at hfact
+            have hpop : op = pop := by
+              have := hmatch.2 0 pop (by rw [hp0]); rw [hpay] at this; simpa using this
+            by_cases hle : pop.val ≤ 5
+            · rw [if_pos hle] at hfact
+              simp only [Option.some.injEq] at hfact; subst hfact
+              have hr := byte_result_lt256 busMap m hbus hok' op a b c hpay (by rw [hpop]; exact hle)
+              rw [hax] at hr; exact hr
+            · rw [if_neg hle] at hfact
+              rcases hp2 : pattern[2]? with _ | o2
+              · rw [hp2] at hfact; simp at hfact
+              · rcases o2 with _ | pw
+                · rw [hp2] at hfact; simp at hfact
+                · rw [hp2] at hfact
+                  dsimp only at hfact
+                  split_ifs at hfact with hop6
+                  · simp only [Option.some.injEq] at hfact; subst hfact
+                    have hpw : b = pw := by
+                      have := hmatch.2 2 pw (by rw [hp2]); rw [hpay] at this; simpa using this
+                    have hb6 := byte_op6_bound busMap m hbus hok' op a b c hpay
+                      (by rw [hpop]; exact hop6)
+                    rw [hpw, hax] at hb6; exact hb6
       · -- memory data slot 5: a full-record read has 16-bit data
         rename_i hbus
         split_ifs at hfact with hm1

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,29 +77,39 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
-## 0b. SP1 (rsp): after the register-vs-RAM disequality (entry 93), the residual is bitwise + RAM-vs-RAM
+## 0b. SP1 (rsp): after entries 93–95, the residual is the dead-upper-byte ISA floor + carry slots
 
-Entry 93 landed the reciprocal nonzero-witness address-disequality certificate (`addrNonzeroNeq`),
-closing 65 % of the SP1 variable gap (agg 2.938× → 3.535×; gap vs powdr 3715 → 1318 vars) and 41 %
-of the bus gap (1.957× → 2.236×; 3209 → 1902). Per-case-by-variables W/L/T now 1/54/45. Remaining,
-biggest first (measured on `sp1_both.json`):
+Entries 93–95 landed three general, proven mechanisms — the reciprocal nonzero-witness
+address-disequality certificate (`addrNonzeroNeq`), affine bound propagation in `byteJustifiedW`, and
+the SP1 byte-op result-slot bound — taking SP1 from **variables 2.938× → 3.538×, bus 1.957× → 2.457×**
+(aggregate var gap vs powdr 3715 → 1310, bus gap 3209 → 1080; per-case-by-variables W/L/T 0/69/31 →
+1/54/45). OpenVM is untouched (keccak byte-identical; the result-slot bound is SP1-only). The
+register-access chains now telescope almost fully (apc_024 memory 186 → 70; most registers at powdr's
+2). What remains, biggest first:
 
-- **Dead upper bitwise-result bytes (var + bus).** SP1's bitwise chip decomposes a 32/16-bit op into
-  4 byte-XOR lookups producing `result_0..7`, but a store of a ≤16-bit result only writes
-  `result_0 + 256·result_1`; powdr proves the upper store limbs `= 0`, which makes the
-  `result_2..7` + `b/c_low_bytes_1..3` XOR cluster a **disconnected component** it drops entirely
-  (apc_001 residual = exactly this, 12 v / 12 bus). Dominates the big k256-like cases
-  (apc_024/040 bitwise_operation 152 v in powdr; apc still far above). Needs: prove the high store
-  limbs are `0` (from the operands' high bytes being `0`, or a width/mask fact), then a
-  disconnected-component / dead-witness drop. Size the residue; likely the single biggest SP1 lever
-  left. **Next target.**
-- **RAM-vs-RAM telescoping.** Two accesses to the *same* RAM pointer separated by accesses to a
-  *different* RAM pointer: needs two computed addresses proven `≠`. `addrTwoRootNeq` handles the
-  same-base-different-immediate case; genuinely different bases need either a two-root pin on both or
-  a nonzero-witness on their difference (extend `addrNonzeroNeq` to consult a witness for
-  `Σ(m_i − S_i)` directly, not only a subset-sum match — and to scalar multiples of a witness).
-- **Certificate generalizations** (cheap follow-ups to entry 93): match a witness up to a nonzero
-  *scalar* (`g = λ·Σ(m_i − S_i)`), not just `±1`; and recognize reciprocal constraints in more
+- **Dead upper bitwise-result bytes — the variable gap; likely an apc *floor*, not a missing pass.**
+  SP1's bitwise chip decomposes a 32-bit AND/OR/XOR into 4 byte-op lookups producing `result₀..₇`
+  (2 per byte via the shift-check trick), and the operand bytes `b/c_low_bytes_2,3` are **free
+  witnesses** occurring *only* in the upper byte-op lookups and the destination register's upper
+  data limbs. When the source operands are 16-bit the true upper result is `0`, and powdr pins it —
+  but that uses the **ISA zero-extension fact** (the op zero-extends, so the register's upper 16 bits
+  are `0`). apc has no such fact: the upper limbs are genuinely unconstrained in the input, and
+  zeroing them changes a *stateful* memory side-effect, so it is **not a sound local refinement**.
+  Dominates apc_024/040 (bitwise_operation 304 v vs powdr 152) and the other k256-heavy blocks
+  (apc_016/017/029/060/030/080…). Only routes: (a) an audited SP1 semantics addition asserting the
+  zero-extension invariant (changes the audited surface — out of scope for the AI-only loop), or
+  (b) a genuine liveness proof that the register's upper bits are overwritten-before-read within the
+  block (needs the memory continuity argument extended to sub-limb liveness). Neither is a cheap pass.
+  **Census the exact residue before attempting; treat as a floor for now.**
+- **Carry / negative-coefficient memory slots (bus).** The last register chains that don't fully
+  telescope (apc_024 addr 7/15) carry data like `add_value − 2¹⁶·higher_limb` (a low-limb/borrow
+  expression, coefficient `p − 65536`) or `2¹³·lower` needing a tighter-than-byte limb bound.
+  `affineJustified`'s natural-number bound can't certify a large/negative coefficient (its `M < p`
+  no-wrap check fails). A borrow-aware justification (recognize `x − 2ᵏ·y` as the low limb of a
+  decomposition with its own range check, or read a direct range-check on the slot *expression*)
+  would drain these; medium effort, bus-only.
+- **Certificate generalizations** (cheap follow-ups to entry 93): match a nonzero witness up to a
+  nonzero *scalar* (`g = λ·Σ(mᵢ − Sᵢ)`), not just `±1`; recognize reciprocal constraints in more
   additive shapes if a census finds `addrNonzeroNeq` missing live pairs.
 
 ## 0. wasm-eth: variable gap closed; global range-obligation repack is the last axis (after entries 87–89)

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,6 +77,31 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
+## 0b. SP1 (rsp): after the register-vs-RAM disequality (entry 93), the residual is bitwise + RAM-vs-RAM
+
+Entry 93 landed the reciprocal nonzero-witness address-disequality certificate (`addrNonzeroNeq`),
+closing 65 % of the SP1 variable gap (agg 2.938× → 3.535×; gap vs powdr 3715 → 1318 vars) and 41 %
+of the bus gap (1.957× → 2.236×; 3209 → 1902). Per-case-by-variables W/L/T now 1/54/45. Remaining,
+biggest first (measured on `sp1_both.json`):
+
+- **Dead upper bitwise-result bytes (var + bus).** SP1's bitwise chip decomposes a 32/16-bit op into
+  4 byte-XOR lookups producing `result_0..7`, but a store of a ≤16-bit result only writes
+  `result_0 + 256·result_1`; powdr proves the upper store limbs `= 0`, which makes the
+  `result_2..7` + `b/c_low_bytes_1..3` XOR cluster a **disconnected component** it drops entirely
+  (apc_001 residual = exactly this, 12 v / 12 bus). Dominates the big k256-like cases
+  (apc_024/040 bitwise_operation 152 v in powdr; apc still far above). Needs: prove the high store
+  limbs are `0` (from the operands' high bytes being `0`, or a width/mask fact), then a
+  disconnected-component / dead-witness drop. Size the residue; likely the single biggest SP1 lever
+  left. **Next target.**
+- **RAM-vs-RAM telescoping.** Two accesses to the *same* RAM pointer separated by accesses to a
+  *different* RAM pointer: needs two computed addresses proven `≠`. `addrTwoRootNeq` handles the
+  same-base-different-immediate case; genuinely different bases need either a two-root pin on both or
+  a nonzero-witness on their difference (extend `addrNonzeroNeq` to consult a witness for
+  `Σ(m_i − S_i)` directly, not only a subset-sum match — and to scalar multiples of a witness).
+- **Certificate generalizations** (cheap follow-ups to entry 93): match a witness up to a nonzero
+  *scalar* (`g = λ·Σ(m_i − S_i)`), not just `±1`; and recognize reciprocal constraints in more
+  additive shapes if a census finds `addrNonzeroNeq` missing live pairs.
+
 ## 0. wasm-eth: variable gap closed; global range-obligation repack is the last axis (after entries 87–89)
 
 The `wasm-eth` corpus (100 cases, merged #131) had apc **far behind** powdr — the worst cases

--- a/docs/log.md
+++ b/docs/log.md
@@ -3621,3 +3621,28 @@ size-monotone; OpenVM keccak byte-identical (2021 v / 186 c / 1752 bus) and its 
 ({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. Remaining SP1 gap:
 the ALU-intermediate / dead-upper-bitwise-byte families (apc_024/040/030 lead) and RAM-vs-RAM
 telescoping — see `docs/ideas.md`. **Worked: yes.**
+
+### 94. Affine bound propagation justifies multi-limb memory slots (SP1 bus 2.236× → 2.301×, variable-neutral)
+
+Follow-up to entry 93. A telescoped memory read can only be *dropped* by `busPairCancel` once its
+data limbs are justified 16-bit (else the drop would lose the range obligation). SP1's k256-heavy
+blocks (apc_024/040/030) store affine limb recompositions — `256·hi + lo`, `result₀ + 256·result₁` —
+in memory data slots, which are genuinely `< 2¹⁶` when the limbs are bytes, but `byteJustifiedW` only
+recognized constants, single variables, and single-variable finite-domain expressions, so those
+slots stayed "unjustified" and the pairs could not cancel (the emit path can only make byte-256
+checks, not 16-bit ones).
+
+**New arm `affineJustified` in `byteJustifiedW` (`BusPairCancel.lean`, `Implementation/` only).**
+Linearize the slot; with a per-variable value bound `bᵥ` from `findVarBound`, the field value of
+`const + Σ cᵥ·v` is at most the natural number `const.val + Σ cᵥ.val·(bᵥ − 1)`, and equals it (no
+wraparound) when that bound is `< p` — so if the bound is also `< 2¹⁶` the slot is 16-bit. Pure
+natural-number bound arithmetic (`LinExpr.natBound` / `LinExpr.eval_val_lt`), field-general, no
+primality; strictly a new disjunct, so nothing else changed.
+
+**Impact (`benchmark.py --vm sp1`):** bus interactions **2.236× → 2.301×** agg (aggregate bus gap vs
+powdr 1902 → 1646, −256 interactions); variables unchanged (3.535×), constraints unchanged — a
+lexicographically clean bus win. Size-monotone ⇒ no OpenVM regression: keccak byte-identical
+(2021 v / 186 c / 1752 bus), runtime unchanged (200 s). Proof integrity green; no
+`sorry`/`axiom`/`native_decide`. The residual SP1 bus gap is the long same-register access chains
+whose interior pairs still don't telescope (busUnify pairing) and the dead upper bitwise bytes —
+see `docs/ideas.md`. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3646,3 +3646,26 @@ lexicographically clean bus win. Size-monotone ⇒ no OpenVM regression: keccak 
 `sorry`/`axiom`/`native_decide`. The residual SP1 bus gap is the long same-register access chains
 whose interior pairs still don't telescope (busUnify pairing) and the dead upper bitwise bytes —
 see `docs/ideas.md`. **Worked: yes.**
+
+### 95. Bound the SP1 byte-op result slot (SP1 bus 2.301× → 2.457×, variable-neutral)
+
+The affine justification of entry 94 needs *each* limb of a recomposition bounded. On the k256-heavy
+blocks the memory data limbs are XOR results (`result₀ + 256·result₁`), but SP1's `slotBound` only
+bounded the byte-bus operand slots (2, 3) and the op-6 range-check result — not the result slot of
+an AND/OR/XOR/U8Range/LTU/MSB op, so `findVarBound` could not bound `result₀`/`result₁` and the
+recomposition stayed unjustified.
+
+**`slotBoundImpl` slot-1 arm extended (`Sp1Facts.lean`, no audit surface — a wrong fact fails to
+compile).** For a byte-bus message whose op selector is constant and `≤ 5`, the result `a` (slot 1)
+is a byte: AND/OR/XOR of bytes are bytes (`Nat.and_le_left` / `Nat.or_lt_two_pow` /
+`Nat.xor_lt_two_pow`), U8Range forces `a = 0`, LTU is a comparison bit, MSB is `b ≫ 7 ≤ 1` — proved
+uniformly in `byte_result_lt256`; op-6 keeps its `2^w` bound. `findVarBound` now bounds byte-op
+result variables to `256`, so the affine arm justifies the XOR-result recompositions and their
+telescoped register reads drop.
+
+**Impact (`benchmark.py --vm sp1`):** bus interactions **2.301× → 2.457×** agg (aggregate bus gap vs
+powdr 1646 → 1080, −566); variables essentially unchanged (3.535× → 3.538×). SP1-only change
+(`Sp1Facts`), so OpenVM is untouched by construction. Proof integrity green; no
+`sorry`/`axiom`/`native_decide`. Cumulative over entries 93–95: SP1 variables 2.938× → 3.538×, bus
+1.957× → 2.457× (var gap 3715 → 1310, bus gap 3209 → 1080). Residual: dead upper bitwise bytes
+(the variable gap) and the tail of the long register chains — see `docs/ideas.md`. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3586,3 +3586,38 @@ layout; OpenVM declares no `rangeCheckAt` and keeps `SubsumedRange`, so it is a 
 green ({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. Remaining SP1
 gap = ALU-intermediate variables (free witnesses powdr inlines) and register-vs-RAM address
 disequality (powdr's sort-based memory argument) — see `docs/ideas.md`. **Worked: yes.**
+
+### 93. Register-vs-RAM address disequality via reciprocal nonzero-witnesses (SP1 vars 2.938× → 3.535×, bus 1.957× → 2.236×)
+
+Closes the larger of the two SP1 gaps entry 92 identified. powdr telescopes register read/write
+pairs *across* the interleaved RAM accesses of a basic block; apc's memory-cancellation shields
+(`busUnify` / `busPairCancel`, certificates in `AddrDiseq.lean`) could not, because none of
+`addrConstsNeq` / `addrAffineNeq` / `addrTwoRootNeq` can refute a RAM access as different-address
+from a register. A register address is a small constant with high limbs literally `0`; a RAM
+address `(e₂, e₃, e₄)` is pinned "not a register" by SP1's reciprocal constraint
+`inv·(e₃ + e₄) − 1 = 0`, i.e. `e₃ + e₄ ≠ 0`. No *single* address slot is provably nonzero (either
+high limb alone may be `0`), so all three existing certificates miss it and every register-access
+pair is blocked by the first interleaved RAM access.
+
+**New certificate `addrNonzeroNeq` (`AddrDiseq.lean`, `Implementation/` only, no audit surface).**
+Reads any constraint `a·b + k = 0` with `k` a nonzero constant as a pair of **nonzero witnesses**
+(both factors are nonzero, since `a·b = −k ≠ 0`; `reciprocalWits?` / `NonzeroWits.build`), then
+refutes an address match when some *subset* `T` of the shape's address slots has limb-difference sum
+`Σ_{i∈T}(mᵢ − Sᵢ)` structurally equal (up to sign) to a witness `g`: were the addresses equal that
+sum would vanish, contradicting `g ≠ 0`. Purely linear + one reciprocal constraint — no bounds, no
+primality. Strictly extends `addrAffineNeq` (a nonzero *constant* difference is the witness-free
+special case). Wired into both shields (`busUnify` `checkPair`/`findConsumer`, `busPairCancel`
+`midRefuted`); the two-root and nonzero tables are bundled into one memoized `AddrCerts` thunk so the
+`busPairCancel` threading changed only types, not call sites.
+
+**Impact (`benchmark.py --vm sp1`, 100 rsp cases):** variables **2.938× → 3.535×** agg
+(gap vs powdr −1.042× → −0.445×, i.e. the aggregate var gap 3715 → 1318, **65 % closed**); bus
+**1.957× → 2.236×** (gap −0.864× → −0.585×, bus gap 3209 → 1902); per-case-by-variables W/L/T
+0/69/31 → 1/54/45. apc_001 148 v / 84 bus → 125 v / 74 bus (powdr 113 / 62).
+
+**No OpenVM regression:** the certificate only *enables* more (sound) telescoping, so it is
+size-monotone; OpenVM keccak byte-identical (2021 v / 186 c / 1752 bus) and its runtime unchanged
+(198 s vs main's 202 s on this container, within variance). Proof integrity green
+({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. Remaining SP1 gap:
+the ALU-intermediate / dead-upper-bitwise-byte families (apc_024/040/030 lead) and RAM-vs-RAM
+telescoping — see `docs/ideas.md`. **Worked: yes.**


### PR DESCRIPTION
## What

Three general, proven `Implementation/`-only changes that close most of the SP1 (`rsp`) memory-optimization gap identified at the end of #152. Each generalizes existing machinery rather than adding a bespoke pass; correctness follows from the passes' own `PassCorrect` / the bus-fact soundness proofs, so there is **no new audit surface**.

**1. Register-vs-RAM address disequality (`addrNonzeroNeq`, `AddrDiseq.lean`).** powdr telescopes register read/write pairs *across* a basic block's interleaved RAM accesses; apc's memory-cancellation shields could not, because none of `addrConstsNeq` / `addrAffineNeq` / `addrTwoRootNeq` can refute a RAM access as different-address from a register — a register address has high limbs literally `0`, while a RAM address is pinned "not a register" only by a *reciprocal* constraint `inv·(hi₁ + hi₂) − 1 = 0` whose high-limb **sum** is nonzero (no single limb is). The new certificate reads any `a·b + k = 0` (`k ≠ 0`) as a pair of nonzero witnesses and refutes an address match when a subset of the address-slot differences sums (up to sign) to a witness. Wired into both `busUnify` and `busPairCancel` shields.

**2. Affine bound propagation in `byteJustifiedW` (`BusPairCancel.lean`).** A telescoped read is only droppable once its data limbs are justified 16-bit. SP1 stores affine limb recompositions (`256·hi + lo`, `result₀ + 256·result₁`) in memory data slots — genuinely `< 2¹⁶` when the limbs are bytes — but `byteJustifiedW` only knew constants / single variables. The new arm linearizes the slot and, with per-variable bounds from `findVarBound`, bounds `const + Σ cᵥ·v` by the natural number `const.val + Σ cᵥ.val·(bᵥ − 1)`, exact when that is `< p` (no wraparound). Field-general, no primality.

**3. Bound the SP1 byte-op result slot (`Sp1Facts.lean`).** #2 needs each limb bounded, but the recomposition limbs are often XOR results, and `slotBound` only bounded operand slots + the op-6 range result. Extended so a byte-bus message with a constant op selector `≤ 5` bounds its result `a` (slot 1) to `256` (AND/OR/XOR of bytes are bytes, U8Range/LTU/MSB give `0`/a bit; `byte_result_lt256`).

## Impact (`Benchmarks/benchmark.py --vm sp1`, 100 rsp cases)

| measure | before (#152) | this PR | powdr |
|---|---|---|---|
| variables | 2.938× | **3.538×** | 3.980× |
| bus interactions | 1.957× | **2.457×** | 2.822× |

Aggregate gap vs powdr: variables **3715 → 1310** (−65%), bus **3209 → 1080** (−66%). Per-case-by-variables W/L/T **0/69/31 → 1/54/45**. Example apc_024: memory bus 186 → 70 (powdr 40; most registers now telescope to powdr's 2).

## No OpenVM regression

All three are size-monotone or SP1-only. OpenVM `openvm-eth` is byte-for-byte unchanged (variables 4.552× / bus 3.557× / W/L/T 31/7/62 — identical to `main`), keccak byte-identical (2021 v / 186 c / 1752 bus), keccak runtime unchanged (~200 s vs `main`'s ~202 s). `Scripts/check-proof-integrity.sh` green — the correctness theorems still depend only on `{propext, Classical.choice, Quot.sound}`; no `sorry`/`axiom`/`native_decide`.

## Not addressed (documented in `docs/ideas.md`)

The residual variable gap is the **dead upper bitwise-result bytes**: SP1's bitwise chip leaves the destination register's upper data limbs as *free witnesses*, which powdr pins to `0` using an **ISA zero-extension fact**. apc has no such fact — the limbs are unconstrained in the input and zeroing them would change a stateful memory side-effect, so it is not a sound local refinement without an audited SP1-semantics addition. The residual bus gap is a handful of carry/negative-coefficient memory slots (`x − 2¹⁶·y`) that the affine bound can't certify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DidddHhUnC1UxRT9hG9nGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DidddHhUnC1UxRT9hG9nGR)_