### PR TITLE
SP1: late OR-identity result substitution (vars 3.745× → 3.784×)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -39,6 +39,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.SeqzCollapse
 import ApcOptimizer.Implementation.OptimizerPasses.ScaledZero
 import ApcOptimizer.Implementation.OptimizerPasses.RangeForceZero
 import ApcOptimizer.Implementation.OptimizerPasses.RangeBool
+import ApcOptimizer.Implementation.OptimizerPasses.IdentitySubst
 
 set_option autoImplicit false
 
@@ -142,6 +143,9 @@ def codaPasses (b : DegreeBound) : List (String × VerifiedPassW p) :=
     -- The pass drains every packable pair internally, so it needs no fixpoint wrapper.
     ("tupleRange", tupleRangePass.guardDegree b),
     ("bytePackLate", VerifiedPassW.guardDegree b (iterateToFixpoint ByteCheckPack.byteCheckPackPass)),
+    -- After all packing has run, rename each OR-identity result to its operand: a variable win with
+    -- no re-packing (doing it in the cleanup cycle instead explodes the byte-check packing).
+    ("identitySubst", IdentitySubst.identitySubstPass.guardDegree b),
     ("monicScale", monicScalePass.withFacts.guardDegree b),
     ("constFoldEnd", constantFoldPass.withFacts.guardDegree b),
     -- Collapse recognised `sltu x, 1` (seqz) LessThan gadgets to the two-line is-zero gadget,

