### PR TITLE
Runtime: de-quadratify the large-case hot loops (keccak/SHA scale)

### DIFF
--- a/ApcOptimizer/Implementation/JsonParser.lean
+++ b/ApcOptimizer/Implementation/JsonParser.lean
@@ -151,6 +151,41 @@ private def parseBusInteraction (j : Lean.Json) :
     payload := payload
   }
 
+/-! ### Variable interning
+
+The JSON parser mints a fresh `String` (and `Variable`) per *occurrence* — ~10⁵ heap-distinct
+copies of a few thousand names on a large export. Interning rebuilds the parsed system with one
+shared `Variable` object per distinct value: the runtime's `String` equality has a pointer
+fast-path (`lean_string_eq`: `s1 == s2 || …`), so every later equality test on equal names — the
+bulk of `Variable` comparisons in hash maps, dedups and substitution lookups across the whole
+optimizer — short-circuits without touching the bytes. The interned system is **the same value**
+(`Variable`s compare equal), so nothing downstream can observe the difference except time. -/
+
+/-- Collect one canonical `Variable` object per distinct value. -/
+private def collectVars (m : Std.HashMap Variable Variable) : Expression p →
+    Std.HashMap Variable Variable
+  | .const _ => m
+  | .var v => if m.contains v then m else m.insert v v
+  | .add a b => collectVars (collectVars m a) b
+  | .mul a b => collectVars (collectVars m a) b
+
+/-- Rebuild an expression with every variable replaced by its canonical (equal, shared) object. -/
+private def internExpr (m : Std.HashMap Variable Variable) : Expression p → Expression p
+  | .const c => .const c
+  | .var v => .var (m.getD v v)
+  | .add a b => .add (internExpr m a) (internExpr m b)
+  | .mul a b => .mul (internExpr m a) (internExpr m b)
+
+/-- Intern all variables of a freshly-parsed system (see the section comment). -/
+private def internSystem (cs : ConstraintSystem p) : ConstraintSystem p :=
+  let m := cs.busInteractions.foldl
+    (fun m bi => bi.payload.foldl collectVars (collectVars m bi.multiplicity))
+    (cs.algebraicConstraints.foldl collectVars ∅)
+  { algebraicConstraints := cs.algebraicConstraints.map (internExpr m),
+    busInteractions := cs.busInteractions.map (fun bi =>
+      { bi with multiplicity := internExpr m bi.multiplicity,
+                payload := bi.payload.map (internExpr m) }) }
+
 /-- Parse the field-generic, bus-map-agnostic part of a powdr export: the top-level JSON (so callers
     can pull the `bus_map` out with the right per-VM parser), the constraint system under the
     `machine` key, and the `next_free_id` cursor if present (`none` for a raw CLI export; the FFI
@@ -179,7 +214,7 @@ private def parseMachinePart (jsonStr : String) :
   -- powdr's `ColumnAllocator` cursor; absent or non-numeric parses as `none`.
   let nextFreeId? := (json.getObjVal? "next_free_id").toOption.bind (·.getNat?.toOption)
 
-  let system : ConstraintSystem p := {
+  let system : ConstraintSystem p := internSystem {
     algebraicConstraints := constraints,
     busInteractions := busInteractions
   }

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -2102,24 +2102,47 @@ theorem checkCancel_sound (cs : ConstraintSystem p) (bs : BusSemantics p) (facts
       (hAeq ▸ hshield) hnp
     exact ⟨Rp, hRpmem, provRecv_sound shape busId hp1 S Rp hRpprov env⟩
 
-/-- The scan behind `dropWits`: the first interaction of `arr` (positions ascending from `k`,
-    skipping any value equal to the dropped pair) that derives an `interactionBound` for `v` —
-    exactly the interaction `findVarBound` over the remaining region finds first, at the same
-    early-exit cost, with no region list materialized. (Fuel-structured for the easy induction;
-    called with `fuel := arr.size`, which reaches every position.) -/
-def dropWitsGo {bs : BusSemantics p} (facts : BusFacts p bs)
+/-- Candidate positions of bound-deriving interactions, per variable: every array position whose
+    interaction derives an `interactionBound` for the variable, ascending. Built once per
+    invocation (the per-interaction multiplicity constant and constant-payload pattern are hoisted
+    via `interactionBoundPat`); **untrusted** — `dropWitsIdxGo` re-checks liveness, the dropped
+    pair, and the bound itself at every use, so a stale or wrong entry costs time, never
+    soundness. Complete by construction: `interactionBound` reads only the fixed array entry, so
+    a position bounding `v` at build time still bounds it at use. -/
+def buildBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (Expression p))) : Std.HashMap Variable (List Nat) :=
+  (arr.toList.zipIdx).foldr (fun bik m =>
+    let bi := bik.1
+    let mval? := bi.multiplicity.constValue?
+    let pat := bi.payload.map Expression.constValue?
+    bi.payload.foldl (fun m e =>
+      match e with
+      | .var v =>
+        -- skip repeated occurrences of the same variable within one payload
+        if (m.getD v []).head? = some bik.2 then m
+        else
+          match interactionBoundPat bs facts bi mval? pat v with
+          | some _ => m.insert v (bik.2 :: m.getD v [])
+          | none => m
+      | _ => m) m) ∅
+
+/-- The scan behind `dropWits`: the first of `v`'s indexed candidate positions (ascending,
+    skipping dead entries and any value equal to the dropped pair) that still derives an
+    `interactionBound` for `v` — exactly the interaction the full array scan found first, at
+    bucket cost. -/
+def dropWitsIdxGo {bs : BusSemantics p} (facts : BusFacts p bs)
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (S R : BusInteraction (Expression p))
-    (v : Variable) : Nat → Nat → Option (BusInteraction (Expression p))
-  | 0, _ => none
-  | fuel + 1, k =>
+    (v : Variable) : List Nat → Option (BusInteraction (Expression p))
+  | [] => none
+  | k :: ks =>
     if h : k < arr.size then
       if alive[k]?.getD false && !decide (arr[k] = S) && !decide (arr[k] = R) then
         match interactionBound bs facts arr[k] v with
         | some _ => some arr[k]
-        | none => dropWitsGo facts arr alive S R v fuel (k + 1)
-      else dropWitsGo facts arr alive S R v fuel (k + 1)
-    else none
+        | none => dropWitsIdxGo facts arr alive S R v ks
+      else dropWitsIdxGo facts arr alive S R v ks
+    else dropWitsIdxGo facts arr alive S R v ks
 
 /-- First interaction of a plain list deriving an `interactionBound` for `v` — used to consult the
     emitted byte checks, which live outside the stable array (`checksOld`), preserving the old
@@ -2134,36 +2157,39 @@ def firstBoundIn {bs : BusSemantics p} (facts : BusFacts p bs) (v : Variable) :
     | none => firstBoundIn facts v rest
 
 /-- The witness lookup for a candidate drop: the first bound-deriving interaction other than the
