### PR TITLE
SP1: drain dead-byte clusters + degenerate range checks (vars 3.672×→3.745×, bus 2.488×→2.553×)

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -45,6 +45,13 @@ structure ByteXorSpec (p : ℕ) where
   xorOp : ZMod p
   /-- Op-selector value denoting the pair range-check (`op₁, op₂` bytes, `result = 0`). -/
   pairOp : ZMod p
+  /-- Op-selector value denoting the bitwise-OR relation `result = op₁ | op₂` (`op₁, op₂` bytes), if
+      the bus has such an op. `none` when the VM's bitwise bus has no OR op (e.g. OpenVM's, which is
+      XOR + range only). Soundness lives in `BusFacts.byteBoolSound`. -/
+  orOp : Option (ZMod p) := none
+  /-- Op-selector value denoting the bitwise-AND relation `result = op₁ & op₂` (`op₁, op₂` bytes), if
+      the bus has such an op. `none` when the VM's bitwise bus has no AND op. -/
+  andOp : Option (ZMod p) := none
   /-- Reorder a physical payload into logical `(op, operand₁, operand₂, result)`. -/
   decode : {α : Type} → List α → Option (α × α × α × α)
   /-- Build a physical payload from logical `(op, operand₁, operand₂, result)` — the inverse
@@ -256,6 +263,22 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
         (op = spec.pairOp →
            (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r = 0))
+  /-- Soundness of the optional `orOp`/`andOp` bitwise relations a `byteXorSpec` may declare —
+      split out from `byteXorSpec_sound` so the XOR/pair soundness tuple its many consumers
+      destructure is unperturbed. For a payload decoding to `(op, o₁, o₂, r)`: when `op = orOp` the
+      message is accepted exactly when `o₁, o₂` are bytes and `r = o₁ | o₂`; when `op = andOp`,
+      exactly when `o₁, o₂` are bytes and `r = o₁ & o₂`. Vacuous where the op is `none` (OpenVM,
+      `trivial`). -/
+  byteBoolSound :
+    ∀ (busId : Nat) (spec : ByteXorSpec p), byteXorSpec busId = some spec →
+      ∀ (pl : List (ZMod p)) (op o1 o2 r mult : ZMod p),
+        spec.decode pl = some (op, o1, o2, r) →
+        (∀ oop, spec.orOp = some oop → op = oop →
+           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+             ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r.val = Nat.lor o1.val o2.val)) ∧
+        (∀ aop, spec.andOp = some aop → op = aop →
+           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+             ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r.val = Nat.land o1.val o2.val))
   /-- A pure single-value range check at an arbitrary payload position, generalising the fixed
       `[x, b]` layout: `rangeCheckAt busId pattern = some (valSlot, bound)` means every
       multiplicity-`1` message on `busId` matching `pattern` breaks no invariant and is accepted
@@ -298,5 +321,6 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   zeroRangeEq_sound := by intro _ h; exact absurd h (by simp)
   byteXorSpec _ := none
   byteXorSpec_sound := by intro _ _ h; exact absurd h (by simp)
+  byteBoolSound := by intro _ _ h; exact absurd h (by simp)
   rangeCheckAt _ _ := none
   rangeCheckAt_sound := by intro _ _ _ _ h; exact absurd h (by simp)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -745,6 +745,18 @@ def openVmFacts (p : ℕ) [NeZero p]
           ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
         unfold violates; rw [hbus]
         simp [isByte, ZMod.val_eq_zero, and_assoc]
+  -- OpenVM's bitwise-lookup bus has no OR/AND op (XOR + range only), so `orOp`/`andOp` default to
+  -- `none` and the boolean-op soundness is vacuous.
+  byteBoolSound := by
+    intro busId spec hspec
+    have hbus : busMap busId = some .bitwiseLookup := by
+      revert hspec; cases hb : busMap busId with
+      | none => simp
+      | some t => cases t <;> simp
+    simp only [hbus] at hspec
+    obtain rfl := (Option.some.inj hspec).symm
+    intro pl op o1 o2 r mult hdec
+    exact ⟨fun oop hor _ => absurd hor (by simp), fun aop hand _ => absurd hand (by simp)⟩
   -- OpenVM keeps `SubsumedRange` (its dedicated variable-range-checker bus); the layout-agnostic
   -- `rangeCheckAt` is only needed for SP1's op-6 byte-bus range check.
   rangeCheckAt _ _ := none

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -38,6 +38,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.DigitFold
 import ApcOptimizer.Implementation.OptimizerPasses.SeqzCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.ScaledZero
 import ApcOptimizer.Implementation.OptimizerPasses.RangeForceZero
+import ApcOptimizer.Implementation.OptimizerPasses.RangeBool
 
 set_option autoImplicit false
 
@@ -91,6 +92,7 @@ def cleanupPasses (b : DegreeBound) : List (String × VerifiedPassW p) :=
   let pw := PrimeWitness.of p
   [ ("zeroWidthRange", (ZeroWidthRange.zeroWidthRangePass pw).guardDegree b),
     ("rangeForceZero", RangeForceZero.rangeForceZeroPass.guardDegree b),
+    ("rangeBool", (RangeBool.rangeBoolPass pw).guardDegree b),
     ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree b),
     ("carryBranch", (carryBranchPass pw).guardDegree b),
     ("gauss", gaussElimPass.withFacts.guardDegree b),

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -37,6 +37,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.OneHotAnnihilate
 import ApcOptimizer.Implementation.OptimizerPasses.DigitFold
 import ApcOptimizer.Implementation.OptimizerPasses.SeqzCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.ScaledZero
+import ApcOptimizer.Implementation.OptimizerPasses.RangeForceZero
 
 set_option autoImplicit false
 