--- a/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
@@ -1,0 +1,207 @@
+import ApcOptimizer.Implementation.OptimizerPasses.SubstMap
+import ApcOptimizer.Implementation.OptimizerPasses.XorEqExtract
+
+set_option autoImplicit false
+
+/-! # Late identity-result substitution
+
+An OR interaction decoding to `(orOp, byte_var, 0, result)` — or the mirror `(orOp, 0, byte_var,
+result)` — is `result = byte_var | 0 = byte_var`, so `result` is a redundant copy of the surviving
+operand. powdr substitutes it away. Adding the equality `result = byte_var` in the *cleanup* cycle
+(so Gauss eliminates it) is correct but regresses SP1's k256 blocks: the substitution changes the
+byte-check expressions and the *coda* re-packing (`splitBytePair`/`bytePack`) and `reencode` then
+materialise a swarm of fresh byte checks and variables. Doing it **late** — a single batch `substF`
+after all packing has run — captures the variable win without any re-packing: the interactions are
+only renamed, so bus and constraint counts are unchanged and the `result` variables simply disappear.
+
+Soundness is `ConstraintSystem.substF_correct`: each mapped pair `result ↦ byte_var` is forced by the
+interaction's acceptance through `BusFacts.byteBoolSound` (the OR relation with one operand fixed to
+`0`, in either slot). No audited surface; `trivial`/OpenVM declare no `orOp`, so the map is empty and
+this is a no-op there. Wrapped in `iterateToFixpoint` so operand→operand chains collapse over
+iterations. -/
+
+namespace IdentitySubst
+
+variable {p : ℕ}
+
+/-- `ZMod.val` is injective in nonzero characteristic. -/
+private theorem val_inj {p : ℕ} [NeZero p] {a b : ZMod p} (h : a.val = b.val) : a = b :=
+  (ZMod.natCast_rightInverse a).symm.trans ((congrArg _ h).trans (ZMod.natCast_rightInverse b))
+
+/-- The variable of a bare-variable expression, else `none`. -/
+def asVar (e : Expression p) : Option Variable :=
+  match e with | .var v => some v | _ => none
+
+theorem asVar_spec (e : Expression p) (v : Variable) (h : asVar e = some v) :
+    e = Expression.var v := by
+  cases e with
+  | var v' => simp only [asVar, Option.some.injEq] at h; subst h; rfl
+  | const c => simp [asVar] at h
+  | add a b => simp [asVar] at h
+  | mul a b => simp [asVar] at h
+
+/-- The operand variable of an OR-identity `(op, o1, o2, r)`: the non-zero operand when the other is
+    the constant `0` (so `r = o1 | o2` collapses to that operand). -/
+def orIdentityOperand (o1 o2 : Expression p) : Option Variable :=
+  if o2 = Expression.const 0 then asVar o1
+  else if o1 = Expression.const 0 then asVar o2
+  else none
+
+theorem orIdentityOperand_spec (o1 o2 : Expression p) (v : Variable)
+    (h : orIdentityOperand o1 o2 = some v) :
+    (o1 = Expression.var v ∧ o2 = Expression.const 0)
+      ∨ (o2 = Expression.var v ∧ o1 = Expression.const 0) := by
+  unfold orIdentityOperand at h
+  split_ifs at h with ho2 ho1
+  · exact Or.inl ⟨asVar_spec o1 v h, ho2⟩
+  · exact Or.inr ⟨asVar_spec o2 v h, ho1⟩
+
+/-- The `(result, operand)` pair of an OR-identity interaction decoding to `(orOp, o1, o2, result)`
+    where one operand is `0` and the surviving operand is a bare variable distinct from the result. -/
+def identityPairAt {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) : Option (Variable × Variable) :=
+  match facts.byteXorSpec bi.busId with
+  | some spec =>
+    match spec.orOp with
+    | some oop =>
+      match spec.decode bi.payload with
+      | some (op, o1, o2, r) =>
+        match r with
+        | .var rv =>
+          if bi.multiplicity = Expression.const 1 ∧ op = Expression.const oop then
+            match orIdentityOperand o1 o2 with
+            | some o1v => if rv = o1v then none else some (rv, o1v)
+            | none => none
+          else none
+        | _ => none
+      | none => none
+    | none => none
+  | none => none
+
+/-- Structure of a recognised identity pair. -/
+theorem identityPairAt_spec {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (rv o1v : Variable)
+    (h : identityPairAt facts bi = some (rv, o1v)) :
+    ∃ (spec : ByteXorSpec p) (oop : ZMod p) (o1 o2 : Expression p),
+      facts.byteXorSpec bi.busId = some spec ∧ bi.multiplicity = Expression.const 1 ∧
+      spec.orOp = some oop ∧
+      spec.decode bi.payload = some (Expression.const oop, o1, o2, Expression.var rv) ∧
+      orIdentityOperand o1 o2 = some o1v := by
+  unfold identityPairAt at h
+  split at h
+  · rename_i spec hspec
+    split at h
+    · rename_i oop hoop
+      split at h
+      · rename_i op o1 o2 r hdec
+        cases r with
+        | var rv' =>
+          split_ifs at h with hcond
+          obtain ⟨hmc, hop⟩ := hcond
+          cases hoo : orIdentityOperand o1 o2 with
+          | none => rw [hoo] at h; simp at h
+          | some o1v' =>
+            rw [hoo] at h
+            simp only [] at h
+            split_ifs at h with hne
+            simp only [Option.some.injEq, Prod.mk.injEq] at h
+            obtain ⟨rfl, rfl⟩ := h
+            exact ⟨spec, oop, o1, o2, hspec, hmc, hoop, hop ▸ hdec, hoo⟩
+        | const _ => exact absurd h (by simp)
+        | add _ _ => exact absurd h (by simp)
+        | mul _ _ => exact absurd h (by simp)
+      · exact absurd h (by simp)
+    · exact absurd h (by simp)
+  · exact absurd h (by simp)
+
+/-- A recognised identity pair is forced by acceptance: `env rv = env o1v`. -/
+theorem identityPairAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (rv o1v : Variable)
+    (h : identityPairAt facts bi = some (rv, o1v)) (env : Variable → ZMod p)
+    (hviol : bs.violatesConstraint (bi.eval env) = false) : env rv = env o1v := by
+  obtain ⟨spec, oop, o1, o2, hspec, hmc, hoop, hdec, hoo⟩ := identityPairAt_spec facts bi rv o1v h
+  have hdecEv : spec.decode (bi.eval env).payload
+      = some (oop, o1.eval env, o2.eval env, env rv) := by
+    show spec.decode (bi.payload.map (fun e => e.eval env)) = _
+    rw [spec.decode_map, hdec]; rfl
+  obtain ⟨horc, _⟩ := facts.byteBoolSound bi.busId spec hspec (bi.eval env).payload
+    oop (o1.eval env) (o2.eval env) (env rv) (bi.eval env).multiplicity hdecEv
+  haveI := spec.pNeZero
+  obtain ⟨_, _, hrval⟩ := (horc oop hoop rfl).mp hviol
+  rcases orIdentityOperand_spec o1 o2 o1v hoo with ⟨ho1, ho2⟩ | ⟨ho2, ho1⟩
+  · have ho1e : o1.eval env = env o1v := by rw [ho1]; rfl
+    have ho2e : o2.eval env = 0 := by rw [ho2]; rfl
+    rw [ho1e, ho2e, ZMod.val_zero] at hrval
+    exact val_inj (by rw [hrval]; simp)
+  · have ho1e : o1.eval env = 0 := by rw [ho1]; rfl
+    have ho2e : o2.eval env = env o1v := by rw [ho2]; rfl
+    rw [ho1e, ho2e, ZMod.val_zero] at hrval
+    exact val_inj (by rw [hrval]; simp)
+
+/-- Candidate operands for a result `y`: the operand of every recognised identity whose result is `y`. -/
+def identityCandidates {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (y : Variable) : List (Expression p) :=
+  cs.busInteractions.filterMap (fun bi =>
+    match identityPairAt facts bi with
+    | some (rv, o1v) => if rv = y then some (Expression.var o1v) else none
+    | none => none)
+
+/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). -/
+def identityF {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    Variable → Option (Expression p) :=
+  fun y => (identityCandidates facts cs y).head?
+
+theorem identityF_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (y : Variable) (t : Expression p) (h : identityF facts cs y = some t) :
+    ∃ (o1v : Variable) (bi : BusInteraction (Expression p)), t = Expression.var o1v ∧
+      bi ∈ cs.busInteractions ∧ identityPairAt facts bi = some (y, o1v) := by
+  unfold identityF at h
+  have hmem : t ∈ identityCandidates facts cs y := by
+    cases hc : identityCandidates facts cs y with
+    | nil => rw [hc] at h; simp at h
+    | cons a l => rw [hc] at h; simp only [List.head?_cons, Option.some.injEq] at h; subst h; simp
+  obtain ⟨bi, hbi, hmap⟩ := List.mem_filterMap.1 hmem
+  cases hp : identityPairAt facts bi with
+  | none => rw [hp] at hmap; simp at hmap
+  | some pr =>
+    obtain ⟨rv, o1v⟩ := pr
+    rw [hp] at hmap
+    dsimp only at hmap
+    split_ifs at hmap with hrv
+    simp only [Option.some.injEq] at hmap
+    subst hmap; subst hrv
+    exact ⟨o1v, bi, rfl, hbi, hp⟩
+
+/-- The pass: batch-substitute every OR-identity result by its operand. -/
+def identitySubstStep : VerifiedPassW p := fun cs bs facts =>
+  if h1ne : (1 : ZMod p) ≠ 0 then
+    ⟨cs.substF (identityF facts cs), [],
+      cs.substF_correct (identityF facts cs) bs
+        (by
+          intro env hsat y t hf
+          obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
+          have hviol : bs.violatesConstraint (bi.eval env) = false := by
+            refine hsat.2 bi hbi ?_
+            obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := identityPairAt_spec facts bi y o1v hpair
+            show (bi.multiplicity.eval env) ≠ 0
+            rw [hmc]; simpa using h1ne
+          show env y = (Expression.var o1v).eval env
+          exact identityPairAt_sound facts bi y o1v hpair env hviol)
+        (by
+          intro y t hf z hz
+          obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
+          simp only [Expression.vars, List.mem_singleton] at hz
+          rw [hz]
+          obtain ⟨spec, oop, o1, o2, hspec, _, _, hdec, hoo⟩ :=
+            identityPairAt_spec facts bi y o1v hpair
+          obtain ⟨ho1m, ho2m, _⟩ := spec.decode_mem _ _ _ _ _ hdec
+          rcases orIdentityOperand_spec o1 o2 o1v hoo with ⟨ho1, _⟩ | ⟨ho2, _⟩
+          · exact ConstraintSystem.mem_vars_of_payload hbi (ho1 ▸ ho1m) (by simp [Expression.vars])
+          · exact ConstraintSystem.mem_vars_of_payload hbi (ho2 ▸ ho2m) (by simp [Expression.vars]))⟩
+  else
+    ⟨cs, [], PassCorrect.refl cs bs⟩
+
+/-- Run the identity substitution to a fixpoint so operand→operand chains collapse. -/
+def identitySubstPass : VerifiedPassW p := iterateToFixpoint identitySubstStep
+
+end IdentitySubst

--- a/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
@@ -138,39 +138,40 @@ theorem identityPairAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     rw [ho1e, ho2e, ZMod.val_zero] at hrval
     exact val_inj (by rw [hrval]; simp)
 
-/-- Candidate operands for a result `y`: the operand of every recognised identity whose result is `y`. -/
-def identityCandidates {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
-    (y : Variable) : List (Expression p) :=
-  cs.busInteractions.filterMap (fun bi =>
-    match identityPairAt facts bi with
-    | some (rv, o1v) => if rv = y then some (Expression.var o1v) else none
-    | none => none)
+/-- All recognised `(result, operand)` identity pairs in the system, computed once. Hoisting this out
+    of the per-variable lookup below keeps `substF` — which calls the map once per variable
+    occurrence — from re-`filterMap`ping (and re-decoding) every bus interaction on each visit; the
+    lookup becomes a linear scan of this (small) list instead. -/
+def identityPairs {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    List (Variable × Variable) :=
+  cs.busInteractions.filterMap (identityPairAt facts)
 
-/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). -/
+/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). The pair
+    list is captured once (see `identityPairs`), so this is cheap to apply repeatedly. -/
 def identityF {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
     Variable → Option (Expression p) :=
-  fun y => (identityCandidates facts cs y).head?
+  let pairs := identityPairs facts cs
+  fun y => (pairs.filterMap (fun pr => if pr.1 = y then some (Expression.var pr.2) else none)).head?
 
 theorem identityF_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
     (y : Variable) (t : Expression p) (h : identityF facts cs y = some t) :
     ∃ (o1v : Variable) (bi : BusInteraction (Expression p)), t = Expression.var o1v ∧
       bi ∈ cs.busInteractions ∧ identityPairAt facts bi = some (y, o1v) := by
-  unfold identityF at h
-  have hmem : t ∈ identityCandidates facts cs y := by
-    cases hc : identityCandidates facts cs y with
+  have hmem : t ∈ (identityPairs facts cs).filterMap
+      (fun pr => if pr.1 = y then some (Expression.var pr.2) else none) := by
+    simp only [identityF] at h
+    cases hc : (identityPairs facts cs).filterMap
+        (fun pr => if pr.1 = y then some (Expression.var pr.2) else none) with
     | nil => rw [hc] at h; simp at h
     | cons a l => rw [hc] at h; simp only [List.head?_cons, Option.some.injEq] at h; subst h; simp
-  obtain ⟨bi, hbi, hmap⟩ := List.mem_filterMap.1 hmem
-  cases hp : identityPairAt facts bi with
-  | none => rw [hp] at hmap; simp at hmap
-  | some pr =>
-    obtain ⟨rv, o1v⟩ := pr
-    rw [hp] at hmap
-    dsimp only at hmap
-    split_ifs at hmap with hrv
-    simp only [Option.some.injEq] at hmap
-    subst hmap; subst hrv
-    exact ⟨o1v, bi, rfl, hbi, hp⟩
+  obtain ⟨pr, hpr, hval⟩ := List.mem_filterMap.1 hmem
+  obtain ⟨rv, o1v⟩ := pr
+  obtain ⟨bi, hbi, hpair⟩ := List.mem_filterMap.1 hpr
+  simp only at hval
+  split_ifs at hval with hy
+  simp only [Option.some.injEq] at hval
+  subst hval; subst hy
+  exact ⟨o1v, bi, rfl, hbi, hpair⟩
 
 /-- The pass: batch-substitute every OR-identity result by its operand. -/
 def identitySubstStep : VerifiedPassW p := fun cs bs facts =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
@@ -173,34 +173,40 @@ theorem identityF_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : Constr
   subst hval; subst hy
   exact ⟨o1v, bi, rfl, hbi, hpair⟩
 
-/-- The pass: batch-substitute every OR-identity result by its operand. -/
+/-- The pass: batch-substitute every OR-identity result by its operand. When the system has no
+    recognised identities — e.g. any OpenVM circuit, whose bitwise bus declares no `orOp` — the `[]`
+    branch returns it unchanged, skipping the whole-system `substF` traversal (which would be a no-op
+    but still walks every expression). This keeps the pass ~free wherever it finds nothing to do. -/
 def identitySubstStep : VerifiedPassW p := fun cs bs facts =>
-  if h1ne : (1 : ZMod p) ≠ 0 then
-    ⟨cs.substF (identityF facts cs), [],
-      cs.substF_correct (identityF facts cs) bs
-        (by
-          intro env hsat y t hf
-          obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
-          have hviol : bs.violatesConstraint (bi.eval env) = false := by
-            refine hsat.2 bi hbi ?_
-            obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := identityPairAt_spec facts bi y o1v hpair
-            show (bi.multiplicity.eval env) ≠ 0
-            rw [hmc]; simpa using h1ne
-          show env y = (Expression.var o1v).eval env
-          exact identityPairAt_sound facts bi y o1v hpair env hviol)
-        (by
-          intro y t hf z hz
-          obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
-          simp only [Expression.vars, List.mem_singleton] at hz
-          rw [hz]
-          obtain ⟨spec, oop, o1, o2, hspec, _, _, hdec, hoo⟩ :=
-            identityPairAt_spec facts bi y o1v hpair
-          obtain ⟨ho1m, ho2m, _⟩ := spec.decode_mem _ _ _ _ _ hdec
-          rcases orIdentityOperand_spec o1 o2 o1v hoo with ⟨ho1, _⟩ | ⟨ho2, _⟩
-          · exact ConstraintSystem.mem_vars_of_payload hbi (ho1 ▸ ho1m) (by simp [Expression.vars])
-          · exact ConstraintSystem.mem_vars_of_payload hbi (ho2 ▸ ho2m) (by simp [Expression.vars]))⟩
-  else
-    ⟨cs, [], PassCorrect.refl cs bs⟩
+  match identityPairs facts cs with
+  | [] => ⟨cs, [], PassCorrect.refl cs bs⟩
+  | _ :: _ =>
+    if h1ne : (1 : ZMod p) ≠ 0 then
+      ⟨cs.substF (identityF facts cs), [],
+        cs.substF_correct (identityF facts cs) bs
+          (by
+            intro env hsat y t hf
+            obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
+            have hviol : bs.violatesConstraint (bi.eval env) = false := by
+              refine hsat.2 bi hbi ?_
+              obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := identityPairAt_spec facts bi y o1v hpair
+              show (bi.multiplicity.eval env) ≠ 0
+              rw [hmc]; simpa using h1ne
+            show env y = (Expression.var o1v).eval env
+            exact identityPairAt_sound facts bi y o1v hpair env hviol)
+          (by
+            intro y t hf z hz
+            obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
+            simp only [Expression.vars, List.mem_singleton] at hz
+            rw [hz]
+            obtain ⟨spec, oop, o1, o2, hspec, _, _, hdec, hoo⟩ :=
+              identityPairAt_spec facts bi y o1v hpair
+            obtain ⟨ho1m, ho2m, _⟩ := spec.decode_mem _ _ _ _ _ hdec
+            rcases orIdentityOperand_spec o1 o2 o1v hoo with ⟨ho1, _⟩ | ⟨ho2, _⟩
+            · exact ConstraintSystem.mem_vars_of_payload hbi (ho1 ▸ ho1m) (by simp [Expression.vars])
+            · exact ConstraintSystem.mem_vars_of_payload hbi (ho2 ▸ ho2m) (by simp [Expression.vars]))⟩
+    else
+      ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-- Run the identity substitution to a fixpoint so operand→operand chains collapse. -/
 def identitySubstPass : VerifiedPassW p := iterateToFixpoint identitySubstStep

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -77,7 +77,7 @@ LANDED are done — the remainder still adds up to the current gaps):
 
 ---
 
-## 0b. SP1 (rsp): after entries 93–99, the residual is the identity-result packing sensitivity + memory telescoping
+## 0b. SP1 (rsp): after entries 93–100, the residual is memory telescoping (identity-result packing solved, entry 100)
 
 **Entries 97–99 landed the dead-byte clusters and the degenerate range checks.** SP1 rsp
 **variables 3.686× → 3.745×, bus 2.518× → 2.553×** (aggregate var gap vs powdr 837 → 658, bus gap
@@ -89,21 +89,26 @@ LANDED are done — the remainder still adds up to the current gaps):
 - **Entry 99** (`RangeBool.lean`): SP1 op-6 width-1 check `[6, x, 1, 0]` → booleanity `x·(x−1)=0` +
   drop (the `rangeCheckAt` half of `ZeroWidthRange`'s width-1 arm). −44 bus gap (+44 constraints).
 
-The k256 blocks (apc_024/030/040) still trail (apc_024 550 v vs powdr 490). Two residual levers,
-both **investigated and found to need architectural work, not an incremental pass**:
+The k256 blocks (apc_024/030/040) still trail (apc_024 518 v vs powdr 490, after entry 100). Entry
+100 landed the first of the two residual levers below (identity-result substitution, done late);
+memory telescoping remains and needs architectural work, not an incremental pass:
 
-### The identity-result packing sensitivity (biggest var lever, ~60 vars/k256-case) · BLOCKED
+### The identity-result packing sensitivity (biggest var lever, ~60 vars/k256-case) · SOLVED (entry 100)
 
-The `[1, result, byte_var, 0]` OR interactions (`result = OR(byte_var, 0) = byte_var`) leave `result`
-as a redundant copy powdr substitutes away (`result := byte_var`). Enabling that in `xorEqExtract`
-(a bare-variable target, not just a constant) is **correct** — but measured a **regression** on
-apc_024 (556→612 v, 431→561 bus). Diagnosis (single-var vs const-only export diff): **memory is
-untouched (32/32 both)**; the blow-up is a **range-check re-packing/re-encode explosion** — op-3
-byte-pairs +44, op-6 +88, and `reencode` materialises +56 fresh byte variables when the substitution
-changes the byte-check expressions. So the win requires making the packing/`reencode` passes
-*representation-robust* (idempotent under a `result := byte_var` rename), not the extraction itself.
-The extraction infrastructure (`ByteXorSpec.orOp/andOp`, `byteBoolSound`, `boolEq?`) is landed and
-proven — only the constant-target guard holds it back.
+The `[1, result, byte_var, 0]` OR interactions (`result = OR(byte_var, 0) = byte_var`), and their
+mirror `[1, result, 0, byte_var]`, leave `result` as a redundant copy powdr substitutes away
+(`result := byte_var`). Enabling that *in the cleanup cycle* (a bare-variable target in `xorEqExtract`)
+is **correct** but measured a **regression** on apc_024 (556→612 v, 431→561 bus): the diagnosis
+(single-var vs const-only export diff) was **memory untouched (32/32 both)**, the blow-up a
+**range-check re-packing/re-encode explosion** — op-3 byte-pairs +44, op-6 +88, and `reencode`
+materialises +56 fresh byte variables when the substitution changes the byte-check expressions *before*
+the coda re-packs them. The earlier note concluded the win needed *representation-robust* packing.
+**The actual fix was simpler: do the rename LATE.** `IdentitySubst.lean` (entry 100) runs a single
+batch `substF` in the coda *after* all packing (`splitBytePair`/`bytePack`/`reencode`) has finished, so
+the interactions are only renamed — bus and constraint counts are untouched and the `result` variables
+just vanish. Variable-monotone by construction; **SP1 rsp var gap 658 → 542 (−116), 0 regressions**,
+bus/constraints byte-identical, OpenVM a structural no-op (`orOp = none`). The extraction
+infrastructure (`ByteXorSpec.orOp/andOp`, `byteBoolSound`) it reuses was landed in entry 97.
 
 
 Entries 93–96 landed four general, proven, `Implementation/`-only mechanisms — the reciprocal

--- a/docs/log.md
+++ b/docs/log.md
@@ -3771,3 +3771,38 @@ finite-domain passes) — the dropped checks become +44 degree-2 constraints (th
 no `rangeCheckAt` and the pass is prime-gated, so it is a no-op there (keeps `ZeroWidthRange`) —
 keccak byte-identical. Proof integrity green ({propext, Classical.choice, Quot.sound}); no
 `sorry`/`axiom`/`native_decide`. **Worked: yes.**
+
+### 100. Late OR-identity result substitution (`IdentitySubst.lean`, SP1 vars 3.745× → 3.784×)
+
+powdr's optimizer substitutes away every OR interaction that computes `result = byte_var | 0`: with
+one operand fixed to the constant `0`, `result` is a redundant copy of the surviving operand, so the
+`result` variable can be renamed to it. SP1's k256 blocks emit these on the byte bus as
+`[orOp, byte_var, 0, result]` and its mirror `[orOp, 0, byte_var, result]` (the `BusFacts` decode
+gives logical `(op, o1, o2, r)`); apc kept the `result` variables, powdr dropped them all.
+
+The naive fix — seed `result = byte_var` as an equality in the *cleanup* cycle so Gauss eliminates
+it — is correct but *regresses* the k256 blocks: the substitution rewrites the byte-check
+expressions, and the *coda* re-packing (`splitBytePair` / `bytePack`) plus `reencode` then
+materialise a swarm of fresh byte checks and variables, a net loss. `IdentitySubst` instead does the
+rename **late** — a single batch `substF` in the coda *after* all packing has run (right after
+`bytePackLate`): the interactions are only renamed, so bus and constraint counts are untouched and
+the `result` variables simply disappear. `identityPairAt` reads the `orOp` through the
+layout-agnostic `BusFacts.byteXorSpec` / `byteBoolSound` facts, recognises a mult-1 message whose
+result slot is a bare variable and one operand slot (either one) is the constant `0`, and emits the
+`result ↦ operand` pair; `identityF` collects them into a map and `ConstraintSystem.substF_correct`
+discharges soundness (each pair is forced by the OR relation at an accepting assignment). Wrapped in
+`iterateToFixpoint` so operand→operand chains collapse. The pass is **variable-monotone by
+construction**: `substF` deletes the substituted `result` variables and preserves the bus- and
+constraint-interaction *structure* exactly, so it can only lower the variable count and never touches
+the other two axes.
+
+**Impact (`benchmark.py --vm sp1`, rsp 100 cases):** variables **3.745× → 3.784×** (aggregate var
+gap vs powdr **658 → 542**, −116), bus interactions **unchanged at 2.553×** (gap 765) and constraints
+unchanged (the rename adds/drops nothing). Largest k256 case apc_024: **553 → 518** vars (powdr 490).
+**0 regressions** — per-case diff vs the #161 baseline: 13 cases improved on variables (116 saved),
+and *every* case has `Δbus = 0, Δconstraints = 0` (the pass is variable-monotone). SP1 keccak is
+covered by the same monotonicity guarantee (bus/constraints untouched). **No OpenVM regression:**
+OpenVM's bitwise bus declares no `orOp` (XOR + range only), so `identityPairAt` returns `none`
+everywhere → empty substitution map → genuine no-op; keccak byte-identical (2021 vars / 186
+constraints / 1752 bus interactions). Proof integrity green ({propext, Classical.choice, Quot.sound});
+no `sorry`/`axiom`/`native_decide`. **Worked: yes.**


### PR DESCRIPTION
## Summary

Adds `IdentitySubst`, a new coda pass that renames each OR-identity result to its operand.

An SP1 byte-bus OR interaction `[orOp, result, byte_var, 0]` (and its mirror `[orOp, result, 0, byte_var]`) computes `result = byte_var | 0 = byte_var`, so `result` is a redundant copy of the surviving operand. powdr substitutes it away; apc kept these variables. This pass renames them away with a single batch `substF` in the coda, run **after** all byte-check packing (`splitBytePair`/`bytePack`/`reencode`) has finished — so the interactions are only *renamed*: bus and constraint counts are untouched and the `result` variables simply disappear. Doing the same substitution in the cleanup cycle instead explodes the coda re-packing (a measured regression — this is exactly why the extraction infra landed in #161 kept a constant-only target guard; this PR resolves that blocked lever).

## Impact (`benchmark.py --vm sp1`, rsp 100 cases)

| axis | before (#161) | after | powdr |
|---|---|---|---|
| variables | 3.745× | **3.784×** | 3.980× |
| bus interactions | 2.553× | 2.553× | 2.822× |

- Aggregate variable gap vs powdr **658 → 542** (−116).
- Bus and constraints **unchanged** (rename-only).
- **0 regressions** — per-case diff vs #161: 13 cases improved on variables (116 saved), and *every* case has `Δbus = 0, Δconstraints = 0`. The pass is variable-monotone by construction.
- Largest k256 case apc_024: **553 → 518** vars (powdr 490).

## Correctness

- Soundness via `ConstraintSystem.substF_correct`: each `result ↦ operand` pair is forced by the OR relation at any accepting assignment, read through the layout-agnostic `byteXorSpec` / `byteBoolSound` bus facts. No audited surface touched; correctness follows from the pass's own `PassCorrect`.
- **OpenVM: structural no-op** — OpenVM's bitwise bus declares no `orOp` (XOR + range only), so the substitution map is empty; keccak byte-identical.
- Proof integrity green (`{propext, Classical.choice, Quot.sound}`); no `sorry`/`axiom`/`native_decide`.

## Notes

- SP1 keccak is covered by the same variable-monotonicity guarantee (bus/constraints untouched); its effectiveness numbers come from CI. (keccak is XOR/AND-heavy with essentially no OR ops, so this pass is near-empty there.)
- `IdentitySubst` precomputes the recognised `(result, operand)` pair list once (captured by the map closure) so `substF`'s per-occurrence lookup is a linear scan of that small list rather than a re-scan of every bus interaction.

Docs: log entry 100; `ideas.md` §0b updated (the identity-result packing sensitivity, previously BLOCKED, is solved by doing the rename late — memory telescoping is now the sole SP1 rsp residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172asXbkaAHzFPCoVAPt4R4)_