-    dropped pair — first among the live stable-array entries (ascending, exactly the order the old
-    compact array had for the surviving originals), then among the previously-emitted checks
-    `checksOld` (which trailed the originals in the old array) — followed by this drop's emitted
-    checks. Every returned interaction is a member of the remaining region (`dropWits_mem`). -/
+    dropped pair — first among the live stable-array entries (through the per-variable position
+    index `bidx`, ascending, exactly the order the old full-array scan visited), then among the
+    previously-emitted checks `checksOld` (which trailed the originals in the old array) —
+    followed by this drop's emitted checks. Every returned interaction is a member of the
+    remaining region (`dropWits_mem`). -/
 def dropWits {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (S R : BusInteraction (Expression p))
     (checksOld emitted : List (BusInteraction (Expression p))) (v : Variable) :
     List (BusInteraction (Expression p)) :=
-  match dropWitsGo facts arr alive S R v arr.size 0 with
+  match dropWitsIdxGo facts arr alive S R v (bidx.getD v []) with
   | some bi => bi :: emitted
   | none =>
     match firstBoundIn facts v checksOld with
     | some bi => bi :: emitted
     | none => emitted
 
-theorem dropWitsGo_mem {bs : BusSemantics p} (facts : BusFacts p bs)
+theorem dropWitsIdxGo_mem {bs : BusSemantics p} (facts : BusFacts p bs)
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (S R : BusInteraction (Expression p))
-    (v : Variable) (fuel : Nat) :
-    ∀ (k : Nat) {bi : BusInteraction (Expression p)},
-      dropWitsGo facts arr alive S R v fuel k = some bi →
+    (v : Variable) :
+    ∀ (ks : List Nat) {bi : BusInteraction (Expression p)},
+      dropWitsIdxGo facts arr alive S R v ks = some bi →
       bi ∈ liveSeg arr alive 0 arr.size ∧ bi ≠ S ∧ bi ≠ R := by
-  induction fuel with
-  | zero =>
-    intro k bi h
-    exact absurd h (by simp [dropWitsGo])
-  | succ fuel ih =>
-    intro k bi h
-    rw [dropWitsGo] at h
+  intro ks
+  induction ks with
+  | nil =>
+    intro bi h
+    exact absurd h (by simp [dropWitsIdxGo])
+  | cons k rest ih =>
+    intro bi h
+    rw [dropWitsIdxGo] at h
     split_ifs at h with hk hcond
     · -- in range, live, not the dropped pair
       revert h
@@ -2179,8 +2205,9 @@ theorem dropWitsGo_mem {bs : BusSemantics p} (facts : BusFacts p bs)
         · exact fun he => by simp [he] at hnR
       | none =>
         intro h
-        exact ih (k + 1) h
-    · exact ih (k + 1) h
+        exact ih h
+    · exact ih h
+    · exact ih h
 
 theorem firstBoundIn_mem {bs : BusSemantics p} (facts : BusFacts p bs) (v : Variable) :
     ∀ (l : List (BusInteraction (Expression p))) {bi : BusInteraction (Expression p)},
@@ -2199,20 +2226,22 @@ theorem firstBoundIn_mem {bs : BusSemantics p} (facts : BusFacts p bs) (v : Vari
     entries other than the dropped pair are in `A ++ B ++ C`, and so are the previously-emitted
     checks `checksOld`. -/
 theorem dropWits_mem {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (S R : BusInteraction (Expression p))
     (checksOld emitted : List (BusInteraction (Expression p)))
     {A B C : List (BusInteraction (Expression p))}
     (horig : ∀ bi ∈ liveSeg arr alive 0 arr.size, bi ≠ S → bi ≠ R → bi ∈ A ++ B ++ C)
     (hchecks : ∀ bi ∈ checksOld, bi ∈ A ++ B ++ C) :
-    ∀ v, ∀ bi ∈ dropWits facts arr alive S R checksOld emitted v, bi ∈ A ++ B ++ C ++ emitted := by
+    ∀ v, ∀ bi ∈ dropWits facts bidx arr alive S R checksOld emitted v,
+      bi ∈ A ++ B ++ C ++ emitted := by
   intro v bi hbi
   unfold dropWits at hbi
-  cases hgo : dropWitsGo facts arr alive S R v arr.size 0 with
+  cases hgo : dropWitsIdxGo facts arr alive S R v (bidx.getD v []) with
   | some bi' =>
     rw [hgo] at hbi
     rcases List.mem_cons.1 hbi with rfl | hbi
-    · obtain ⟨hmem, hne1, hne2⟩ := dropWitsGo_mem facts arr alive S R v arr.size 0 hgo
+    · obtain ⟨hmem, hne1, hne2⟩ := dropWitsIdxGo_mem facts arr alive S R v _ hgo
       exact List.mem_append_left _ (horig bi hmem hne1 hne2)
     · exact List.mem_append_right _ hbi
   | none =>
@@ -2312,7 +2341,7 @@ def mkDropResult (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
     (domCs : List (Expression p)) (hdomCs : ∀ c ∈ domCs, c ∈ cs0.algebraicConstraints)
     (candsOf : Variable → List (Expression p))
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs0.algebraicConstraints)
-    (fidx : Std.HashMap Variable (List Nat))
+    (fidx bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (Expression p))) (hsz : alive.size = arr.size)
     (iP jP : Nat) (S R : BusInteraction (Expression p)) (slots : List Nat) (bound : Nat)
@@ -2328,7 +2357,7 @@ def mkDropResult (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
     (hmid : ∀ m0 ∈ liveSeg arr alive (iP + 1) (jP - iP - 1), midRefuted shape T busId S m0 = true)
     (hshield : shieldOk shape T busId S (liveSeg arr alive 0 iP) = true)
     (hchk : checkCancel deep bs facts M domCs candsOf
-      (dropWits facts arr alive S R checksOld checks) (dropFormWits fidx arr alive S R)
+      (dropWits facts bidx arr alive S R checksOld checks) (dropFormWits fidx arr alive S R)
       busId shape slots bound S R checks = true) :
     DropResult cs0 bs arr alive checksOld := by
   let A := liveSeg arr alive 0 iP
@@ -2354,10 +2383,10 @@ def mkDropResult (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
       { mkCs cs0 arr alive checksOld with
         busInteractions := A ++ B ++ (C' ++ checksOld) ++ checks } [] bs :=
     checkCancel_sound (mkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep busId shape hshape slots bound
-      T M domCs candsOf (dropWits facts arr alive S R checksOld checks)
+      T M domCs candsOf (dropWits facts bidx arr alive S R checksOld checks)
       (dropFormWits fidx arr alive S R)
       A S B R (C' ++ checksOld) hslots checks hsplit hdomCs hcands
-      (dropWits_mem facts arr alive S R checksOld checks horig hchecks)
+      (dropWits_mem facts bidx arr alive S R checksOld checks horig hchecks)
       (dropFormWits_mem fidx arr alive S R horig checks) hmid hshield hchk
   have hdropL : liveSeg arr aliveNew 0 arr.size = A ++ B ++ C' :=
     liveSeg_drop arr alive iP jP arr.size hij hjsz hisz hjsz' aliveNew rfl
@@ -2398,7 +2427,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
     (bcBus? : Option (Nat × ByteXorSpec p))
-    (fidx : Std.HashMap Variable (List Nat))
+    (fidx bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (Expression p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -2407,7 +2436,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
     let S := arr[i]
     -- (thunked: Lean is strict, and the continuation must not run once a pair is accepted)
     let next := fun (_ : Unit) => findCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive busId shape
-      hshape T M domCsT candsT bcBus? fidx arr alive checksOld hsz idx (i + 1)
+      hshape T M domCsT candsT bcBus? fidx bidx arr alive checksOld hsz idx (i + 1)
     if haliveS : alive[i]?.getD false = true then
     if decide (multConst S = some shape.setNewMult) && decide (S.busId = busId) then
       match hfm : firstMatchAt M arr alive busId S i (idx.getD
@@ -2439,11 +2468,11 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
           | none => next ()
           | some (slots, bound) =>
           if hchk0 : checkCancel deep bs facts M domCsT.get.val candsT.get.lookup
-              (dropWits facts arr alive S R checksOld []) (dropFormWits fidx arr alive S R)
+              (dropWits facts bidx arr alive S R checksOld []) (dropFormWits fidx arr alive S R)
               busId shape slots bound S R [] = true then
             some (mkDropResult cs0 bs facts hp1 deep hdeep busId shape hshape T M
               domCsT.get.val domCsT.get.property candsT.get.lookup (fun x => candsT.get.lookup_mem x)
-              fidx arr alive checksOld hsz i j S R slots bound [] checksOld (List.append_nil checksOld).symm
+              fidx bidx arr alive checksOld hsz i j S R slots bound [] checksOld (List.append_nil checksOld).symm
               false 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk0)
           else
           -- Unjustified byte slots are materialized as one explicit self-check on a `byteXorSpec`
@@ -2453,7 +2482,7 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
           -- check is therefore never a send/receive candidate. It lives only in the threaded
           -- `checks` list (consulted by `dropWits` for byte justification), at the logical tail.
           let unjust := unjustifiedSlots bound deep domCsT.get.val candsT.get.lookup bs facts
-            (dropWits facts arr alive S R checksOld []) (dropFormWits fidx arr alive S R) slots R
+            (dropWits facts bidx arr alive S R checksOld []) (dropFormWits fidx arr alive S R) slots R
           let checks : List (BusInteraction (Expression p)) :=
             match unjust, bcBus? with
             | [slot], some (bcBus, spec) => (R.payload[slot]?).elim [] (fun e =>
@@ -2461,11 +2490,11 @@ def findCancelGoIdx (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : Bu
             | _, _ => []
           if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
             if hchk : checkCancel deep bs facts M domCsT.get.val candsT.get.lookup
-                (dropWits facts arr alive S R checksOld checks) (dropFormWits fidx arr alive S R)
+                (dropWits facts bidx arr alive S R checksOld checks) (dropFormWits fidx arr alive S R)
                 busId shape slots bound S R checks = true then
               some (mkDropResult cs0 bs facts hp1 deep hdeep busId shape hshape T M
                 domCsT.get.val domCsT.get.property candsT.get.lookup (fun x => candsT.get.lookup_mem x)
-                fidx arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
+                fidx bidx arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
                 true 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk)
             else next ()
           else next ()
@@ -2489,7 +2518,7 @@ def findCancel (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFact
     (M : Thunk (EqConstraintMap p cs0.algebraicConstraints))
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
-    (fidx : Std.HashMap Variable (List Nat))
+    (fidx bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (Expression p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -2498,18 +2527,18 @@ def findCancel (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFact
   | _, [] => none
   | curIdx, busId :: rest =>
     if curIdx < resumeIdx then
-      findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx arr alive checksOld
+      findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx bidx arr alive checksOld
         hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match findCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive busId shape hshape
-            T M domCsT candsT bcBus? fidx arr alive checksOld hsz idx startPos with
+            T M domCsT candsT bcBus? fidx bidx arr alive checksOld hsz idx startPos with
         | some dr => some { dr with dropIdx := curIdx }
-        | none => findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx arr
+        | none => findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx bidx arr
             alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
-      | none => findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx arr alive
+      | none => findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx bidx arr alive
           checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
 
 /-- Cancel every droppable pair in one pass invocation, iterating over a *stable* tombstoned array
@@ -2529,13 +2558,13 @@ def cancelLoop (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFact
     (domCsT : Thunk { l : List (Expression p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (VarCsIdx p cs0.algebraicConstraints))
     (bcBus? : Option (Nat × ByteXorSpec p)) (busIds : List Nat)
-    (fidx : Std.HashMap Variable (List Nat))
+    (fidx bidx : Std.HashMap Variable (List Nat))
     (arr : Array (BusInteraction (Expression p)))
     (idx : Std.HashMap UInt64 (List Nat))
     (alive : Array Bool) (checksOld : List (BusInteraction (Expression p)))
     (hsz : alive.size = arr.size) (resumeIdx resumePos : Nat)
     (hcur : PassCorrect cs0 (mkCs cs0 arr alive checksOld) [] bs) : PassResult cs0 bs :=
-  match hfc : findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx arr alive
+  match hfc : findCancel cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT fidx bidx arr alive
       checksOld hsz idx bcBus? resumeIdx resumePos 0 busIds with
   | none =>
     -- Materialize the final compact interaction list once, tail-recursively (`liveArr`), and
@@ -2548,7 +2577,7 @@ def cancelLoop (cs0 : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFact
   | some dr =>
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
-    cancelLoop cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT bcBus? busIds fidx arr idx
+    cancelLoop cs0 bs facts hp1 deep hdeep aggressive T M domCsT candsT bcBus? busIds fidx bidx arr idx
       dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos (hcur.andThen dr.step)
   termination_by liveCount arr alive
   decreasing_by exact dr.decreases
@@ -2587,8 +2616,9 @@ def busPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : VerifiedPassW 
     have hcur : PassCorrect cs (mkCs cs arr alive []) [] bs := by
       rw [mkCs_all cs arr rfl alive halltrue]; exact PassCorrect.refl cs bs
     let fidx := buildFormIdx bs arr
+    let bidx := buildBoundIdx bs facts arr
     cancelLoop cs bs facts hp1 deep (fun h => pw.correct h) aggressive T M domCsT candsT
       (busIds.findSome? (fun k => match facts.byteXorSpec k with
         | some spec => if spec.bound = 256 then some (k, spec) else none
-        | none => none)) busIds fidx arr idx alive [] hsz 0 0 hcur
+        | none => none)) busIds fidx bidx arr idx alive [] hsz 0 0 hcur
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -47,6 +48,19 @@ def buildStep (varsOf : α → List Variable) (ai : α × Nat) (idx : CovIndex) 
     variables it mentions (or into `varless` when it mentions none). -/
 def build (varsOf : α → List Variable) (items : List α) : CovIndex :=
   items.zipIdx.foldr (buildStep varsOf) ⟨∅, []⟩
+
+/-- `build`, skipping items with more than `maxVars` distinct variables. An item is *covered* by
+    a target `xs` only when **all** its variables lie in `xs`, so for consumers whose targets
+    never exceed `maxVars` variables the pruned index yields the identical covered sets — while
+    hot-variable buckets stay small: a selector-style variable occurs in hundreds of wide items,
+    none of which a small target can ever cover, and exactly those items are pruned. Only for
+    *untrusted* consumers (the re-check-at-use discipline) or callers that separately know
+    `|xs| ≤ maxVars`. -/
+def buildPruned (varsOf : α → List Variable) (maxVars : Nat) (items : List α) : CovIndex :=
+  items.zipIdx.foldr (fun ai idx =>
+    if (HashedDedup.hashedEraseDups (hash ·) (varsOf ai.1)).length ≤ maxVars then
+      buildStep varsOf ai idx
+    else idx) ⟨∅, []⟩
 
 /-- The candidate positions for target `xs`: every position bucketed under a variable of `xs`,
     plus the variable-less positions. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -72,6 +72,64 @@ def coveredIdxUnord (idx : CovIndex) (arr : Array α) (Q : α → Bool) (xs : Li
   uniq.filterMap (fun i =>
     if h : i < arr.size then (if Q arr[i] then some arr[i] else none) else none)
 
+/-- One walk of the candidate positions returning both the `Q`-covered items and the sub-list of
+    those whose position is flagged in `act` — one gather with `Q` evaluated once per position and
+    no per-item hashing. Consumers needing a covered set *and* its flagged (e.g. non-redundant)
+    subset get both from a single scan. -/
+def gatherBoth (arr : Array α) (Q : α → Bool) (act : Array Bool) : List Nat → List α × List α
+  | [] => ([], [])
+  | i :: rest =>
+    let r := gatherBoth arr Q act rest
+    if h : i < arr.size then
+      if Q arr[i] then
+        (arr[i] :: r.1, if act[i]?.getD false then arr[i] :: r.2 else r.2)
+      else r
+    else r
+
+/-- Every item of the flagged sublist is a genuine `Q`-passing item of `arr`. -/
+theorem gatherBoth_snd_mem (arr : Array α) (Q : α → Bool) (act : Array Bool) :
+    ∀ (l : List Nat) {e : α}, e ∈ (gatherBoth arr Q act l).2 →
+      ∃ i, ∃ _h : i < arr.size, arr[i] = e ∧ Q e = true := by
+  intro l
+  induction l with
+  | nil => intro e he; simp [gatherBoth] at he
+  | cons i rest ih =>
+    intro e he
+    rw [gatherBoth] at he
+    by_cases h : i < arr.size
+    · rw [dif_pos h] at he
+      by_cases hq : Q arr[i]
+      · rw [if_pos hq] at he
+        dsimp only at he
+        by_cases ha : (act[i]?.getD false) = true
+        · rw [if_pos ha] at he
+          rcases List.mem_cons.1 he with rfl | he'
+          · exact ⟨i, h, rfl, hq⟩
+          · exact ih he'
+        · rw [if_neg ha] at he
+          exact ih he
+      · rw [if_neg hq] at he
+        exact ih he
+    · rw [dif_neg h] at he
+      exact ih he
+
+/-- The `gatherBoth` covered set and flagged subset over the deduplicated candidate positions of
+    target `xs` (the `coveredIdxUnord` gather, done once for both lists). -/
+def coveredIdxBoth (idx : CovIndex) (arr : Array α) (Q : α → Bool) (act : Array Bool)
+    (xs : List Variable) : List α × List α :=
+  let uniq := ((candidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+  gatherBoth arr Q act uniq
+
+/-- Soundness of the flagged sublist for an array threaded with its list equation. -/
+theorem coveredIdxBoth_snd_mem_of_eq (idx : CovIndex) (l : List α) (arr : Array α)
+    (harr : arr = l.toArray) (Q : α → Bool) (act : Array Bool) (xs : List Variable)
+    {e : α} (he : e ∈ (coveredIdxBoth idx arr Q act xs).2) : e ∈ l ∧ Q e = true := by
+  subst harr
+  obtain ⟨i, hi, hei, hq⟩ := gatherBoth_snd_mem l.toArray Q act _ he
+  subst hei
+  have hi' : i < l.length := by simpa using hi
+  exact ⟨by simp [l.getElem_mem hi'], hq⟩
+
 /-- **Soundness.** Every item `coveredIdx` returns is a genuine item of `arr` (hence of the
     underlying list) that satisfies `Q`. This is all the enumeration proofs need; the index need
     not be complete for correctness (completeness only affects effectiveness, checked empirically). -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Dedup.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -186,6 +187,20 @@ theorem dedupStatelessFast_eq_nil (bs : BusSemantics p)
     dedupStatelessFast bs ∅ bis = dedupStateless bs [] bis :=
   dedupStatelessFast_eq bs bis [] ∅ (by intro bi; simp [Std.HashMap.getD_empty])
 
+/-! ## Hash-bucketed constraint dedup
+
+`List.dedup` on the constraint list is O(C²·E) structural comparisons (28k constraints on
+keccak's first cycle); `HashedDedup.hashedDedup` is its proven-identical bucketed twin. -/
+
+/-- The bucketed constraint dedup: identical output to `List.dedup`, one-bucket membership
+    tests instead of whole-tail scans. -/
+def dedupConstraintsFast (l : List (Expression p)) : List (Expression p) :=
+  HashedDedup.hashedDedup Expression.bHash l
+
+theorem dedupConstraintsFast_eq (l : List (Expression p)) :
+    dedupConstraintsFast l = l.dedup :=
+  HashedDedup.hashedDedup_eq Expression.bHash l
+
 /-! ## The pass -/
 
 /-- The deduplicated system. -/
@@ -238,12 +253,13 @@ theorem ConstraintSystem.dedup_correct (cs : ConstraintSystem p) (bs : BusSemant
     `ConstraintSystem.dedup` (`dedupFast_eq`), so it inherits `dedup_correct`. -/
 def ConstraintSystem.dedupFast (cs : ConstraintSystem p) (bs : BusSemantics p) :
     ConstraintSystem p :=
-  { algebraicConstraints := cs.algebraicConstraints.dedup,
+  { algebraicConstraints := dedupConstraintsFast cs.algebraicConstraints,
     busInteractions := dedupStatelessFast bs ∅ cs.busInteractions }
 
 theorem ConstraintSystem.dedupFast_eq (cs : ConstraintSystem p) (bs : BusSemantics p) :
     cs.dedupFast bs = cs.dedup bs := by
-  simp only [ConstraintSystem.dedupFast, ConstraintSystem.dedup, dedupStatelessFast_eq_nil]
+  simp only [ConstraintSystem.dedupFast, ConstraintSystem.dedup, dedupStatelessFast_eq_nil,
+    dedupConstraintsFast_eq]
 
 /-- The duplicate-removal pass (runs the hash-bucketed dedup; correctness via `dedupFast_eq`). -/
 def dedupPass : VerifiedPass p := fun cs bs =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1,6 +1,8 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
 import ApcOptimizer.Implementation.OptimizerPasses.Gauss
 import ApcOptimizer.Implementation.OptimizerPasses.CoveredIndex
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
+import ApcOptimizer.Implementation.OptimizerPasses.Dedup
 
 set_option autoImplicit false
 
@@ -327,14 +329,18 @@ theorem allBox_eq (pred : List (Variable × ZMod p) → Bool)
 /-! ## Building the table -/
 
 /-- Constraint-sourced domains: for each constraint that is a product of affine factors in a
-    single variable (up to 3 distinct variables tried), record the root domains. -/
+    single variable (up to 3 distinct variables tried), record the root domains. Each pending
+    entry carries its precomputed deduped variable list (= `c.vars.dedup`, computed once per
+    constraint by the pass body and shared with the target list and the redundancy filter). -/
 def addConstraintDoms [Fact p.Prime] {cs : ConstraintSystem p} {bs : BusSemantics p} :
-    (pending : List (Expression p)) → (∀ c ∈ pending, c ∈ cs.algebraicConstraints) →
+    (pending : List (Expression p × List Variable)) →
+    (∀ cv ∈ pending, cv.1 ∈ cs.algebraicConstraints) →
     DomainTable p cs bs → DomainTable p cs bs
   | [], _, T => T
-  | c :: rest, hmem, T =>
-    let hc := hmem c (List.mem_cons_self ..)
-    let hrest := fun c' h => hmem c' (List.mem_cons_of_mem _ h)
+  | cv :: rest, hmem, T =>
+    let c := cv.1
+    let hc : c ∈ cs.algebraicConstraints := hmem cv (List.mem_cons_self ..)
+    let hrest := fun cv' h => hmem cv' (List.mem_cons_of_mem _ h)
     let rec addVars (xs : List Variable) (T : DomainTable p cs bs) : DomainTable p cs bs :=
       match xs with
       | [] => T
@@ -344,8 +350,7 @@ def addConstraintDoms [Fact p.Prime] {cs : ConstraintSystem p} {bs : BusSemantic
             addVars xs (T.insertEntry x (.explicit d)
               (fun env hsat => rootsIn_sound x c d hr env (hsat.1 c hc)))
         | none => addVars xs T
-    let vs := c.vars.dedup
-    addConstraintDoms rest hrest (if vs.length ≤ 3 then addVars vs T else T)
+    addConstraintDoms rest hrest (if cv.2.length ≤ 3 then addVars cv.2 T else T)
 
 /-- The raw-variable payload entries of an interaction. -/
 def payloadRawVars (bi : BusInteraction (Expression p)) : List Variable :=
@@ -365,6 +370,21 @@ def interactionDomainF (bs : BusSemantics p) (facts : BusFacts p bs)
   match interactionBound bs facts bi x with
   | none => none
   | some bound => if bound ≤ maxDomainBound then some (.range bound) else none
+
+/-- `interactionDomainF` with the per-interaction multiplicity constant and constant-payload
+    pattern hoisted (see `interactionBoundPat`): definitionally the same function at the
+    canonical arguments. -/
+def interactionDomainFPat (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (mval? : Option (ZMod p))
+    (pat : List (Option (ZMod p))) (x : Variable) : Option (FiniteDomain p) :=
+  match interactionBoundPat bs facts bi mval? pat x with
+  | none => none
+  | some bound => if bound ≤ maxDomainBound then some (.range bound) else none
+
+theorem interactionDomainFPat_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) :
+    interactionDomainFPat bs facts bi bi.multiplicity.constValue?
+      (bi.payload.map Expression.constValue?) x = interactionDomainF bs facts bi x := rfl
 
 theorem interactionDomainF_sound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) (x : Variable) (d : FiniteDomain p)
@@ -393,17 +413,22 @@ def addBusDoms [NeZero p] {cs : ConstraintSystem p} {bs : BusSemantics p}
   | bi :: rest, hmem, T =>
     let hbi := hmem bi (List.mem_cons_self ..)
     let hrest := fun bi' h => hmem bi' (List.mem_cons_of_mem _ h)
+    -- Per-interaction values hoisted out of the per-variable lookup (`interactionDomainFPat_eq`
+    -- transports each hit back to the canonical `interactionDomainF` for the soundness proof).
+    let mval? := bi.multiplicity.constValue?
+    let pat := bi.payload.map Expression.constValue?
     let rec addVars (xs : List Variable) (T : DomainTable p cs bs) : DomainTable p cs bs :=
       match xs with
       | [] => T
       | x :: xs =>
-        match hr : interactionDomainF bs facts bi x with
+        match hr : interactionDomainFPat bs facts bi mval? pat x with
         | some d =>
             addVars xs (T.insertEntry x d
-              (fun env hsat => interactionDomainF_sound bs facts bi x d hr env
+              (fun env hsat => interactionDomainF_sound bs facts bi x d
+                (interactionDomainFPat_eq bs facts bi x ▸ hr) env
                 (hsat.2 bi hbi)))
         | none => addVars xs T
-    addBusDoms facts rest hrest (addVars (payloadRawVars bi).dedup T)
+    addBusDoms facts rest hrest (addVars (HashedDedup.hashedDedup (hash ·) (payloadRawVars bi)) T)
 
 /-! ## Joint enumeration against the table
 
@@ -885,9 +910,11 @@ def maxEnumWork : Nat := 524288
 def biInformative (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) : Bool :=
   bi.payload.any (fun e => !(e.isVar || e.constValue?.isSome)) ||
-  bi.payload.any (fun e => match e with
-    | .var x => (interactionBound bs facts bi x).isNone
-    | _ => false)
+  (let mval? := bi.multiplicity.constValue?
+   let pat := bi.payload.map Expression.constValue?
+   bi.payload.any (fun e => match e with
+     | .var x => (interactionBoundPat bs facts bi mval? pat x).isNone
+     | _ => false))
 
 /-- Is this constraint *redundant* for enumeration — identically zero on the box of its own
     variables' domains (from `T`)? Such a constraint is then zero on every larger box that contains
@@ -897,8 +924,8 @@ def biInformative (bs : BusSemantics p) (facts : BusFacts p bs)
     practice they are the overwhelming majority of the covered constraints. `false` (keep it) when
     the sub-box is unbounded or too large to check cheaply. -/
 def constraintRedundant {cs : ConstraintSystem p} {bs : BusSemantics p} (T : DomainTable p cs bs)
-    (c : Expression p) : Bool :=
-  match T.doms c.vars.dedup with
+    (c : Expression p) (vs : List Variable) : Bool :=
+  match T.doms vs with
   | none => false
   | some d =>
     (d.map (fun yd => yd.2.size)).prod ≤ maxEnumSize &&
@@ -1212,16 +1239,18 @@ theorem scanNone_unsat {cs : ConstraintSystem p} {bs : BusSemantics p}
     scans get O(1) positional access while `forcedOver` still recovers list membership for its
     soundness witnesses. Replaces the per-target full-system `filter`s (`coveredCs` / `coveredBis` /
     `activeCs.filter`) — the dominant runtime cost on large circuits — with an O(local) lookup. -/
-structure ForcedIdx (cs : ConstraintSystem p) (activeCs : List (Expression p)) where
+structure ForcedIdx (cs : ConstraintSystem p) where
   csIdx : CoveredIndex.CovIndex
   arrCs : Array (Expression p)
   harrCs : arrCs = cs.algebraicConstraints.toArray
   bisIdx : CoveredIndex.CovIndex
   arrBis : Array (BusInteraction (Expression p))
   harrBis : arrBis = cs.busInteractions.toArray
-  activeIdx : CoveredIndex.CovIndex
-  arrActive : Array (Expression p)
-  harrActive : arrActive = activeCs.toArray
+  /-- Per-position non-redundancy flags, parallel to `arrCs`: the per-target *active* covered set
+      is the covered set restricted to flagged positions (`gatherBoth`), so no third bucket gather
+      — and no third index — is needed. Untrusted: the flags only select which covered constraints
+      feed the survivor test, and dropping constraints only weakens it. -/
+  actFlags : Array Bool
 
 /-- All checked forced constants over the variable set `xs` (the vars of one target
     constraint or interaction): scan the domain box once against everything the set
@@ -1238,8 +1267,7 @@ structure ForcedIdx (cs : ConstraintSystem p) (activeCs : List (Expression p)) w
     covered items, which `scanForced_sound` accepts (`hactive`/membership). -/
 def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
     (T : DomainTable p cs bs)
-    (activeCs : List (Expression p)) (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints)
-    (fidx : ForcedIdx cs activeCs)
+    (fidx : ForcedIdx cs)
     (xs : List Variable) : List ((x : Variable) × { c : ZMod p //
       ∀ env, cs.satisfies bs env → env x = c }) :=
   match hdoms : T.doms xs with
@@ -1256,18 +1284,22 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts
       -- analogous drop for *obligations* is not worthwhile: an interaction's sub-box is large and
       -- its payload evaluation costly, and it is covered by few targets, so verifying its
       -- redundancy costs about what it would save.)
-      let esFull := CoveredIndex.coveredIdxUnord fidx.csIdx fidx.arrCs (fun c => c.varsInF xs) xs
+      -- one gather serves both the full covered set (informativeness gate + work cap) and its
+      -- non-redundant subset (the survivor filter) — flagged by position, no per-item hashing
+      let esBoth := CoveredIndex.coveredIdxBoth fidx.csIdx fidx.arrCs (fun c => c.varsInF xs)
+        fidx.actFlags xs
+      let esFull := esBoth.1
+      let es := esBoth.2
       let bis := CoveredIndex.coveredIdxUnord fidx.bisIdx fidx.arrBis
         (fun bi => bi.varsInF xs && !bs.isStateful bi.busId) xs
-      let es := CoveredIndex.coveredIdxUnord fidx.activeIdx fidx.arrActive
-        (fun c => c.varsInF xs) xs
       let informative := !esFull.isEmpty || bis.any (biInformative bs facts)
       if informative && boxSize * (esFull.length + bis.length) ≤ maxEnumWork then
         have hes : ∀ e ∈ es, e ∈ cs.algebraicConstraints ∧ e.varsIn xs = true := by
           intro e he
-          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdxUnord_mem_of_eq fidx.activeIdx activeCs
-            fidx.arrActive fidx.harrActive (fun c => c.varsInF xs) xs he
-          refine ⟨hactiveCs e hMem, ?_⟩
+          obtain ⟨hMem, hQ⟩ := CoveredIndex.coveredIdxBoth_snd_mem_of_eq fidx.csIdx
+            cs.algebraicConstraints fidx.arrCs fidx.harrCs (fun c => c.varsInF xs)
+            fidx.actFlags xs he
+          refine ⟨hMem, ?_⟩
           rw [← Expression.varsInF_eq]; exact hQ
         have hbis : ∀ bi ∈ bis, bi ∈ cs.busInteractions ∧ bi.varsIn xs = true := by
           intro bi hbi
@@ -1316,16 +1348,15 @@ def varSetKey (xs : List Variable) : String :=
     skipping variable sets already enumerated. `activeCs` (the non-redundant constraints) and its
     membership witness are threaded to `forcedOver`. -/
 def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
-    (T : DomainTable p cs bs) (activeCs : List (Expression p))
-    (hactiveCs : ∀ c ∈ activeCs, c ∈ cs.algebraicConstraints) (fidx : ForcedIdx cs activeCs) :
+    (T : DomainTable p cs bs) (fidx : ForcedIdx cs) :
     List (List Variable) → Std.HashSet String → Solved p cs bs → Solved p cs bs
   | [], _, σ => σ
   | xs :: rest, seen, σ =>
     let key := varSetKey xs
-    if seen.contains key then collectForced facts T activeCs hactiveCs fidx rest seen σ
+    if seen.contains key then collectForced facts T fidx rest seen σ
     else
-      let found := forcedOver facts T activeCs hactiveCs fidx xs
-      collectForced facts T activeCs hactiveCs fidx rest (seen.insert key)
+      let found := forcedOver facts T fidx xs
+      collectForced facts T fidx rest (seen.insert key)
         (σ.insertAll (found.map (fun f => (f.1, .const f.2.val)))
           (by
             intro env hsat yt hyt
@@ -1346,21 +1377,29 @@ def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =
     have hp : p.Prime := pw.correct hpB
     haveI : Fact p.Prime := ⟨hp⟩
     haveI : NeZero p := ⟨hp.ne_zero⟩
+    -- Each item's deduped variable list is computed once (`hashedDedup_eq` keeps it the exact
+    -- `List.dedup` value) and shared between the domain-table build, the redundancy filter, and
+    -- the target list — previously three independent `.dedup` scans per item.
+    let csVs := cs.algebraicConstraints.map (fun c =>
+      (c, HashedDedup.hashedDedup (hash ·) c.vars))
     let T : DomainTable p cs bs :=
       addBusDoms facts cs.busInteractions (fun _ h => h)
-        (addConstraintDoms cs.algebraicConstraints (fun _ h => h) DomainTable.empty)
-    let targets := cs.algebraicConstraints.map (fun e => e.vars.dedup) ++
-      cs.busInteractions.map (fun bi => bi.vars.dedup)
-    let activeCs := cs.algebraicConstraints.filter (fun c => !constraintRedundant T c)
-    let fidx : ForcedIdx cs activeCs :=
+        (addConstraintDoms csVs
+          (fun cv hcv => by
+            obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hcv
+            exact hc)
+          DomainTable.empty)
+    let targets := csVs.map (·.2) ++
+      cs.busInteractions.map (fun bi => HashedDedup.hashedDedup (hash ·) bi.vars)
+    let actFlags : Array Bool :=
+      (csVs.map (fun cv => !constraintRedundant T cv.1 cv.2)).toArray
+    let fidx : ForcedIdx cs :=
       { csIdx := CoveredIndex.build Expression.vars cs.algebraicConstraints,
         arrCs := cs.algebraicConstraints.toArray, harrCs := rfl,
         bisIdx := CoveredIndex.build BusInteraction.vars cs.busInteractions,
         arrBis := cs.busInteractions.toArray, harrBis := rfl,
-        activeIdx := CoveredIndex.build Expression.vars activeCs,
-        arrActive := activeCs.toArray, harrActive := rfl }
-    let σ := collectForced facts T activeCs (fun _ h => (List.mem_filter.1 h).1) fidx targets ∅
-      Solved.empty
+        actFlags := actFlags }
+    let σ := collectForced facts T fidx targets ∅ Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1394,9 +1394,16 @@ def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =
     let actFlags : Array Bool :=
       (csVs.map (fun cv => !constraintRedundant T cv.1 cv.2)).toArray
     let fidx : ForcedIdx cs :=
-      { csIdx := CoveredIndex.build Expression.vars cs.algebraicConstraints,
+      -- The index builds insert each position once per *distinct* variable (the raw `vars` lists
+      -- carry one entry per occurrence; the gathers deduplicate positions anyway, so buckets and
+      -- covered sets are unchanged — the inserts and bucket scans just stop paying per-occurrence).
+      { csIdx := CoveredIndex.build
+          (fun c => HashedDedup.hashedEraseDups (hash ·) (Expression.vars c))
+          cs.algebraicConstraints,
         arrCs := cs.algebraicConstraints.toArray, harrCs := rfl,
-        bisIdx := CoveredIndex.build BusInteraction.vars cs.busInteractions,
+        bisIdx := CoveredIndex.build
+          (fun bi => HashedDedup.hashedEraseDups (hash ·) (BusInteraction.vars bi))
+          cs.busInteractions,
         arrBis := cs.busInteractions.toArray, harrBis := rfl,
         actFlags := actFlags }
     let σ := collectForced facts T fidx targets ∅ Solved.empty

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -444,6 +444,17 @@ def systemHasFoldable (cs : ConstraintSystem p) (xs : List Variable)
     cs.busInteractions.any (fun bi =>
       bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
 
+/-- `systemHasFoldable` with the non-covered constraints (`rest = coveredBy`'s complement)
+    precomputed by the caller — the direct path partitions the constraint list once per target,
+    so the gate does not re-evaluate `coveredBy` per constraint. Same Bool (`any` over the
+    complement filter ⟺ `any` with the conjunction). Purely an efficiency gate, like
+    `systemHasFoldable` itself. -/
+def systemHasFoldableW (cs : ConstraintSystem p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) (rest : List (Expression p)) : Bool :=
+  rest.any (fun c => c.hasFoldable xs survs) ||
+    cs.busInteractions.any (fun bi =>
+      bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
+
 /-! ### The index-local gate
 
 `systemHasFoldable` is a full-system scan run once per target — the dominant cost of this pass.
@@ -627,15 +638,18 @@ covered set is computed **once** per target and reused for the survivor filter
 (`groupSurvivorsE es`, provably `groupSurvivors cs xs doms` — the old code paid the full filter
 a second time inside `groupSurvivors`). -/
 
-/-- One checked fold for a candidate group, given the covered set `es = coveredCsOf cs xs`. -/
+/-- One checked fold for a candidate group, given the covered set `es = coveredCsOf cs xs` and
+    its complement `csRest` (the non-covered constraints, feeding the no-op gate without a second
+    `coveredBy` sweep). -/
 def foldStepWith [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (xs : List Variable)
-    (es : List (Expression p)) (hes : es = coveredCsOf cs xs) : PassResult cs bs :=
+    (es : List (Expression p)) (csRest : List (Expression p))
+    (hes : es = coveredCsOf cs xs) : PassResult cs bs :=
   match hdoms : groupDoms es xs with
   | none => ⟨cs, [], PassCorrect.refl cs bs⟩
   | some doms =>
     if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
       let survs := groupSurvivorsE es doms
-      if 1 ≤ survs.length && systemHasFoldable cs xs survs then
+      if 1 ≤ survs.length && systemHasFoldableW cs xs survs csRest then
         have hsurv : groupSurvivors cs xs doms = survs := by
           show groupSurvivors cs xs doms = groupSurvivorsE es doms
           rw [hes]; rfl
@@ -643,14 +657,20 @@ def foldStepWith [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) 
       else ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs, [], PassCorrect.refl cs bs⟩
 
-/-- Direct-path fold loop: recompute `coveredCsOf cs xs` per target (no index). -/
+/-- Direct-path fold loop: one `partition` per target computes the covered set and its complement
+    together (no index, and no second `coveredBy` sweep for the gate). -/
 def foldLoopDirect [Fact p.Prime] (bs : BusSemantics p) :
     List (List Variable) → (cs : ConstraintSystem p) → PassResult cs bs
   | [], cs => ⟨cs, [], PassCorrect.refl cs bs⟩
   | xs :: rest, cs =>
-    let r1 := foldStepWith bs cs xs (coveredCsOf cs xs) rfl
-    let r2 := foldLoopDirect bs rest r1.out
-    ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
+    match hpr : cs.algebraicConstraints.partition (coveredBy xs) with
+    | (es, csRest) =>
+      let r1 := foldStepWith bs cs xs es csRest (by
+        rw [List.partition_eq_filter_filter] at hpr
+        injection hpr with h1 _
+        exact h1.symm)
+      let r2 := foldLoopDirect bs rest r1.out
+      ⟨r2.out, r1.derivs ++ r2.derivs, r1.correct.andThen r2.correct⟩
 
 /-- Systems with at least this many algebraic constraints use the inverted index; smaller ones use
     the direct per-target `coveredCsOf` scan (see the section comment). Purely a runtime gate —
@@ -670,12 +690,14 @@ def domainFoldPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bsem =>
     -- with a variable that has *no* single-variable constraint anywhere can never pass
     -- `groupDoms`. Skipping those targets up front (one hash lookup per variable) avoids the
     -- per-target covered-set scan for the ubiquitous byte-limb groups, exactly.
-    let svSet : Std.HashSet Variable := cs.algebraicConstraints.foldl (init := ∅) fun s c =>
-      match c.vars.dedup with
+    -- Each constraint's deduped variable list is computed once (`hashedDedup_eq` keeps it the
+    -- exact `List.dedup` value) and shared between the single-variable set and the target list.
+    let csVs := cs.algebraicConstraints.map (fun c => HashedDedup.hashedDedup (hash ·) c.vars)
+    let svSet : Std.HashSet Variable := csVs.foldl (init := ∅) fun s vs =>
+      match vs with
       | [x] => s.insert x
       | _ => s
-    let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
-      let vs := c.vars.dedup
+    let targets := dedupHash (csVs.filterMap (fun vs =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
         some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -480,13 +480,23 @@ and rebuilt only on an accepted fold (`cs` changes), carrying the proofs tying i
 `cs` via `FoldIdx`. Effectiveness is bit-identical (the covered set is unchanged); only the scan is
 faster. -/
 
+/-- Per-item variable list with duplicates removed: the index build otherwise inserts one bucket
+    entry per *occurrence* (and the per-target gathers then re-deduplicate them). Same membership,
+    so bucket completeness is unchanged (`hashedEraseDups_eq` + `mem_eraseDups`). -/
+def dedupVarsOf (c : Expression p) : List Variable :=
+  HashedDedup.hashedEraseDups (hash ·) c.vars
+
+/-- `dedupVarsOf` for interactions (multiplicity + payload occurrences). -/
+def dedupBiVarsOf (bi : BusInteraction (Expression p)) : List Variable :=
+  HashedDedup.hashedEraseDups (hash ·) bi.vars
+
 /-- The prebuilt covered-constraint index for the current `cs`, with the proofs tying it to `cs` so
     the covered set it yields is provably `coveredCsOf cs xs` (`coveredCsIdx_eq`), plus the
     proof-free data the index-local `systemHasFoldableIdx` gate consumes: the interaction-side
     inverted index and the (normally empty) const-foldable item lists. -/
 structure FoldIdx (cs : ConstraintSystem p) where
   idx : CoveredIndex.CovIndex
-  hidx : idx = CoveredIndex.build Expression.vars cs.algebraicConstraints
+  hidx : idx = CoveredIndex.build dedupVarsOf cs.algebraicConstraints
   arr : Array (Expression p)
   harr : arr = cs.algebraicConstraints.toArray
   bisIdx : CoveredIndex.CovIndex
@@ -496,11 +506,11 @@ structure FoldIdx (cs : ConstraintSystem p) where
 
 /-- Build the index for a system (by construction the equalities hold `rfl`). -/
 def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
-  idx := CoveredIndex.build Expression.vars cs.algebraicConstraints
+  idx := CoveredIndex.build dedupVarsOf cs.algebraicConstraints
   hidx := rfl
   arr := cs.algebraicConstraints.toArray
   harr := rfl
-  bisIdx := CoveredIndex.build BusInteraction.vars cs.busInteractions
+  bisIdx := CoveredIndex.build dedupBiVarsOf cs.busInteractions
   arrBis := cs.busInteractions.toArray
   cfCs := cs.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
   cfBis := cs.busInteractions.filter (fun bi =>
@@ -516,15 +526,24 @@ def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
     rebuild-per-accepted-fold cost on fold-heavy circuits. -/
 def FoldIdx.refresh {cs : ConstraintSystem p} (old : FoldIdx cs) (ro : ConstraintSystem p) :
     FoldIdx ro where
-  idx := CoveredIndex.build Expression.vars ro.algebraicConstraints
+  idx := CoveredIndex.build dedupVarsOf ro.algebraicConstraints
   hidx := rfl
   arr := ro.algebraicConstraints.toArray
   harr := rfl
   bisIdx := old.bisIdx
   arrBis := ro.busInteractions.toArray
-  cfCs := ro.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
-  cfBis := ro.busInteractions.filter (fun bi =>
-    bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
+  -- The const-foldable lists were two more full-system filters per accepted fold. A fold never
+  -- *creates* a variable-free compound node (`foldRewrite` replaces the maximal
+  -- constant-on-survivors node by a constant leaf, so a parent that became var-free would itself
+  -- have been the maximal node), so the fresh filter is always a subset of the old list — when
+  -- the old list is **empty** (the normal, post-constant-fold state) the fresh one is provably
+  -- empty too and the filters are skipped outright; otherwise recompute exactly as before, so
+  -- the gate value (and the pass output) is bit-for-bit unchanged.
+  cfCs := if old.cfCs.isEmpty then [] else
+    ro.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
+  cfBis := if old.cfBis.isEmpty then [] else
+    ro.busInteractions.filter (fun bi =>
+      bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
 
 /-- The index-local form of `systemHasFoldable` (see the section comment above): scan only the
     items sharing a variable with `xs` (through the inverted indexes, candidate positions
@@ -584,8 +603,12 @@ theorem coveredBy_shares_var (xs : List Variable) (c : Expression p) (h : covere
 theorem coveredCsIdx_eq (cs : ConstraintSystem p) (xs : List Variable) (fidx : FoldIdx cs) :
     CoveredIndex.coveredIdx fidx.idx fidx.arr (coveredBy xs) xs = coveredCsOf cs xs := by
   rw [fidx.hidx, fidx.harr, coveredCsOf]
-  exact CoveredIndex.coveredIdx_eq_filter Expression.vars cs.algebraicConstraints (coveredBy xs) xs
-    (fun i _hi hQ => coveredBy_shares_var xs cs.algebraicConstraints[i] hQ)
+  exact CoveredIndex.coveredIdx_eq_filter dedupVarsOf cs.algebraicConstraints (coveredBy xs) xs
+    (fun i _hi hQ => by
+      obtain ⟨v, hv, hvxs⟩ := coveredBy_shares_var xs cs.algebraicConstraints[i] hQ
+      exact ⟨v, by
+        rw [dedupVarsOf, HashedDedup.hashedEraseDups_eq]
+        exact List.mem_eraseDups.2 hv, hvxs⟩)
 
 /-- One checked fold for a candidate group (identity unless the group has a bounded domain, at least
     one survivor, and some foldable subexpression). The per-target covered scan is served from the

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainProp.lean
@@ -317,6 +317,28 @@ def interactionBound (bs : BusSemantics p) (facts : BusFacts p bs)
       | none => none
       | some slot => facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) slot
 
+/-- `interactionBound` with the multiplicity constant and the constant-payload pattern computed
+    once by the caller — they are per-*interaction* values, and callers that query every payload
+    variable of an interaction would otherwise recompute the pattern (a full payload fold) per
+    variable. Definitionally the same function at the canonical arguments
+    (`interactionBoundPat_eq`). -/
+def interactionBoundPat (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (mval? : Option (ZMod p))
+    (pat : List (Option (ZMod p))) (x : Variable) : Option Nat :=
+  match mval? with
+  | none => none
+  | some mval =>
+    if mval = 0 then none
+    else
+      match varSlot x bi.payload with
+      | none => none
+      | some slot => facts.slotBound bi.busId mval pat slot
+
+theorem interactionBoundPat_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (Expression p)) (x : Variable) :
+    interactionBoundPat bs facts bi bi.multiplicity.constValue?
+      (bi.payload.map Expression.constValue?) x = interactionBound bs facts bi x := rfl
+
 theorem interactionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (Expression p)) (x : Variable) (bound : Nat)
     (h : interactionBound bs facts bi x = some bound) (env : Variable → ZMod p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -38,11 +39,13 @@ def btCert (singles : List (Expression p)) (c : Expression p) : Bool :=
 
 /-- Cheap mirror of `btCert` over a precomputed (pure, memoized) domain lookup — a prefilter
     only; accepted candidates re-run the real certificate, so the proofs consume `btCert`
-    alone. -/
+    alone. The distinct-variable list is computed once (bucketed, `hashedEraseDups_eq` keeps it
+    the identical list) instead of three `eraseDups` scans per constraint. -/
 def btPre (domOf : Variable → Option (List (ZMod p))) (c : Expression p) : Bool :=
-  2 ≤ c.vars.eraseDups.length &&
-  (let doms := c.vars.eraseDups.filterMap (fun v => (domOf v).map (fun d => (v, d)))
-   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
+  2 ≤ vs.length &&
+  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = vs) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (assignments doms).all (fun pt => decide (c.eval (envOf pt) = 0)))
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/HashedDedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/HashedDedup.lean
@@ -1,0 +1,150 @@
+import ApcOptimizer.Implementation.OptimizerPasses.FactPass
+
+set_option autoImplicit false
+
+/-! # Hash-bucketed `eraseDups`
+
+`List.eraseDups` keeps the first occurrence of each element, testing each new element against the
+whole kept-so-far list — O(n²) structural comparisons. `hashedEraseDups` carries the kept set
+bucketed by a caller-supplied structural hash, so each test scans one bucket;
+`hashedEraseDups_eq` proves the output is the **identical list**, so callers keep their proofs
+(and their byte-identical behavior) by rewriting along it. Generic in the element type; with
+`LawfulBEq` the hash needs no congruence side condition. -/
+
+namespace HashedDedup
+
+variable {α : Type} [BEq α] [LawfulBEq α] [Hashable UInt64]
+
+/-- `List.eraseDupsBy.loop (· == ·)` with the kept-so-far list `bs` mirrored as hash buckets:
+    the membership test scans only the bucket of the candidate's hash. -/
+def loop (hf : α → UInt64) : List α → List α → Std.HashMap UInt64 (List α) → List α
+  | [], bs, _ => bs.reverse
+  | a :: as, bs, m =>
+    if a ∈ m.getD (hf a) [] then loop hf as bs m
+    else loop hf as (a :: bs) (m.insert (hf a) (a :: m.getD (hf a) []))
+
+theorem loop_eq (hf : α → UInt64) :
+    ∀ (as bs : List α) (m : Std.HashMap UInt64 (List α)),
+      (∀ x : α, x ∈ bs ↔ x ∈ m.getD (hf x) []) →
+      loop hf as bs m = List.eraseDupsBy.loop (· == ·) as bs := by
+  intro as
+  induction as with
+  | nil => intro bs m _; rfl
+  | cons a rest ih =>
+    intro bs m h
+    rw [loop, List.eraseDupsBy.loop]
+    have hany : bs.any (a == ·) = decide (a ∈ bs) := by
+      by_cases hmem : a ∈ bs
+      · rw [decide_eq_true hmem, List.any_eq_true]
+        exact ⟨a, hmem, beq_self_eq_true a⟩
+      · rw [decide_eq_false hmem, List.any_eq_false]
+        intro x hx hax
+        exact hmem ((eq_of_beq hax).symm ▸ hx)
+    by_cases hmem : a ∈ bs
+    · rw [if_pos ((h a).mp hmem), hany, decide_eq_true hmem]
+      exact ih bs m h
+    · rw [if_neg (fun hc => hmem ((h a).mpr hc)), hany, decide_eq_false hmem]
+      show _ = List.eraseDupsBy.loop (· == ·) rest (a :: bs)
+      exact ih (a :: bs) (m.insert (hf a) (a :: m.getD (hf a) []))
+        (by
+          intro x
+          rw [Std.HashMap.getD_insert]
+          by_cases hbh : hf a = hf x
+          · rw [if_pos (by simpa using hbh), List.mem_cons, List.mem_cons]
+            have hx := h x
+            rw [← hbh] at hx
+            exact or_congr_right hx
+          · have hxne : x ≠ a := fun he => hbh (by rw [he])
+            rw [if_neg (by simpa using hbh), List.mem_cons]
+            exact (or_iff_right hxne).trans (h x))
+
+/-- Hash-bucketed `List.eraseDups`: identical output, one-bucket membership tests. -/
+def hashedEraseDups (hf : α → UInt64) (l : List α) : List α :=
+  loop hf l [] ∅
+
+theorem hashedEraseDups_eq (hf : α → UInt64) (l : List α) :
+    hashedEraseDups hf l = l.eraseDups :=
+  loop_eq hf l [] ∅ (by intro x; simp [Std.HashMap.getD_empty])
+
+/-! ## Hash-bucketed `List.dedup`
+
+`List.dedup` keeps the **last** occurrence of each duplicate (`dedup (a :: l)` drops `a` when
+`a ∈ l`), testing each head against its tail — O(n²). The bucketed twin walks the list carrying
+the *remaining-tail multiset* as hash buckets: the head is kept exactly when it no longer occurs
+in its bucket, which is `a ∈ l` by the count invariant — so `hashedDedup_eq` proves the output is
+the identical list. Requires `DecidableEq` (like `List.dedup`). -/
+
+section Dedup
+
+/-- The multiset of a list, bucketed by hash (buckets keep every occurrence). -/
+def bucketCounts (hf : α → UInt64) : List α → Std.HashMap UInt64 (List α)
+  | [] => ∅
+  | a :: rest => let m := bucketCounts hf rest; m.insert (hf a) (a :: m.getD (hf a) [])
+
+theorem bucketCounts_count (hf : α → UInt64) (l : List α) (x : α) :
+    ((bucketCounts hf l).getD (hf x) []).count x = l.count x := by
+  induction l with
+  | nil => simp [bucketCounts, Std.HashMap.getD_empty]
+  | cons a rest ih =>
+    simp only [bucketCounts, Std.HashMap.getD_insert]
+    by_cases hbh : hf a = hf x
+    · rw [if_pos (by simpa using hbh), hbh, List.count_cons, List.count_cons, ih]
+    · have hxne : x ≠ a := fun he => hbh (by rw [he])
+      rw [if_neg (by simpa using hbh), List.count_cons, ih,
+        if_neg (by simpa using Ne.symm hxne), Nat.add_zero]
+
+/-- One occurrence of `a` removed from its bucket: the multiset of `a :: rest` becomes the
+    multiset of `rest`. -/
+def bucketErase (hf : α → UInt64) (m : Std.HashMap UInt64 (List α)) (a : α) :
+    Std.HashMap UInt64 (List α) :=
+  m.insert (hf a) ((m.getD (hf a) []).erase a)
+
+theorem bucketErase_count (hf : α → UInt64) {m : Std.HashMap UInt64 (List α)}
+    {a : α} {rest : List α}
+    (h : ∀ x : α, (m.getD (hf x) []).count x = (a :: rest).count x)
+    (x : α) : ((bucketErase hf m a).getD (hf x) []).count x = rest.count x := by
+  simp only [bucketErase, Std.HashMap.getD_insert]
+  by_cases hbh : hf a = hf x
+  · rw [if_pos (by simpa using hbh), List.count_erase, hbh, h x, List.count_cons,
+      Nat.add_sub_cancel]
+  · have hxne : x ≠ a := fun he => hbh (by rw [he])
+    rw [if_neg (by simpa using hbh), h x, List.count_cons, if_neg (by simpa using Ne.symm hxne),
+      Nat.add_zero]
+
+variable [DecidableEq α]
+
+/-- `List.dedup` with the remaining-tail multiset carried as hash buckets. -/
+def dedupGo (hf : α → UInt64) : Std.HashMap UInt64 (List α) → List α → List α
+  | _, [] => []
+  | m, a :: rest =>
+    let m' := bucketErase hf m a
+    if a ∈ m'.getD (hf a) [] then dedupGo hf m' rest
+    else a :: dedupGo hf m' rest
+
+theorem dedupGo_eq (hf : α → UInt64) :
+    ∀ (l : List α) (m : Std.HashMap UInt64 (List α)),
+      (∀ x : α, (m.getD (hf x) []).count x = l.count x) →
+      dedupGo hf m l = l.dedup := by
+  intro l
+  induction l with
+  | nil => intro m _; rfl
+  | cons a rest ih =>
+    intro m h
+    rw [dedupGo]
+    have h' := fun x => bucketErase_count hf h x
+    have hmem : (a ∈ (bucketErase hf m a).getD (hf a) []) ↔ a ∈ rest := by
+      rw [← List.count_pos_iff, ← List.count_pos_iff, h' a]
+    by_cases hin : a ∈ rest
+    · rw [if_pos (hmem.mpr hin), List.dedup_cons_of_mem hin, ih _ h']
+    · rw [if_neg (fun hc => hin (hmem.mp hc)), List.dedup_cons_of_notMem hin, ih _ h']
+
+/-- Hash-bucketed `List.dedup`: identical output, one-bucket membership tests. -/
+def hashedDedup (hf : α → UInt64) (l : List α) : List α :=
+  dedupGo hf (bucketCounts hf l) l
+
+theorem hashedDedup_eq (hf : α → UInt64) (l : List α) : hashedDedup hf l = l.dedup :=
+  dedupGo_eq hf l (bucketCounts hf l) (bucketCounts_count hf l)
+
+end Dedup
+
+end HashedDedup

--- a/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
@@ -146,32 +146,54 @@ def identityPairs {bs : BusSemantics p} (facts : BusFacts p bs) (cs : Constraint
     List (Variable × Variable) :=
   cs.busInteractions.filterMap (identityPairAt facts)
 
-/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). The pair
-    list is captured once (see `identityPairs`), so this is cheap to apply repeatedly. -/
+/-- First-wins key→value map of a pair list: the value stored for `y` is the first pair keyed `y`,
+    exactly the `filterMap … |>.head?` semantics, at one hash lookup per query. -/
+def firstWins : List (Variable × Variable) → Std.HashMap Variable Variable →
+    Std.HashMap Variable Variable
+  | [], m => m
+  | pr :: rest, m => firstWins rest (if m.contains pr.1 then m else m.insert pr.1 pr.2)
+
+theorem firstWins_mem : ∀ (pairs : List (Variable × Variable))
+    (m : Std.HashMap Variable Variable) (y v : Variable),
+    (firstWins pairs m)[y]? = some v → m[y]? = some v ∨ (y, v) ∈ pairs := by
+  intro pairs
+  induction pairs with
+  | nil => intro m y v h; exact Or.inl h
+  | cons pr rest ih =>
+    intro m y v h
+    rcases ih _ y v h with hm | hr
+    · by_cases hc : m.contains pr.1
+      · rw [if_pos hc] at hm
+        exact Or.inl hm
+      · rw [if_neg hc, Std.HashMap.getElem?_insert] at hm
+        by_cases hy : (pr.1 == y) = true
+        · rw [if_pos hy] at hm
+          simp only [Option.some.injEq] at hm
+          have h1 : pr.1 = y := by simpa using hy
+          exact Or.inr (List.mem_cons.2 (Or.inl (by rw [← h1, ← hm])))
+        · rw [if_neg hy] at hm
+          exact Or.inl hm
+    · exact Or.inr (List.mem_cons_of_mem _ hr)
+
+/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). Backed
+    by a first-wins hash map built once, so `substF` — which queries it per variable occurrence —
+    pays one hash lookup instead of a pair-list scan per occurrence. -/
 def identityF {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
     Variable → Option (Expression p) :=
-  let pairs := identityPairs facts cs
-  fun y => (pairs.filterMap (fun pr => if pr.1 = y then some (Expression.var pr.2) else none)).head?
+  let m := firstWins (identityPairs facts cs) ∅
+  fun y => m[y]?.map Expression.var
 
 theorem identityF_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
     (y : Variable) (t : Expression p) (h : identityF facts cs y = some t) :
     ∃ (o1v : Variable) (bi : BusInteraction (Expression p)), t = Expression.var o1v ∧
       bi ∈ cs.busInteractions ∧ identityPairAt facts bi = some (y, o1v) := by
-  have hmem : t ∈ (identityPairs facts cs).filterMap
-      (fun pr => if pr.1 = y then some (Expression.var pr.2) else none) := by
-    simp only [identityF] at h
-    cases hc : (identityPairs facts cs).filterMap
-        (fun pr => if pr.1 = y then some (Expression.var pr.2) else none) with
-    | nil => rw [hc] at h; simp at h
-    | cons a l => rw [hc] at h; simp only [List.head?_cons, Option.some.injEq] at h; subst h; simp
-  obtain ⟨pr, hpr, hval⟩ := List.mem_filterMap.1 hmem
-  obtain ⟨rv, o1v⟩ := pr
-  obtain ⟨bi, hbi, hpair⟩ := List.mem_filterMap.1 hpr
-  simp only at hval
-  split_ifs at hval with hy
-  simp only [Option.some.injEq] at hval
-  subst hval; subst hy
-  exact ⟨o1v, bi, rfl, hbi, hpair⟩
+  simp only [identityF, Option.map_eq_some_iff] at h
+  obtain ⟨v, hv, rfl⟩ := h
+  rcases firstWins_mem _ _ y v hv with hm | hpair
+  · rw [Std.HashMap.getElem?_empty] at hm
+    exact absurd hm (by simp)
+  · obtain ⟨bi, hbi, hpairAt⟩ := List.mem_filterMap.1 hpair
+    exact ⟨v, bi, rfl, hbi, hpairAt⟩
 
 /-- The pass: batch-substitute every OR-identity result by its operand. When the system has no
     recognised identities — e.g. any OpenVM circuit, whose bitwise bus declares no `orOp` — the `[]`

--- a/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IdentitySubst.lean
@@ -175,25 +175,79 @@ theorem firstWins_mem : ∀ (pairs : List (Variable × Variable))
           exact Or.inl hm
     · exact Or.inr (List.mem_cons_of_mem _ hr)
 
-/-- The identity map: `result ↦ operand` for every recognised OR identity (first per key). Backed
-    by a first-wins hash map built once, so `substF` — which queries it per variable occurrence —
-    pays one hash lookup instead of a pair-list scan per occurrence. -/
-def identityF {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
-    Variable → Option (Expression p) :=
-  let m := firstWins (identityPairs facts cs) ∅
-  fun y => m[y]?.map Expression.var
+/-- Resolve a mapped variable through operand→operand chains, fuel-bounded (a cycle burns fuel
+    and stops harmlessly — the fixpoint wrapper then discards the no-op, exactly as it discarded
+    the old one-link-per-iteration swaps). Compressing the chains lets one `substF` collapse a
+    whole chain, so the fixpoint converges in ~2 iterations instead of one per link. -/
+def resolveGo (m : Std.HashMap Variable Variable) : Nat → Variable → Variable
+  | 0, v => v
+  | fuel + 1, v =>
+    match m[v]? with
+    | some w => resolveGo m fuel w
+    | none => v
 
-theorem identityF_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
-    (y : Variable) (t : Expression p) (h : identityF facts cs y = some t) :
-    ∃ (o1v : Variable) (bi : BusInteraction (Expression p)), t = Expression.var o1v ∧
-      bi ∈ cs.busInteractions ∧ identityPairAt facts bi = some (y, o1v) := by
-  simp only [identityF, Option.map_eq_some_iff] at h
-  obtain ⟨v, hv, rfl⟩ := h
-  rcases firstWins_mem _ _ y v hv with hm | hpair
+theorem resolveGo_sound (m : Std.HashMap Variable Variable) (env : Variable → ZMod p)
+    (hm : ∀ a b, m[a]? = some b → env a = env b) :
+    ∀ (fuel : Nat) (v : Variable), env (resolveGo m fuel v) = env v := by
+  intro fuel
+  induction fuel with
+  | zero => intro v; rfl
+  | succ fuel ih =>
+    intro v
+    rw [resolveGo]
+    cases hv : m[v]? with
+    | some w => rw [ih w, hm v w hv]
+    | none => rfl
+
+theorem resolveGo_prop (m : Std.HashMap Variable Variable) (P : Variable → Prop)
+    (hm : ∀ (a b : Variable), m[a]? = some b → P b) :
+    ∀ (fuel : Nat) (v : Variable), P v → P (resolveGo m fuel v) := by
+  intro fuel
+  induction fuel with
+  | zero => intro v hv; exact hv
+  | succ fuel ih =>
+    intro v hv
+    rw [resolveGo]
+    cases hmv : m[v]? with
+    | some w => exact ih w (hm v w hmv)
+    | none => exact hv
+
+/-- The mapped pairs, with the operand side path-compressed. -/
+def identityMap {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p) :
+    Std.HashMap Variable Variable :=
+  firstWins (identityPairs facts cs) ∅
+
+/-- The identity substitution over a prebuilt map: `result ↦ operand` (first per key), the
+    operand resolved through chains (`resolveGo`). The map is a **parameter**, computed once by
+    the pass body — a def-local `let … ; fun y => …` is re-evaluated per query by arity
+    expansion, which made the old form rebuild the pair list per variable occurrence (measured
+    2.8 s on apc_030 for a 4-pair map). -/
+def identityFm (m : Std.HashMap Variable Variable) (fuel : Nat) :
+    Variable → Option (Expression p) :=
+  fun y => m[y]?.map (fun w => Expression.var (resolveGo m fuel w))
+
+/-- Every stored pair comes from a recognised OR identity of the system. -/
+theorem identityMap_mem {bs : BusSemantics p} (facts : BusFacts p bs) (cs : ConstraintSystem p)
+    (y v : Variable) (h : (identityMap facts cs)[y]? = some v) :
+    ∃ (bi : BusInteraction (Expression p)),
+      bi ∈ cs.busInteractions ∧ identityPairAt facts bi = some (y, v) := by
+  rcases firstWins_mem _ _ y v h with hm | hpair
   · rw [Std.HashMap.getElem?_empty] at hm
     exact absurd hm (by simp)
   · obtain ⟨bi, hbi, hpairAt⟩ := List.mem_filterMap.1 hpair
-    exact ⟨v, bi, rfl, hbi, hpairAt⟩
+    exact ⟨bi, hbi, hpairAt⟩
+
+/-- A recognised pair's operand is a variable of the system (it sits in the interaction's
+    payload). -/
+theorem identityMap_operand_mem {bs : BusSemantics p} (facts : BusFacts p bs)
+    (cs : ConstraintSystem p) (y v : Variable) (h : (identityMap facts cs)[y]? = some v) :
+    v ∈ cs.vars := by
+  obtain ⟨bi, hbi, hpair⟩ := identityMap_mem facts cs y v h
+  obtain ⟨spec, oop, o1, o2, hspec, _, _, hdec, hoo⟩ := identityPairAt_spec facts bi y v hpair
+  obtain ⟨ho1m, ho2m, _⟩ := spec.decode_mem _ _ _ _ _ hdec
+  rcases orIdentityOperand_spec o1 o2 v hoo with ⟨ho1, _⟩ | ⟨ho2, _⟩
+  · exact ConstraintSystem.mem_vars_of_payload hbi (ho1 ▸ ho1m) (by simp [Expression.vars])
+  · exact ConstraintSystem.mem_vars_of_payload hbi (ho2 ▸ ho2m) (by simp [Expression.vars])
 
 /-- The pass: batch-substitute every OR-identity result by its operand. When the system has no
     recognised identities — e.g. any OpenVM circuit, whose bitwise bus declares no `orOp` — the `[]`
@@ -204,29 +258,38 @@ def identitySubstStep : VerifiedPassW p := fun cs bs facts =>
   | [] => ⟨cs, [], PassCorrect.refl cs bs⟩
   | _ :: _ =>
     if h1ne : (1 : ZMod p) ≠ 0 then
-      ⟨cs.substF (identityF facts cs), [],
-        cs.substF_correct (identityF facts cs) bs
+      -- Bind the map (and its fuel) here, fully applied — see `identityFm` on why the map must
+      -- not live behind the substitution closure's missing argument.
+      let m := identityMap facts cs
+      ⟨cs.substF (identityFm m m.size), [],
+        cs.substF_correct (identityFm m m.size) bs
           (by
             intro env hsat y t hf
-            obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
-            have hviol : bs.violatesConstraint (bi.eval env) = false := by
-              refine hsat.2 bi hbi ?_
-              obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := identityPairAt_spec facts bi y o1v hpair
-              show (bi.multiplicity.eval env) ≠ 0
-              rw [hmc]; simpa using h1ne
-            show env y = (Expression.var o1v).eval env
-            exact identityPairAt_sound facts bi y o1v hpair env hviol)
+            -- each stored pair is forced by its interaction's acceptance …
+            have hm : ∀ a b, (identityMap facts cs)[a]? = some b → env a = env b := by
+              intro a b hab
+              obtain ⟨bi, hbi, hpair⟩ := identityMap_mem facts cs a b hab
+              have hviol : bs.violatesConstraint (bi.eval env) = false := by
+                refine hsat.2 bi hbi ?_
+                obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := identityPairAt_spec facts bi a b hpair
+                show (bi.multiplicity.eval env) ≠ 0
+                rw [hmc]; simpa using h1ne
+              exact identityPairAt_sound facts bi a b hpair env hviol
+            -- … and the resolved target composes those equalities along the chain
+            simp only [identityFm, Option.map_eq_some_iff] at hf
+            obtain ⟨w, hw, rfl⟩ := hf
+            show env y = env (resolveGo (identityMap facts cs) (identityMap facts cs).size w)
+            rw [resolveGo_sound (identityMap facts cs) env hm]
+            exact hm y w hw)
           (by
             intro y t hf z hz
-            obtain ⟨o1v, bi, rfl, hbi, hpair⟩ := identityF_mem facts cs y t hf
+            simp only [identityFm, Option.map_eq_some_iff] at hf
+            obtain ⟨w, hw, rfl⟩ := hf
             simp only [Expression.vars, List.mem_singleton] at hz
             rw [hz]
-            obtain ⟨spec, oop, o1, o2, hspec, _, _, hdec, hoo⟩ :=
-              identityPairAt_spec facts bi y o1v hpair
-            obtain ⟨ho1m, ho2m, _⟩ := spec.decode_mem _ _ _ _ _ hdec
-            rcases orIdentityOperand_spec o1 o2 o1v hoo with ⟨ho1, _⟩ | ⟨ho2, _⟩
-            · exact ConstraintSystem.mem_vars_of_payload hbi (ho1 ▸ ho1m) (by simp [Expression.vars])
-            · exact ConstraintSystem.mem_vars_of_payload hbi (ho2 ▸ ho2m) (by simp [Expression.vars]))⟩
+            exact resolveGo_prop (identityMap facts cs) (· ∈ cs.vars)
+              (fun a b hab => identityMap_operand_mem facts cs a b hab) _ w
+              (identityMap_operand_mem facts cs y w hw))⟩
     else
       ⟨cs, [], PassCorrect.refl cs bs⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
@@ -1,5 +1,7 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
 import ApcOptimizer.Implementation.OptimizerPasses.MemoryUnify
+import ApcOptimizer.Implementation.OptimizerPasses.Dedup
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -519,6 +521,16 @@ end BoundIdx
 
 /-! ## The pass -/
 
+/-- The per-slot seed walk of `interactionSeeds`, with the constant-payload pattern `pat`
+    computed once by the caller instead of once per slot. -/
+def interactionSeedsGo {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bnd : Variable → Option Nat) (bi : BusInteraction (Expression p)) (mval : ZMod p)
+    (pat : List (Option (ZMod p))) : List (Expression p) :=
+  (List.range bi.payload.length).flatMap (fun i =>
+    match bi.payload[i]?, facts.slotBound bi.busId mval pat i with
+    | some e, some B => slotSeeds bnd B e
+    | _, _ => [])
+
 /-- All seeds of one interaction: every payload slot with a `slotBound`. -/
 def interactionSeeds {bs : BusSemantics p} (facts : BusFacts p bs)
     (bnd : Variable → Option Nat) (bi : BusInteraction (Expression p)) :
@@ -527,12 +539,7 @@ def interactionSeeds {bs : BusSemantics p} (facts : BusFacts p bs)
   | none => []
   | some mval =>
     if mval = 0 then []
-    else
-      (List.range bi.payload.length).flatMap (fun i =>
-        match bi.payload[i]?,
-              facts.slotBound bi.busId mval (bi.payload.map Expression.constValue?) i with
-        | some e, some B => slotSeeds bnd B e
-        | _, _ => [])
+    else interactionSeedsGo facts bnd bi mval (bi.payload.map Expression.constValue?)
 
 theorem interactionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     (bnd : Variable → Option Nat) (bi : BusInteraction (Expression p))
@@ -550,6 +557,7 @@ theorem interactionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     · rw [if_pos hmz] at hs
       exact absurd hs (by simp)
     rw [if_neg hmz] at hs
+    unfold interactionSeedsGo at hs
     rw [List.mem_flatMap] at hs
     obtain ⟨i, _, hsi⟩ := hs
     cases hpe : bi.payload[i]? with
@@ -584,8 +592,9 @@ theorem interactionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     consumed as a bound-`1` slot (an equality pins the integer window to `{0}`). -/
 def allSeeds {bs : BusSemantics p} (facts : BusFacts p bs) (bnd : Variable → Option Nat)
     (cs : ConstraintSystem p) : List (Expression p) :=
-  (cs.busInteractions.flatMap (interactionSeeds facts bnd) ++
-    cs.algebraicConstraints.flatMap (fun c => slotSeeds bnd 1 c)).eraseDups
+  HashedDedup.hashedEraseDups Expression.bHash
+    (cs.busInteractions.flatMap (interactionSeeds facts bnd) ++
+      cs.algebraicConstraints.flatMap (fun c => slotSeeds bnd 1 c))
 
 theorem allSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     (bnd : Variable → Option Nat) (cs : ConstraintSystem p) (env : Variable → ZMod p)
@@ -594,6 +603,7 @@ theorem allSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     ∀ s ∈ allSeeds facts bnd cs, s.eval env = 0 := by
   intro s hs
   unfold allSeeds at hs
+  rw [HashedDedup.hashedEraseDups_eq] at hs
   rcases List.mem_append.1 (List.mem_eraseDups.1 hs) with h | h
   · obtain ⟨bi, hbi, hsi⟩ := List.mem_flatMap.1 h
     exact interactionSeeds_sound facts bnd bi env hbnd (hsat.2 bi hbi) s hsi
@@ -615,8 +625,13 @@ theorem allSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
 def intervalForcePass : VerifiedPassW p := fun cs bs facts =>
   let idx := BoundIdx.build bs facts cs.busInteractions
   let seeds := allSeeds facts (fun v => idx.map[v]?) cs
-  let new := (seeds.filter (fun e => e.vars.all (fun z => cs.vars.contains z))).filter
-    (fun e => !cs.algebraicConstraints.contains e)
+  -- One hash set / one hash-bucket map instead of per-seed scans of the occurrence list and the
+  -- constraint list (both O(system) per seed). Same Bools, so the output is unchanged.
+  let varSet : Std.HashSet Variable := Std.HashSet.ofList cs.vars
+  let csBuckets : Std.HashMap UInt64 (List (Expression p)) :=
+    cs.algebraicConstraints.foldl (fun m c => m.insert c.bHash (c :: m.getD c.bHash [])) ∅
+  let new := (seeds.filter (fun e => e.vars.all (fun z => varSet.contains z))).filter
+    (fun e => !(csBuckets.getD e.bHash []).contains e)
   if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
   else
     ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
@@ -628,6 +643,8 @@ def intervalForcePass : VerifiedPassW p := fun cs bs facts =>
        (fun e he z hz => by
          have hp := (List.mem_filter.1 (List.mem_of_mem_filter he)).2
          simp only [List.all_eq_true] at hp
-         exact List.contains_iff_mem.mp (hp z hz))⟩
+         have hz' := hp z hz
+         rw [Std.HashSet.contains_ofList] at hz'
+         exact List.contains_iff_mem.mp hz')⟩
 
 end IntervalForce

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1563,7 +1563,8 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (b : DegreeBound) (useId
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
            hchk⟩,
-         (CoveredIndex.buildPruned Expression.vars 8 ro.algebraicConstraints),
+         (if useIdx then CoveredIndex.buildPruned Expression.vars 8 ro.algebraicConstraints
+          else ⟨∅, []⟩),
          ro.algebraicConstraints.toArray,
          ⟨Std.HashSet.ofList ro.vars, fun x hx => by
            rw [Std.HashSet.contains_ofList] at hx
@@ -1620,8 +1621,14 @@ def reencodePass (b : DegreeBound) : VerifiedPass p := fun cs bsem =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
         some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    reencodeLoop bsem b true targets 0 cs
-      (CoveredIndex.buildPruned Expression.vars 8 cs.algebraicConstraints)
+    -- The raw-count gate is back after CI showed the always-indexed form losing ~19% on the
+    -- dense openvm-eth blocks (reencode 1.19x) with no keccak gain: below the threshold the
+    -- direct per-target scan wins. The indexed side keeps the pruned build — identical covered
+    -- sets (a >8-distinct-var item can never be covered by a <=8-var target), smaller buckets.
+    let useIdx := 8192 <= cs.algebraicConstraints.length
+    reencodeLoop bsem b useIdx targets 0 cs
+      (if useIdx then CoveredIndex.buildPruned Expression.vars 8 cs.algebraicConstraints
+       else ⟨∅, []⟩)
       cs.algebraicConstraints.toArray
       ⟨Std.HashSet.ofList cs.vars, fun x hx => by
         rw [Std.HashSet.contains_ofList] at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1563,7 +1563,7 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (b : DegreeBound) (useId
            (fun x hx => of_decide_eq_true (List.all_eq_true.mp hxsB x hx))
            (fun b hbm => of_decide_eq_true (List.all_eq_true.mp hbn b hbm))
            hchk⟩,
-         (if useIdx then CoveredIndex.build Expression.vars ro.algebraicConstraints else ⟨∅, []⟩),
+         (CoveredIndex.buildPruned Expression.vars 8 ro.algebraicConstraints),
          ro.algebraicConstraints.toArray,
          ⟨Std.HashSet.ofList ro.vars, fun x hx => by
            rw [Std.HashSet.contains_ofList] at hx
@@ -1609,18 +1609,19 @@ def reencodePass (b : DegreeBound) : VerifiedPass p := fun cs bsem =>
     -- Same single-variable-constraint prefilter as `domainFoldPass`: a group variable without
     -- one can never obtain a domain, so `buildReencode`'s `groupDoms` would reject the target
     -- after paying its covered-set lookup.
-    let svSet : Std.HashSet Variable := cs.algebraicConstraints.foldl (init := ∅) fun s c =>
-      match c.vars.dedup with
+    -- Each constraint's deduped variable list is computed once (`hashedDedup_eq` keeps it the
+    -- exact `List.dedup` value) and shared between the single-variable set and the target list.
+    let csVs := cs.algebraicConstraints.map (fun c => HashedDedup.hashedDedup (hash ·) c.vars)
+    let svSet : Std.HashSet Variable := csVs.foldl (init := ∅) fun s vs =>
+      match vs with
       | [x] => s.insert x
       | _ => s
-    let targets := dedupHash (cs.algebraicConstraints.filterMap (fun c =>
-      let vs := c.vars.dedup
+    let targets := dedupHash (csVs.filterMap (fun vs =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
         some (vs.mergeSort (fun a b => compare a b != .gt))
       else none))
-    let useIdx := 8192 ≤ cs.algebraicConstraints.length
-    reencodeLoop bsem b useIdx targets 0 cs
-      (if useIdx then CoveredIndex.build Expression.vars cs.algebraicConstraints else ⟨∅, []⟩)
+    reencodeLoop bsem b true targets 0 cs
+      (CoveredIndex.buildPruned Expression.vars 8 cs.algebraicConstraints)
       cs.algebraicConstraints.toArray
       ⟨Std.HashSet.ofList cs.vars, fun x hx => by
         rw [Std.HashSet.contains_ofList] at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Gauss
 import ApcOptimizer.Implementation.OptimizerPasses.DomainProp
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -523,13 +524,26 @@ structure RPSeen (p : ℕ) (cs : ConstraintSystem p) where
     otherwise make every boolean variable a (never-unifiable, expensive-to-reject) candidate. -/
 def rpCandidates (c : Expression p) :
     List (Variable × (ZMod p × List (Variable × ZMod p) × ZMod p × ZMod p)) :=
-  c.vars.eraseDups.filterMap (fun x =>
-    match twoRootOf? c x with
-    | some (k, A, δ) =>
-      if 256 ≤ min (k⁻¹ * δ).val (p - (k⁻¹ * δ).val) then
-        some (x, (k, A.terms, A.const, δ))
-      else none
-    | none => none)
+  -- The two factors are linearized **once**, not once per candidate variable (`twoRootOf?`
+  -- would re-walk both factor trees per variable); each `x` then reads its coefficient and
+  -- x-free part off the shared linear forms — exactly `twoRootOf?`'s values, so the candidate
+  -- list (and the pass output) is unchanged.
+  match c with
+  | .mul f1 f2 =>
+    (match linearize f1, linearize f2 with
+     | some l1, some l2 =>
+       (HashedDedup.hashedEraseDups (hash ·) c.vars).filterMap (fun x =>
+         let k := l1.coeff x
+         let A := (l1.others x).norm
+         let A2 := (l2.others x).norm
+         if k ≠ 0 ∧ l2.coeff x = k ∧ A2.terms = A.terms then
+           let δ := A2.const - A.const
+           if 256 ≤ min (k⁻¹ * δ).val (p - (k⁻¹ * δ).val) then
+             some (x, (k, A.terms, A.const, δ))
+           else none
+         else none)
+     | _, _ => [])
+  | _ => []
 
 /-- Hash of a candidate key, used to bucket the `seen` accumulator. It reads only fields that the
     `key == key'` test compares, so equal keys hash equally — bucketing never hides a twin — while

--- a/Main.lean
+++ b/Main.lean
@@ -315,12 +315,18 @@ partial def runCycleTimed {p : ℕ} (passes : List (String × VerifiedPassW p))
   pure (c, a)
 
 /-- Iterate the cleanup cycle to a fixpoint (mirroring `iterateToFixpoint`), accumulating per-pass
-    time and counting iterations. -/
+    time and counting iterations. Reports each iteration's resulting sizes and wall time, so the
+    fixpoint's convergence tail (how little the late cycles shrink) is visible. -/
 partial def profileLoop {p : ℕ} (passes : List (String × VerifiedPassW p))
     (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (acc : Std.HashMap String Nat) (iter : Nat) :
     IO (ConstraintSystem p × Std.HashMap String Nat × Nat) := do
+  let t0 ← IO.monoMsNow
   let (cs', acc') ← runCycleTimed passes cs bs facts acc
+  let t1 ← IO.monoMsNow
+  let st := statsOf cs'
+  IO.println s!"  cycle {iter}: {st.vars} vars, {st.busInteractions} bus, \
+    {st.constraints} constraints ({t1 - t0} ms)"
   if cs'.sizeKey < cs.sizeKey then
     profileLoop passes cs' bs facts acc' (iter + 1)
   else

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -162,23 +162,28 @@ substrate), not setup cost.
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
 index gate**  ·  *high value at eth/mid-keccak scale*. Partially **done (entry 105)**:
-   - ~~reencode's 8192 gate~~ **done**: always-indexed via `CoveredIndex.buildPruned` — items
-     with more than 8 distinct variables can never be covered by a ≤8-variable target, so pruning
-     them keeps the covered sets identical *and* keeps hot-variable buckets small (the reason the
-     gate existed). Proof-free: reencode's covered set was already untrusted (`checkReencode` is
-     the authority).
+   - reencode: the pruned index (`CoveredIndex.buildPruned`, entry 105 — items with more than 8
+     distinct variables can never be covered by a ≤8-variable target, so pruning keeps covered
+     sets identical) stays, but **behind the 8192 gate again** (entry 107): CI measured
+     always-indexed at 1.19× on the dense openvm-eth blocks with no keccak gain — the entry-73a
+     direct-path trade-off is real. Do not retire the gate without a same-runner A/B on eth.
    - ~~domainFold's direct-path double `coveredBy` sweep~~ **done**: one `partition` per target
      feeds both the covered set and the no-op gate (`systemHasFoldableW`).
    - ~~both passes' doubled `c.vars.dedup` setup~~ **done** (`hashedDedup`, computed once).
-   - **Still open — the domainFold indexed path** (keccak cycles 0-2, C ≥ 8192): its covered set
-     is proof-bearing (`coveredCsIdx_eq` demands the exact build tie), so the pruned index and
-     stale-bucket refresh don't directly apply. The right fix: generalize `foldOut_correct` to
-     any `es ⊆` the covered set (soundness only needs survivor *supersets* — fewer constraints →
-     more survivors → `constOnSurvs` more conservative), making the gather fully untrusted; then
-     prune + stale-refresh apply and the per-accept `CoveredIndex.build` rebuild (O(S) × #accepts)
-     disappears. Note `systemHasFoldableIdx` may only *over*-approximate, never under — a pruned
-     gate misses wide items with foldable sub-nodes inside `xs`, so the gate needs the unpruned
-     buckets (or no gate: always `foldOut`, content-identical when nothing folds).
+   - **Still open — domainFold's per-accept rebuild** (instrumented on keccak: 830 doms-bearing
+     targets, **482 accepts**, each paying `foldOut` + a constraint-index rebuild; entry 107
+     already removed the two per-accept const-foldable refilters and made all builds insert per
+     distinct variable). The remaining rebuild exists because `foldOut` *reorders* constraints
+     (rewritten-uncovered ++ covered-verbatim), invalidating bucket positions. Candidate fixes,
+     hardest-but-best first: (a) position-remap refresh — the reorder is a computable stable
+     partition, so buckets can be remapped in O(entries) integer work without re-hashing (needs
+     the completeness proof restated over the remap); (b) generalize `foldOut_correct` to any
+     covered *subset* (soundness only needs survivor supersets), making the gather untrusted —
+     but `systemHasFoldableIdx` must never under-approximate (a false negative skips a real fold
+     and changes output; a false positive triggers a no-op `foldOut` which *also* changes output
+     via the reorder), so the gate needs exact, current buckets either way; (c) make `foldOut`
+     order-preserving — simplest and fixes everything, but changes output order, so it needs a
+     full effectiveness re-validation rather than byte-identity.
    - **Still open — reencode's `checkReencode`** re-runs the covered scan after `buildReencode`
      (`Reencode.lean:852/858`); rarely reached (post-gates), so low value now.
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -137,10 +137,10 @@ proof-free*. Confirmed quadratics, in rough per-case cost order:
      left-fold reformulation `ok' = (pr m ∨ ok) ∧ ref m` is exact but pairwise in `S`).
    - `busPairCancel`: `shieldOk` re-scans (and `liveArr` **materializes**) the whole before-region
      per candidate send (`BusPairCancel.lean:1861/2428`) — O(B²) time *and* allocation on the long
-     same-address chains the pass exists for. Same file: `dropWits` scans the whole array from
-     position 0 per queried variable (`:2146`) — give it the `buildFormIdx` treatment; in coda
-     mode the `addrHash` bucket is O(B) per hot address (`:1255`) — add a position cursor.
-     **Still open.**
+     same-address chains the pass exists for; in coda mode the `addrHash` bucket is O(B) per hot
+     address (`:1255`) — add a position cursor. **Still open.** ~~`dropWits` from-0 array scan per
+     queried variable~~ **done (entry 105)**: per-variable position index (`buildBoundIdx`),
+     re-checked at use.
    - ~~`dedup` constraint-side `List.dedup` O(C²·E)~~ **done (entry 104)**: bucketed
      proven-identical twin (`HashedDedup.hashedDedup`), keccak 6.6 s → noise.
    - ~~`intervalForce` seed filters / `eraseDups` / per-slot pattern re-maps~~ **done (entry
@@ -161,18 +161,26 @@ enumeration core itself (SP1 apc_030's 19 s single-cycle spike) is untouched: th
 substrate), not setup cost.
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
-index gate**  ·  *high value at eth/mid-keccak scale*. Both passes have a proven-equal inverted
-index (`coveredCsIdx_eq`) that is **disabled below 8192 constraints**
-(`DomainFold.lean:658/682`, `Reencode.lean:1498/1621`) — so every eth case and keccak cycles 3+
-run the direct O(targets × system) path (reencode is apc_100's single most expensive pass). The
-gate exists because dense small systems lose on bucket gathering; replace raw count with a
-sharing-density criterion, or make the index path cheap enough to win everywhere. Independent of
-the gate: domainFold evaluates `coveredBy` twice per (target × constraint)
-(`coveredCsOf` + `systemHasFoldable`, `DomainFold.lean:651/443`) — thread the covered set through;
-reencode's `checkReencode` re-runs the *third* full covered scan after `buildReencode`'s
-(`Reencode.lean:852/858`) — thread `es` + `doms` through (small `hes ▸` plumbing, transport core
-untouched); and both passes recompute `c.vars.dedup` twice per constraint in setup
-(`DomainFold.lean:674/678`, `Reencode.lean:1613/1617`).
+index gate**  ·  *high value at eth/mid-keccak scale*. Partially **done (entry 105)**:
+   - ~~reencode's 8192 gate~~ **done**: always-indexed via `CoveredIndex.buildPruned` — items
+     with more than 8 distinct variables can never be covered by a ≤8-variable target, so pruning
+     them keeps the covered sets identical *and* keeps hot-variable buckets small (the reason the
+     gate existed). Proof-free: reencode's covered set was already untrusted (`checkReencode` is
+     the authority).
+   - ~~domainFold's direct-path double `coveredBy` sweep~~ **done**: one `partition` per target
+     feeds both the covered set and the no-op gate (`systemHasFoldableW`).
+   - ~~both passes' doubled `c.vars.dedup` setup~~ **done** (`hashedDedup`, computed once).
+   - **Still open — the domainFold indexed path** (keccak cycles 0-2, C ≥ 8192): its covered set
+     is proof-bearing (`coveredCsIdx_eq` demands the exact build tie), so the pruned index and
+     stale-bucket refresh don't directly apply. The right fix: generalize `foldOut_correct` to
+     any `es ⊆` the covered set (soundness only needs survivor *supersets* — fewer constraints →
+     more survivors → `constOnSurvs` more conservative), making the gather fully untrusted; then
+     prune + stale-refresh apply and the per-accept `CoveredIndex.build` rebuild (O(S) × #accepts)
+     disappears. Note `systemHasFoldableIdx` may only *over*-approximate, never under — a pruned
+     gate misses wide items with foldable sub-nodes inside `xs`, so the gate needs the unpruned
+     buckets (or no gate: always `foldOut`, content-identical when nothing folds).
+   - **Still open — reencode's `checkReencode`** re-runs the covered scan after `buildReencode`
+     (`Reencode.lean:852/858`); rarely reached (post-gates), so low value now.
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
    - **Variable interning-lite, `Implementation/`-only**: the parser mints a fresh `String` per

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -130,41 +130,35 @@ proof-free*. Confirmed quadratics, in rough per-case cost order:
      re-scans the mid region `findConsumer` just stepped over (`BusUnify.lean:217/146`); each
      step can hit `addrNonzeroNeq` = O(2^A·C) (`AddrDiseq.lean:519`). Fix: `(busId, addrHash)`
      position buckets (port `recvIndexAll`), and thunk the eager `TwoRootMap`/`NonzeroWits`
-     builds (`BusUnify.lean:309-311`) so no-op invocations skip them.
+     builds (`BusUnify.lean:309-311`) so no-op invocations skip them. **Still open.** Note the
+     scan semantics are load-bearing: every stepped-over message must be *excluded*, so an
+     address-bucketed jump cannot skip the blocker checks — the win is bounding the scan via
+     per-position precomputed address forms, or a per-address-key incremental fold (complex; the
+     left-fold reformulation `ok' = (pr m ∨ ok) ∧ ref m` is exact but pairwise in `S`).
    - `busPairCancel`: `shieldOk` re-scans (and `liveArr` **materializes**) the whole before-region
      per candidate send (`BusPairCancel.lean:1861/2428`) — O(B²) time *and* allocation on the long
-     same-address chains the pass exists for. A per-sweep suffix table of `shieldScan` results (or
-     a left-to-right open-sends accumulator) makes it O(B); the Bool is identical so
-     `checkCancel_sound` keeps its hypothesis. Same file: `dropWits` scans the whole array from
+     same-address chains the pass exists for. Same file: `dropWits` scans the whole array from
      position 0 per queried variable (`:2146`) — give it the `buildFormIdx` treatment; in coda
      mode the `addrHash` bucket is O(B) per hot address (`:1255`) — add a position cursor.
-   - `dedup`: the constraint side is still `List.dedup` = O(C²·E) structural comparisons
-     (`Dedup.lean:241`) — 28k constraints in keccak cycle 0, ~230k for SHA. Bucket by the
-     existing `Expression.bHash` exactly as `dedupStatelessFast` already does for interactions;
-     the `dedupStatelessFast_eq` proof pattern transfers.
-   - `intervalForce`: per-seed `cs.vars.contains` over the *non-deduped occurrence list* and
-     per-seed `algebraicConstraints.contains` (`IntervalForce.lean:618-619`), `eraseDups` =
-     O(seeds²·E) (`:585`), the O(t²) `walk` with `seen ++ rest` re-summing (`:245`), and O(P²)
-     payload `List` indexing (`:531`). Fix: one `HashSet` of vars + one hash-bucketed constraint
-     set per invocation, running window sums, arrays.
-   - `rootPairUnify`: `twoRootOf?` re-linearizes both factors per candidate var and again per
-     checked pair (`RootPairUnify.lean:74/427`), and `anyVarBound` re-scans all interactions per
-     pair with no memo (`:397`). Linearize once per constraint, carry the decomposition in
-     `RPSeen`, memoize `anyVarBound` per variable.
-   - `flagFold`: `c.vars.eraseDups` (O(E_c²)) recomputed 3-4× per constraint across
-     `singleVarCs`/`btPre`/`btCert` (`FlagFold.lean:25/43/32`); compute once, via HashSet.
+     **Still open.**
+   - ~~`dedup` constraint-side `List.dedup` O(C²·E)~~ **done (entry 104)**: bucketed
+     proven-identical twin (`HashedDedup.hashedDedup`), keccak 6.6 s → noise.
+   - ~~`intervalForce` seed filters / `eraseDups` / per-slot pattern re-maps~~ **done (entry
+     104)**: keccak 20.7 s → 1.1 s. (`walk`'s O(t²) with `maxTerms = 32` cap remains — bounded,
+     low value.)
+   - ~~`rootPairUnify` re-linearization per candidate var~~ **done (entry 104)** — factors
+     linearized once per constraint. `anyVarBound` memoization across pairs still open (only
+     matters if key-matched pairs are common; measure first).
+   - ~~`flagFold` triple `eraseDups` in `btPre`~~ **done (entry 104)**. `singleVarCs`/`btCert`
+     still recompute per-constraint `eraseDups`, but only on gate-passing constraints (proofs
+     unfold them — rework only if they show up in profiles).
 
-**R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  *high value on SP1 + keccak,
-proof-free*. Four measured hot spots (`DomainBatch.lean`): (a) the covered-set gather runs
-**three times per target** (`forcedOver:1259-1262`) and `es ⊆ esFull` makes the third gather pure
-duplication — gather once, filter by a redundancy flag; hot-variable buckets (selector/is_real
-vars with O(C) buckets) are re-gathered and mostly Q-rejected per target — cap or skip oversized
-buckets (index incompleteness only costs effectiveness of *this* probe, and only via `seen`-dedup
-order). (b) `c.vars.dedup` = O(occ²) recomputed 3× per item (`:347/1352/901`) — compute each
-item's deduped var set once per invocation. (c) `constraintRedundant` full-box scans (`:899`).
-(d) `interactionBound` re-maps `constValue?` over the whole payload per raw slot (O(P²) per
-interaction, `DomainProp.lean:318`) — cache the constant-pattern per interaction. Also applies to
-`biInformative` (`:887`).
+**R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  **done (entry 104)** except:
+(c) `constraintRedundant` full-box scans (`:899`) remain (they pay once to save per-target work);
+hot-variable bucket capping remains open (not byte-identical — the gates read `esFull`). The
+enumeration core itself (SP1 apc_030's 19 s single-cycle spike) is untouched: that lever is
+**cross-cycle memoization of enumeration negatives** (needs pass-state threading — R6's
+substrate), not setup cost.
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
 index gate**  ·  *high value at eth/mid-keccak scale*. Both passes have a proven-equal inverted
@@ -187,9 +181,9 @@ untouched); and both passes recompute `c.vars.dedup` twice per constraint in set
      every hit-comparison O(1). Swap the `Hashable Variable` instance
      (`Implementation/Variable.lean:19`, unaudited) to hash `powdrId?` first — O(1) vs O(name
      length) on almost every key. `Spec.lean`'s `Variable` stays untouched.
-   - `identitySubst`: the substitution closure linear-scans the pair list per variable occurrence
-     (`IdentitySubst.lean:154`) — 2.7 s on apc_030. HashMap it; optionally resolve
-     operand→operand chains up front to drop the `iterateToFixpoint` wrapper.
+   - `identitySubst`: ~~HashMap the pair lookup~~ done (entry 104), but apc_030 still shows
+     2.8 s — the cost is elsewhere in its fixpoint (probably the per-iteration `identityPairs`
+     re-decode + `substF` + double `sizeKey`); profile before more work.
    - `normalize`: `linearize` re-runs on the whole subtree at every node along non-affine paths
      (O(E·depth), `Normalize.lean:306`); fuse into one bottom-up pass returning per-node linear
      forms. Also feeds gauss's per-constraint reduce.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -189,9 +189,12 @@ index gate**  ·  *high value at eth/mid-keccak scale*. Partially **done (entry 
      every hit-comparison O(1). Swap the `Hashable Variable` instance
      (`Implementation/Variable.lean:19`, unaudited) to hash `powdrId?` first — O(1) vs O(name
      length) on almost every key. `Spec.lean`'s `Variable` stays untouched.
-   - `identitySubst`: ~~HashMap the pair lookup~~ done (entry 104), but apc_030 still shows
-     2.8 s — the cost is elsewhere in its fixpoint (probably the per-iteration `identityPairs`
-     re-decode + `substF` + double `sizeKey`); profile before more work.
+   - ~~`identitySubst`~~ **done (entry 106)**: the 2.8 s was an **arity-expansion bug** — a
+     `def … : X → Y := let heavy := …; fun y => …` re-evaluates `heavy` per call (the map was
+     rebuilt per queried occurrence). 2827 ms → 9 ms on apc_030. **Working rule: bind heavy
+     values in the fully-applied pass body and pass them as parameters** (the `FlagFold`
+     comment's pattern); when a pass's profile makes no sense relative to its work, suspect this
+     first and bisect with a skip-the-body experiment.
    - `normalize`: `linearize` re-runs on the whole subtree at every node along non-affine paths
      (O(E·depth), `Normalize.lean:306`); fuse into one bottom-up pass returning per-node linear
      forms. Also feeds gauss's per-constraint reduce.

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -218,16 +218,19 @@ pointer magic); `andThen` propagates; `iterateToFixpoint` skips both `sizeKey` r
 when the whole cycle is unchanged, and carries the previous cycle's `sizeKey` forward instead of
 recomputing `cs.sizeKey` (`FactPass.lean:77`, one redundant O(E) HashSet build per cycle today).
 
-**R6. Cross-cycle dirtiness (the real fix for no-op rescans)**  ·  *large refactor, do after
-R1-R5*. Even with all per-pass fixes, every cycle re-runs every pass over the whole system, and
-~61 % of invocations find nothing (#146's measurement; whole-system version gating catches 0 %
-because the fixpoint only retains changing cycles). The powdr-style fix is a worklist: stable
-item positions + tombstones + a variable→positions occurrence index, passes consume/produce
-dirty-sets, substitutions dirty only the items mentioning the substituted variables. PR #146
-(`IndexedState`, stacked on #145 `FactStore`) built the substrate but nothing consumes it; PR
-#145's lesson stands — input-dependent caches without incremental maintenance don't pay. If R1-R5
-land and large cases are still cycle-bound, this is the next mountain; budget for reworking
-`Basic.lean`/`FactPass.lean` pass signatures (allowed: it is implementation, not audited surface).
+**R6. Cross-cycle dirtiness (the real fix for no-op rescans)**  ·  *large refactor; the cheap
+slice is now a measured dead end*. **Do not build a cross-cycle negative-memo for domainBatch**:
+per-target fingerprints (target vars + domain descriptors + covered es/bis content hashes) were
+measured across invocations — keccak repeats only **62 of 16,748** enumerations with unchanged
+inputs (0.4 %), apc_030 257 of 1,641 (16 %, and its expensive cycle-5 enumeration is first-time)
+— gauss's per-cycle substitutions rewrite the covered sets, so the fingerprints churn. Any
+cross-cycle scheme must therefore be *finer* than whole-target skipping (powdr-style dirty
+worklists where a substitution dirties only the items mentioning substituted variables — the full
+#146 architecture), and its payoff must be re-estimated per pass first: at target granularity the
+~61 % invocation-level no-op measurement does **not** translate into reusable work. domainBatch's
+remaining cost is *productive first-time enumeration*; the levers there are effectiveness-side
+(replace enumeration classes with algebra, cf. the quadratic-roots effectiveness idea 1) or
+intra-enumeration (survivor-scan compilation is already tuned).
 
 **R7. Intra-pass parallelism**  ·  *wall-clock lever, orthogonal*. The per-target enumeration in
 domainBatch/reencode/domainFold is embarrassingly parallel and pure; `Task.spawn`/`Task.get` with

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -92,21 +92,157 @@ global rebuild — collect every surviving range obligation, drop solver-implied
 exact-cover — is bus-only and variable-neutral. Caution: 2–7-bit checks must not be packed as
 bytes (weakens them).
 
-## Runtime notes
+## Runtime
 
-- CI's effectiveness-matrix runtime row is parallel-contended and rough (±10% swings between
-  identical-code runs are common in the history); the serial `Runtime Bench` workflow is the real
-  measure. Entry 101–103 local serial A/B on the four heaviest rsp cases was flat-to-better
-  (apc_030 22.6 → 21.9 s; busPairCancel itself got faster — fewer surviving pairs to rescan).
-- `domainBatch` dominates heavy SP1 cases (16 of apc_030's 22 s). The still-open leftovers from
-  the entry-90 audit that matter at SP1 scale: cross-cycle memoization of enumeration negatives
-  (needs a `Basic.lean` glue change — weigh against the audit-surface rule), gauss's O(V²)
-  resolved-map maintenance, busUnify/busPairCancel positional O(B²) scans. Variable interning in
-  the parser (names are fresh strings per occurrence; ~10–15 % of big-case time) remains the best
-  cross-cutting constant-factor lever, `Implementation/`-only.
-- Never feed a whole-region lookup into a per-query justification arm (the entry-102 lesson:
-  63 s/case). Untrusted, re-checked position indexes (`buildFormIdx`, `recvIndexAll`) are the
-  pattern — they cost time on a bad entry, never soundness.
+Rewritten 2026-07-18 from a fresh profiling session (per-pass `profile`, per-cycle timing, gdb
+stack sampling, and a size-scaling sweep — all on this container, serial). **Runtime is
+end-to-end quadratic in circuit size** (openvm-eth sweep: input 2.3k → 8.8k items costs
+1.8 s → 24.6 s, exponent ≈ 1.95), and the largest inputs are exactly where it hurts: openvm
+keccak (28.6k constraints / 13.3k interactions / 27.5k vars) takes **252 s**; openvm SHA is ~8×
+keccak, so anything superlinear is fatal there.
+
+### Where the time goes (measured)
+
+- keccak per-pass (254 s profile): domainFold 48 s, domainBatch 48 s, reencode 42 s,
+  busPairCancel 26 s, intervalForce 21 s, flagFold 16 s, busUnify 12.5 s, rootPairUnify 9.4 s,
+  dedup 6.6 s, bytePack 5.5 s, gauss 4.5 s — no single villain; the cost is systemic.
+- keccak per-cycle (10 cycles): **cycles 0–2 are ~80 % of the total** (system still 28k→9.7k
+  constraints there); the tail cycles 6–9 are ~1 % each. Fixing the big-system per-pass
+  quadratics matters more than fixing the fixpoint tail.
+- eth apc_100 (5.7k constraints, 24.6 s, 8 cycles): reencode 6.2 s is the top pass (unindexed —
+  see idea R3); the last three cycles cost 20 % to remove 24 vars + 5 bus; the final (no-change)
+  cycle burns 1.7 s.
+- SP1 apc_030 (26.8 s): domainBatch 19 s, **all in one cycle** (the enumeration unlocks late);
+  identitySubst 2.7 s.
+- gdb samples (keccak, mid-run): `findConsumer` (busUnify), `reencodeLoop`, `foldLoopDirect`
+  (domainFold's unindexed path), `collectForBus` — matching the analysis below.
+
+### Open runtime ideas, priority order
+
+Priority = impact at SHA scale (8× keccak) ÷ effort. The pattern for all index work stays the
+entry-90 discipline: *untrusted, re-checked-at-use* candidate indexes (`buildFormIdx`,
+`recvIndexAll`, `CoveredIndex`) — a wrong index entry costs time, never soundness, so most of
+these need no new proof.
+
+**R1. Kill the true O(N²) loops that dominate the big early cycles**  ·  *high value, mostly
+proof-free*. Confirmed quadratics, in rough per-case cost order:
+   - `busUnify.findConsumer` scans forward through the whole tail per send, and `checkPair`
+     re-scans the mid region `findConsumer` just stepped over (`BusUnify.lean:217/146`); each
+     step can hit `addrNonzeroNeq` = O(2^A·C) (`AddrDiseq.lean:519`). Fix: `(busId, addrHash)`
+     position buckets (port `recvIndexAll`), and thunk the eager `TwoRootMap`/`NonzeroWits`
+     builds (`BusUnify.lean:309-311`) so no-op invocations skip them.
+   - `busPairCancel`: `shieldOk` re-scans (and `liveArr` **materializes**) the whole before-region
+     per candidate send (`BusPairCancel.lean:1861/2428`) — O(B²) time *and* allocation on the long
+     same-address chains the pass exists for. A per-sweep suffix table of `shieldScan` results (or
+     a left-to-right open-sends accumulator) makes it O(B); the Bool is identical so
+     `checkCancel_sound` keeps its hypothesis. Same file: `dropWits` scans the whole array from
+     position 0 per queried variable (`:2146`) — give it the `buildFormIdx` treatment; in coda
+     mode the `addrHash` bucket is O(B) per hot address (`:1255`) — add a position cursor.
+   - `dedup`: the constraint side is still `List.dedup` = O(C²·E) structural comparisons
+     (`Dedup.lean:241`) — 28k constraints in keccak cycle 0, ~230k for SHA. Bucket by the
+     existing `Expression.bHash` exactly as `dedupStatelessFast` already does for interactions;
+     the `dedupStatelessFast_eq` proof pattern transfers.
+   - `intervalForce`: per-seed `cs.vars.contains` over the *non-deduped occurrence list* and
+     per-seed `algebraicConstraints.contains` (`IntervalForce.lean:618-619`), `eraseDups` =
+     O(seeds²·E) (`:585`), the O(t²) `walk` with `seen ++ rest` re-summing (`:245`), and O(P²)
+     payload `List` indexing (`:531`). Fix: one `HashSet` of vars + one hash-bucketed constraint
+     set per invocation, running window sums, arrays.
+   - `rootPairUnify`: `twoRootOf?` re-linearizes both factors per candidate var and again per
+     checked pair (`RootPairUnify.lean:74/427`), and `anyVarBound` re-scans all interactions per
+     pair with no memo (`:397`). Linearize once per constraint, carry the decomposition in
+     `RPSeen`, memoize `anyVarBound` per variable.
+   - `flagFold`: `c.vars.eraseDups` (O(E_c²)) recomputed 3-4× per constraint across
+     `singleVarCs`/`btPre`/`btCert` (`FlagFold.lean:25/43/32`); compute once, via HashSet.
+
+**R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  *high value on SP1 + keccak,
+proof-free*. Four measured hot spots (`DomainBatch.lean`): (a) the covered-set gather runs
+**three times per target** (`forcedOver:1259-1262`) and `es ⊆ esFull` makes the third gather pure
+duplication — gather once, filter by a redundancy flag; hot-variable buckets (selector/is_real
+vars with O(C) buckets) are re-gathered and mostly Q-rejected per target — cap or skip oversized
+buckets (index incompleteness only costs effectiveness of *this* probe, and only via `seen`-dedup
+order). (b) `c.vars.dedup` = O(occ²) recomputed 3× per item (`:347/1352/901`) — compute each
+item's deduped var set once per invocation. (c) `constraintRedundant` full-box scans (`:899`).
+(d) `interactionBound` re-maps `constValue?` over the whole payload per raw slot (O(P²) per
+interaction, `DomainProp.lean:318`) — cache the constant-pattern per interaction. Also applies to
+`biInformative` (`:887`).
+
+**R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
+index gate**  ·  *high value at eth/mid-keccak scale*. Both passes have a proven-equal inverted
+index (`coveredCsIdx_eq`) that is **disabled below 8192 constraints**
+(`DomainFold.lean:658/682`, `Reencode.lean:1498/1621`) — so every eth case and keccak cycles 3+
+run the direct O(targets × system) path (reencode is apc_100's single most expensive pass). The
+gate exists because dense small systems lose on bucket gathering; replace raw count with a
+sharing-density criterion, or make the index path cheap enough to win everywhere. Independent of
+the gate: domainFold evaluates `coveredBy` twice per (target × constraint)
+(`coveredCsOf` + `systemHasFoldable`, `DomainFold.lean:651/443`) — thread the covered set through;
+reencode's `checkReencode` re-runs the *third* full covered scan after `buildReencode`'s
+(`Reencode.lean:852/858`) — thread `es` + `doms` through (small `hes ▸` plumbing, transport core
+untouched); and both passes recompute `c.vars.dedup` twice per constraint in setup
+(`DomainFold.lean:674/678`, `Reencode.lean:1613/1617`).
+
+**R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
+   - **Variable interning-lite, `Implementation/`-only**: the parser mints a fresh `String` per
+     occurrence (`Variable.ofPowdrName`, `JsonParser.lean:101`); intern one shared object per
+     distinct name so the runtime's pointer fast-path (`lean_string_eq`: `s1 == s2 || …`) makes
+     every hit-comparison O(1). Swap the `Hashable Variable` instance
+     (`Implementation/Variable.lean:19`, unaudited) to hash `powdrId?` first — O(1) vs O(name
+     length) on almost every key. `Spec.lean`'s `Variable` stays untouched.
+   - `identitySubst`: the substitution closure linear-scans the pair list per variable occurrence
+     (`IdentitySubst.lean:154`) — 2.7 s on apc_030. HashMap it; optionally resolve
+     operand→operand chains up front to drop the `iterateToFixpoint` wrapper.
+   - `normalize`: `linearize` re-runs on the whole subtree at every node along non-affine paths
+     (O(E·depth), `Normalize.lean:306`); fuse into one bottom-up pass returning per-node linear
+     forms. Also feeds gauss's per-constraint reduce.
+   - `gauss`: skip `c.substF σ.fn |> normalize` for constraints mentioning no solved key, and skip
+     sweep 2 when sweep 1 adopted nothing (`Gauss.lean:592`). (PR #156 has a proven dirty-sweep
+     variant of this — check its status before redoing.)
+
+**R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
+*medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs
+`withinDegreeB` — a full AST walk — on every pass output, ~30×/cycle, ~245×/run
+(`FactPass.lean:98`), even though most invocations return `cs` itself (the #146 measurement: ~61 %
+of invocations are no-op full scans). Add an `unchanged : Option (out = cs ∧ derivs = [])` field
+(default `none`) to `PassResult`; no-op branches supply `some ⟨rfl, rfl⟩`; `guardDegree` returns
+`r` directly when set (out = cs is within-degree by the pipeline invariant — provable, not
+pointer magic); `andThen` propagates; `iterateToFixpoint` skips both `sizeKey` recomputations
+when the whole cycle is unchanged, and carries the previous cycle's `sizeKey` forward instead of
+recomputing `cs.sizeKey` (`FactPass.lean:77`, one redundant O(E) HashSet build per cycle today).
+
+**R6. Cross-cycle dirtiness (the real fix for no-op rescans)**  ·  *large refactor, do after
+R1-R5*. Even with all per-pass fixes, every cycle re-runs every pass over the whole system, and
+~61 % of invocations find nothing (#146's measurement; whole-system version gating catches 0 %
+because the fixpoint only retains changing cycles). The powdr-style fix is a worklist: stable
+item positions + tombstones + a variable→positions occurrence index, passes consume/produce
+dirty-sets, substitutions dirty only the items mentioning the substituted variables. PR #146
+(`IndexedState`, stacked on #145 `FactStore`) built the substrate but nothing consumes it; PR
+#145's lesson stands — input-dependent caches without incremental maintenance don't pay. If R1-R5
+land and large cases are still cycle-bound, this is the next mountain; budget for reworking
+`Basic.lean`/`FactPass.lean` pass signatures (allowed: it is implementation, not audited surface).
+
+**R7. Intra-pass parallelism**  ·  *wall-clock lever, orthogonal*. The per-target enumeration in
+domainBatch/reencode/domainFold is embarrassingly parallel and pure; `Task.spawn`/`Task.get` with
+ordered joins keeps the output deterministic. CI runners have 32 cores; the serial Runtime Bench
+would show the win directly. Worth it only after the algorithmic waste is gone (parallelizing a
+triple-redundant gather is throwing cores at garbage).
+
+### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **Whole-system content-hash gating of passes across cycles**: catches ~0 % — the fixpoint only
+  retains cycles that changed something, so some pass always dirties the hash (#146 measurement).
+  Only fine-grained dirtiness (R6) reaches the ~61 % no-op invocations.
+- **Unsafe pointer-identity freshness checks** (`@[implemented_by]` ptr-eq): rejected — breaks the
+  fully-machine-checked, three-axioms-only guarantee (#145 discussion). The safe variant is the
+  `unchanged` *proof* field of R5.
+- **Eager per-sweep variable→bound witness maps in busPairCancel**: ~30× the work of the
+  early-exit query-time scan on eth (entry 90). Query-time scans + per-variable *position*
+  indexes are the pattern.
+- **Feeding whole regions into per-query justification arms**: 63 s/case for −3 interactions
+  (entry 102). Use a position index or nothing.
+- CI notes: the effectiveness-matrix runtime row is parallel-contended (±10 % noise); the serial
+  `Runtime Bench` workflow (dispatch-only, openvm sets only) is the real A/B. This container has
+  ±15 % run-to-run variance; keccak numbers above were taken serially, and the per-cycle keccak
+  run was inflated ~30 % by a concurrent gdb sampler — compare shapes, not absolutes, and let CI
+  arbitrate.
 
 ## Measured dead ends (do not re-propose without new evidence)
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -3906,3 +3906,52 @@ eth spot checks identical (OpenVM declares no `orOp`, so both arms are structura
 the reorder is output-neutral on the checked cases). Cumulative today (entries 101–103): SP1
 vars 3.784× → 3.922×, bus 2.553× → 2.703× (var gap 442 → 55, bus gap 765 → 319). Proof integrity
 green; no `sorry`/`axiom`/`native_decide`. **Worked: yes.**
+
+### 104. Runtime: de-quadratify per-pass hot loops — bucketed dedups, hoisted patterns, single covered gather (output byte-identical)
+
+Pure **runtime** work following a fresh profiling session (measurements and the full prioritized
+plan are in the rewritten `docs/ideas.md` Runtime section): end-to-end scaling is quadratic
+(openvm-eth size sweep exponent ≈ 1.95), keccak (28.6k constraints / 13.3k interactions) takes
+252 s, and openvm SHA is ~8× keccak — the quadratic loops are what matters. This entry lands the
+proof-cheap slice of R1/R2/R4; every change is output-preserving and verified byte-identical.
+
+**New shared module `HashedDedup.lean`**: hash-bucketed twins of `List.eraseDups` (keep-first)
+and `List.dedup` (keep-last), each **proven to return the identical list**
+(`hashedEraseDups_eq` / `hashedDedup_eq`, generic over `LawfulBEq`/`DecidableEq` with any
+`α → UInt64` hash) — so callers rewrite along the equality and keep their proofs and their exact
+output. The O(n²) whole-tail membership tests become one-bucket scans.
+
+- **dedup**: the constraint side was still plain `List.dedup` = O(C²·E) deep comparisons —
+  the single clearest quadratic at SHA scale (230k constraints). Now `hashedDedup
+  Expression.bHash`. keccak: 6.6 s → below the profiler's noise floor.
+- **intervalForce** (keccak **20.7 s → 1.1 s**, apc_030 231 → 99 ms): `allSeeds`'s O(seeds²·E)
+  `eraseDups` → `hashedEraseDups`; the per-seed `cs.vars.contains` scan over the ~10⁵-entry
+  occurrence list → one `Std.HashSet` (`contains_ofList` transports the load-bearing "no new
+  variable" check); the per-seed `algebraicConstraints.contains` deep scan → one `bHash`-bucket
+  map; the per-slot recomputation of the constant-payload pattern → hoisted per interaction
+  (`interactionSeedsGo`).
+- **domainBatch**: each item's deduped variable list is computed **once** and shared between the
+  domain-table build, the redundancy filter, and the target list (was 3 × O(occ²) per item);
+  `forcedOver`'s three per-target covered gathers become **one** (`CoveredIndex.gatherBoth`
+  returns the covered set and its non-redundant subset off per-position flags — the third index
+  build is gone too); `interactionBound`'s per-variable payload re-fold is hoisted per
+  interaction (`interactionBoundPat`/`interactionDomainFPat`, definitional `rfl` equalities, also
+  applied to `biInformative`).
+- **identitySubst**: the substitution closure linear-scanned the pair list per variable
+  occurrence; now a first-wins `Std.HashMap` (`firstWins_mem` keeps the membership proof).
+- **flagFold** (`btPre`): the distinct-variable list is computed once per constraint (was 3
+  `eraseDups` scans); `btPre` is a proof-opaque prefilter, so nothing else moves.
+- **rootPairUnify** (`rpCandidates`): the two factors are linearized **once per constraint**
+  instead of once per candidate variable (`twoRootOf?` re-walked both trees per variable).
+
+**Verification**: output **byte-identical** on an 11-case set (openvm keccak, 4 eth, 2 wasm-eth,
+3 sp1-rsp incl. the k256-heavy apc_024/030, sp1 keccak) via `opt-export` diff. `lake build`
+warning-free; proof integrity green ({propext, Classical.choice, Quot.sound}).
+
+**Measured** (this container, ±15 % run-to-run): keccak `profile` 254 → 258 s *total* — the two
+clean wins above (−26 s) are offset by same-code swings in domainFold/reencode/domainBatch
+(+18 % on unchanged code between two same-binary runs), so the serial Runtime Bench CI A/B is
+the authoritative number. apc_030 26.9 s: the remaining cost is the cycle-5 domainBatch
+enumeration itself (19 s, productive — cross-cycle memoization is the lever, ideas R6) and
+identitySubst's fixpoint (2.8 s, cause not yet attributed). **Worked: yes (asymptotics), CI
+pending (wall time).**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4016,3 +4016,31 @@ them as parameters. Audited the other `Variable → Option (Expression p)` closu
 `ptFun`, `groupSubst`) — none carries a heavy `let`.
 
 Build warning-free; proof integrity green; byte-identical exports. **Worked: yes.**
+
+### 107. Runtime: cheaper domainFold accepts, deduped index builds, reencode gate restored (output byte-identical)
+
+Instrumented counts on keccak reframed domainFold's cost: its per-step work is tiny (830 doms-
+bearing targets, es ≤ 10, boxes ≤ 243, cycles 1-4 find nothing) but **482 accepted folds** each
+paid `FoldIdx.refresh` — a full constraint-index rebuild plus two more full-system const-foldable
+filters — and `foldOut`. Changes, all verified byte-identical (11-case export set):
+
+- **`FoldIdx.refresh`**: the const-foldable lists are recomputed only when the old ones are
+  nonempty. A fold never *creates* a var-free compound node (`foldRewrite` replaces the maximal
+  constant node wholesale), so fresh ⊆ old; old-empty (the normal, post-constant-fold state)
+  forces fresh-empty and the two O(S) filters per accept are skipped with the gate value
+  bit-for-bit unchanged.
+- **Index builds insert per *distinct* variable** (`dedupVarsOf` via `hashedEraseDups`): the raw
+  `vars` lists carry one entry per occurrence, so buckets were multiplicity-bloated — inserts,
+  bucket scans, and the per-target gather HashSets all paid per occurrence. Same buckets as sets,
+  gathers dedup positions anyway → byte-identical; `coveredCsIdx_eq`'s completeness hypothesis
+  transports through `mem_eraseDups`. Applied to `FoldIdx.mk'`/`refresh` and domainBatch's
+  `ForcedIdx`.
+- **reencode's size gate is back** (CI showed always-indexed at 1.19× on the dense openvm-eth
+  blocks with no keccak gain — the entry-73a trade-off is real); the ≥8192 side keeps the pruned
+  build from entry 105.
+
+CI verdicts for entries 104-105 (same-runner serial A/B): **keccak 130.4 → 105.0 s (0.81×)** —
+busPairCancel 0.32×, intervalForce 0.04×, dedup 0.06×; openvm-eth total 0.95× (batch 1).
+Remaining keccak: domainFold 30.8 s / reencode 29.9 s / domainBatch 21.9 s — the per-accept
+`foldOut` + rebuild and the enumeration core; next levers recorded in ideas (R6 cross-cycle
+negatives, position-remap refresh). **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3987,3 +3987,32 @@ domainFold fusion + setup dedups; batch5: + pruned-index reencode). Build warnin
 integrity green. The remaining structural item is the domainFold *indexed* path (keccak cycles
 0-2): generalize `foldOut_correct` to untrusted covered subsets so the pruned index and
 stale-bucket refresh apply there too — recorded in `docs/ideas.md` R3. **Worked: pending CI.**
+
+### 106. Runtime: parse-time variable interning + the identitySubst arity-expansion bug (2827 ms → 9 ms)
+
+Third runtime batch. Two changes, both output byte-identical (11-case export set):
+
+- **Variable interning (`JsonParser.lean`)**: the parser minted a fresh `String` per variable
+  *occurrence* (~10⁵ heap-distinct copies of a few thousand names). `internSystem` rebuilds the
+  parsed system with one shared `Variable` object per distinct value — the same *value*, so
+  nothing downstream can observe it except time: the Lean runtime's string equality
+  (`lean_string_eq`) starts with a pointer test, so every equal-name comparison across the whole
+  optimizer (hash-map probes, dedups, substitution lookups) now short-circuits.
+- **identitySubst was rebuilding its map per variable occurrence.** Profiling showed the pass at
+  2.8 s on apc_030 with… 4 pairs and 607 interactions, and bisection pinned all of it on the one
+  `substF`. Cause: `identityF`'s shape `def identityF facts cs : Variable → Option _ :=
+  let m := …; fun y => …` — the compiler arity-expands the def, so the `let` (pair extraction +
+  map build over every interaction) re-ran **per queried occurrence**. (The pre-104 pair-list
+  version had the same bug; entry 104's HashMap swap kept the shape, so it didn't help.) The fix
+  is the parameter-passing pattern `FlagFold` already documents: `identityFm` takes the prebuilt
+  map as an argument, bound by a `let` in the fully-applied pass body. apc_030's identitySubst:
+  **2827 ms → 9 ms** (case total 26.8 → 24.6 s). Bonus: `resolveGo` path-compresses
+  operand→operand chains (fuel-bounded, cycles stop harmlessly and the fixpoint wrapper discards
+  the no-op exactly as before), so chains collapse in one `substF`.
+
+**Working rule (added to ideas):** a `def … : X → Y := let heavy := …; fun y => …` re-evaluates
+`heavy` per call by arity expansion — bind heavy values in the fully-applied pass body and pass
+them as parameters. Audited the other `Variable → Option (Expression p)` closures (`Solved.fn`,
+`ptFun`, `groupSubst`) — none carries a heavy `let`.
+
+Build warning-free; proof integrity green; byte-identical exports. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -3955,3 +3955,35 @@ the authoritative number. apc_030 26.9 s: the remaining cost is the cycle-5 doma
 enumeration itself (19 s, productive — cross-cycle memoization is the lever, ideas R6) and
 identitySubst's fixpoint (2.8 s, cause not yet attributed). **Worked: yes (asymptotics), CI
 pending (wall time).**
+
+### 105. Runtime: busPairCancel witness index, domainFold scan fusion, reencode always-indexed via pruning (output byte-identical)
+
+Second runtime batch (plan R1/R3 in `docs/ideas.md`; entry 104 was the first). CI's serial
+Runtime Bench for entry 104 landed at **0.95× total on openvm-eth** (intervalForce 0.26×, dedup
+0.32×, rootPairUnify 0.80×) with the effectiveness matrix at **+0.000× and per-case sizes
+identical on all five benchmark sets** — the byte-identity discipline holds at corpus scale.
+This batch, same discipline:
+
+- **busPairCancel `dropWits`**: the byte-justification witness lookup scanned the whole stable
+  array from position 0 per queried variable (O(B) per query, O(B²·P) across a drop chain). New
+  per-variable position index `buildBoundIdx` (built once per invocation, multiplicity/pattern
+  hoisted via `interactionBoundPat`); `dropWitsIdxGo` walks the variable's ascending candidate
+  positions re-checking liveness, the dropped pair, and the bound at use — the exact interaction
+  the full scan found first, at bucket cost, untrusted-index discipline (`dropWitsIdxGo_mem`
+  mirrors the old membership lemma).
+- **domainFold direct path**: one `List.partition` per target now feeds both the covered set and
+  the no-op gate (`systemHasFoldableW` takes the precomputed complement), where `coveredBy` was
+  evaluated twice per (target × constraint); setup computes each constraint's deduped variable
+  list once (`hashedDedup`) for the single-variable set and the target list.
+- **reencode**: the 8192-constraint index gate is retired — the pass is **always indexed**
+  through the new `CoveredIndex.buildPruned`: items with more than 8 distinct variables are left
+  out of the buckets, which keeps the covered sets *identical* (a ≤8-variable target can never
+  cover them) while shrinking exactly the hot-variable buckets that made the index lose on dense
+  small systems (the gate's raison d'être). Proof-free: reencode's covered set was already
+  untrusted (`checkReencode` re-derives everything). Setup dedup shared as in domainFold.
+
+**Verification**: output byte-identical on the 11-case export set (batch4: dropWits index +
+domainFold fusion + setup dedups; batch5: + pruned-index reencode). Build warning-free; proof
+integrity green. The remaining structural item is the domainFold *indexed* path (keccak cycles
+0-2): generalize `foldOut_correct` to untrusted covered subsets so the pruned index and
+stale-bucket refresh apply there too — recorded in `docs/ideas.md` R3. **Worked: pending CI.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4044,3 +4044,20 @@ busPairCancel 0.32×, intervalForce 0.04×, dedup 0.06×; openvm-eth total 0.95�
 Remaining keccak: domainFold 30.8 s / reencode 29.9 s / domainBatch 21.9 s — the per-accept
 `foldOut` + rebuild and the enumeration core; next levers recorded in ideas (R6 cross-cycle
 negatives, position-remap refresh). **Worked: yes.**
+
+### 108. Runtime: cross-cycle negative-memo for domainBatch measured — dead end (no code change)
+
+Before building the R6 pass-state substrate (thread a scratch state through the cleanup fixpoint,
+memoize per-target enumeration fingerprints so a target that forced nothing is skipped next
+cycle), the hit rate was measured directly: per-enumeration signatures (target-variable hash +
+box size + covered constraint/interaction content hashes) traced across all invocations.
+**keccak: 16,748 enumerations, 62 repeats with unchanged inputs (0.4 %). apc_030: 1,641 / 257
+(16 %), with the dominant cycle-5 enumeration all first-time.** Gauss's per-cycle batch
+substitution rewrites the covered items, so the fingerprints churn every cycle — whole-target
+cross-cycle memoization has nothing to reuse, on exactly the cases that matter. Recorded as a
+measured dead end in `docs/ideas.md` R6 (any cross-cycle scheme must be finer-grained than
+target skipping, and per-pass payoff must be measured first — the invocation-level "61 % no-op"
+figure does not translate to target-level reuse). domainBatch's remaining cost is productive
+first-time enumeration; its levers are effectiveness-side (quadratic-root algebra replacing
+enumeration classes). Instrumentation reverted; no behavioral change. **Worked: n/a
+(measurement; saved the refactor).**


### PR DESCRIPTION
## Goal

Make the optimizer's runtime scale acceptably on large cases. Fresh measurements (recorded in the rewritten `docs/ideas.md` runtime section) show end-to-end **quadratic scaling** (openvm-eth sweep exponent ≈ 1.95; keccak = 252 s at 28.6k constraints / 13.3k interactions), and openvm SHA is ~8× keccak — so the quadratic per-pass loops are the target, in priority order R1–R7 of the ideas file.

## Status

Every commit is output-preserving — CI's effectiveness matrix reports **+0.000× with per-case circuit sizes identical on all five benchmark sets**; each batch is additionally verified byte-identical locally on an 11-case `opt-export` set before pushing.

- [x] Fresh profiling session + rewritten runtime ideas (`docs/ideas.md`); per-cycle profiler output
- [x] **Batch 1** — `f296b90` (log 104): hash-bucketed proven-identical `eraseDups`/`dedup` twins (`HashedDedup`); dedup pass constraint side O(C²·E)→O(C·E); intervalForce seed pipeline; domainBatch dedup-once + single covered-gather + pattern hoisting; flagFold `btPre`; rootPairUnify linearize-once. **CI serial: eth 0.95×; intervalForce 0.24×, dedup 0.33×.**
- [x] **Batch 2** — `4b8adf1` (log 105): busPairCancel `dropWits` per-variable position index; domainFold direct-path partition fusion; reencode pruned index. **CI serial: keccak 130.4 → 105.0 s (0.81×)** — busPairCancel 0.32×, intervalForce 0.04×, dedup 0.06×; but reencode 1.19× on eth (fixed in batch 4).
- [x] **Batch 3** — `d1fe35d` (log 106): parse-time variable interning; identitySubst **arity-expansion fix** (the substitution closure rebuilt its map per variable occurrence): **2827 ms → 9 ms** on apc_030.
- [x] **Batch 4** — `c5ad885` + `82fdd7f` (log 107): keccak's domainFold cost is **482 accepted folds × (index rebuild + 2 full-system const-foldable refilters)**; the cf refilters are now skipped when provably empty, all `CoveredIndex` builds insert per *distinct* variable instead of per occurrence, and reencode's 8192 size gate is restored (always-indexed lost 19% on dense eth blocks; the indexed side keeps the pruned build). **CI in flight (two Runtime Bench runs dispatched).**
- [x] **Measurement** — `6059acd` (log 108): the planned R6 cross-cycle negative-memo for domainBatch is a **measured dead end** — keccak repeats only 62 of 16,748 enumerations with unchanged inputs (0.4%); gauss's per-cycle substitutions churn the fingerprints. Recorded in ideas so the substrate isn't built for this purpose.

## Planned next (from `docs/ideas.md`, priority order)

- [ ] **R3 leftover**: domainFold per-accept index rebuild — position-remap refresh (the fold's reorder is a computable stable partition), or `foldOut_correct` generalized to untrusted covered subsets, or order-preserving `foldOut` (needs effectiveness re-validation, not byte-identity)
- [ ] **R1 leftovers**: busUnify `findConsumer` O(B²) scan (scan semantics load-bearing); busPairCancel `shieldOk` prefix rescans + coda `addrHash` bucket cursor
- [ ] **R5**: framework `unchanged` tracking (skip per-pass degree walks / sizeKey recomputation)
- [ ] domainBatch's remaining cost is productive first-time enumeration — the lever is effectiveness-side (quadratic-root algebra replacing enumeration classes, ideas effectiveness idea 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lfh26eTbP8zAV6EiVrNFRH