@@ -89,6 +90,7 @@ def cleanupPasses (b : DegreeBound) : List (String × VerifiedPassW p) :=
   -- the `Bool` in O(1) instead of re-running `decide (Nat.Prime p)` per invocation per iteration).
   let pw := PrimeWitness.of p
   [ ("zeroWidthRange", (ZeroWidthRange.zeroWidthRangePass pw).guardDegree b),
+    ("rangeForceZero", RangeForceZero.rangeForceZeroPass.guardDegree b),
     ("xorEqExtract", XorEqExtract.xorEqExtractPass.guardDegree b),
     ("carryBranch", (carryBranchPass pw).guardDegree b),
     ("gauss", gaussElimPass.withFacts.guardDegree b),

--- a/ApcOptimizer/Implementation/OptimizerPasses/RangeBool.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RangeBool.lean
@@ -1,0 +1,143 @@
+import ApcOptimizer.Implementation.OptimizerPasses.ZeroWidthRange
+import ApcOptimizer.Implementation.OptimizerPasses.SubsumedCheck
+
+set_option autoImplicit false
+
+/-! # Width-1 range check → booleanity on SP1's op-6 (the `rangeCheckAt` half of `ZeroWidthRange`)
+
+`ZeroWidthRange` converts a width-1 range check `[expr, 1]` (`expr < 2`, i.e. `expr ∈ {0,1}`) on
+OpenVM's variable-range bus to the degree-2 booleanity `expr·(expr − 1) = 0`, dropping the bus
+interaction (a bus win, `bus ≻ constraints`). SP1 carries the same checks on its byte bus as op-6
+`[6, x, 1, 0]`. This pass reads them through the layout-agnostic `BusFacts.rangeCheckAt` fact: when
+it reports `bound = 2` at a slot holding a bare variable `x`, an accepted mult-1 message is exactly
+`x·(x−1) = 0`, so the pass adds that constraint and drops the check.
+
+Two `PassCorrect` steps (as in `ZeroWidthRange`): **add** the booleanity — entailed by acceptance,
+side effects unchanged — then **drop** the now-entailed checks (`filterBusEntailed_correct`). The
+booleanity's backward direction (`x·(x−1) = 0 → x < 2`) needs an integral domain, so the pass is
+prime-gated (`PrimeWitness`). Restricting the value slot to a bare variable keeps every added
+constraint at degree 2, within the identity bound, so `guardDegree` never reverts the pass.
+`trivial`/OpenVM declare no `rangeCheckAt`, so this is a no-op there. -/
+
+namespace RangeBool
+
+variable {p : ℕ}
+
+/-- The booleanity constraint `x·(x−1)` of a width-1 (`bound = 2`) op-6 check whose value slot is a
+    bare variable `x`; `none` otherwise. -/
+def boolCheck? {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?) with
+  | some (valSlot, bound) =>
+    if bi.multiplicity = Expression.const 1 ∧ bound = 2 then
+      match bi.payload[valSlot]? with
+      | some (Expression.var x) => some (ZeroWidthRange.boolC (Expression.var x))
+      | _ => none
+    else none
+  | none => none
+
+theorem boolCheck?_spec {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : boolCheck? facts bi = some c) :
+    ∃ valSlot x, facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?)
+        = some (valSlot, 2) ∧ bi.multiplicity = Expression.const 1 ∧
+        bi.payload[valSlot]? = some (Expression.var x) ∧ c = ZeroWidthRange.boolC (Expression.var x) := by
+  unfold boolCheck? at h
+  split at h
+  · rename_i vs bd hrc
+    split_ifs at h with hcond
+    obtain ⟨hmc, rfl⟩ := hcond
+    cases hp : bi.payload[vs]? with
+    | none => simp only [hp] at h; simp at h
+    | some ex =>
+      cases ex with
+      | var x =>
+        simp only [hp] at h; simp only [Option.some.injEq] at h
+        exact ⟨vs, x, hrc, hmc, hp, h.symm⟩
+      | const _ => simp only [hp] at h; simp at h
+      | add _ _ => simp only [hp] at h; simp at h
+      | mul _ _ => simp only [hp] at h; simp at h
+  · exact absurd h (by simp)
+
+/-- A recognised width-1 check lives on a stateless bus. -/
+theorem boolCheck?_stateless {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : boolCheck? facts bi = some c) :
+    bs.isStateful bi.busId = false := by
+  obtain ⟨valSlot, x, hrc, _, _, _⟩ := boolCheck?_spec facts bi c h
+  exact (facts.rangeCheckAt_sound bi.busId (bi.payload.map Expression.constValue?) valSlot 2 hrc).1
+
+/-- For a recognised width-1 check, acceptance is exactly the booleanity of its value variable. -/
+theorem boolCheck?_violates_iff {bs : BusSemantics p} (hp : Nat.Prime p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : boolCheck? facts bi = some c)
+    (env : Variable → ZMod p) : bs.violatesConstraint (bi.eval env) = false ↔ c.eval env = 0 := by
+  obtain ⟨valSlot, x, hrc, hmc, hxp, rfl⟩ := boolCheck?_spec facts bi c h
+  obtain ⟨_, hm⟩ := facts.rangeCheckAt_sound bi.busId (bi.payload.map Expression.constValue?)
+    valSlot 2 hrc
+  have hmult : (bi.eval env).multiplicity = 1 := by
+    show bi.multiplicity.eval env = 1; rw [hmc]; rfl
+  obtain ⟨_, hiff⟩ := hm (bi.eval env) rfl hmult (matches_evalPattern bi.payload env)
+  have hget : (bi.eval env).payload[valSlot]? = some (env x) := by
+    show (bi.payload.map (fun e => e.eval env))[valSlot]? = some (env x)
+    rw [List.getElem?_map, hxp]; rfl
+  rw [hiff (env x) hget, ZeroWidthRange.boolC_eval]
+  simpa only [Expression.eval] using ZeroWidthRange.val_lt_two_iff hp (env x)
+
+/-- The pass: replace every width-1 op-6 range check on a bare variable by its booleanity. -/
+def rangeBoolPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =>
+  if h1ne : (1 : ZMod p) ≠ 0 then
+    if hpr : pw.isPrime = true then
+      have hp : Nat.Prime p := pw.correct hpr
+      let newC := cs.busInteractions.filterMap (boolCheck? facts)
+      let out1 : ConstraintSystem p :=
+        { cs with algebraicConstraints := cs.algebraicConstraints ++ newC }
+      let keep := fun bi => (boolCheck? facts bi).isNone
+      have hstep1 : PassCorrect cs out1 [] bs := by
+        refine PassCorrect.ofEnvEq ?_ ?_ ?_ ?_
+        · intro env hsat
+          exact ⟨env, ⟨fun c hc => hsat.1 c (List.mem_append_left _ hc), hsat.2⟩, BusState.equiv_refl _⟩
+        · intro hcs env hsat
+          exact hcs env ⟨fun c hc => hsat.1 c (List.mem_append_left _ hc), hsat.2⟩
+        · intro z hz
+          rw [ConstraintSystem.mem_vars] at hz ⊢
+          rcases hz with ⟨c, hc, hzc⟩ | ⟨bi, hbi, hbrest⟩
+          · rcases List.mem_append.1 hc with hc | hc
+            · exact Or.inl ⟨c, hc, hzc⟩
+            · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
+              obtain ⟨_, x, _, _, hxp, rfl⟩ := boolCheck?_spec facts bi c hval
+              exact Or.inr ⟨bi, hbi, Or.inr ⟨Expression.var x, List.mem_of_getElem? hxp,
+                ZeroWidthRange.boolC_vars _ z hzc⟩⟩
+          · exact Or.inr ⟨bi, hbi, hbrest⟩
+        · intro env hadm hsat
+          refine ⟨⟨fun c hc => ?_, hsat.2⟩, hadm, BusState.equiv_refl _⟩
+          rcases List.mem_append.1 hc with hc | hc
+          · exact hsat.1 c hc
+          · obtain ⟨bi, hbi, hval⟩ := List.mem_filterMap.1 hc
+            have hmult : (bi.eval env).multiplicity = 1 := by
+              obtain ⟨_, _, _, hm, _, _⟩ := boolCheck?_spec facts bi c hval
+              show bi.multiplicity.eval env = 1; rw [hm]; rfl
+            have hviol : bs.violatesConstraint (bi.eval env) = false :=
+              hsat.2 bi hbi (by rw [hmult]; exact h1ne)
+            exact (boolCheck?_violates_iff hp facts bi c hval env).1 hviol
+      have hstep2 : PassCorrect out1 (out1.filterBus keep) [] bs := by
+        refine out1.filterBusEntailed_correct bs keep ?_ ?_
+        · intro bi _ hkf
+          obtain ⟨e, he⟩ : ∃ e, boolCheck? facts bi = some e := by
+            have hkf' : (boolCheck? facts bi).isNone = false := hkf
+            cases hopt : boolCheck? facts bi with
+            | none => rw [hopt] at hkf'; simp at hkf'
+            | some e => exact ⟨e, rfl⟩
+          exact boolCheck?_stateless facts bi e he
+        · intro bi hbi hkf env hsatf _
+          obtain ⟨e, he⟩ : ∃ e, boolCheck? facts bi = some e := by
+            have hkf' : (boolCheck? facts bi).isNone = false := hkf
+            cases hopt : boolCheck? facts bi with
+            | none => rw [hopt] at hkf'; simp at hkf'
+            | some e => exact ⟨e, rfl⟩
+          have hemem : e ∈ (out1.filterBus keep).algebraicConstraints :=
+            List.mem_append_right _ (List.mem_filterMap.2 ⟨bi, hbi, he⟩)
+          rw [boolCheck?_violates_iff hp facts bi e he env]
+          exact hsatf.1 e hemem
+      ⟨out1.filterBus keep, [], hstep1.andThen hstep2⟩
+    else ⟨cs, [], PassCorrect.refl cs bs⟩
+  else ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end RangeBool

--- a/ApcOptimizer/Implementation/OptimizerPasses/RangeForceZero.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RangeForceZero.lean
@@ -1,0 +1,107 @@
+import ApcOptimizer.Implementation.OptimizerPasses.SubsumedCheck
+import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+
+set_option autoImplicit false
+
+/-! # Width-0 range check → equality (the `rangeCheckAt` generalisation of `ZeroWidthRange`)
+
+`ZeroWidthRange` converts a width-0 range check on OpenVM's dedicated variable-range-checker bus
+(`[expr, 0]`, i.e. `expr < 2⁰ = 1`, i.e. `expr = 0`) to the algebraic equality `expr = 0`, which
+Gauss consumes. SP1 carries the same degenerate checks on its byte bus as op-6 `[6, expr, 0, 0]`
+(the layout `ZeroWidthRange`'s `zeroRangeEq`/`varRangeBus` facts do not describe), and their value
+slot is often a whole **linear form** — a decomposition equality like
+`higher_limb = result₀ + 256·result₁ + …`. This pass reads them through the layout-agnostic
+`BusFacts.rangeCheckAt` fact: when it reports `bound = 1` at a slot, an accepted message forces that
+slot's expression to `0`, so the pass **seeds that expression as an algebraic constraint**
+(`ConstraintSystem.addConstraints_correct`). Gauss then eliminates a variable and the now-constant
+`[6, 0, 0, 0]` check is dropped by `tautoBus`.
+
+Purely the accepted-set `↔` of `rangeCheckAt` at `bound = 1`; no bus specifics beyond the fact.
+`trivial`/OpenVM declare no `rangeCheckAt`, so this is a no-op there (OpenVM keeps `ZeroWidthRange`
+on its own bus). Gated on `(1 : ZMod p) ≠ 0` (every prime field; identity on `ZMod 1`). -/
+
+namespace RangeForceZero
+
+variable {p : ℕ}
+
+/-- The forced-zero expression of `bi`: its value-slot expression, when `bi` is a mult-1 range
+    check whose `rangeCheckAt` bound is `1` (`= 2⁰`, so the slot is `< 1`, i.e. `0`). -/
+def forceZeroAt {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?) with
+  | some (valSlot, bound) =>
+    if bi.multiplicity = Expression.const 1 ∧ bound = 1 then
+      -- skip an already-constant slot: it would seed a trivial `0` every cycle until `tautoBus`
+      -- drops the now-constant check.
+      match bi.payload[valSlot]? with
+      | some e => if e.constValue?.isNone then some e else none
+      | none => none
+    else none
+  | none => none
+
+theorem forceZeroAt_spec {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (e : Expression p) (h : forceZeroAt facts bi = some e) :
+    ∃ valSlot, facts.rangeCheckAt bi.busId (bi.payload.map Expression.constValue?)
+        = some (valSlot, 1) ∧ bi.multiplicity = Expression.const 1 ∧ bi.payload[valSlot]? = some e := by
+  unfold forceZeroAt at h
+  split at h
+  · rename_i vs bd hrc
+    split_ifs at h with hcond
+    obtain ⟨hmc, rfl⟩ := hcond
+    cases hp : bi.payload[vs]? with
+    | none => simp only [hp] at h; simp at h
+    | some e' =>
+      simp only [hp] at h
+      split_ifs at h with hc
+      simp only [Option.some.injEq] at h
+      subst h
+      exact ⟨vs, hrc, hmc, hp⟩
+  · exact absurd h (by simp)
+
+/-- Every accepted-and-active width-0 check forces its slot expression to `0`. -/
+theorem forceZeroAt_sound {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (e : Expression p) (h1ne : (1 : ZMod p) ≠ 0)
+    (h : forceZeroAt facts bi = some e) (env : Variable → ZMod p) (hsat : cs.satisfies bs env)
+    (hbi : bi ∈ cs.busInteractions) : e.eval env = 0 := by
+  obtain ⟨valSlot, hrc, hmc, hget⟩ := forceZeroAt_spec facts bi e h
+  obtain ⟨_, hm⟩ := facts.rangeCheckAt_sound bi.busId (bi.payload.map Expression.constValue?)
+    valSlot 1 hrc
+  have hmult : (bi.eval env).multiplicity = 1 := by
+    show bi.multiplicity.eval env = 1; rw [hmc]; rfl
+  obtain ⟨_, hiff⟩ := hm (bi.eval env) rfl hmult (matches_evalPattern bi.payload env)
+  have hviol : bs.violatesConstraint (bi.eval env) = false := by
+    refine hsat.2 bi hbi ?_; rw [hmult]; exact h1ne
+  have hgetEv : (bi.eval env).payload[valSlot]? = some (e.eval env) := by
+    show (bi.payload.map (fun t => t.eval env))[valSlot]? = some (e.eval env)
+    rw [List.getElem?_map, hget]; rfl
+  have hlt : (e.eval env).val < 1 := (hiff (e.eval env) hgetEv).mp hviol
+  exact (ZMod.val_eq_zero _).mp (by omega)
+
+/-- The seeds: the forced-zero expression of every recognised width-0 check. -/
+def forceZeroSeeds {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (Expression p) :=
+  cs.busInteractions.filterMap (forceZeroAt facts)
+
+theorem forceZeroSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (env : Variable → ZMod p) (h1ne : (1 : ZMod p) ≠ 0) (hsat : cs.satisfies bs env) :
+    ∀ e ∈ forceZeroSeeds facts cs, e.eval env = 0 := by
+  intro e he
+  obtain ⟨bi, hbi, hf⟩ := List.mem_filterMap.1 he
+  exact forceZeroAt_sound facts cs bi e h1ne hf env hsat hbi
+
+/-- The pass: seed `expr = 0` for every width-0 (`bound = 1`) range check. -/
+def rangeForceZeroPass : VerifiedPassW p := fun cs bs facts =>
+  if h1ne : (1 : ZMod p) ≠ 0 then
+    let new := (forceZeroSeeds facts cs).filter (fun e => e.vars.all (fun z => cs.vars.contains z))
+    ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+      cs.addConstraints_correct bs new
+        (fun env _ hsat e he =>
+          forceZeroSeeds_sound facts cs env h1ne hsat e (List.mem_of_mem_filter he))
+        (fun e he z hz => by
+          have hp := (List.mem_filter.1 he).2
+          simp only [List.all_eq_true] at hp
+          exact List.contains_iff_mem.mp (hp z hz))⟩
+  else
+    ⟨cs, [], PassCorrect.refl cs bs⟩
+
+end RangeForceZero

--- a/ApcOptimizer/Implementation/OptimizerPasses/ScaledZero.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ScaledZero.lean
@@ -176,6 +176,47 @@ theorem zero_of_bounds {p : ℕ} (v c : ZMod p) (B1 B2 : Nat)
   have : c.val ≤ c.val * v.val := Nat.le_mul_of_pos_right _ (by omega)
   omega
 
+/-- The two-term generalization of `zero_of_bounds`: a byte-slot value `k·v − k·w` (both `v`, `w`
+    bounded by `B`) that is `< B2` with `k ≥ B2` (genuinely scaled) and no wraparound
+    (`k·(B−1) ≤ p − B2`) forces `v = w`. The `k`-scaled difference of two bytes is either `0` (when
+    `v = w`) or has field value `≥ B2` (a multiple of `k` on one side, `≥ p − k·(B−1) ≥ B2` on the
+    other), so `< B2` pins it to `0`. This is exactly the SP1 `lbu; xor; sb` dead-byte OR operand
+    `8323072·(b_low − higher)`: a byte, forcing `b_low = higher`. -/
+theorem two_term_zero {p : ℕ} [NeZero p] (v w k : ZMod p) (B B2 : Nat)
+    (hv : v.val < B) (hw : w.val < B) (hB2 : 1 ≤ B2)
+    (hk : B2 ≤ k.val) (hnw : k.val * (B - 1) ≤ p - B2)
+    (hs : (k * v - k * w).val < B2) : v = w := by
+  have hp : 0 < p := Nat.pos_of_ne_zero (NeZero.ne p)
+  have hnwlt : k.val * (B - 1) < p := lt_of_le_of_lt hnw (by omega)
+  have hmul : k * v - k * w = k * (v - w) := by ring
+  rw [hmul] at hs
+  rcases Nat.lt_or_ge v.val w.val with hlt | hle
+  · -- v.val < w.val: `k·(v−w) = −(k·(w−v))` has value `≥ B2`, contradicting `hs`.
+    exfalso
+    have hd'val : (w - v).val = w.val - v.val := ZMod.val_sub (le_of_lt hlt)
+    have hd'pos : 1 ≤ (w - v).val := by rw [hd'val]; omega
+    have hkwv_val : (k * (w - v)).val = k.val * (w - v).val := by
+      rw [ZMod.val_mul, Nat.mod_eq_of_lt (lt_of_le_of_lt
+        (Nat.mul_le_mul_left _ (by rw [hd'val]; omega)) hnwlt)]
+    have hkwv_ne : k * (w - v) ≠ 0 := by
+      intro h0
+      rw [h0, ZMod.val_zero] at hkwv_val
+      have : k.val ≤ k.val * (w - v).val := Nat.le_mul_of_pos_right _ (by omega)
+      omega
+    haveI : NeZero (k * (w - v)) := ⟨hkwv_ne⟩
+    have hneg : k * (v - w) = -(k * (w - v)) := by ring
+    rw [hneg, ZMod.val_neg_of_ne_zero, hkwv_val] at hs
+    have hle2 : k.val * (w - v).val ≤ p - B2 :=
+      le_trans (Nat.mul_le_mul_left _ (by rw [hd'val]; omega)) hnw
+    have hB2p : B2 ≤ p := le_of_lt (lt_of_le_of_lt hk (ZMod.val_lt k))
+    -- `p − X < B2` (hs) but `X ≤ p − B2` (hle2) ⇒ `p − X ≥ B2`: contradiction (`X` opaque to omega).
+    generalize hX : k.val * (w - v).val = X at hs hle2
+    omega
+  · -- v.val ≥ w.val: `d = v − w` is a nonneg byte, so `zero_of_bounds` applies.
+    have hdval : (v - w).val = v.val - w.val := ZMod.val_sub hle
+    have hdB : (v - w).val < B := by rw [hdval]; omega
+    exact sub_eq_zero.mp (zero_of_bounds (v - w) k B B2 hdB hs hk hnwlt)
+
 /-- `v` is provably `0`: bare-bounded by `B1` and scaled-bounded by `(c, B2)` over `cs`'s
     interactions, with `c ≥ B2` and the no-wrap `c·(B1−1) < p`. -/
 def scaledZeroOk {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
@@ -232,15 +273,202 @@ theorem scaledZeroSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
   show env v = 0
   exact scaledZeroOk_sound facts cs v hok env hsat
 
-/-- The pass: add the entailed `v = 0` for every candidate the joint byte bounds pin to zero. -/
+/-! ## Two-term scaled slots (`k·v − k·w`)
+
+The SP1 `lbu; xor; sb` dead-byte OR operands are byte slots holding `8323072·(b_low − higher)` — a
+`k·v − k·w` form, not a single scaled variable. Its byte bound forces `v = w` (`two_term_zero`),
+which `Gauss` uses to merge the two limbs; the emptied operand then reaches the constant `0` and the
+result byte is dropped by `xorEqExtract`'s OR arm. -/
+
+/-- `v − w` as an expression (`v + (−1)·w`). -/
+def pairDiff (v w : Variable) : Expression p :=
+  Expression.add (Expression.var v) (Expression.mul (Expression.const (-1)) (Expression.var w))
+
+theorem pairDiff_eval (v w : Variable) (env : Variable → ZMod p) :
+    (pairDiff v w).eval env = env v - env w := by
+  simp only [pairDiff, Expression.eval]; ring
+
+/-- If `L` is a two-term form `ca·a + cb·b` with `ca + cb = 0`, extract `(v, w, k)` with the
+    smaller-`val` coefficient as `k`, oriented so `L = k·v − k·w`. -/
+def twoTermParts (L : LinExpr p) : Option (Variable × Variable × ZMod p) :=
+  if L.const = 0 then
+    match L.terms with
+    | [(a, ca), (b, cb)] =>
+      if ca + cb = 0 then
+        if ca.val ≤ cb.val then some (a, b, ca) else some (b, a, cb)
+      else none
+    | _ => none
+  else none
+
+theorem twoTermParts_eval (L : LinExpr p) (v w : Variable) (k : ZMod p)
+    (h : twoTermParts L = some (v, w, k)) (env : Variable → ZMod p) :
+    L.eval env = k * env v - k * env w := by
+  obtain ⟨cst, terms⟩ := L
+  unfold twoTermParts at h
+  by_cases hconst : cst = 0
+  · rw [if_pos hconst] at h
+    rcases terms with _ | ⟨⟨a, ca⟩, _ | ⟨⟨b, cb⟩, _ | rest⟩⟩
+    · simp at h
+    · simp at h
+    · -- terms = [(a, ca), (b, cb)]
+      dsimp only at h
+      by_cases hsum : ca + cb = 0
+      · rw [if_pos hsum] at h
+        by_cases hle : ca.val ≤ cb.val
+        · rw [if_pos hle] at h
+          simp only [Option.some.injEq, Prod.mk.injEq] at h
+          obtain ⟨rfl, rfl, rfl⟩ := h
+          simp only [LinExpr.eval, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+          linear_combination hconst + (env b) * hsum
+        · rw [if_neg hle] at h
+          simp only [Option.some.injEq, Prod.mk.injEq] at h
+          obtain ⟨rfl, rfl, rfl⟩ := h
+          simp only [LinExpr.eval, List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+          linear_combination hconst + (env a) * hsum
+      · rw [if_neg hsum] at h; simp at h
+    · simp at h
+  · rw [if_neg hconst] at h; simp at h
+
+/-- A single slot's two-term seed: the emptied difference `v − w` when payload slot `i` linearizes to
+    `k·v − k·w`, has a byte bound `B2`, and both variables are bounded so `two_term_zero` applies. -/
+def pair2SeedAt {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (mval : ZMod p) (i : Nat) : Option (Expression p) :=
+  if 0 < p then
+    match bi.payload[i]?, facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) i with
+    | some e, some B2 =>
+      match linearize e with
+      | some L =>
+        match twoTermParts L with
+        | some (v, w, k) =>
+          match findVarBound bs facts cs.busInteractions v,
+                findVarBound bs facts cs.busInteractions w with
+          | some Bv, some Bw =>
+            if 1 ≤ B2 ∧ B2 ≤ k.val ∧ k.val * (max Bv Bw - 1) ≤ p - B2 then
+              some (pairDiff v w)
+            else none
+          | _, _ => none
+        | none => none
+      | none => none
+    | _, _ => none
+  else none
+
+theorem pair2SeedAt_sound {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (mval : ZMod p) (i : Nat) (e : Expression p)
+    (hmc : bi.multiplicity.constValue? = some mval) (hmz : mval ≠ 0)
+    (h : pair2SeedAt facts cs bi mval i = some e) (env : Variable → ZMod p)
+    (hsat : cs.satisfies bs env) (hbi : bi ∈ cs.busInteractions) : e.eval env = 0 := by
+  have hbus : ∀ bi' ∈ cs.busInteractions, (bi'.eval env).multiplicity ≠ 0 →
+      bs.violatesConstraint (bi'.eval env) = false := fun bi' hbi' => hsat.2 bi' hbi'
+  unfold pair2SeedAt at h
+  have hp0 : 0 < p := by
+    rcases Nat.eq_zero_or_pos p with hp | hp
+    · subst hp; simp at h
+    · exact hp
+  rw [if_pos hp0] at h
+  haveI : NeZero p := ⟨by omega⟩
+  cases hpe : bi.payload[i]? with
+  | none => rw [hpe] at h; simp at h
+  | some ei =>
+    cases hsb : facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) i with
+    | none => rw [hpe, hsb] at h; simp at h
+    | some B2 =>
+      rw [hpe, hsb] at h
+      cases hL : linearize ei with
+      | none => simp only [hL] at h; simp at h
+      | some L =>
+        cases htt : twoTermParts L with
+        | none => simp only [hL, htt] at h; simp at h
+        | some vwk =>
+          obtain ⟨v, w, k⟩ := vwk
+          cases hbv : findVarBound bs facts cs.busInteractions v with
+          | none => simp only [hL, htt, hbv] at h; simp at h
+          | some Bv =>
+            cases hbw : findVarBound bs facts cs.busInteractions w with
+            | none => simp only [hL, htt, hbv, hbw] at h; simp at h
+            | some Bw =>
+              simp only [hL, htt, hbv, hbw] at h
+              split at h
+              · rename_i hcond
+                obtain ⟨hB2, hkB2, hnw⟩ := hcond
+                simp only [Option.some.injEq] at h
+                subst h
+                -- the interaction is active, hence accepted
+                have hmeval : (bi.eval env).multiplicity = mval :=
+                  bi.multiplicity.constValue?_sound mval hmc env
+                have hviol : bs.violatesConstraint (bi.eval env) = false := by
+                  apply hbus bi hbi; rw [hmeval]; exact hmz
+                -- the slot value `ei.eval env` is bounded by `B2`
+                have hget : (bi.eval env).payload[i]? = some (ei.eval env) := by
+                  show (bi.payload.map (fun t => t.eval env))[i]? = some (ei.eval env)
+                  rw [List.getElem?_map, hpe]; rfl
+                have hsb' : facts.slotBound (bi.eval env).busId (bi.eval env).multiplicity
+                    (bi.payload.map Expression.constValue?) i = some B2 := by
+                  show facts.slotBound bi.busId (bi.eval env).multiplicity _ i = some B2
+                  rw [hmeval]; exact hsb
+                have hbound : (ei.eval env).val < B2 :=
+                  facts.slotBound_sound (bi.eval env) (bi.payload.map Expression.constValue?) i B2
+                    (ei.eval env) hsb' (matches_evalPattern bi.payload env) hviol hget
+                -- `ei.eval env = k·v − k·w`
+                have heq : ei.eval env = k * env v - k * env w := by
+                  rw [linearize_eval ei L hL env, twoTermParts_eval L v w k htt env]
+                rw [heq] at hbound
+                -- bounds on v, w
+                have hvb : (env v).val < Bv :=
+                  findVarBound_sound bs facts cs.busInteractions v Bv hbv env hbus
+                have hwb : (env w).val < Bw :=
+                  findVarBound_sound bs facts cs.busInteractions w Bw hbw env hbus
+                have hvB : (env v).val < max Bv Bw := lt_of_lt_of_le hvb (le_max_left _ _)
+                have hwB : (env w).val < max Bv Bw := lt_of_lt_of_le hwb (le_max_right _ _)
+                have := two_term_zero (env v) (env w) k (max Bv Bw) B2 hvB hwB hB2 hkB2 hnw hbound
+                rw [pairDiff_eval]; rw [this]; ring
+              · exact absurd h (by simp)
+
+/-- Every two-term seed over the whole system (one per forceable byte slot). -/
+def pair2Seeds {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (Expression p) :=
+  cs.busInteractions.flatMap (fun bi =>
+    match bi.multiplicity.constValue? with
+    | some mval => if mval = 0 then [] else
+        (List.range bi.payload.length).filterMap (pair2SeedAt facts cs bi mval)
+    | none => [])
+
+theorem pair2Seeds_sound {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (env : Variable → ZMod p) (hsat : cs.satisfies bs env) :
+    ∀ e ∈ pair2Seeds facts cs, e.eval env = 0 := by
+  intro e he
+  unfold pair2Seeds at he
+  rw [List.mem_flatMap] at he
+  obtain ⟨bi, hbi, he2⟩ := he
+  cases hmc : bi.multiplicity.constValue? with
+  | none => simp only [hmc] at he2; simp at he2
+  | some mval =>
+    simp only [hmc] at he2
+    by_cases hmz : mval = 0
+    · rw [if_pos hmz] at he2; simp at he2
+    · rw [if_neg hmz] at he2
+      rw [List.mem_filterMap] at he2
+      obtain ⟨i, _, hseed⟩ := he2
+      exact pair2SeedAt_sound facts cs bi mval i e hmc hmz hseed env hsat hbi
+
+/-- Combined soundness of the single-variable and two-term seeds. -/
+theorem allSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (env : Variable → ZMod p) (hsat : cs.satisfies bs env) :
+    ∀ e ∈ scaledZeroSeeds facts cs ++ pair2Seeds facts cs, e.eval env = 0 := by
+  intro e he
+  rcases List.mem_append.1 he with h | h
+  · exact scaledZeroSeeds_sound facts cs env hsat e h
+  · exact pair2Seeds_sound facts cs env hsat e h
+
+/-- The pass: add the entailed `v = 0` (single scaled variable) and `v − w = 0` (two-term scaled
+    slot) for every candidate the byte bounds pin. -/
 def scaledZeroPass : VerifiedPassW p := fun cs bs facts =>
-  let seeds := scaledZeroSeeds facts cs
+  let seeds := scaledZeroSeeds facts cs ++ pair2Seeds facts cs
   let new := seeds.filter (fun e => e.vars.all (fun z => cs.vars.contains z))
   if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
   else
     ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
      cs.addConstraints_correct bs new
-       (fun env _ hsat e he => scaledZeroSeeds_sound facts cs env hsat e (List.mem_of_mem_filter he))
+       (fun env _ hsat e he => allSeeds_sound facts cs env hsat e (List.mem_of_mem_filter he))
        (fun e he z hz => by
          have hp := (List.mem_filter.1 he).2
          simp only [List.all_eq_true] at hp

--- a/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
@@ -124,76 +124,253 @@ private theorem sub255_val {p : ℕ} (hp : 256 ≤ p) (a : ZMod p) (ha : a.val <
     _ = (((255 - a.val : ℕ) : ZMod p)).val := by rw [Nat.cast_sub hle, hcast255]
     _ = 255 - a.val := ZMod.val_natCast_of_lt (by omega)
 
-/-- Extract every constant-operand XOR equality and add it as an algebraic constraint. -/
+/-- The entailment of a single recognized XOR equality, factored out of the pass so the pass can
+    combine it with the OR/AND extraction below. -/
+theorem xorEq?_eval (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (env : Variable → ZMod p)
+    (h1ne : (1 : ZMod p) ≠ 0) (h : xorEq? bs facts bi = some c) (hbi : bi ∈ cs.busInteractions)
+    (hsat : cs.satisfies bs env) : c.eval env = 0 := by
+  obtain ⟨spec, o1, o2, r, hspec, hmult, hdec, hcase⟩ := xorEq?_spec bs facts bi c h
+  have hviol : bs.violatesConstraint (bi.eval env) = false := by
+    refine hsat.2 bi hbi ?_
+    show (bi.multiplicity.eval env) ≠ 0
+    rw [hmult]; simpa using h1ne
+  obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound bi.busId spec hspec
+  have hdecEv : spec.decode (bi.eval env).payload
+      = some (spec.xorOp, o1.eval env, o2.eval env, r.eval env) := by
+    show spec.decode (bi.payload.map (fun e => e.eval env)) = _
+    rw [spec.decode_map, hdec]; rfl
+  obtain ⟨ho1b, ho2b, hrval⟩ :=
+    ((hsound (bi.eval env).payload spec.xorOp (o1.eval env) (o2.eval env) (r.eval env)
+      (bi.eval env).multiplicity hdecEv).1 rfl).mp hviol
+  haveI := spec.pNeZero
+  rcases hcase with ⟨hz, rfl⟩ | ⟨hz, rfl⟩ | ⟨hp, hbnd, hz, rfl⟩ | ⟨hp, hbnd, hz, rfl⟩
+  · rw [subE_eval]
+    have hzero : (o1.eval env) = 0 := by rw [hz]; rfl
+    rw [hzero, ZMod.val_zero] at hrval
+    rw [val_inj _ _ (hrval.trans (Nat.zero_xor _)), sub_self]
+  · rw [subE_eval]
+    have hzero : (o2.eval env) = 0 := by rw [hz]; rfl
+    rw [hzero, ZMod.val_zero] at hrval
+    rw [val_inj _ _ (hrval.trans (Nat.xor_zero _)), sub_self]
+  · rw [subE_eval, complE_eval]
+    have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
+    have h255v : (255 : ZMod p).val = 255 := by
+      rw [← hcast255, ZMod.val_natCast_of_lt (by omega)]
+    have ho1 : (o1.eval env) = 255 := by rw [hz]; rfl
+    rw [ho1, h255v] at hrval
+    have hx : (r.eval env).val = 255 - (o2.eval env).val := by
+      rw [hrval, show Nat.xor 255 (o2.eval env).val = Nat.xor (o2.eval env).val 255
+        from Nat.xor_comm _ _]
+      exact nat_xor_255 _ (hbnd ▸ ho2b)
+    rw [val_inj _ _ (hx.trans (sub255_val hp _ (hbnd ▸ ho2b)).symm), sub_self]
+  · rw [subE_eval, complE_eval]
+    have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
+    have h255v : (255 : ZMod p).val = 255 := by
+      rw [← hcast255, ZMod.val_natCast_of_lt (by omega)]
+    have ho2 : (o2.eval env) = 255 := by rw [hz]; rfl
+    rw [ho2, h255v] at hrval
+    have hx : (r.eval env).val = 255 - (o1.eval env).val := by
+      rw [hrval]; exact nat_xor_255 _ (hbnd ▸ ho1b)
+    rw [val_inj _ _ (hx.trans (sub255_val hp _ (hbnd ▸ ho1b)).symm), sub_self]
+
+/-- The variables of a recognized XOR equality come from the interaction's payload. -/
+theorem xorEq?_vars (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : xorEq? bs facts bi = some c)
+    (hbi : bi ∈ cs.busInteractions) (zv : Variable) (hz : zv ∈ c.vars) : zv ∈ cs.vars := by
+  obtain ⟨spec, o1, o2, r, _, _, hdec, hcase⟩ := xorEq?_spec bs facts bi c h
+  obtain ⟨ho1m, ho2m, hrm⟩ := spec.decode_mem _ _ _ _ _ hdec
+  rcases hcase with ⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, _, _, rfl⟩ | ⟨_, _, _, rfl⟩ <;>
+    rcases List.mem_append.1 (by simpa only [subE, complE, Expression.vars,
+      List.append_assoc, List.nil_append] using hz) with h_r | h_o
+  · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+  · exact ConstraintSystem.mem_vars_of_payload hbi ho2m h_o
+  · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+  · exact ConstraintSystem.mem_vars_of_payload hbi ho1m h_o
+  · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+  · exact ConstraintSystem.mem_vars_of_payload hbi ho2m h_o
+  · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+  · exact ConstraintSystem.mem_vars_of_payload hbi ho1m h_o
+
+/-! ## OR / AND constant-operand extraction (generalizing the XOR case above)
+
+The same closure holds for the two other affine-in-one-operand bitwise ops a byte bus may carry
+(declared as `spec.orOp` / `spec.andOp`, see `BusFacts.byteBoolSound`): with a **zero** operand,
+`x | 0 = x` pins the result to the other operand (`z = y` / `z = x`), and `x & 0 = 0` pins it to
+the constant `0` (`z = 0`). SP1's byte bus has both ops (`orOp = 1`, `andOp = 0`); OpenVM's declares
+neither, so this is a no-op there.
+
+**Constant target only.** For OR the pin `z = y` is emitted only when the surviving operand `y` is
+a *constant* — so Gauss substitutes `z` by a constant, never by a wider expression. (Emitting
+`z = k·(u − v)` for the scaled dead-byte operands of `lbu; xor; sb` would *expand* the clean byte
+`z` into a two-term affine and block memory cancellation — a regression. Those operands are driven
+to the constant `0` by `scaledZero` first, and *then* recognized here.) AND's target is always the
+constant `0`, so it is unconditional. -/
+
+/-- A substitution target Gauss can inline without disturbing anything: a *constant*. Pinning
+    `result` to a wider expression — even a bare variable — turned out to displace the intermediate
+    byte apc's memory cancellation was keying on and to block downstream telescoping (measured
+    regression on the SP1 k256 blocks), so only constant targets are taken. The scaled dead-byte
+    operands `k·(u − v)` reach a constant `0` here only after `scaledZero` forces `u = v`. -/
+def simpleTarget (e : Expression p) : Bool := e.constValue?.isSome
+
+/-- Does `op` match the (optional) op-selector value `o`? -/
+def opIs (o : Option (ZMod p)) (op : Expression p) : Bool :=
+  match o with
+  | some v => decide (op = Expression.const v)
+  | none => false
+
+theorem opIs_iff {o : Option (ZMod p)} {op : Expression p} :
+    opIs o op = true ↔ ∃ v, o = some v ∧ op = Expression.const v := by
+  unfold opIs
+  cases o with
+  | none => simp
+  | some v => simp
+
+/-- The entailed equality from a constant-**zero**-operand OR/AND interaction, emitted only when the
+    result is pinned to a *constant*: `r − o₂` / `r − o₁` for OR with a constant surviving operand,
+    and `r` (i.e. `r = 0`) for AND. -/
+def boolEq? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Expression p) :=
+  match facts.byteXorSpec bi.busId with
+  | none => none
+  | some spec =>
+    if bi.multiplicity = Expression.const 1 then
+      match spec.decode bi.payload with
+      | some (op, o1, o2, r) =>
+        if opIs spec.orOp op then
+          if o1 = Expression.const 0 then
+            (if simpleTarget o2 then some (subE r o2) else none)
+          else if o2 = Expression.const 0 then
+            (if simpleTarget o1 then some (subE r o1) else none)
+          else none
+        else if opIs spec.andOp op then
+          if o1 = Expression.const 0 ∨ o2 = Expression.const 0 then some r
+          else none
+        else none
+      | none => none
+    else none
+
+/-- Structure of a recognized OR/AND interaction. -/
+theorem boolEq?_spec (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : boolEq? bs facts bi = some c) :
+    ∃ (spec : ByteXorSpec p) (op o1 o2 r : Expression p),
+      facts.byteXorSpec bi.busId = some spec ∧ bi.multiplicity = Expression.const 1 ∧
+      spec.decode bi.payload = some (op, o1, o2, r) ∧
+        ((∃ oop, spec.orOp = some oop ∧ op = Expression.const oop ∧
+            ((o1 = Expression.const 0 ∧ c = subE r o2)
+              ∨ (o2 = Expression.const 0 ∧ c = subE r o1)))
+          ∨ (∃ aop, spec.andOp = some aop ∧ op = Expression.const aop ∧
+              ((o1 = Expression.const 0 ∨ o2 = Expression.const 0) ∧ c = r))) := by
+  unfold boolEq? at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i spec hspec
+    split at h
+    · rename_i hmult
+      split at h
+      · rename_i op o1 o2 r hdec
+        refine ⟨spec, op, o1, o2, r, hspec, hmult, hdec, ?_⟩
+        split at h
+        · rename_i hor
+          obtain ⟨oop, hoeq, hopeq⟩ := opIs_iff.1 hor
+          refine Or.inl ⟨oop, hoeq, hopeq, ?_⟩
+          split_ifs at h with h1 h2 h3 h4
+          · exact Or.inl ⟨h1, by simpa using h.symm⟩
+          · exact Or.inr ⟨h3, by simpa using h.symm⟩
+        · split at h
+          · rename_i hand
+            obtain ⟨aop, haeq, hopeq⟩ := opIs_iff.1 hand
+            refine Or.inr ⟨aop, haeq, hopeq, ?_⟩
+            split_ifs at h with h1
+            · exact ⟨h1, by simpa using h.symm⟩
+          · exact absurd h (by simp)
+      · exact absurd h (by simp)
+    · exact absurd h (by simp)
+
+/-- The entailment of a single recognized OR/AND equality (through `BusFacts.byteBoolSound`). -/
+theorem boolEq?_eval (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (env : Variable → ZMod p)
+    (h1ne : (1 : ZMod p) ≠ 0) (h : boolEq? bs facts bi = some c) (hbi : bi ∈ cs.busInteractions)
+    (hsat : cs.satisfies bs env) : c.eval env = 0 := by
+  obtain ⟨spec, op, o1, o2, r, hspec, hmult, hdec, hcase⟩ := boolEq?_spec bs facts bi c h
+  have hviol : bs.violatesConstraint (bi.eval env) = false := by
+    refine hsat.2 bi hbi ?_
+    show (bi.multiplicity.eval env) ≠ 0
+    rw [hmult]; simpa using h1ne
+  have hdecEv : spec.decode (bi.eval env).payload
+      = some (op.eval env, o1.eval env, o2.eval env, r.eval env) := by
+    show spec.decode (bi.payload.map (fun e => e.eval env)) = _
+    rw [spec.decode_map, hdec]; rfl
+  obtain ⟨horc, handc⟩ := facts.byteBoolSound bi.busId spec hspec (bi.eval env).payload
+    (op.eval env) (o1.eval env) (o2.eval env) (r.eval env) (bi.eval env).multiplicity hdecEv
+  haveI := spec.pNeZero
+  rcases hcase with ⟨oop, hspecOr, hopeq, hcc⟩ | ⟨aop, hspecAnd, hopeq, hcc⟩
+  · have hopev : op.eval env = oop := by rw [hopeq]; rfl
+    obtain ⟨_, _, hrval⟩ := (horc oop hspecOr hopev).mp hviol
+    rcases hcc with ⟨hz, rfl⟩ | ⟨hz, rfl⟩
+    · rw [subE_eval]
+      have ho1z : (o1.eval env) = 0 := by rw [hz]; rfl
+      rw [ho1z, ZMod.val_zero] at hrval
+      have heq : (r.eval env).val = (o2.eval env).val := by rw [hrval]; simp
+      rw [val_inj _ _ heq, sub_self]
+    · rw [subE_eval]
+      have ho2z : (o2.eval env) = 0 := by rw [hz]; rfl
+      rw [ho2z, ZMod.val_zero] at hrval
+      have heq : (r.eval env).val = (o1.eval env).val := by rw [hrval]; simp
+      rw [val_inj _ _ heq, sub_self]
+  · have hopev : op.eval env = aop := by rw [hopeq]; rfl
+    obtain ⟨_, _, hrval⟩ := (handc aop hspecAnd hopev).mp hviol
+    obtain ⟨hz, rfl⟩ := hcc
+    refine (ZMod.val_eq_zero _).mp ?_
+    rcases hz with hz | hz
+    · have : (o1.eval env) = 0 := by rw [hz]; rfl
+      rw [this, ZMod.val_zero] at hrval; rw [hrval]; simp
+    · have : (o2.eval env) = 0 := by rw [hz]; rfl
+      rw [this, ZMod.val_zero] at hrval; rw [hrval]; simp
+
+/-- The variables of a recognized OR/AND equality come from the interaction's payload. -/
+theorem boolEq?_vars (bs : BusSemantics p) (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (bi : BusInteraction (Expression p)) (c : Expression p) (h : boolEq? bs facts bi = some c)
+    (hbi : bi ∈ cs.busInteractions) (zv : Variable) (hz : zv ∈ c.vars) : zv ∈ cs.vars := by
+  obtain ⟨spec, op, o1, o2, r, _, _, hdec, hcase⟩ := boolEq?_spec bs facts bi c h
+  obtain ⟨ho1m, ho2m, hrm⟩ := spec.decode_mem _ _ _ _ _ hdec
+  rcases hcase with ⟨oop, _, _, hcc⟩ | ⟨aop, _, _, hcc⟩
+  · rcases hcc with ⟨_, rfl⟩ | ⟨_, rfl⟩ <;>
+      rcases List.mem_append.1 (by simpa only [subE, Expression.vars,
+        List.append_assoc, List.nil_append] using hz) with h_r | h_o
+    · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+    · exact ConstraintSystem.mem_vars_of_payload hbi ho2m h_o
+    · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
+    · exact ConstraintSystem.mem_vars_of_payload hbi ho1m h_o
+  · obtain ⟨_, rfl⟩ := hcc
+    exact ConstraintSystem.mem_vars_of_payload hbi hrm hz
+
+/-- Extract every constant-operand XOR/OR/AND equality and add it as an algebraic constraint. The
+    XOR half (`xorEq?`) and the OR/AND half (`boolEq?`) are independent recognizers; their outputs
+    are concatenated and each is entailed by its interaction's acceptance. -/
 def xorEqExtractPass : VerifiedPassW p := fun cs bs facts =>
   if h1ne : (1 : ZMod p) ≠ 0 then
     let new := cs.busInteractions.filterMap (xorEq? bs facts)
+      ++ cs.busInteractions.filterMap (boolEq? bs facts)
     ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
       cs.addConstraints_correct bs new
         (by
           -- entailment: each added equality holds on every satisfying assignment
           intro env _ hsat c hc
-          obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-          obtain ⟨spec, o1, o2, r, hspec, hmult, hdec, hcase⟩ := xorEq?_spec bs facts bi c hbc
-          have hviol : bs.violatesConstraint (bi.eval env) = false := by
-            refine hsat.2 bi hbi ?_
-            show (bi.multiplicity.eval env) ≠ 0
-            rw [hmult]; simpa using h1ne
-          obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound bi.busId spec hspec
-          have hdecEv : spec.decode (bi.eval env).payload
-              = some (spec.xorOp, o1.eval env, o2.eval env, r.eval env) := by
-            show spec.decode (bi.payload.map (fun e => e.eval env)) = _
-            rw [spec.decode_map, hdec]; rfl
-          obtain ⟨ho1b, ho2b, hrval⟩ :=
-            ((hsound (bi.eval env).payload spec.xorOp (o1.eval env) (o2.eval env) (r.eval env)
-              (bi.eval env).multiplicity hdecEv).1 rfl).mp hviol
-          haveI := spec.pNeZero
-          rcases hcase with ⟨hz, rfl⟩ | ⟨hz, rfl⟩ | ⟨hp, hbnd, hz, rfl⟩ | ⟨hp, hbnd, hz, rfl⟩
-          · rw [subE_eval]
-            have hzero : (o1.eval env) = 0 := by rw [hz]; rfl
-            rw [hzero, ZMod.val_zero] at hrval
-            rw [val_inj _ _ (hrval.trans (Nat.zero_xor _)), sub_self]
-          · rw [subE_eval]
-            have hzero : (o2.eval env) = 0 := by rw [hz]; rfl
-            rw [hzero, ZMod.val_zero] at hrval
-            rw [val_inj _ _ (hrval.trans (Nat.xor_zero _)), sub_self]
-          · rw [subE_eval, complE_eval]
-            have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
-            have h255v : (255 : ZMod p).val = 255 := by
-              rw [← hcast255, ZMod.val_natCast_of_lt (by omega)]
-            have ho1 : (o1.eval env) = 255 := by rw [hz]; rfl
-            rw [ho1, h255v] at hrval
-            have hx : (r.eval env).val = 255 - (o2.eval env).val := by
-              rw [hrval, show Nat.xor 255 (o2.eval env).val = Nat.xor (o2.eval env).val 255
-                from Nat.xor_comm _ _]
-              exact nat_xor_255 _ (hbnd ▸ ho2b)
-            rw [val_inj _ _ (hx.trans (sub255_val hp _ (hbnd ▸ ho2b)).symm), sub_self]
-          · rw [subE_eval, complE_eval]
-            have hcast255 : ((255 : ℕ) : ZMod p) = (255 : ZMod p) := by norm_cast
-            have h255v : (255 : ZMod p).val = 255 := by
-              rw [← hcast255, ZMod.val_natCast_of_lt (by omega)]
-            have ho2 : (o2.eval env) = 255 := by rw [hz]; rfl
-            rw [ho2, h255v] at hrval
-            have hx : (r.eval env).val = 255 - (o1.eval env).val := by
-              rw [hrval]; exact nat_xor_255 _ (hbnd ▸ ho1b)
-            rw [val_inj _ _ (hx.trans (sub255_val hp _ (hbnd ▸ ho1b)).symm), sub_self])
+          rcases List.mem_append.1 hc with hc | hc
+          · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+            exact xorEq?_eval bs facts cs bi c env h1ne hbc hbi hsat
+          · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+            exact boolEq?_eval bs facts cs bi c env h1ne hbc hbi hsat)
         (by
           -- no new variables: each equality's variables come from the interaction's payload
           intro c hc zv hz
-          obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-          obtain ⟨spec, o1, o2, r, _, _, hdec, hcase⟩ := xorEq?_spec bs facts bi c hbc
-          obtain ⟨ho1m, ho2m, hrm⟩ := spec.decode_mem _ _ _ _ _ hdec
-          rcases hcase with ⟨_, rfl⟩ | ⟨_, rfl⟩ | ⟨_, _, _, rfl⟩ | ⟨_, _, _, rfl⟩ <;>
-            rcases List.mem_append.1 (by simpa only [subE, complE, Expression.vars,
-              List.append_assoc, List.nil_append] using hz) with h_r | h_o
-          · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
-          · exact ConstraintSystem.mem_vars_of_payload hbi ho2m h_o
-          · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
-          · exact ConstraintSystem.mem_vars_of_payload hbi ho1m h_o
-          · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
-          · exact ConstraintSystem.mem_vars_of_payload hbi ho2m h_o
-          · exact ConstraintSystem.mem_vars_of_payload hbi hrm h_r
-          · exact ConstraintSystem.mem_vars_of_payload hbi ho1m h_o)⟩
+          rcases List.mem_append.1 hc with hc | hc
+          · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+            exact xorEq?_vars bs facts cs bi c hbc hbi zv hz
+          · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
+            exact boolEq?_vars bs facts cs bi c hbc hbi zv hz)⟩
   else
     ⟨cs, [], PassCorrect.refl cs bs⟩
 

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -601,7 +601,8 @@ def sp1Facts (p : ℕ) [NeZero p]
       match busMap busId with
       | some .byteLookup =>
           if 256 ≤ p then
-            some { bound := 256, xorOp := 2, pairOp := 3, decode := sp1ByteDecode,
+            some { bound := 256, xorOp := 2, pairOp := 3, orOp := some 1, andOp := some 0,
+                   decode := sp1ByteDecode,
                    encode := sp1ByteEncode, decode_map := sp1ByteDecode_map,
                    decode_mem := sp1ByteDecode_mem, decode_encode := sp1ByteDecode_encode,
                    decode_eq_encode := sp1ByteDecode_eq_encode, encode_map := sp1ByteEncode_map,
@@ -644,6 +645,38 @@ def sp1Facts (p : ℕ) [NeZero p]
                 = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
             unfold violates; rw [hbus]
             simp [hp3, isByte, ZMod.val_eq_zero, and_assoc]
+      · rw [if_neg hp] at hspec; exact absurd hspec (by simp)
+    -- SP1's byte bus also carries OR (op 1, `a = b | c`) and AND (op 0, `a = b & c`); both
+    -- range-check `b, c` to bytes, exactly like XOR. Declared in the spec as `orOp`/`andOp`.
+    byteBoolSound := by
+      intro busId spec hspec
+      have hbus : busMap busId = some .byteLookup := by
+        revert hspec; cases hb : busMap busId with
+        | none => simp
+        | some t => cases t <;> simp
+      simp only [hbus] at hspec
+      by_cases hp : 256 ≤ p
+      · rw [if_pos hp] at hspec
+        obtain rfl := (Option.some.inj hspec).symm
+        have hcast1 : ((1 : ℕ) : ZMod p) = (1 : ZMod p) := by norm_cast
+        have hp1 : (1 : ZMod p).val = 1 := by rw [← hcast1]; exact ZMod.val_natCast_of_lt (by omega)
+        have hp0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+        intro pl op o1 o2 r mult hdec
+        rw [sp1ByteDecode_some] at hdec
+        subst hdec
+        refine ⟨fun oop hor hopeq => ?_, fun aop hand hopeq => ?_⟩
+        · obtain rfl : oop = 1 := by simpa using hor.symm
+          subst hopeq
+          show violates busMap { busId := busId, multiplicity := mult, payload := [1, r, o1, o2] }
+              = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.lor o1.val o2.val
+          unfold violates; rw [hbus]
+          simp [hp1, isByte, and_assoc]
+        · obtain rfl : aop = 0 := by simpa using hand.symm
+          subst hopeq
+          show violates busMap { busId := busId, multiplicity := mult, payload := [0, r, o1, o2] }
+              = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.land o1.val o2.val
+          unfold violates; rw [hbus]
+          simp [hp0, isByte, and_assoc]
       · rw [if_neg hp] at hspec; exact absurd hspec (by simp)
     -- SP1's op-6 (`Range`) byte-bus check `[6, a, w, 0]` (w ≤ 16) is a pure range check on `a`
     -- (`a < 2^w`), so a subsumed-check dropper can remove it when `a` is already bounded.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,7 +77,14 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
-## 0b. SP1 (rsp): after entries 93–96, the residual is the carry / negative-coefficient memory slots
+## 0b. SP1 (rsp): after entries 93–97, the residual is the carry / negative-coefficient memory slots
+
+**Entry 97 landed the dead-byte OR/AND clusters** (`xorEqExtract` generalized XOR→OR/AND with a
+constant-only target; `scaledZero` gained the two-term slot `k·v − k·w` forcing `v = w`). SP1 rsp
+**variables 3.686× → 3.735×, bus 2.518× → 2.523×** (aggregate var gap vs powdr 837 → 687, bus gap
+876 → 860; 33 cases improved, 0 regressed). OpenVM keccak byte-identical throughout. The k256 blocks
+(apc_024/030/040) still trail (apc_024 556 v vs powdr 490): the residual is the memory slots below.
+
 
 Entries 93–96 landed four general, proven, `Implementation/`-only mechanisms — the reciprocal
 nonzero-witness address-disequality certificate (`addrNonzeroNeq`), affine bound propagation in
@@ -96,13 +103,21 @@ existing fold/`slotFun`/disconnected passes cascade it. No spec change was ever 
 
 What remains, biggest first:
 
-- **Carry / negative-coefficient memory slots (bus).** The last register chains that don't fully
-  telescope (apc_024 addr 7/15) carry data like `add_value − 2¹⁶·higher_limb` (a low-limb/borrow
-  expression, coefficient `p − 65536`) or `2¹³·lower` needing a tighter-than-byte limb bound.
-  `affineJustified`'s natural-number bound can't certify a large/negative coefficient (its `M < p`
-  no-wrap check fails). A borrow-aware justification (recognize `x − 2ᵏ·y` as the low limb of a
-  decomposition with its own range check, or read a direct range-check on the slot *expression*)
-  would drain these; medium effort, bus-only.
+- **Carry / negative-coefficient memory slots (bus + vars, the big residual on the k256 blocks).**
+  The register/RAM pairs that still don't telescope (apc_024/030/040) carry data limbs like
+  `65536·(higher_limb_26 − higher_limb_27) + 8192·lower_limb_26 + higher_limb_0_27` — coefficient
+  `p − 65536` — that are 16-bit **only when `higher_limb_26 = higher_limb_27`** (a same-address
+  telescoping relation). `affineJustified`'s natural bound fails on the negative coefficient, and the
+  sign-split (entry 97's `two_term_zero` machinery, which *does* handle mixed signs) still can't
+  justify it because the slot is genuinely wide unless the relation holds — powdr's global sort-based
+  memory argument establishes it; apc's *local* pair-cancellation checks the 16-bit obligation
+  per-pair, before the relation is known, so it's circular. Two angles, both non-trivial: (a) a
+  **relation-aware justification** — when a memory pair at address A is being cancelled, the
+  send/receive data equality `d_send = d_recv` it would establish is exactly what makes the
+  negative-coefficient slot 16-bit, so justify-then-cancel could be interleaved; (b) unify the
+  interleaved same-address limb variables (`higher_limb_26`/`_27`) *before* the range check via a
+  memory-value equality pass. Simpler slices that DID land are gone (the `8192·lower_limb` slots,
+  `lower_limb < 8` from an op-6 `[6, _, 3, 0]`, are already justified by `affineJustified`).
 - **Certificate generalizations** (cheap follow-ups to entry 93): match a nonzero witness up to a
   nonzero *scalar* (`g = λ·Σ(mᵢ − Sᵢ)`), not just `±1`; recognize reciprocal constraints in more
   additive shapes if a census finds `addrNonzeroNeq` missing live pairs.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,13 +77,33 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
-## 0b. SP1 (rsp): after entries 93–97, the residual is the carry / negative-coefficient memory slots
+## 0b. SP1 (rsp): after entries 93–99, the residual is the identity-result packing sensitivity + memory telescoping
 
-**Entry 97 landed the dead-byte OR/AND clusters** (`xorEqExtract` generalized XOR→OR/AND with a
-constant-only target; `scaledZero` gained the two-term slot `k·v − k·w` forcing `v = w`). SP1 rsp
-**variables 3.686× → 3.735×, bus 2.518× → 2.523×** (aggregate var gap vs powdr 837 → 687, bus gap
-876 → 860; 33 cases improved, 0 regressed). OpenVM keccak byte-identical throughout. The k256 blocks
-(apc_024/030/040) still trail (apc_024 556 v vs powdr 490): the residual is the memory slots below.
+**Entries 97–99 landed the dead-byte clusters and the degenerate range checks.** SP1 rsp
+**variables 3.686× → 3.745×, bus 2.518× → 2.553×** (aggregate var gap vs powdr 837 → 658, bus gap
+876 → 765; 0 regressions; OpenVM keccak byte-identical throughout):
+- **Entry 97**: `xorEqExtract` generalized XOR→OR/AND (constant-only target — a wider target
+  regresses; see below); `scaledZero` gained the two-term slot `k·v − k·w` forcing `v = w`.
+- **Entry 98** (`RangeForceZero.lean`): SP1 op-6 width-0 check `[6, L, 0, 0]` → the equality `L = 0`
+  (via `rangeCheckAt` bound 1), Gauss-consumable. −23 var gap, −51 bus gap.
+- **Entry 99** (`RangeBool.lean`): SP1 op-6 width-1 check `[6, x, 1, 0]` → booleanity `x·(x−1)=0` +
+  drop (the `rangeCheckAt` half of `ZeroWidthRange`'s width-1 arm). −44 bus gap (+44 constraints).
+
+The k256 blocks (apc_024/030/040) still trail (apc_024 550 v vs powdr 490). Two residual levers,
+both **investigated and found to need architectural work, not an incremental pass**:
+
+### The identity-result packing sensitivity (biggest var lever, ~60 vars/k256-case) · BLOCKED
+
+The `[1, result, byte_var, 0]` OR interactions (`result = OR(byte_var, 0) = byte_var`) leave `result`
+as a redundant copy powdr substitutes away (`result := byte_var`). Enabling that in `xorEqExtract`
+(a bare-variable target, not just a constant) is **correct** — but measured a **regression** on
+apc_024 (556→612 v, 431→561 bus). Diagnosis (single-var vs const-only export diff): **memory is
+untouched (32/32 both)**; the blow-up is a **range-check re-packing/re-encode explosion** — op-3
+byte-pairs +44, op-6 +88, and `reencode` materialises +56 fresh byte variables when the substitution
+changes the byte-check expressions. So the win requires making the packing/`reencode` passes
+*representation-robust* (idempotent under a `result := byte_var` rename), not the extraction itself.
+The extraction infrastructure (`ByteXorSpec.orOp/andOp`, `byteBoolSound`, `boolEq?`) is landed and
+proven — only the constant-target guard holds it back.
 
 
 Entries 93–96 landed four general, proven, `Implementation/`-only mechanisms — the reciprocal

--- a/docs/log.md
+++ b/docs/log.md
@@ -3698,3 +3698,34 @@ regression:** keccak byte-identical (2021 v / 186 c / 1752 bus), runtime ~218 s 
 integrity green ({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`.
 Residual bus gap: the carry / negative-coefficient memory slots (`x − 2¹⁶·y`) — see `docs/ideas.md`.
 **Worked: yes.**
+
+### 97. Generalize constant-operand bitwise extraction to OR/AND + two-term scaled-zero (SP1 vars 3.672× → 3.735×, bus 2.488× → 2.523×)
+
+Drains the SP1 `lbu; xor; sb` dead-byte clusters that entry 96 (`scaledZero`, single scaled variable)
+could not: their OR operands are `8323072·(b_low − higher)` — a *two-term* scaled form, not a single
+`k·v`. Two general, proven, `Implementation/`-only mechanisms, synergistic:
+
+- **`xorEqExtract` generalized from XOR to OR/AND.** The pass already extracts the affine equality a
+  constant-operand XOR entails (`z = y` for `x ⊕ 0`); OR and AND have the same zero-operand affine
+  laws (`x | 0 = x`, `x & 0 = 0`). `ByteXorSpec` gains optional `orOp`/`andOp` op-selector values
+  (SP1 `1`/`0`; OpenVM `none`) and a new `BusFacts.byteBoolSound` fact (soundness split out so the
+  xor/pair tuple its 8 consumers destructure is unperturbed). The OR arm fires **only when the
+  surviving operand is a constant** — pinning `result` to a wider expression (even a bare variable)
+  displaces the intermediate byte apc's memory cancellation keys on and blocks telescoping (measured
+  +56 var / +132 bus regression on apc_024). AND's target is always the constant `0`.
+- **`scaledZero` gains the two-term slot (`ScaledZero.lean`, `two_term_zero` + `pair2Seeds`).** A
+  byte slot `k·v − k·w` (both bytes, `k ≥ B2`, no wrap `k·(B−1) ≤ p − B2`) forces `v = w`: the
+  `k`-scaled difference of two bytes is either `0` or has field value `≥ B2` (multiple of `k` on one
+  side, `≥ p − k·(B−1)` on the other). Seeds the unit-coefficient `v − w = 0`, which Gauss uses to
+  merge the two limbs. The emptied OR operand then reaches the constant `0`, and the OR arm folds
+  `result = 0` — dropping the dead byte, its op-6 range check, and the operand limb.
+
+**Impact (`benchmark.py --vm sp1`, 100 rsp cases):** variables **3.672× → 3.735×** agg (aggregate var
+gap vs powdr 880 → 687, −193), bus **2.488× → 2.523×** (bus gap 976 → 860, −116), constraints
+9.359× → 9.457×. Per-case: **33 improved, 0 regressed.** apc_024 579 v / 458 bus → 556 v / 431 bus;
+apc_030/040 similar (the k256-heavy blocks). **No OpenVM regression:** OpenVM declares no `orOp`/`andOp`
+and has no huge-scale byte slots, so both mechanisms are no-ops there — keccak byte-identical (2021 v /
+186 c / 1752 bus). Proof integrity green ({propext, Classical.choice, Quot.sound}); no
+`sorry`/`axiom`/`native_decide`. Residual SP1 gap: the carry / negative-coefficient memory slots
+(`65536·(h₂₆ − h₂₇) + …`), only 16-bit modulo a telescoping relation apc's local pair-cancellation
+can't establish — see `docs/ideas.md`. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3749,3 +3749,25 @@ over entries 97–98: SP1 vars 3.672× → 3.743×, bus 2.488× → 2.539× (var
 976 → 809). **No OpenVM regression:** OpenVM declares no `rangeCheckAt`, so the pass is a no-op there
 (keeps `ZeroWidthRange` on its own bus) — keccak byte-identical. Proof integrity green
 ({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. **Worked: yes.**
+
+### 99. Width-1 range check → booleanity on SP1's op-6 (`RangeBool.lean`, bus 2.539× → 2.553×)
+
+The width-1 companion to entry 98, the `rangeCheckAt` half of `ZeroWidthRange`'s booleanity arm.
+SP1 carries width-1 checks `[6, x, 1, 0]` (`x < 2`, i.e. `x ∈ {0,1}`) on its byte bus; powdr drops
+them all (0 op-6 w=1 vs apc's ~8 on the k256 blocks). `rangeBoolPass` reads them through
+`BusFacts.rangeCheckAt` (`bound = 2`) and, when the value slot is a bare variable, replaces the bus
+interaction by the degree-2 booleanity `x·(x − 1) = 0` — a two-step `PassCorrect` (add the
+booleanity, entailed by acceptance; drop the now-entailed check via `filterBusEntailed_correct`),
+exactly as `ZeroWidthRange` does on OpenVM's own bus. Prime-gated (`x·(x−1)=0 → x < 2` needs an
+integral domain); the bare-variable restriction keeps every added constraint at degree 2, within the
+identity bound. Reuses `ZeroWidthRange.boolC` / `val_lt_two_iff`.
+
+**Impact (`benchmark.py --vm sp1`):** bus interactions **2.539× → 2.553×** (aggregate bus gap vs
+powdr 809 → 765, −44), variables **3.743× → 3.745×** (var gap 664 → 658, the booleanity feeds the
+finite-domain passes) — the dropped checks become +44 degree-2 constraints (the lowest-priority axis;
+`bus ≻ constraints`, so trading a bus interaction for a constraint is a win, and powdr does the same).
+0 var/bus regressions. Cumulative over entries 97–99: SP1 vars 3.672× → 3.745×, bus 2.488× → 2.553×
+(var gap 880 → 658, bus gap 976 → 765 — each ~25 % closed). **No OpenVM regression:** OpenVM declares
+no `rangeCheckAt` and the pass is prime-gated, so it is a no-op there (keeps `ZeroWidthRange`) —
+keccak byte-identical. Proof integrity green ({propext, Classical.choice, Quot.sound}); no
+`sorry`/`axiom`/`native_decide`. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3729,3 +3729,23 @@ and has no huge-scale byte slots, so both mechanisms are no-ops there — keccak
 `sorry`/`axiom`/`native_decide`. Residual SP1 gap: the carry / negative-coefficient memory slots
 (`65536·(h₂₆ − h₂₇) + …`), only 16-bit modulo a telescoping relation apc's local pair-cancellation
 can't establish — see `docs/ideas.md`. **Worked: yes.**
+
+### 98. Width-0 range check → equality on SP1's op-6 (`RangeForceZero.lean`, vars 3.735× → 3.743×, bus 2.523× → 2.539×)
+
+The `rangeCheckAt` generalization of `ZeroWidthRange`'s width-0 arm. `ZeroWidthRange` converts a
+width-0 range check `[expr, 0]` (`expr < 2⁰ = 1`, i.e. `expr = 0`) on OpenVM's variable-range bus to
+the algebraic equality `expr = 0`; SP1 carries the same degenerate checks on its byte bus as op-6
+`[6, expr, 0, 0]`, whose value slot is often a whole linear form — a decomposition equality like
+`higher_limb = result₀ + 256·result₁ + …`. The new `rangeForceZeroPass` reads them through the
+layout-agnostic `BusFacts.rangeCheckAt` fact (already used by `SubsumedCheck`): when it reports
+`bound = 1`, an accepted mult-1 message forces that slot's expression to `0`, so the pass seeds it as
+a constraint (`addConstraints_correct`). Gauss eliminates a variable; the now-constant `[6, 0, 0, 0]`
+check is dropped by `tautoBus`. A non-constant guard keeps the pass from re-seeding a trivial `0`
+before the drop lands.
+
+**Impact (`benchmark.py --vm sp1`):** variables **3.735× → 3.743×**, bus **2.523× → 2.539×**
+(aggregate var gap vs powdr 687 → 664, bus gap 860 → 809; 7 cases improved, 0 regressed). Cumulative
+over entries 97–98: SP1 vars 3.672× → 3.743×, bus 2.488× → 2.539× (var gap 880 → 664, bus gap
+976 → 809). **No OpenVM regression:** OpenVM declares no `rangeCheckAt`, so the pass is a no-op there
+(keeps `ZeroWidthRange` on its own bus) — keccak byte-identical. Proof integrity green
+({propext, Classical.choice, Quot.sound}); no `sorry`/`axiom`/`native_decide`. **Worked: yes.**


### PR DESCRIPTION
Three proven effectiveness wins on the SP1 benchmarks, each a **generalization of an existing mechanism** (no new bespoke passes where a generalization sufficed). No audited surface touched; no `sorry`/`axiom`/`native_decide`; proof integrity green (`{propext, Classical.choice, Quot.sound}`). **OpenVM keccak byte-identical throughout** (2021 v / 186 c / 1752 bus).

## Changes

**1. Dead-byte OR/AND clusters** (`BusFacts`, `Sp1Facts`, `OpenVmFacts`, `XorEqExtract`, `ScaledZero`)
The SP1 `lbu; xor; sb` dead bytes were handled for XOR but not OR/AND, and their operands are two-term scaled forms `8323072·(b_low − higher)` that `scaledZero` (single scaled variable) could not force.
- `xorEqExtract` generalized XOR→OR/AND: `ByteXorSpec` gains optional `orOp`/`andOp` selectors (SP1 `1`/`0`; OpenVM `none`) + a new `byteBoolSound` fact. The OR arm fires only when the surviving operand is a **constant** (a wider target displaces the byte apc's memory cancellation keys on — measured regression otherwise).
- `scaledZero` gains the two-term slot `k·v − k·w` (`two_term_zero` + `pair2Seeds`): a byte slot of that shape with `k ≥ B2` and no wrap forces `v = w`; Gauss merges the limbs, the emptied operand reaches `0`, and the OR arm folds `result = 0`.

**2. Width-0 op-6 → equality** (`RangeForceZero.lean`)
SP1's degenerate width-0 range check `[6, L, 0, 0]` (`L < 1`, i.e. `L = 0`) — often a decomposition equality `higher_limb = result₀ + 256·result₁ + …` — is seeded as `L = 0` via the layout-agnostic `rangeCheckAt` fact; Gauss consumes it, `tautoBus` drops the now-constant check. The `rangeCheckAt` generalization of `ZeroWidthRange`'s width-0 arm.

**3. Width-1 op-6 → booleanity** (`RangeBool.lean`)
Width-1 check `[6, x, 1, 0]` on a bare variable → `x·(x−1) = 0` + drop (two-step `PassCorrect`, prime-gated, degree-2), the `rangeCheckAt` half of `ZeroWidthRange`'s booleanity arm. Reuses `ZeroWidthRange.boolC` / `val_lt_two_iff`.

OpenVM declares no `orOp`/`andOp`/`rangeCheckAt`, so all three are no-ops there.

## Impact (`benchmark.py --vm sp1`, 100 rsp cases)

| measure | before | after | powdr |
|---|---|---|---|
| variables | 3.672× | **3.745×** | 3.980× |
| bus interactions | 2.488× | **2.553×** | 2.822× |

Aggregate var gap vs powdr **880 → 658**, bus gap **976 → 765** (~25 % each), **0 regressions**. SP1 keccak also improved (3586→3564 v, 2489→2409 bus).

## Remaining gap (documented in `docs/ideas.md`)

The k256 residual is two architectural levers, each investigated and found to need more than an incremental pass: (a) **identity-result elimination** — the extraction is landed and proven, but a bare-variable target triggers a range-check re-packing / `reencode` explosion (memory is untouched); (b) **memory telescoping** of the negative-coefficient data slots, which are 16-bit only modulo a same-address relation powdr's global memory argument establishes but apc's local pair-cancellation cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172asXbkaAHzFPCoVAPt4R4)_