### PR TITLE
Runtime: keccak 0.49× on the serial bench (93 s → 46 s) — index-preserving domainFold, busUnify sweep, reencode degree pre-gate, parallel domainBatch

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -293,6 +293,7 @@ theorem ConstraintSystem.boxRewrite_correct [Fact p.Prime]
     have hmem := List.mem_of_mem_filter hc
     have hs : c.vars.eraseDups.length ≤ 1 := by
       have h1 := (List.mem_filter.1 hc).2
+      rw [HashedDedup.hashedEraseDups_eq] at h1
       have h2 : c.vars.eraseDups.length = 1 := by simpa using h1
       omega
     exact List.mem_map.2 ⟨c, hmem, brRw_singleVar _ _ c hs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -210,56 +210,219 @@ def SplitCand (p : ℕ) (L : List (BusInteraction (Expression p))) :=
       × List (BusInteraction (Expression p)) //
     L = c.1 ++ c.2.1 :: c.2.2.1 ++ c.2.2.2.1 :: c.2.2.2.2 }
 
-/-- Scan forward from a send `S` for its consumer: the first same-address receive, with every
-    message before it excludable (different address, or inactive). Returns `(mid, R, post)` on
-    success — together with the recomposition proof `revMid.reverse ++ rest = mid ++ R :: post`
-    — or `none` if a possibly-same-address active non-receive blocks the window. -/
-def findConsumer (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints) (nw : NonzeroWits p constraints)
-    (S : BusInteraction (Expression p)) :
-    (revMid rest : List (BusInteraction (Expression p))) →
-    Option ({ mrp : List (BusInteraction (Expression p)) × BusInteraction (Expression p)
-      × List (BusInteraction (Expression p)) //
-      revMid.reverse ++ rest = mrp.1 ++ mrp.2.1 :: mrp.2.2 })
-  | _, [] => none
-  | revMid, r :: rest =>
-      if decide (multConst r = some (-shape.setNewMult)) && addrConstsEq shape S r then
-        some ⟨(revMid.reverse, r, rest), rfl⟩
-      else if addrConstsNeq shape S r || addrAffineNeq shape S r || addrTwoRootNeq shape T S r
-          || addrNonzeroNeq shape nw S r || decide (multConst r = some 0) then
-        (findConsumer shape T nw S (r :: revMid) rest).map (fun ⟨mrp, hmrp⟩ =>
-          ⟨mrp, by
-            rw [← hmrp, List.reverse_cons, List.append_assoc]
-            rfl⟩)
-      else none
+/-! ### The consumer sweep
 
-/-- One candidate per active send `S`, pairing it with its consumer receive (`findConsumer`),
-    each carrying its split equation by construction. Linear in the number of sends × scan
-    length, so no O(n²) blow-up on large buses. `checkPair` re-verifies the pair conditions. -/
-def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
-    (T : TwoRootMap p constraints) (nw : NonzeroWits p constraints)
+The historical `findConsumer` scanned forward through the tail once **per send**; with every
+stepped-over message re-tested per scan the pass was O(B²) per bus (each position is crossed by
+every open window spanning it) — the dominant busUnify cost on large circuits. The sweep below
+walks each bus's interaction list **once**, keeping the open send windows in a map keyed by a
+canonical address key:
+
+* Two interactions satisfy `addrConstsEq` **iff** their canonical keys (`addrKey?`: each present
+  address slot, constant-valued slots normalized to their literal constant) are equal — so the
+  consumer test for an incoming message is one map probe.
+* A message whose address slots are **all constant** is provably invisible to every open window
+  at a *different* all-constant key: some slot carries two different constants, so
+  `addrConstsNeq` excludes it there (and `addrConstsEq` rejects it as a consumer). Only the one
+  window at the message's own key runs the full branch test (`stepTest` — `findConsumer`'s arms
+  in `findConsumer`'s order). Windows with a *symbolic* key component (`symOpen`, rare) are
+  tested literally against every message, as is every window when the message itself has a
+  symbolic address slot — exactly the pairs the per-send scans also paid for.
+* A window closes on its consumer (emitting the candidate) or on a blocker, exactly where
+  `findConsumer` stopped; a send opens a window (an *excluded-but-surviving* same-key window is
+  moved to the literally-tested side list, so even that degenerate case keeps every window the
+  per-send scans had).
+
+The sweep is *untrusted* for everything except the split equations — `checkPair` re-verifies all
+pair conditions on every emitted candidate — and the split equation is recovered positionally:
+`mid` is a `take` of the send's stored suffix, justified by drop arithmetic (`emitCand`).
+Candidates are sorted back into send-position order, so the emitted list is the one the per-send
+scans produced. -/
+
+/-- One message tested against one open window — `findConsumer`'s branch order, verbatim. -/
+inductive StepRes
+  | consumer
+  | excluded
+  | blocker
+
+/-- The two-root / nonzero-witness certificate tables are passed as `Thunk`s so an invocation
+    that never reaches the expensive arms (every pair decided by the constant or affine
+    certificate — the common case) never builds them. -/
+def stepTest (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : Thunk (TwoRootMap p constraints)) (nw : Thunk (NonzeroWits p constraints))
+    (S m : BusInteraction (Expression p)) : StepRes :=
+  if decide (multConst m = some (-shape.setNewMult)) && addrConstsEq shape S m then .consumer
+  else if addrConstsNeq shape S m || addrAffineNeq shape S m || addrTwoRootNeq shape T.get S m
+      || addrNonzeroNeq shape nw.get S m || decide (multConst m = some 0) then .excluded
+  else .blocker
+
+/-- A canonical address key. Equality of keys is exactly `addrConstsEq`: per slot, either both
+    expressions are constant-valued with the same value (both canonicalize to the same literal)
+    or they are syntactically equal (and then their `constValue?`s agree, so canonicalization
+    preserves the equality; a constant-valued and a non-constant slot can never be syntactically
+    equal, so the two canonical forms never collide). -/
+structure AddrKey (p : ℕ) where
+  exprs : List (Expression p)
+deriving DecidableEq
+
+instance : Hashable (AddrKey p) :=
+  ⟨fun k => k.exprs.foldl (fun h e => mixHash h e.structHash) 7⟩
+
+/-- The canonical key of an interaction's address slots, `none` if a slot is missing (such a
+    message never `addrConstsEq`-matches anything, so it can neither open a window nor consume
+    one). -/
+def addrKey? (shape : MemoryBusShape) (bi : BusInteraction (Expression p)) :
+    Option (AddrKey p) :=
+  (shape.addressFields.foldr (fun slot acc =>
+    match acc, bi.payload[slot]? with
+    | some ks, some e =>
+      match e.constValue? with
+      | some c => some (.const c :: ks)
+      | none => some (e :: ks)
+    | _, _ => none) (some [])).map AddrKey.mk
+
+/-- Whether every component of a canonical key is a literal constant. -/
+def AddrKey.allConst (k : AddrKey p) : Bool :=
+  k.exprs.all fun e => match e with
+    | .const _ => true
+    | _ => false
+
+/-- An open send window: the send, its split context (`L = revPre.reverse ++ S :: restAfter`),
+    and its position `i = revPre.length`. -/
+structure OpenRec (p : ℕ) (L : List (BusInteraction (Expression p))) where
+  revPre : List (BusInteraction (Expression p))
+  S : BusInteraction (Expression p)
+  restAfter : List (BusInteraction (Expression p))
+  i : Nat
+  hi : revPre.length = i
+  hsplit : L = revPre.reverse ++ S :: restAfter
+
+/-- The split equation of an emitted candidate, by drop arithmetic from the send-time and
+    consume-time split equations — no per-step bookkeeping while a window is open. -/
+theorem split_of_positions {L revPre restAfter revSeen post : List (BusInteraction (Expression p))}
+    {S R : BusInteraction (Expression p)} {i j : Nat}
+    (hi : revPre.length = i) (hsplit : L = revPre.reverse ++ S :: restAfter)
+    (hj : revSeen.length = j) (hnow : L = revSeen.reverse ++ R :: post) (hlt : i < j) :
+    L = revPre.reverse ++ S :: restAfter.take (j - i - 1) ++ R :: post := by
+  have hRA : restAfter = L.drop (i + 1) := by
+    have h1 : L = (revPre.reverse ++ [S]) ++ restAfter := by
+      rw [hsplit]; simp
+    rw [h1, List.drop_left' (by simp [hi])]
+  have hRp : R :: post = L.drop j := by
+    rw [hnow, List.drop_left' (by simp [hj])]
+  have hdrop : restAfter.drop (j - i - 1) = R :: post := by
+    rw [hRA, List.drop_drop, hRp]
+    congr 1
+    omega
+  have hn : L = revPre.reverse ++ S :: (restAfter.take (j - i - 1) ++ R :: post) := by
+    rw [← hdrop, List.take_append_drop]
+    exact hsplit
+  simpa [List.append_assoc] using hn
+
+/-- Assemble the split candidate for a consumed window, tagged with its send position. `mid` is
+    recovered positionally from the send's stored suffix (`take (j−i−1)`), and the split equation
+    is `split_of_positions`. (The `i < j` check always holds — the window was opened strictly
+    earlier — but deciding it is O(1) and discharges the arithmetic side conditions.) -/
+def emitCand {L : List (BusInteraction (Expression p))} (w : OpenRec p L)
+    {revSeen : List (BusInteraction (Expression p))} (j : Nat) (hj : revSeen.length = j)
+    (R : BusInteraction (Expression p)) (post : List (BusInteraction (Expression p)))
+    (hnow : L = revSeen.reverse ++ R :: post) : Option (Nat × SplitCand p L) :=
+  if hlt : w.i < j then
+    some (w.i, ⟨(w.revPre.reverse, w.S, w.restAfter.take (j - w.i - 1), R, post),
+      split_of_positions w.hi w.hsplit hj hnow hlt⟩)
+  else none
+
+/-- The sweep: one pass over the bus's interaction list, windows keyed as described above.
+    `acc` collects `(sendPosition, candidate)` pairs (order restored by the caller's sort). -/
+def sweepGo (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : Thunk (TwoRootMap p constraints)) (nw : Thunk (NonzeroWits p constraints))
     (L : List (BusInteraction (Expression p))) :
-    (revPre rest : List (BusInteraction (Expression p))) →
-    (hinv : L = revPre.reverse ++ rest) →
-    List (SplitCand p L)
-  | _, [], _ => []
-  | revPre, S :: rest, hinv =>
-      (if decide (multConst S = some shape.setNewMult) then
-        match findConsumer shape T nw S [] rest with
-        | some ⟨(mid, R, post), hmrp⟩ =>
-          [⟨(revPre.reverse, S, mid, R, post), by
-            rw [hinv]
-            have h : rest = mid ++ R :: post := hmrp
-            rw [h]
-            simp⟩]
-        | none => []
-       else []) ++ candidateSplits shape T nw L (S :: revPre) rest
-        (by rw [hinv, List.reverse_cons, List.append_assoc]; rfl)
+    (revSeen rest : List (BusInteraction (Expression p))) →
+    (hsplit : L = revSeen.reverse ++ rest) → (j : Nat) → (hj : revSeen.length = j) →
+    (constOpen : Std.HashMap (AddrKey p) (OpenRec p L)) →
+    (symOpen : List (OpenRec p L)) →
+    (acc : List (Nat × SplitCand p L)) →
+    List (Nat × SplitCand p L)
+  | _, [], _, _, _, _, _, acc => acc
+  | revSeen, m :: rest', hsplit, j, hj, constOpen, symOpen, acc =>
+    let mKey? := addrKey? shape m
+    let mAllConst := match mKey? with
+      | some k => k.allConst
+      | none => false
+    -- (1) constant-keyed windows: an all-constant message only meets the window at its own key
+    --     (it is `addrConstsNeq`-excluded at every other constant key); a symbolic-address
+    --     message meets every one.
+    let (constOpen, acc) :=
+      if mAllConst then
+        match mKey? with
+        | some k =>
+          match constOpen[k]? with
+          | some w =>
+            match stepTest shape T nw w.S m with
+            | .consumer =>
+              (constOpen.erase k,
+               match emitCand w j hj m rest' hsplit with
+               | some c => c :: acc
+               | none => acc)
+            | .excluded => (constOpen, acc)
+            | .blocker => (constOpen.erase k, acc)
+          | none => (constOpen, acc)
+        | none => (constOpen, acc)
+      else
+        let (drops, acc) := constOpen.toList.foldl (init := (([] : List (AddrKey p)), acc))
+          fun (ds, a) kw =>
+            match stepTest shape T nw kw.2.S m with
+            | .consumer =>
+              (kw.1 :: ds,
+               match emitCand kw.2 j hj m rest' hsplit with
+               | some c => c :: a
+               | none => a)
+            | .excluded => (ds, a)
+            | .blocker => (kw.1 :: ds, a)
+        (drops.foldl (·.erase ·) constOpen, acc)
+    -- (2) symbolic-keyed windows are tested literally against every message.
+    let (symOpen, acc) :=
+      if symOpen.isEmpty then (symOpen, acc) else
+      symOpen.foldr (init := (([] : List (OpenRec p L)), acc)) fun w (so, a) =>
+        match stepTest shape T nw w.S m with
+        | .consumer =>
+          (so,
+           match emitCand w j hj m rest' hsplit with
+           | some c => c :: a
+           | none => a)
+        | .excluded => (w :: so, a)
+        | .blocker => (so, a)
+    -- (3) a send opens its window. A same-key window that survived (1) as *excluded* moves to
+    --     the literally-tested side list, so no window the per-send scans had is lost.
+    let (constOpen, symOpen) :=
+      if decide (multConst m = some shape.setNewMult) then
+        match mKey? with
+        | some k =>
+          let w : OpenRec p L := ⟨revSeen, m, rest', j, hj, hsplit⟩
+          if k.allConst then
+            match constOpen[k]? with
+            | some old => (constOpen.insert k w, old :: symOpen)
+            | none => (constOpen.insert k w, symOpen)
+          else (constOpen, w :: symOpen)
+        | none => (constOpen, symOpen)
+      else (constOpen, symOpen)
+    sweepGo shape T nw L (m :: revSeen) rest'
+      (by rw [hsplit, List.reverse_cons, List.append_assoc]; rfl) (j + 1)
+      (by simp [hj]) constOpen symOpen acc
 
-/-- Collect the entailed equalities for one bus, with proof. -/
+/-- All consumer candidates of one bus, in send-position order — the same list the per-send
+    `findConsumer` scans produced, computed by a single sweep. -/
+def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
+    (T : Thunk (TwoRootMap p constraints)) (nw : Thunk (NonzeroWits p constraints))
+    (L : List (BusInteraction (Expression p))) : List (SplitCand p L) :=
+  ((sweepGo shape T nw L [] L rfl 0 rfl ∅ [] []).mergeSort
+    (fun a b => decide (a.1 ≤ b.1))).map (·.2)
+
+/-- Collect the entailed equalities for one bus, with proof. The certificate tables are
+    `Thunk`s, forced only when a candidate reaches `checkPair`'s expensive arms. -/
 def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
-    (nw : NonzeroWits p cs.algebraicConstraints)
+    (hp1 : (1 : ZMod p) ≠ 0) (T : Thunk (TwoRootMap p cs.algebraicConstraints))
+    (nw : Thunk (NonzeroWits p cs.algebraicConstraints))
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape) :
     List (SplitCand p (cs.busInteractions.filter (fun bi => bi.busId = busId))) →
@@ -268,19 +431,19 @@ def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
   | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
   | ⟨(pre, S, mid, R, post), hsplit⟩ :: rest =>
     let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T nw busId shape hshape rest
-    if hchk : checkPair shape T nw S mid R = true then
+    if hchk : checkPair shape T.get nw.get S mid R = true then
       ⟨memEqConstraints shape S R ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
-        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T nw hsplit
-            hchk env hadm hsat c h
+        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T.get nw.get
+            hsplit hchk env hadm hsat c h
         · exact hacc env hadm hsat c h⟩
     else ⟨acc, hacc⟩
 
 /-- Collect over every declared bus, with proof. -/
 def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (hp1 : (1 : ZMod p) ≠ 0) (T : TwoRootMap p cs.algebraicConstraints)
-    (nw : NonzeroWits p cs.algebraicConstraints) :
+    (hp1 : (1 : ZMod p) ≠ 0) (T : Thunk (TwoRootMap p cs.algebraicConstraints))
+    (nw : Thunk (NonzeroWits p cs.algebraicConstraints)) :
     List Nat →
     { out : List (Expression p) //
         ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
@@ -290,8 +453,8 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     match hshape : facts.memShape busId with
     | some shape =>
       let ⟨eqs, heqs⟩ := collectForBus cs bs facts hp1 T nw busId shape hshape
-        (candidateSplits shape T nw _ []
-          (cs.busInteractions.filter (fun bi => bi.busId = busId)) rfl)
+        (candidateSplits shape T nw
+          (cs.busInteractions.filter (fun bi => bi.busId = busId)))
       ⟨eqs ++ acc, by
         intro env hadm hsat c hc
         rcases List.mem_append.1 hc with h | h
@@ -304,11 +467,15 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     trivially zero). Replaces `memoryUnifyBatchPass`, `execChainPass`, and `chainUnifyPass`. -/
 def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
-    -- precompute the per-variable two-root data once (memoized `twoRootOf?`), so the
-    -- address-disequality certificate is a constant-time hash lookup per candidate pair
-    let T := TwoRootMap.build cs.algebraicConstraints
-    -- reciprocal (nonzero-witness) forms, for the register-vs-RAM address-disequality certificate
-    let nw := NonzeroWits.build cs.algebraicConstraints
+    -- The per-variable two-root data (memoized `twoRootOf?`) and the reciprocal nonzero-witness
+    -- forms back the two expensive address-disequality certificates. Both are `Thunk`ed: they are
+    -- built (once, memoized) only if some window test reaches those arms — an invocation whose
+    -- pairs are all decided by the constant/affine certificates never pays the O(#constraints)
+    -- builds.
+    let T : Thunk (TwoRootMap p cs.algebraicConstraints) :=
+      Thunk.mk fun _ => TwoRootMap.build cs.algebraicConstraints
+    let nw : Thunk (NonzeroWits p cs.algebraicConstraints) :=
+      Thunk.mk fun _ => NonzeroWits.build cs.algebraicConstraints
     let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1 T nw
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
     -- keep only equalities over existing columns, so the pass introduces no new variable

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -202,6 +202,23 @@ theorem checkPair_sound (cs : ConstraintSystem p) (bs : BusSemantics p)
 
 /-! ## The pass -/
 
+/-- Every variable of an entailed slot equality comes from the receive's or the send's payload —
+    so the pass's "no new variable" side condition holds *by construction* and needs no runtime
+    membership scan over the system's occurrence list. -/
+theorem memEqConstraints_vars (shape : MemoryBusShape) (S Rt : BusInteraction (Expression p))
+    {c : Expression p} (hc : c ∈ memEqConstraints shape S Rt) {z : Variable} (hz : z ∈ c.vars) :
+    (∃ e ∈ Rt.payload, z ∈ e.vars) ∨ (∃ e ∈ S.payload, z ∈ e.vars) := by
+  unfold memEqConstraints at hc
+  obtain ⟨i, _hi, rfl⟩ := List.mem_map.1 hc
+  simp only [eqExpr, Expression.vars, List.mem_append, List.not_mem_nil, false_or] at hz
+  rcases hz with hz | hz
+  · cases hR : Rt.payload[i]? with
+    | none => rw [hR] at hz; simp [Expression.vars] at hz
+    | some e => rw [hR] at hz; exact Or.inl ⟨e, List.mem_of_getElem? hR, hz⟩
+  · cases hS : S.payload[i]? with
+    | none => rw [hS] at hz; simp [Expression.vars] at hz
+    | some e => rw [hS] at hz; exact Or.inr ⟨e, List.mem_of_getElem? hS, hz⟩
+
 /-- One `(pre, S, mid, R, post)` candidate, carrying the split equation it was constructed
     from. -/
 def SplitCand (p : ℕ) (L : List (BusInteraction (Expression p))) :=
@@ -418,8 +435,10 @@ def candidateSplits (shape : MemoryBusShape) {constraints : List (Expression p)}
   ((sweepGo shape T nw L [] L rfl 0 rfl ∅ [] []).mergeSort
     (fun a b => decide (a.1 ≤ b.1))).map (·.2)
 
-/-- Collect the entailed equalities for one bus, with proof. The certificate tables are
-    `Thunk`s, forced only when a candidate reaches `checkPair`'s expensive arms. -/
+/-- Collect the entailed equalities for one bus, with proof — soundness *and* the by-construction
+    "no new variable" guarantee (`memEqConstraints_vars`), so the pass needs no runtime
+    variable-membership scan. The certificate tables are `Thunk`s, forced only when a candidate
+    reaches `checkPair`'s expensive arms. -/
 def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (T : Thunk (TwoRootMap p cs.algebraicConstraints))
     (nw : Thunk (NonzeroWits p cs.algebraicConstraints))
@@ -427,17 +446,35 @@ def collectForBus (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFa
     (hshape : facts.memShape busId = some shape) :
     List (SplitCand p (cs.busInteractions.filter (fun bi => bi.busId = busId))) →
     { out : List (Expression p) //
-        ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
-  | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
+        (∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0) ∧
+        ∀ c ∈ out, ∀ z ∈ c.vars, z ∈ cs.vars }
+  | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp), fun _ h => absurd h (by simp)⟩
   | ⟨(pre, S, mid, R, post), hsplit⟩ :: rest =>
     let ⟨acc, hacc⟩ := collectForBus cs bs facts hp1 T nw busId shape hshape rest
     if hchk : checkPair shape T.get nw.get S mid R = true then
+      have hSmem : S ∈ cs.busInteractions := by
+        have h : S ∈ cs.busInteractions.filter (fun bi => bi.busId = busId) := by
+          rw [hsplit]
+          exact List.mem_append_left _ (List.mem_append_right _ List.mem_cons_self)
+        exact List.mem_of_mem_filter h
+      have hRmem : R ∈ cs.busInteractions := by
+        have h : R ∈ cs.busInteractions.filter (fun bi => bi.busId = busId) := by
+          rw [hsplit]
+          exact List.mem_append_right _ List.mem_cons_self
+        exact List.mem_of_mem_filter h
       ⟨memEqConstraints shape S R ++ acc, by
-        intro env hadm hsat c hc
-        rcases List.mem_append.1 hc with h | h
-        · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T.get nw.get
-            hsplit hchk env hadm hsat c h
-        · exact hacc env hadm hsat c h⟩
+        constructor
+        · intro env hadm hsat c hc
+          rcases List.mem_append.1 hc with h | h
+          · exact checkPair_sound cs bs facts hp1 busId shape hshape pre S mid R post T.get nw.get
+              hsplit hchk env hadm hsat c h
+          · exact hacc.1 env hadm hsat c h
+        · intro c hc z hz
+          rcases List.mem_append.1 hc with h | h
+          · rcases memEqConstraints_vars shape S R h hz with ⟨e, he, hze⟩ | ⟨e, he, hze⟩
+            · exact ConstraintSystem.mem_vars_of_payload hRmem he hze
+            · exact ConstraintSystem.mem_vars_of_payload hSmem he hze
+          · exact hacc.2 c h z hz⟩
     else ⟨acc, hacc⟩
 
 /-- Collect over every declared bus, with proof. -/
@@ -446,8 +483,9 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
     (nw : Thunk (NonzeroWits p cs.algebraicConstraints)) :
     List Nat →
     { out : List (Expression p) //
-        ∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0 }
-  | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp)⟩
+        (∀ env, cs.admissible bs env → cs.satisfies bs env → ∀ c ∈ out, c.eval env = 0) ∧
+        ∀ c ∈ out, ∀ z ∈ c.vars, z ∈ cs.vars }
+  | [] => ⟨[], fun _ _ _ _ h => absurd h (by simp), fun _ h => absurd h (by simp)⟩
   | busId :: rest =>
     let ⟨acc, hacc⟩ := collectAllBuses cs bs facts hp1 T nw rest
     match hshape : facts.memShape busId with
@@ -456,10 +494,15 @@ def collectAllBuses (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : Bus
         (candidateSplits shape T nw
           (cs.busInteractions.filter (fun bi => bi.busId = busId)))
       ⟨eqs ++ acc, by
-        intro env hadm hsat c hc
-        rcases List.mem_append.1 hc with h | h
-        · exact heqs env hadm hsat c h
-        · exact hacc env hadm hsat c h⟩
+        constructor
+        · intro env hadm hsat c hc
+          rcases List.mem_append.1 hc with h | h
+          · exact heqs.1 env hadm hsat c h
+          · exact hacc.1 env hadm hsat c h
+        · intro c hc z hz
+          rcases List.mem_append.1 hc with h | h
+          · exact heqs.2 c h z hz
+          · exact hacc.2 c h z hz⟩
     | none => ⟨acc, hacc⟩
 
 /-- The unified bus-unification pass: add the entailed consecutive send→receive slot equalities
@@ -478,36 +521,30 @@ def busUnifyPass : VerifiedPassW p := fun cs bs facts =>
       Thunk.mk fun _ => NonzeroWits.build cs.algebraicConstraints
     let ⟨eqs, heqs⟩ := collectAllBuses cs bs facts hp1 T nw
       ((cs.busInteractions.map (fun bi => bi.busId)).dedup)
-    -- keep only equalities over existing columns, so the pass introduces no new variable
-    -- (the real slot equalities are built from `cs`'s payloads, so none are dropped).
-    -- The membership test `z ∈ cs.vars` is the load-bearing "no new variable" check, run for
-    -- every variable of every candidate equality. `cs.vars` is the whole occurrence list (~10⁴
-    -- entries on large blocks), so the per-`z` **linear** list scan dominated this filter. Build a
-    -- `Std.HashSet` of it once and test membership in O(1); `Std.HashSet.contains_ofList` transports
-    -- the check back to genuine list membership `z ∈ cs.vars` (all the correctness proof needs).
-    let csVarSet := Std.HashSet.ofList cs.vars
-    -- The already-present test (`cs.algebraicConstraints.contains c`) is likewise a per-equality
-    -- O(#constraints) deep structural scan — most equalities *are* already present from the
-    -- previous cycle. Bucket the constraints by structural hash once and compare within the
-    -- bucket; the result is the identical Bool (hash inequality proves inequality).
-    let csHashes : Std.HashMap UInt64 (List (Expression p)) :=
-      cs.algebraicConstraints.foldl (fun m c =>
-        let h := c.structHash
-        m.insert h (c :: m.getD h [])) ∅
-    let containsC : Expression p → Bool := fun c =>
-      (csHashes.getD c.structHash []).any (fun c' => c' == c)
-    let new := eqs.filter
-      (fun c => !c.normalize.fold.isConstZero && !containsC c
-        && c.vars.all (fun z => csVarSet.contains z))
-    if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+    -- Nothing collected (the common late-cycle case): skip the filter-table build outright.
+    if eqs.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else
-      ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
-       cs.addConstraints_correct bs new
-         (fun env hadm hsat c hc => heqs env hadm hsat c (List.mem_of_mem_filter hc))
-         (fun c hc z hz => by
-           have hp := (List.mem_filter.1 hc).2
-           simp only [Bool.and_eq_true, List.all_eq_true] at hp
-           have hz' : csVarSet.contains z = true := hp.2 z hz
-           rw [Std.HashSet.contains_ofList] at hz'
-           exact List.contains_iff_mem.mp hz')⟩
+      -- The "no new variable" side condition holds **by construction** — every equality's
+      -- variables come from payload slots of `cs`'s own interactions (`memEqConstraints_vars`,
+      -- carried through `collectAllBuses`) — so the old per-variable membership scan over the
+      -- whole occurrence list (`Std.HashSet.ofList cs.vars`, ~10⁵ entries per invocation) is
+      -- gone, with the filter provably unchanged.
+      -- The already-present test (`cs.algebraicConstraints.contains c`) is a per-equality
+      -- O(#constraints) deep structural scan — most equalities *are* already present from the
+      -- previous cycle. Bucket the constraints by structural hash once and compare within the
+      -- bucket; the result is the identical Bool (hash inequality proves inequality).
+      let csHashes : Std.HashMap UInt64 (List (Expression p)) :=
+        cs.algebraicConstraints.foldl (fun m c =>
+          let h := c.structHash
+          m.insert h (c :: m.getD h [])) ∅
+      let containsC : Expression p → Bool := fun c =>
+        (csHashes.getD c.structHash []).any (fun c' => c' == c)
+      let new := eqs.filter
+        (fun c => !c.normalize.fold.isConstZero && !containsC c)
+      if new.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
+      else
+        ⟨{ cs with algebraicConstraints := cs.algebraicConstraints ++ new }, [],
+         cs.addConstraints_correct bs new
+           (fun env hadm hsat c hc => heqs.1 env hadm hsat c (List.mem_of_mem_filter hc))
+           (fun c hc z hz => heqs.2 c (List.mem_of_mem_filter hc) z hz)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CoveredIndex.lean
@@ -328,18 +328,22 @@ theorem filterMap_congr' {β γ : Type _} {f g : β → Option γ} (l : List β)
     | none => rw [List.filterMap_cons_none hfa, List.filterMap_cons_none (ha ▸ hfa), hr]
     | some b => rw [List.filterMap_cons_some hfa, List.filterMap_cons_some (ha ▸ hfa), hr]
 
-/-- **`coveredIdx` equals the plain filter** whenever every `Q`-item shares a variable with `xs`.
-    All the fold/sort machinery collapses: the index gathers every `Q`-position (completeness), the
-    `HashSet` dedup and `mergeSort` reorder them into ascending (i.e. original list) order, and the
-    per-position `Q` re-check reproduces `items.filter Q` exactly. -/
-theorem coveredIdx_eq_filter (varsOf : α → List Variable) (items : List α)
+/-- **`coveredIdx` equals the plain filter for any index whose candidate set is complete** —
+    every in-range `Q`-position must be a candidate of `xs`; *extra* (stale or spurious) candidate
+    positions are harmless because every candidate is re-checked against the in-range bound and
+    `Q`. All the fold/sort machinery collapses: the `HashSet` dedup and `mergeSort` reorder the
+    candidates into ascending (i.e. original list) order, and the per-position `Q` re-check
+    reproduces `items.filter Q` exactly. This is what lets a pass keep one index across in-place
+    (order- and length-preserving, variable-shrinking) system rewrites: completeness survives such
+    rewrites, so no rebuild is needed. `coveredIdx_eq_filter` below is the fresh-`build` instance. -/
+theorem coveredIdx_eq_filter_of_complete (idx : CovIndex) (items : List α)
     (Q : α → Bool) (xs : List Variable)
     (hcomplete : ∀ (i : Nat) (hi : i < items.length),
-      Q items[i] = true → ∃ v ∈ varsOf items[i], v ∈ xs) :
-    coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q := by
+      Q items[i] = true → i ∈ candidates idx xs) :
+    coveredIdx idx items.toArray Q xs = items.filter Q := by
   rw [coveredIdx]
   simp only [List.size_toArray, List.getElem_toArray]
-  set cand := candidates (build varsOf items) xs with hcand
+  set cand := candidates idx xs with hcand
   set gI : Nat → Option α :=
     (fun i => if h : i < items.length then (if Q items[i] then some items[i] else none) else none)
     with hgI
@@ -358,16 +362,8 @@ theorem coveredIdx_eq_filter (varsOf : α → List Variable) (items : List α)
   -- (F3) the sorted list is `≤`-sorted
   have F3 : sortedL.Pairwise (· ≤ ·) := by
     rw [hsortedL]; exact List.sortedLE_mergeSort.pairwise
-  -- (F4) completeness: every in-range `Q`-position is a candidate
-  have F4 : ∀ (i : Nat) (hi : i < items.length), Q items[i] = true → i ∈ cand := by
-    intro i hi hQ
-    obtain ⟨v, hvvars, hvxs⟩ := hcomplete i hi hQ
-    have hz : (items.zipIdx)[i]? = some (items[i], i) := by
-      rw [List.getElem?_zipIdx, List.getElem?_eq_getElem hi]; simp
-    have hmem : (items[i], i) ∈ items.zipIdx := List.mem_of_getElem? hz
-    have hbucket := buildStep_bucket_complete varsOf items.zipIdx items[i] i hmem v hvvars
-    rw [hcand]
-    exact mem_candidates (build varsOf items) xs v i hvxs hbucket
+  -- (F4) completeness: every in-range `Q`-position is a candidate (the hypothesis)
+  have F4 : ∀ (i : Nat) (hi : i < items.length), Q items[i] = true → i ∈ cand := hcomplete
   -- the keep-predicate coincides with `gI`'s definedness
   set keepB : Nat → Bool := (fun i => (gI i).isSome) with hkeepB
   have hkeep_lt : ∀ i, keepB i = true → i < items.length := by
@@ -433,5 +429,28 @@ theorem coveredIdx_eq_filter (varsOf : α → List Variable) (items : List α)
     _ = ((List.range items.length).filter keepB).filterMap gI := by rw [L2]
     _ = (List.range items.length).filterMap gI := (L1 _).symm
     _ = items.filter Q := claim1
+
+/-- **Completeness of a fresh `build`**: every item position is bucketed under each variable
+    `varsOf` yields for it. -/
+theorem build_complete (varsOf : α → List Variable) (items : List α)
+    (i : Nat) (hi : i < items.length) (v : Variable) (hv : v ∈ varsOf items[i]) :
+    i ∈ (build varsOf items).buckets.getD v [] := by
+  have hz : (items.zipIdx)[i]? = some (items[i], i) := by
+    rw [List.getElem?_zipIdx, List.getElem?_eq_getElem hi]; simp
+  exact buildStep_bucket_complete varsOf items.zipIdx items[i] i (List.mem_of_getElem? hz) v hv
+
+/-- **`coveredIdx` of a fresh `build` equals the plain filter** whenever every `Q`-item shares a
+    variable with `xs`: the build is complete (`build_complete`), so every `Q`-position is a
+    candidate. -/
+theorem coveredIdx_eq_filter (varsOf : α → List Variable) (items : List α)
+    (Q : α → Bool) (xs : List Variable)
+    (hcomplete : ∀ (i : Nat) (hi : i < items.length),
+      Q items[i] = true → ∃ v ∈ varsOf items[i], v ∈ xs) :
+    coveredIdx (build varsOf items) items.toArray Q xs = items.filter Q := by
+  refine coveredIdx_eq_filter_of_complete (build varsOf items) items Q xs ?_
+  intro i hi hQ
+  obtain ⟨v, hvvars, hvxs⟩ := hcomplete i hi hQ
+  exact mem_candidates (build varsOf items) xs v i hvxs
+    (build_complete varsOf items i hi v hvvars)
 
 end CoveredIndex

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1344,28 +1344,37 @@ def forcedOver {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts
 def varSetKey (xs : List Variable) : String :=
   String.intercalate "\x00" ((xs.mergeSort (fun a b => compare a b != .gt)).map (fun x => x.name))
 
-/-- Collect forced constants from joint enumerations of the given targets' variable sets,
-    skipping variable sets already enumerated. `activeCs` (the non-redundant constraints) and its
-    membership witness are threaded to `forcedOver`. -/
-def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
-    (T : DomainTable p cs bs) (fidx : ForcedIdx cs) :
-    List (List Variable) → Std.HashSet String → Solved p cs bs → Solved p cs bs
-  | [], _, σ => σ
-  | xs :: rest, seen, σ =>
+/-- The `seen`-deduplicated target list, exactly as the old interleaved fold skipped them (same
+    key, same threading), split out so the per-target enumerations can be spawned in parallel. -/
+def dedupTargets : List (List Variable) → Std.HashSet String → List (List Variable)
+  | [], _ => []
+  | xs :: rest, seen =>
     let key := varSetKey xs
-    if seen.contains key then collectForced facts T fidx rest seen σ
-    else
-      let found := forcedOver facts T fidx xs
-      collectForced facts T fidx rest (seen.insert key)
-        (σ.insertAll (found.map (fun f => (f.1, .const f.2.val)))
-          (by
-            intro env hsat yt hyt
-            obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
-            exact f.2.property env hsat)
-          (by
-            intro yt hyt z hz
-            obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
-            simp [Expression.vars] at hz))
+    if seen.contains key then dedupTargets rest seen
+    else xs :: dedupTargets rest (seen.insert key)
+
+/-- Collect every checked forced constant. The per-target enumerations (`forcedOver`) are
+    independent — every target is evaluated against the same `cs`/domain table/index — so each is
+    spawned as a `Task` and the results are joined **in target order**: `σ` receives exactly the
+    insertions the sequential fold performed, so the pass output is byte-identical and only
+    wall-clock changes (the enumeration core is the optimizer's dominant remaining cost, and it
+    is embarrassingly parallel). -/
+def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
+    (T : DomainTable p cs bs) (fidx : ForcedIdx cs)
+    (targets : List (List Variable)) (seen : Std.HashSet String) (σ0 : Solved p cs bs) :
+    Solved p cs bs :=
+  let tasks := (dedupTargets targets seen).map (fun xs =>
+    Task.spawn fun _ => forcedOver facts T fidx xs)
+  tasks.foldl (init := σ0) fun σ t =>
+    σ.insertAll ((t.get).map (fun f => (f.1, .const f.2.val)))
+      (by
+        intro env hsat yt hyt
+        obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+        exact f.2.property env hsat)
+      (by
+        intro yt hyt z hz
+        obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+        simp [Expression.vars] at hz)
 
 /-! ## The pass -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -1354,27 +1354,42 @@ def dedupTargets : List (List Variable) → Std.HashSet String → List (List Va
     else xs :: dedupTargets rest (seen.insert key)
 
 /-- Collect every checked forced constant. The per-target enumerations (`forcedOver`) are
-    independent — every target is evaluated against the same `cs`/domain table/index — so each is
-    spawned as a `Task` and the results are joined **in target order**: `σ` receives exactly the
-    insertions the sequential fold performed, so the pass output is byte-identical and only
-    wall-clock changes (the enumeration core is the optimizer's dominant remaining cost, and it
-    is embarrassingly parallel). -/
+    independent — every target is evaluated against the same `cs`/domain table/index — so on
+    large systems each is spawned as a `Task` and the results are joined **in target order**:
+    `σ` receives exactly the insertions the sequential fold performed, so the pass output is
+    byte-identical and only wall-clock changes. Small systems keep the plain sequential fold:
+    the corpus's many-small-cases sets run whole cases in parallel (CI's effectiveness matrix),
+    where per-case fan-out only adds spawn overhead and scheduler contention — the parallelism
+    is for the keccak/SHA-scale invocations, matching the passes' other big-case gates.
+    (`parallel` is decided by the caller from the system size.) -/
 def collectForced {cs : ConstraintSystem p} {bs : BusSemantics p} (facts : BusFacts p bs)
-    (T : DomainTable p cs bs) (fidx : ForcedIdx cs)
+    (T : DomainTable p cs bs) (fidx : ForcedIdx cs) (parallel : Bool)
     (targets : List (List Variable)) (seen : Std.HashSet String) (σ0 : Solved p cs bs) :
     Solved p cs bs :=
-  let tasks := (dedupTargets targets seen).map (fun xs =>
-    Task.spawn fun _ => forcedOver facts T fidx xs)
-  tasks.foldl (init := σ0) fun σ t =>
-    σ.insertAll ((t.get).map (fun f => (f.1, .const f.2.val)))
-      (by
-        intro env hsat yt hyt
-        obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
-        exact f.2.property env hsat)
-      (by
-        intro yt hyt z hz
-        obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
-        simp [Expression.vars] at hz)
+  let uniq := dedupTargets targets seen
+  if parallel then
+    let tasks := uniq.map (fun xs => Task.spawn fun _ => forcedOver facts T fidx xs)
+    tasks.foldl (init := σ0) fun σ t =>
+      σ.insertAll ((t.get).map (fun f => (f.1, .const f.2.val)))
+        (by
+          intro env hsat yt hyt
+          obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+          exact f.2.property env hsat)
+        (by
+          intro yt hyt z hz
+          obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+          simp [Expression.vars] at hz)
+  else
+    uniq.foldl (init := σ0) fun σ xs =>
+      σ.insertAll ((forcedOver facts T fidx xs).map (fun f => (f.1, .const f.2.val)))
+        (by
+          intro env hsat yt hyt
+          obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+          exact f.2.property env hsat)
+        (by
+          intro yt hyt z hz
+          obtain ⟨f, hf, rfl⟩ := List.mem_map.1 hyt
+          simp [Expression.vars] at hz)
 
 /-! ## The pass -/
 
@@ -1415,7 +1430,10 @@ def domainBatchPass (pw : PrimeWitness p) : VerifiedPassW p := fun cs bs facts =
           cs.busInteractions,
         arrBis := cs.busInteractions.toArray, harrBis := rfl,
         actFlags := actFlags }
-    let σ := collectForced facts T fidx targets ∅ Solved.empty
+    -- Fan out only at keccak/SHA scale (the same raw-count gate as `domainFoldIndexThreshold`):
+    -- below it the sequential fold is byte-for-byte the same computation without spawn overhead.
+    let σ := collectForced facts T fidx (8192 ≤ cs.algebraicConstraints.length) targets ∅
+      Solved.empty
     if σ.map.isEmpty then ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs.substF σ.fn, [],
       cs.substF_correct σ.fn bs (fun env hsat y t hyt => σ.sound env hsat y t hyt)

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -100,13 +100,13 @@ def foldRewriteGo (xs : List Variable) (survs : List (List (Variable × ZMod p))
   | .const c => .const c
   | .var y => .var y
   | .add a b =>
-      if (Expression.add a b).varsIn xs then
+      if (Expression.add a b).varsInF xs then
         match constOnSurvs survs (.add a b) with
         | some c => .const c
         | none => .add (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
       else .add (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
   | .mul a b =>
-      if (Expression.mul a b).varsIn xs then
+      if (Expression.mul a b).varsInF xs then
         match constOnSurvs survs (.mul a b) with
         | some c => .const c
         | none => .mul (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
@@ -159,16 +159,17 @@ theorem foldRewriteGo_agree (xs : List Variable) (survs : List (List (Variable �
     (hxs : ∀ x ∈ xs, env x = envOf s x) :
     ∀ e : Expression p, (foldRewriteGo xs survs e).eval env = e.eval env := by
   -- For a wholly-in-`xs` expression, `env` and `envOf s` agree on its variables.
-  have hcongr : ∀ e : Expression p, e.varsIn xs = true → e.eval env = e.eval (envOf s) := by
+  have hcongr : ∀ e : Expression p, e.varsInF xs = true → e.eval env = e.eval (envOf s) := by
     intro e he
-    exact Expression.eval_congr e _ _ (fun x hx => hxs x (Expression.varsIn_sound xs e he x hx))
+    exact Expression.eval_congr e _ _ (fun x hx =>
+      hxs x (Expression.varsIn_sound xs e (Expression.varsInF_eq xs e ▸ he) x hx))
   intro e
   induction e with
   | const c => rfl
   | var y => rfl
   | add a b iha ihb =>
       unfold foldRewriteGo
-      by_cases hin : (Expression.add a b).varsIn xs = true
+      by_cases hin : (Expression.add a b).varsInF xs = true
       · rw [if_pos hin]
         cases hc : constOnSurvs survs (.add a b) with
         | none =>
@@ -188,7 +189,7 @@ theorem foldRewriteGo_agree (xs : List Variable) (survs : List (List (Variable �
         rw [iha, ihb]
   | mul a b iha ihb =>
       unfold foldRewriteGo
-      by_cases hin : (Expression.mul a b).varsIn xs = true
+      by_cases hin : (Expression.mul a b).varsInF xs = true
       · rw [if_pos hin]
         cases hc : constOnSurvs survs (.mul a b) with
         | none =>
@@ -251,7 +252,7 @@ theorem foldRewriteGo_vars (xs : List Variable) (survs : List (List (Variable ×
   | var y => intro v hv; exact hv
   | add a b iha ihb =>
       unfold foldRewriteGo
-      by_cases hin : (Expression.add a b).varsIn xs = true
+      by_cases hin : (Expression.add a b).varsInF xs = true
       · rw [if_pos hin]
         cases constOnSurvs survs (.add a b) with
         | none =>
@@ -269,7 +270,7 @@ theorem foldRewriteGo_vars (xs : List Variable) (survs : List (List (Variable ×
         · exact Or.inr (ihb v hv)
   | mul a b iha ihb =>
       unfold foldRewriteGo
-      by_cases hin : (Expression.mul a b).varsIn xs = true
+      by_cases hin : (Expression.mul a b).varsInF xs = true
       · rw [if_pos hin]
         cases constOnSurvs survs (.mul a b) with
         | none =>
@@ -664,10 +665,10 @@ def Expression.hasFoldable (xs : List Variable) (survs : List (List (Variable ×
   | .const _ => false
   | .var _ => false
   | .add a b =>
-      ((Expression.add a b).varsIn xs && (constOnSurvs survs (.add a b)).isSome) ||
+      ((Expression.add a b).varsInF xs && (constOnSurvs survs (.add a b)).isSome) ||
         Expression.hasFoldable xs survs a || Expression.hasFoldable xs survs b
   | .mul a b =>
-      ((Expression.mul a b).varsIn xs && (constOnSurvs survs (.mul a b)).isSome) ||
+      ((Expression.mul a b).varsInF xs && (constOnSurvs survs (.mul a b)).isSome) ||
         Expression.hasFoldable xs survs a || Expression.hasFoldable xs survs b
 
 /-- Does the fold change anything in the system? The no-op gate of the direct (unindexed) path —

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -128,6 +128,27 @@ theorem foldRewrite_eq_self {xs : List Variable} {survs : List (List (Variable �
     {e : Expression p} (h : e.anyVarIn xs = false) : foldRewrite xs survs e = e := by
   rw [foldRewrite, h]; rfl
 
+/-- Does the expression contain a variable-free `add`/`mul` node? For an expression sharing no
+    variable with the group, `hasFoldable` holds iff this does (given a nonempty survivor set). -/
+def Expression.hasConstFoldableNode : Expression p → Bool
+  | .const _ => false
+  | .var _ => false
+  | .add a b =>
+      !(Expression.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+  | .mul a b =>
+      !(Expression.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+
+/-- The direct (unindexed) path's fold rewrite — the historical gate: an expression sharing no
+    variable with the group *and* containing no variable-free compound node has no node the core
+    could fold (a qualifying node is either wholly-in-group with a variable — impossible — or
+    variable-free), so it is returned untouched without walking it node-by-node. Kept exactly as
+    it always was so the direct path (systems below `domainFoldIndexThreshold`, i.e. everything
+    but the keccak/SHA-scale stress cases) is bit-for-bit unchanged; the indexed path uses the
+    `anyVarIn`-gated `foldRewrite`, whose identity-off-index property the sparse fold needs. -/
+def foldRewriteC (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (e : Expression p) : Expression p :=
+  if e.anyVarIn xs || e.hasConstFoldableNode then foldRewriteGo xs survs e else e
+
 /-! ## Agreement with the identity on any survivor-matching environment -/
 
 /-- On an environment that agrees on `xs` with some survivor `s`, `foldRewrite` is
@@ -198,6 +219,17 @@ theorem foldRewrite_agree (xs : List Variable) (survs : List (List (Variable × 
   · exact foldRewriteGo_agree xs survs env s hs hxs e
   · rfl
 
+/-- `foldRewrite_agree` for the direct path's `foldRewriteC` (same split on the gate). -/
+theorem foldRewriteC_agree (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (env : Variable → ZMod p) (s : List (Variable × ZMod p)) (hs : s ∈ survs)
+    (hxs : ∀ x ∈ xs, env x = envOf s x) :
+    ∀ e : Expression p, (foldRewriteC xs survs e).eval env = e.eval env := by
+  intro e
+  unfold foldRewriteC
+  split
+  · exact foldRewriteGo_agree xs survs env s hs hxs e
+  · rfl
+
 /-- Bus-interaction-level agreement, from any expression-level agreement `hag`, applied to the
     multiplicity and every payload slot. -/
 theorem mapExpr_eval_of_agree (g : Expression p → Expression p) (env : Variable → ZMod p)
@@ -263,19 +295,29 @@ theorem foldRewrite_vars (xs : List Variable) (survs : List (List (Variable × Z
   · exact foldRewriteGo_vars xs survs e v hv
   · exact hv
 
+/-- `foldRewrite_vars` for the direct path's `foldRewriteC`. -/
+theorem foldRewriteC_vars (xs : List Variable) (survs : List (List (Variable × ZMod p)))
+    (e : Expression p) : ∀ v ∈ (foldRewriteC xs survs e).vars, v ∈ e.vars := by
+  intro v hv
+  unfold foldRewriteC at hv
+  split at hv
+  · exact foldRewriteGo_vars xs survs e v hv
+  · exact hv
+
 /-! ## Agreement on any environment satisfying the covered constraints
 
 The survivors were enumerated over the group's constraint-derived domains and filtered by the
 covered constraints, so any environment satisfying **all** the covered constraints pins the group
 to one of the survivors — under which `foldRewrite` is the identity. -/
 
-/-- If `env` satisfies every covered constraint, `foldRewrite` (over the survivors of those
-    constraints) is evaluation-preserving on `env`. Prime `p` (for `groupDoms_sound`). -/
-theorem foldRewrite_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs : List Variable)
+/-- If `env` satisfies every covered constraint, the group is pinned to a survivor `env` agrees
+    with on `xs`. Prime `p` (for `groupDoms_sound`). Shared by both rewrites' covered-agreement
+    lemmas. -/
+theorem groupSurvivors_mem_agree [Fact p.Prime] (cs : ConstraintSystem p) (xs : List Variable)
     (doms : List (Variable × List (ZMod p)))
     (hdoms : groupDoms (coveredCsOf cs xs) xs = some doms)
     (env : Variable → ZMod p) (hcov : ∀ c ∈ coveredCsOf cs xs, c.eval env = 0) :
-    ∀ e : Expression p, (foldRewrite xs (groupSurvivors cs xs doms) e).eval env = e.eval env := by
+    ∃ s ∈ groupSurvivors cs xs doms, ∀ x ∈ xs, env x = envOf s x := by
   have hkeys : doms.map Prod.fst = xs := groupDoms_fst (coveredCsOf cs xs) xs doms hdoms
   have hmemdoms : ∀ yd ∈ doms, env yd.1 ∈ yd.2 :=
     groupDoms_sound (coveredCsOf cs xs) xs doms hdoms env hcov
@@ -298,8 +340,28 @@ theorem foldRewrite_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs :
       Expression.eval_congr c _ _
         (fun x hx => (hagree x (Expression.varsIn_sound xs c hcvin x hx)).symm)
     rw [heq]; exact hcov c hc
+  exact ⟨s, hsurv, hagree⟩
+
+/-- If `env` satisfies every covered constraint, `foldRewrite` (over the survivors of those
+    constraints) is evaluation-preserving on `env`. -/
+theorem foldRewrite_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p)))
+    (hdoms : groupDoms (coveredCsOf cs xs) xs = some doms)
+    (env : Variable → ZMod p) (hcov : ∀ c ∈ coveredCsOf cs xs, c.eval env = 0) :
+    ∀ e : Expression p, (foldRewrite xs (groupSurvivors cs xs doms) e).eval env = e.eval env := by
+  obtain ⟨s, hsurv, hagree⟩ := groupSurvivors_mem_agree cs xs doms hdoms env hcov
   intro e
   exact foldRewrite_agree xs (groupSurvivors cs xs doms) env s hsurv hagree e
+
+/-- `foldRewrite_agree_covered` for the direct path's `foldRewriteC`. -/
+theorem foldRewriteC_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs : List Variable)
+    (doms : List (Variable × List (ZMod p)))
+    (hdoms : groupDoms (coveredCsOf cs xs) xs = some doms)
+    (env : Variable → ZMod p) (hcov : ∀ c ∈ coveredCsOf cs xs, c.eval env = 0) :
+    ∀ e : Expression p, (foldRewriteC xs (groupSurvivors cs xs doms) e).eval env = e.eval env := by
+  obtain ⟨s, hsurv, hagree⟩ := groupSurvivors_mem_agree cs xs doms hdoms env hcov
+  intro e
+  exact foldRewriteC_agree xs (groupSurvivors cs xs doms) env s hsurv hagree e
 
 /-! ## The folded output -/
 
@@ -445,6 +507,154 @@ theorem foldOut_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemant
       (foldOut_admissible_iff cs bs xs survs env hag).2 hadm,
       by rw [foldOut_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _⟩
 
+/-! ## The direct path's folded output (historical, reordering)
+
+The direct (unindexed) path keeps the historical fold verbatim — `foldRewriteC`'s gate and the
+rewritten-uncovered ++ covered-verbatim output shape — so systems below
+`domainFoldIndexThreshold` (everything but keccak/SHA-scale) produce bit-for-bit the output they
+always did. Only the indexed path, where the reorder would invalidate the persistent index's
+positions, uses the order-preserving `foldOut`. -/
+
+/-- The historical fold output: rewritten non-covered constraints first, covered constraints
+    verbatim at the end. -/
+def foldOutC (cs : ConstraintSystem p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) : ConstraintSystem p :=
+  { algebraicConstraints :=
+      (cs.algebraicConstraints.filter (fun c => !coveredBy xs c)).map (foldRewriteC xs survs)
+        ++ coveredCsOf cs xs,
+    busInteractions := cs.busInteractions.map (·.mapExpr (foldRewriteC xs survs)) }
+
+/-- Under an agreeing `env`, the folded system's evaluated stateful side effects are the input's. -/
+theorem foldOutC_sideEffects_eq (cs : ConstraintSystem p) (bs : BusSemantics p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) (env : Variable → ZMod p)
+    (hag : ∀ e : Expression p, (foldRewriteC xs survs e).eval env = e.eval env) :
+    (foldOutC cs xs survs).sideEffects bs env = cs.sideEffects bs env := by
+  show ((cs.busInteractions.map (·.mapExpr (foldRewriteC xs survs))).filter
+      (fun bi => bs.isStateful bi.busId)).map
+        (fun bi => let m := bi.eval env; ((m.busId, m.payload), m.multiplicity)) = _
+  rw [List.filter_map]
+  rw [List.filter_congr (fun bi _ => (rfl :
+    ((fun b : BusInteraction (Expression p) => bs.isStateful b.busId) ∘
+      (fun b => b.mapExpr (foldRewriteC xs survs))) bi = bs.isStateful bi.busId))]
+  rw [List.map_map]
+  exact List.map_congr_left (fun bi _ => by
+    simp only [Function.comp_apply, mapExpr_eval_of_agree _ env hag bi])
+
+/-- Under an agreeing `env`, the folded system is admissible iff the input is. -/
+theorem foldOutC_admissible_iff (cs : ConstraintSystem p) (bs : BusSemantics p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) (env : Variable → ZMod p)
+    (hag : ∀ e : Expression p, (foldRewriteC xs survs e).eval env = e.eval env) :
+    (foldOutC cs xs survs).admissible bs env ↔ cs.admissible bs env := by
+  unfold ConstraintSystem.admissible
+  have hmsg : (foldOutC cs xs survs).busInteractions.map (fun bi => bi.eval env)
+      = cs.busInteractions.map (fun bi => bi.eval env) := by
+    show (cs.busInteractions.map (·.mapExpr (foldRewriteC xs survs))).map (fun bi => bi.eval env) = _
+    rw [List.map_map]
+    exact List.map_congr_left (fun bi _ => mapExpr_eval_of_agree _ env hag bi)
+  rw [hmsg]
+
+/-- Folding introduces no variable. -/
+theorem foldOutC_vars_subset (cs : ConstraintSystem p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) :
+    ∀ v ∈ (foldOutC cs xs survs).vars, v ∈ cs.vars := by
+  intro v hv
+  rcases ConstraintSystem.mem_vars.1 hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
+  · simp only [foldOutC, List.mem_append] at hc
+    rcases hc with hc | hc
+    · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 hc
+      exact ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc0)
+        (foldRewriteC_vars xs survs c0 v hcv)
+    · exact ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc) hcv
+  · simp only [foldOutC, List.mem_map] at hbi
+    obtain ⟨bi0, hbi0, rfl⟩ := hbi
+    rcases hbiv with hmv | ⟨e, he, hev⟩
+    · exact ConstraintSystem.mem_vars_of_mult hbi0
+        (foldRewriteC_vars xs survs bi0.multiplicity v hmv)
+    · simp only [BusInteraction.mapExpr] at he
+      obtain ⟨e0, he0, rfl⟩ := List.mem_map.1 he
+      exact ConstraintSystem.mem_vars_of_payload hbi0 he0 (foldRewriteC_vars xs survs e0 v hev)
+
+/-- **Correctness of one fold (direct path).** The folded system refines the input and preserves
+    invariants, with the identity witness (`ofEnvEq`): the covered constraints, kept verbatim, pin
+    the group so the rewrite agrees with the identity on every assignment satisfying either
+    system. -/
+theorem foldOutC_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (xs : List Variable) (doms : List (Variable × List (ZMod p)))
+    (hdoms : groupDoms (coveredCsOf cs xs) xs = some doms) :
+    PassCorrect cs (foldOutC cs xs (groupSurvivors cs xs doms)) [] bs := by
+  set survs := groupSurvivors cs xs doms with hsurv_def
+  -- covered constraints are satisfied by any assignment of the output (kept verbatim) or the input.
+  have hcov_out : ∀ env, (foldOutC cs xs survs).satisfies bs env →
+      ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 := by
+    intro env hsat c hc
+    exact hsat.1 c (by simp only [foldOutC, List.mem_append]; exact Or.inr hc)
+  have hcov_cs : ∀ env, cs.satisfies bs env → ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 :=
+    fun env hsat c hc => hsat.1 c (List.mem_of_mem_filter hc)
+  refine PassCorrect.ofEnvEq ?hsound ?hinv ?hsub ?hcomp
+  case hsub => exact foldOutC_vars_subset cs xs survs
+  case hsound =>
+    intro env hsatout
+    have hag := foldRewriteC_agree_covered cs xs doms hdoms env (hcov_out env hsatout)
+    refine ⟨env, ⟨?_, ?_⟩, ?_⟩
+    · -- every cs constraint holds
+      intro c hc
+      by_cases hccov : coveredBy xs c = true
+      · exact hcov_out env hsatout c (List.mem_filter.2 ⟨hc, hccov⟩)
+      · have hmem : foldRewriteC xs survs c ∈ (foldOutC cs xs survs).algebraicConstraints := by
+          simp only [foldOutC, List.mem_append]
+          exact Or.inl (List.mem_map.2 ⟨c, List.mem_filter.2 ⟨hc, by simpa using hccov⟩, rfl⟩)
+        have := hsatout.1 _ hmem
+        rwa [hag c] at this
+    · -- no cs bus interaction violates
+      intro bi hbi
+      have hmem : bi.mapExpr (foldRewriteC xs survs) ∈ (foldOutC cs xs survs).busInteractions :=
+        List.mem_map.2 ⟨bi, hbi, rfl⟩
+      have hval := mapExpr_eval_of_agree (foldRewriteC xs survs) env hag bi
+      have := hsatout.2 _ hmem
+      rw [hval] at this; exact this
+    · rw [foldOutC_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _
+  case hinv =>
+    intro hinv env hsatout bi' hbi'
+    have hag := foldRewriteC_agree_covered cs xs doms hdoms env (hcov_out env hsatout)
+    -- env satisfies cs (soundness reasoning inlined)
+    have hsatcs : cs.satisfies bs env := by
+      refine ⟨?_, ?_⟩
+      · intro c hc
+        by_cases hccov : coveredBy xs c = true
+        · exact hcov_out env hsatout c (List.mem_filter.2 ⟨hc, hccov⟩)
+        · have hmem : foldRewriteC xs survs c ∈ (foldOutC cs xs survs).algebraicConstraints := by
+            simp only [foldOutC, List.mem_append]
+            exact Or.inl (List.mem_map.2 ⟨c, List.mem_filter.2 ⟨hc, by simpa using hccov⟩, rfl⟩)
+          have := hsatout.1 _ hmem
+          rwa [hag c] at this
+      · intro bi hbi
+        have hmem : bi.mapExpr (foldRewriteC xs survs) ∈ (foldOutC cs xs survs).busInteractions :=
+          List.mem_map.2 ⟨bi, hbi, rfl⟩
+        have hval := mapExpr_eval_of_agree (foldRewriteC xs survs) env hag bi
+        have := hsatout.2 _ hmem
+        rw [hval] at this; exact this
+    obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi'
+    rw [mapExpr_eval_of_agree (foldRewriteC xs survs) env hag bi0]
+    exact hinv env hsatcs bi0 hbi0
+  case hcomp =>
+    intro env hadm hsat
+    have hag := foldRewriteC_agree_covered cs xs doms hdoms env (hcov_cs env hsat)
+    refine ⟨⟨?_, ?_⟩, ?_, ?_⟩
+    · -- every out constraint holds
+      intro c hc
+      simp only [foldOutC, List.mem_append] at hc
+      rcases hc with hc | hc
+      · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 hc
+        rw [hag c0]; exact hsat.1 c0 (List.mem_of_mem_filter hc0)
+      · exact hsat.1 c (List.mem_of_mem_filter hc)
+    · -- no out bus interaction violates
+      intro bi hbi
+      obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
+      rw [mapExpr_eval_of_agree (foldRewriteC xs survs) env hag bi0]
+      exact hsat.2 bi0 hbi0
+    · exact (foldOutC_admissible_iff cs bs xs survs env hag).2 hadm
+    · rw [foldOutC_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _
+
 /-! ## The pass -/
 
 /-- Whether any expression of the system has a maximal wholly-in-group subexpression that folds to a
@@ -460,19 +670,16 @@ def Expression.hasFoldable (xs : List Variable) (survs : List (List (Variable ×
       ((Expression.mul a b).varsIn xs && (constOnSurvs survs (.mul a b)).isSome) ||
         Expression.hasFoldable xs survs a || Expression.hasFoldable xs survs b
 
-/-- Does the fold change anything in the system? The no-op gate of the direct (unindexed) path,
-    with the non-covered constraints (`rest = coveredBy`'s complement) precomputed by the caller —
-    the direct path partitions the constraint list once per target, so the gate does not
-    re-evaluate `coveredBy` per constraint. Each item is gated on `anyVarIn` first, mirroring
-    `foldRewrite`'s reach exactly: an expression sharing no variable with the group is never
-    rewritten. Purely an efficiency gate (a false negative loses a fold; a false positive costs a
-    no-op `foldOut`, which — order-preserving — returns an equal system). -/
+/-- Does the fold change anything in the system? The no-op gate of the direct (unindexed) path —
+    the historical gate, verbatim — with the non-covered constraints (`rest = coveredBy`'s
+    complement) precomputed by the caller: the direct path partitions the constraint list once
+    per target, so the gate does not re-evaluate `coveredBy` per constraint. Purely an efficiency
+    gate. -/
 def systemHasFoldableW (cs : ConstraintSystem p) (xs : List Variable)
     (survs : List (List (Variable × ZMod p))) (rest : List (Expression p)) : Bool :=
-  rest.any (fun c => c.anyVarIn xs && c.hasFoldable xs survs) ||
+  rest.any (fun c => c.hasFoldable xs survs) ||
     cs.busInteractions.any (fun bi =>
-      (bi.multiplicity.anyVarIn xs && bi.multiplicity.hasFoldable xs survs) ||
-        bi.payload.any (fun e => e.anyVarIn xs && e.hasFoldable xs survs))
+      bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
 
 /-! ### The index-local gate
 
@@ -857,7 +1064,7 @@ def foldStepWith [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) 
         have hsurv : groupSurvivors cs xs doms = survs := by
           show groupSurvivors cs xs doms = groupSurvivorsE es doms
           rw [hes]; rfl
-        ⟨foldOut cs xs survs, [], hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms)⟩
+        ⟨foldOutC cs xs survs, [], hsurv ▸ foldOutC_correct cs bs xs doms (hes ▸ hdoms)⟩
       else ⟨cs, [], PassCorrect.refl cs bs⟩
     else ⟨cs, [], PassCorrect.refl cs bs⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -67,15 +67,28 @@ def Expression.anyVarIn (xs : List Variable) : Expression p → Bool
   | .add a b => a.anyVarIn xs || b.anyVarIn xs
   | .mul a b => a.anyVarIn xs || b.anyVarIn xs
 
-/-- Does the expression contain a variable-free `add`/`mul` node? For an expression sharing no
-    variable with the group, `hasFoldable` holds iff this does (given a nonempty survivor set). -/
-def Expression.hasConstFoldableNode : Expression p → Bool
-  | .const _ => false
-  | .var _ => false
-  | .add a b =>
-      !(Expression.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
-  | .mul a b =>
-      !(Expression.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
+/-- `anyVarIn` finds a genuinely shared variable. -/
+theorem Expression.anyVarIn_exists {xs : List Variable} {e : Expression p}
+    (h : e.anyVarIn xs = true) : ∃ v ∈ e.vars, v ∈ xs := by
+  induction e with
+  | const c => simp [Expression.anyVarIn] at h
+  | var y =>
+    rw [Expression.anyVarIn, containsFast_eq] at h
+    exact ⟨y, by simp [Expression.vars], by simpa using h⟩
+  | add a b iha ihb =>
+    rw [Expression.anyVarIn, Bool.or_eq_true] at h
+    rcases h with h | h
+    · obtain ⟨v, hv, hx⟩ := iha h
+      exact ⟨v, by rw [Expression.vars]; exact List.mem_append_left _ hv, hx⟩
+    · obtain ⟨v, hv, hx⟩ := ihb h
+      exact ⟨v, by rw [Expression.vars]; exact List.mem_append_right _ hv, hx⟩
+  | mul a b iha ihb =>
+    rw [Expression.anyVarIn, Bool.or_eq_true] at h
+    rcases h with h | h
+    · obtain ⟨v, hv, hx⟩ := iha h
+      exact ⟨v, by rw [Expression.vars]; exact List.mem_append_left _ hv, hx⟩
+    · obtain ⟨v, hv, hx⟩ := ihb h
+      exact ⟨v, by rw [Expression.vars]; exact List.mem_append_right _ hv, hx⟩
 
 /-! ## The fold rewrite -/
 
@@ -99,14 +112,21 @@ def foldRewriteGo (xs : List Variable) (survs : List (List (Variable × ZMod p))
         | none => .mul (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
       else .mul (foldRewriteGo xs survs a) (foldRewriteGo xs survs b)
 
-/-- The fold rewrite, gated: an expression sharing no variable with the group and containing no
-    variable-free compound node has no node the core could fold (a qualifying node is either
-    wholly-in-group with a variable — impossible — or variable-free), so it is returned untouched
-    without walking it node-by-node. `foldOut` maps this over the *whole* system per accepted
-    fold, and almost all expressions take the cheap branch. -/
+/-- The fold rewrite, gated: an expression sharing no variable with the group is returned
+    untouched (as the *same* object — the identity `foldRewrite_eq_self` is what lets the
+    index-side `foldOutIdx` skip such expressions without even reaching them). A shared-variable
+    expression is walked by the core, which folds every maximal wholly-in-group subexpression —
+    including variable-free compound nodes it contains (`varsIn` is vacuous there); purely
+    variable-free *items* are left to the constant-fold pass. -/
 def foldRewrite (xs : List Variable) (survs : List (List (Variable × ZMod p)))
     (e : Expression p) : Expression p :=
-  if e.anyVarIn xs || e.hasConstFoldableNode then foldRewriteGo xs survs e else e
+  if e.anyVarIn xs then foldRewriteGo xs survs e else e
+
+/-- `foldRewrite` is (definitionally) the identity on an expression sharing no variable with the
+    group — the fact that lets the sparse `foldOutIdx` pass untouched items through by position. -/
+theorem foldRewrite_eq_self {xs : List Variable} {survs : List (List (Variable × ZMod p))}
+    {e : Expression p} (h : e.anyVarIn xs = false) : foldRewrite xs survs e = e := by
+  rw [foldRewrite, h]; rfl
 
 /-! ## Agreement with the identity on any survivor-matching environment -/
 
@@ -283,13 +303,15 @@ theorem foldRewrite_agree_covered [Fact p.Prime] (cs : ConstraintSystem p) (xs :
 
 /-! ## The folded output -/
 
-/-- Fold every non-covered constraint and every bus interaction; keep the covered (domain-pinning)
-    constraints **verbatim** (folding them would collapse them and lose the domain pin). -/
+/-- Fold every non-covered constraint and every bus interaction **in place**; keep the covered
+    (domain-pinning) constraints verbatim, also in place (folding them would collapse them and
+    lose the domain pin). Order- and length-preserving by construction — positions never move and
+    rewrites only ever shrink an expression's variable set — which is what lets the pass keep its
+    inverted index across accepted folds instead of rebuilding it (`FoldIdx.refresh`). -/
 def foldOut (cs : ConstraintSystem p) (xs : List Variable)
     (survs : List (List (Variable × ZMod p))) : ConstraintSystem p :=
-  { algebraicConstraints :=
-      (cs.algebraicConstraints.filter (fun c => !coveredBy xs c)).map (foldRewrite xs survs)
-        ++ coveredCsOf cs xs,
+  { algebraicConstraints := cs.algebraicConstraints.map
+      (fun c => if coveredBy xs c then c else foldRewrite xs survs c),
     busInteractions := cs.busInteractions.map (·.mapExpr (foldRewrite xs survs)) }
 
 /-- Under an agreeing `env`, the folded system's evaluated stateful side effects are the input's. -/
@@ -327,12 +349,13 @@ theorem foldOut_vars_subset (cs : ConstraintSystem p) (xs : List Variable)
     ∀ v ∈ (foldOut cs xs survs).vars, v ∈ cs.vars := by
   intro v hv
   rcases ConstraintSystem.mem_vars.1 hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
-  · simp only [foldOut, List.mem_append] at hc
-    rcases hc with hc | hc
-    · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 hc
-      exact ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc0)
-        (foldRewrite_vars xs survs c0 v hcv)
-    · exact ConstraintSystem.mem_vars_of_constraint (List.mem_of_mem_filter hc) hcv
+  · simp only [foldOut, List.mem_map] at hc
+    obtain ⟨c0, hc0, rfl⟩ := hc
+    by_cases hcov : coveredBy xs c0 = true
+    · rw [if_pos hcov] at hcv
+      exact ConstraintSystem.mem_vars_of_constraint hc0 hcv
+    · rw [if_neg hcov] at hcv
+      exact ConstraintSystem.mem_vars_of_constraint hc0 (foldRewrite_vars xs survs c0 v hcv)
   · simp only [foldOut, List.mem_map] at hbi
     obtain ⟨bi0, hbi0, rfl⟩ := hbi
     rcases hbiv with hmv | ⟨e, he, hev⟩
@@ -342,19 +365,62 @@ theorem foldOut_vars_subset (cs : ConstraintSystem p) (xs : List Variable)
       obtain ⟨e0, he0, rfl⟩ := List.mem_map.1 he
       exact ConstraintSystem.mem_vars_of_payload hbi0 he0 (foldRewrite_vars xs survs e0 v hev)
 
+/-- Under an agreeing `env`, the folded system is satisfied iff the input is: every constraint of
+    either side is (the rewrite of) a constraint of the other, and the rewrite is
+    evaluation-preserving on `env`. -/
+theorem foldOut_satisfies_iff (cs : ConstraintSystem p) (bs : BusSemantics p) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) (env : Variable → ZMod p)
+    (hag : ∀ e : Expression p, (foldRewrite xs survs e).eval env = e.eval env) :
+    (foldOut cs xs survs).satisfies bs env ↔ cs.satisfies bs env := by
+  have hceval : ∀ c : Expression p,
+      (if coveredBy xs c then c else foldRewrite xs survs c).eval env = c.eval env := by
+    intro c
+    by_cases hcov : coveredBy xs c = true
+    · rw [if_pos hcov]
+    · rw [if_neg hcov]; exact hag c
+  constructor
+  · intro hsat
+    refine ⟨fun c hc => ?_, fun bi hbi => ?_⟩
+    · have := hsat.1 _ (List.mem_map.2 ⟨c, hc, rfl⟩ :
+        (if coveredBy xs c then c else foldRewrite xs survs c)
+          ∈ (foldOut cs xs survs).algebraicConstraints)
+      rwa [hceval c] at this
+    · have := hsat.2 _ (List.mem_map.2 ⟨bi, hbi, rfl⟩ :
+        bi.mapExpr (foldRewrite xs survs) ∈ (foldOut cs xs survs).busInteractions)
+      rwa [mapExpr_eval_of_agree _ env hag bi] at this
+  · intro hsat
+    refine ⟨fun c hc => ?_, fun bi hbi => ?_⟩
+    · simp only [foldOut, List.mem_map] at hc
+      obtain ⟨c0, hc0, rfl⟩ := hc
+      rw [hceval c0]
+      exact hsat.1 c0 hc0
+    · simp only [foldOut, List.mem_map] at hbi
+      obtain ⟨bi0, hbi0, rfl⟩ := hbi
+      show ((bi0.mapExpr (foldRewrite xs survs)).eval env).multiplicity ≠ 0 →
+        bs.violatesConstraint ((bi0.mapExpr (foldRewrite xs survs)).eval env) = false
+      rw [mapExpr_eval_of_agree _ env hag bi0]
+      exact hsat.2 bi0 hbi0
+
 /-- **Correctness of one fold.** The folded system refines the input and preserves invariants, with
-    the identity witness (`ofEnvEq`): the covered constraints, kept verbatim, pin the group so the
-    rewrite agrees with the identity on every assignment satisfying either system. -/
+    the identity witness (`ofEnvEq`): the covered constraints, kept verbatim (in place), pin the
+    group so the rewrite agrees with the identity on every assignment satisfying either system. -/
 theorem foldOut_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemantics p)
     (xs : List Variable) (doms : List (Variable × List (ZMod p)))
     (hdoms : groupDoms (coveredCsOf cs xs) xs = some doms) :
     PassCorrect cs (foldOut cs xs (groupSurvivors cs xs doms)) [] bs := by
   set survs := groupSurvivors cs xs doms with hsurv_def
-  -- covered constraints are satisfied by any assignment of the output (kept verbatim) or the input.
+  -- covered constraints are satisfied by any assignment of the output (kept verbatim, in place)
+  -- or the input.
   have hcov_out : ∀ env, (foldOut cs xs survs).satisfies bs env →
       ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 := by
     intro env hsat c hc
-    exact hsat.1 c (by simp only [foldOut, List.mem_append]; exact Or.inr hc)
+    have hcb : coveredBy xs c = true := (List.mem_filter.mp hc).2
+    have hmem : c ∈ (foldOut cs xs survs).algebraicConstraints := by
+      have hm : (if coveredBy xs c then c else foldRewrite xs survs c)
+          ∈ (foldOut cs xs survs).algebraicConstraints :=
+        List.mem_map.2 ⟨c, List.mem_of_mem_filter hc, rfl⟩
+      rwa [if_pos hcb] at hm
+    exact hsat.1 c hmem
   have hcov_cs : ∀ env, cs.satisfies bs env → ∀ c ∈ coveredCsOf cs xs, c.eval env = 0 :=
     fun env hsat c hc => hsat.1 c (List.mem_of_mem_filter hc)
   refine PassCorrect.ofEnvEq ?hsound ?hinv ?hsub ?hcomp
@@ -362,65 +428,22 @@ theorem foldOut_correct [Fact p.Prime] (cs : ConstraintSystem p) (bs : BusSemant
   case hsound =>
     intro env hsatout
     have hag := foldRewrite_agree_covered cs xs doms hdoms env (hcov_out env hsatout)
-    refine ⟨env, ⟨?_, ?_⟩, ?_⟩
-    · -- every cs constraint holds
-      intro c hc
-      by_cases hccov : coveredBy xs c = true
-      · exact hcov_out env hsatout c (List.mem_filter.2 ⟨hc, hccov⟩)
-      · have hmem : foldRewrite xs survs c ∈ (foldOut cs xs survs).algebraicConstraints := by
-          simp only [foldOut, List.mem_append]
-          exact Or.inl (List.mem_map.2 ⟨c, List.mem_filter.2 ⟨hc, by simpa using hccov⟩, rfl⟩)
-        have := hsatout.1 _ hmem
-        rwa [hag c] at this
-    · -- no cs bus interaction violates
-      intro bi hbi
-      have hmem : bi.mapExpr (foldRewrite xs survs) ∈ (foldOut cs xs survs).busInteractions :=
-        List.mem_map.2 ⟨bi, hbi, rfl⟩
-      have hval := mapExpr_eval_of_agree (foldRewrite xs survs) env hag bi
-      have := hsatout.2 _ hmem
-      rw [hval] at this; exact this
-    · rw [foldOut_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _
+    exact ⟨env, (foldOut_satisfies_iff cs bs xs survs env hag).1 hsatout,
+      by rw [foldOut_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _⟩
   case hinv =>
     intro hinv env hsatout bi' hbi'
     have hag := foldRewrite_agree_covered cs xs doms hdoms env (hcov_out env hsatout)
-    -- env satisfies cs (soundness reasoning inlined)
-    have hsatcs : cs.satisfies bs env := by
-      refine ⟨?_, ?_⟩
-      · intro c hc
-        by_cases hccov : coveredBy xs c = true
-        · exact hcov_out env hsatout c (List.mem_filter.2 ⟨hc, hccov⟩)
-        · have hmem : foldRewrite xs survs c ∈ (foldOut cs xs survs).algebraicConstraints := by
-            simp only [foldOut, List.mem_append]
-            exact Or.inl (List.mem_map.2 ⟨c, List.mem_filter.2 ⟨hc, by simpa using hccov⟩, rfl⟩)
-          have := hsatout.1 _ hmem
-          rwa [hag c] at this
-      · intro bi hbi
-        have hmem : bi.mapExpr (foldRewrite xs survs) ∈ (foldOut cs xs survs).busInteractions :=
-          List.mem_map.2 ⟨bi, hbi, rfl⟩
-        have hval := mapExpr_eval_of_agree (foldRewrite xs survs) env hag bi
-        have := hsatout.2 _ hmem
-        rw [hval] at this; exact this
+    have hsatcs : cs.satisfies bs env :=
+      (foldOut_satisfies_iff cs bs xs survs env hag).1 hsatout
     obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi'
     rw [mapExpr_eval_of_agree (foldRewrite xs survs) env hag bi0]
     exact hinv env hsatcs bi0 hbi0
   case hcomp =>
     intro env hadm hsat
     have hag := foldRewrite_agree_covered cs xs doms hdoms env (hcov_cs env hsat)
-    refine ⟨⟨?_, ?_⟩, ?_, ?_⟩
-    · -- every out constraint holds
-      intro c hc
-      simp only [foldOut, List.mem_append] at hc
-      rcases hc with hc | hc
-      · obtain ⟨c0, hc0, rfl⟩ := List.mem_map.1 hc
-        rw [hag c0]; exact hsat.1 c0 (List.mem_of_mem_filter hc0)
-      · exact hsat.1 c (List.mem_of_mem_filter hc)
-    · -- no out bus interaction violates
-      intro bi hbi
-      obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
-      rw [mapExpr_eval_of_agree (foldRewrite xs survs) env hag bi0]
-      exact hsat.2 bi0 hbi0
-    · exact (foldOut_admissible_iff cs bs xs survs env hag).2 hadm
-    · rw [foldOut_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _
+    exact ⟨(foldOut_satisfies_iff cs bs xs survs env hag).2 hsat,
+      (foldOut_admissible_iff cs bs xs survs env hag).2 hadm,
+      by rw [foldOut_sideEffects_eq cs bs xs survs env hag]; exact BusState.equiv_refl _⟩
 
 /-! ## The pass -/
 
@@ -437,34 +460,28 @@ def Expression.hasFoldable (xs : List Variable) (survs : List (List (Variable ×
       ((Expression.mul a b).varsIn xs && (constOnSurvs survs (.mul a b)).isSome) ||
         Expression.hasFoldable xs survs a || Expression.hasFoldable xs survs b
 
-/-- Does the fold change anything in the system? -/
-def systemHasFoldable (cs : ConstraintSystem p) (xs : List Variable)
-    (survs : List (List (Variable × ZMod p))) : Bool :=
-  cs.algebraicConstraints.any (fun c => !coveredBy xs c && c.hasFoldable xs survs) ||
-    cs.busInteractions.any (fun bi =>
-      bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
-
-/-- `systemHasFoldable` with the non-covered constraints (`rest = coveredBy`'s complement)
-    precomputed by the caller — the direct path partitions the constraint list once per target,
-    so the gate does not re-evaluate `coveredBy` per constraint. Same Bool (`any` over the
-    complement filter ⟺ `any` with the conjunction). Purely an efficiency gate, like
-    `systemHasFoldable` itself. -/
+/-- Does the fold change anything in the system? The no-op gate of the direct (unindexed) path,
+    with the non-covered constraints (`rest = coveredBy`'s complement) precomputed by the caller —
+    the direct path partitions the constraint list once per target, so the gate does not
+    re-evaluate `coveredBy` per constraint. Each item is gated on `anyVarIn` first, mirroring
+    `foldRewrite`'s reach exactly: an expression sharing no variable with the group is never
+    rewritten. Purely an efficiency gate (a false negative loses a fold; a false positive costs a
+    no-op `foldOut`, which — order-preserving — returns an equal system). -/
 def systemHasFoldableW (cs : ConstraintSystem p) (xs : List Variable)
     (survs : List (List (Variable × ZMod p))) (rest : List (Expression p)) : Bool :=
-  rest.any (fun c => c.hasFoldable xs survs) ||
+  rest.any (fun c => c.anyVarIn xs && c.hasFoldable xs survs) ||
     cs.busInteractions.any (fun bi =>
-      bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs))
+      (bi.multiplicity.anyVarIn xs && bi.multiplicity.hasFoldable xs survs) ||
+        bi.payload.any (fun e => e.anyVarIn xs && e.hasFoldable xs survs))
 
 /-! ### The index-local gate
 
-`systemHasFoldable` is a full-system scan run once per target — the dominant cost of this pass.
-It decomposes exactly: an expression sharing **no** variable with the group `xs` can only have a
-foldable subexpression that is *variable-free* (`varsIn xs` is vacuous only for var-free nodes),
-and whether an expression has a var-free `add`/`mul` node is independent of `xs` and of the
-(nonempty) survivor set. So the gate equals: (a) any item *sharing a variable* with `xs` — found
-through the inverted indexes — passing the original per-item test, or (b) any item with a
-var-free compound node (precomputed once per invocation; empty after constant folding) sharing
-no variable with `xs`. Purely an efficiency gate, like `systemHasFoldable` itself. -/
+The full-system no-op scan decomposes exactly: `foldRewrite` only ever rewrites an expression
+sharing a variable with the group `xs`, and every item sharing a variable with `xs` is (by bucket
+completeness, `FoldIdx.hidx`/`hbis`) reachable through the inverted indexes. So the gate scans
+only the bucketed candidate positions for `xs`, re-testing each against the current item arrays —
+stale (superset) bucket entries cost a re-test, never a wrong answer. Purely an efficiency gate,
+like `systemHasFoldableW`. -/
 
 /-! ### Indexing the per-target covered-constraint scan
 
@@ -490,67 +507,105 @@ def dedupVarsOf (c : Expression p) : List Variable :=
 def dedupBiVarsOf (bi : BusInteraction (Expression p)) : List Variable :=
   HashedDedup.hashedEraseDups (hash ·) bi.vars
 
-/-- The prebuilt covered-constraint index for the current `cs`, with the proofs tying it to `cs` so
-    the covered set it yields is provably `coveredCsOf cs xs` (`coveredCsIdx_eq`), plus the
-    proof-free data the index-local `systemHasFoldableIdx` gate consumes: the interaction-side
-    inverted index and the (normally empty) const-foldable item lists. -/
+/-- The prebuilt inverted indexes for the current `cs`, carried with **bucket-completeness
+    invariants** rather than build-equalities: every item position is bucketed under each of its
+    variables (`hidx` for constraints, `hbis` for interactions). Completeness is all any consumer
+    needs — the covered-set equality (`coveredCsIdx_eq`, via
+    `CoveredIndex.coveredIdx_eq_filter_of_complete`) and the sparse fold (`foldOutIdx_eq`) both
+    re-check candidates at use, so *superset* (stale) buckets are harmless. That is the point:
+    `foldOut` rewrites items in place and only ever shrinks variable sets, so completeness
+    survives an accepted fold and `FoldIdx.refresh` keeps both bucket maps **without any
+    rebuild**. -/
 structure FoldIdx (cs : ConstraintSystem p) where
   idx : CoveredIndex.CovIndex
-  hidx : idx = CoveredIndex.build dedupVarsOf cs.algebraicConstraints
+  /-- Constraint-side bucket completeness: position `i` is in the bucket of each variable of
+      constraint `i`. (Buckets may also contain stale extras; consumers re-check.) -/
+  hidx : ∀ (i : Nat) (hi : i < cs.algebraicConstraints.length),
+    ∀ v ∈ cs.algebraicConstraints[i].vars, i ∈ idx.buckets.getD v []
   arr : Array (Expression p)
   harr : arr = cs.algebraicConstraints.toArray
   bisIdx : CoveredIndex.CovIndex
+  /-- Interaction-side bucket completeness (multiplicity and payload variables). -/
+  hbis : ∀ (i : Nat) (hi : i < cs.busInteractions.length),
+    ∀ v ∈ (cs.busInteractions[i]).vars, i ∈ bisIdx.buckets.getD v []
   arrBis : Array (BusInteraction (Expression p))
-  cfCs : List (Expression p)
-  cfBis : List (BusInteraction (Expression p))
 
-/-- Build the index for a system (by construction the equalities hold `rfl`). -/
+/-- Build the indexes for a system: a fresh `build` is complete (`CoveredIndex.build_complete`;
+    membership transports through the per-item dedup). -/
 def FoldIdx.mk' (cs : ConstraintSystem p) : FoldIdx cs where
   idx := CoveredIndex.build dedupVarsOf cs.algebraicConstraints
-  hidx := rfl
+  hidx := fun i hi v hv =>
+    CoveredIndex.build_complete dedupVarsOf cs.algebraicConstraints i hi v (by
+      rw [dedupVarsOf, HashedDedup.hashedEraseDups_eq]
+      exact List.mem_eraseDups.2 hv)
   arr := cs.algebraicConstraints.toArray
   harr := rfl
   bisIdx := CoveredIndex.build dedupBiVarsOf cs.busInteractions
+  hbis := fun i hi v hv =>
+    CoveredIndex.build_complete dedupBiVarsOf cs.busInteractions i hi v (by
+      rw [dedupBiVarsOf, HashedDedup.hashedEraseDups_eq]
+      exact List.mem_eraseDups.2 hv)
   arrBis := cs.busInteractions.toArray
-  cfCs := cs.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
-  cfBis := cs.busInteractions.filter (fun bi =>
-    bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
 
-/-- Refresh the index after an accepted fold. The constraint side is rebuilt — the fold reorders
-    constraints, and the covered-set equality (`coveredCsIdx_eq`) needs the exact tie — but the
-    interaction-side *buckets* are reused stale: `foldOut` maps interactions in place (same count
-    and order) and only ever shrinks an expression's variable set (subexpressions are replaced by
-    constants), so the stale buckets are a superset of freshly-built ones. The gate stays exact:
-    candidates are re-tested against the fresh array, and an over-included candidate that still
-    passes the per-item test would make the full scan true as well. This halves the dominant
-    rebuild-per-accepted-fold cost on fold-heavy circuits. -/
-def FoldIdx.refresh {cs : ConstraintSystem p} (old : FoldIdx cs) (ro : ConstraintSystem p) :
-    FoldIdx ro where
-  idx := CoveredIndex.build dedupVarsOf ro.algebraicConstraints
-  hidx := rfl
+/-- A rewrite that introduces no variables per expression keeps an interaction's variables. -/
+theorem mapExpr_vars_subset (g : Expression p → Expression p)
+    (hg : ∀ (e : Expression p) (v : Variable), v ∈ (g e).vars → v ∈ e.vars)
+    (bi : BusInteraction (Expression p)) : ∀ v ∈ (bi.mapExpr g).vars, v ∈ bi.vars := by
+  intro v hv
+  simp only [BusInteraction.mapExpr, BusInteraction.vars, List.mem_append,
+    List.mem_flatMap] at hv ⊢
+  rcases hv with hv | ⟨e, he, hv⟩
+  · exact Or.inl (hg _ v hv)
+  · obtain ⟨e0, he0, rfl⟩ := List.mem_map.1 he
+    exact Or.inr ⟨e0, he0, hg e0 v hv⟩
+
+/-- Refresh the indexes after an accepted fold — **no rebuild**. `foldOut` rewrites items in
+    place (order- and length-preserving) and only ever shrinks an expression's variable set
+    (`foldRewrite_vars`), so both bucket maps stay complete exactly as they are; only the item
+    arrays are re-materialized (O(n) pointer work). Stale bucket entries — positions whose item no
+    longer mentions the variable — are harmless: every consumer re-checks candidates against the
+    current arrays. The rewritten system is passed in as the already-computed value `ro` (with the
+    proof it *is* the fold) so nothing is recomputed here. -/
+def FoldIdx.refresh {cs : ConstraintSystem p} (old : FoldIdx cs) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) (ro : ConstraintSystem p)
+    (hro : ro = foldOut cs xs survs) : FoldIdx ro where
+  idx := old.idx
+  hidx := fun i hi v hv => by
+    subst hro
+    have hlen : i < cs.algebraicConstraints.length := by
+      simpa only [foldOut, List.length_map] using hi
+    have hv' : v ∈ cs.algebraicConstraints[i].vars := by
+      have hgm : (foldOut cs xs survs).algebraicConstraints[i]'hi
+          = (if coveredBy xs (cs.algebraicConstraints[i]'hlen) then
+              cs.algebraicConstraints[i]'hlen
+             else foldRewrite xs survs (cs.algebraicConstraints[i]'hlen)) := by
+        simp only [foldOut, List.getElem_map]
+      rw [hgm] at hv
+      by_cases hcov : coveredBy xs (cs.algebraicConstraints[i]'hlen) = true
+      · rwa [if_pos hcov] at hv
+      · rw [if_neg hcov] at hv
+        exact foldRewrite_vars xs survs _ v hv
+    exact old.hidx i hlen v hv'
   arr := ro.algebraicConstraints.toArray
   harr := rfl
   bisIdx := old.bisIdx
+  hbis := fun i hi v hv => by
+    subst hro
+    have hlen : i < cs.busInteractions.length := by
+      simpa only [foldOut, List.length_map] using hi
+    have hv' : v ∈ (cs.busInteractions[i]'hlen).vars := by
+      have hgm : (foldOut cs xs survs).busInteractions[i]'hi
+          = (cs.busInteractions[i]'hlen).mapExpr (foldRewrite xs survs) := by
+        simp only [foldOut, List.getElem_map]
+      rw [hgm] at hv
+      exact mapExpr_vars_subset _ (foldRewrite_vars xs survs) _ v hv
+    exact old.hbis i hlen v hv'
   arrBis := ro.busInteractions.toArray
-  -- The const-foldable lists were two more full-system filters per accepted fold. A fold never
-  -- *creates* a variable-free compound node (`foldRewrite` replaces the maximal
-  -- constant-on-survivors node by a constant leaf, so a parent that became var-free would itself
-  -- have been the maximal node), so the fresh filter is always a subset of the old list — when
-  -- the old list is **empty** (the normal, post-constant-fold state) the fresh one is provably
-  -- empty too and the filters are skipped outright; otherwise recompute exactly as before, so
-  -- the gate value (and the pass output) is bit-for-bit unchanged.
-  cfCs := if old.cfCs.isEmpty then [] else
-    ro.algebraicConstraints.filter (fun c => c.hasConstFoldableNode)
-  cfBis := if old.cfBis.isEmpty then [] else
-    ro.busInteractions.filter (fun bi =>
-      bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode))
 
-/-- The index-local form of `systemHasFoldable` (see the section comment above): scan only the
-    items sharing a variable with `xs` (through the inverted indexes, candidate positions
-    deduplicated so an item sharing several variables is tested once — `hasFoldable` is the
-    expensive part), plus the precomputed const-foldable items when disjoint from `xs`. Requires
-    a nonempty survivor set (the caller's `1 ≤ survs.length` gate). Equal to
-    `systemHasFoldable cs xs survs`; purely an efficiency gate, so no proof is carried. -/
+/-- The index-local no-op gate (see the section comment above): scan only the items sharing a
+    variable with `xs` (through the inverted indexes, candidate positions deduplicated so an item
+    sharing several variables is tested once — `hasFoldable` is the expensive part), re-testing
+    each against the current arrays. Purely an efficiency gate, so no proof is carried. -/
 def systemHasFoldableIdx {cs : ConstraintSystem p} (fidx : FoldIdx cs) (xs : List Variable)
     (survs : List (List (Variable × ZMod p))) : Bool :=
   (((xs.flatMap (fun v => fidx.idx.buckets.getD v [])).foldl (·.insert ·)
@@ -564,10 +619,7 @@ def systemHasFoldableIdx {cs : ConstraintSystem p} (fidx : FoldIdx cs) (xs : Lis
     if h : i < fidx.arrBis.size then
       let bi := fidx.arrBis[i]
       bi.multiplicity.hasFoldable xs survs || bi.payload.any (fun e => e.hasFoldable xs survs)
-    else false)) ||
-  (fidx.cfCs.any (fun c => !c.anyVarIn xs)) ||
-  (fidx.cfBis.any (fun bi =>
-    !(bi.multiplicity.anyVarIn xs || bi.payload.any (fun e => e.anyVarIn xs))))
+    else false))
 
 /-- An expression with any variable has a nonempty variable list. -/
 theorem hasVar_vars_ne_nil (c : Expression p) (h : c.hasVar = true) : c.vars ≠ [] := by
@@ -599,23 +651,152 @@ theorem coveredBy_shares_var (xs : List Variable) (c : Expression p) (h : covere
   exact ⟨v, hmem, Expression.varsIn_sound xs c (Expression.varsInF_eq xs c ▸ hvin) v hmem⟩
 
 /-- The index yields exactly `coveredCsOf cs xs` for every target — an equality (not just
-    soundness), so the domains it feeds and the `foldOut_correct` proof transport unchanged. -/
+    soundness), so the domains it feeds and the `foldOut_correct` proof transport unchanged. Needs
+    only the completeness invariant (`hidx`), so it holds for refreshed (possibly stale-superset)
+    indexes just as for fresh builds. -/
 theorem coveredCsIdx_eq (cs : ConstraintSystem p) (xs : List Variable) (fidx : FoldIdx cs) :
     CoveredIndex.coveredIdx fidx.idx fidx.arr (coveredBy xs) xs = coveredCsOf cs xs := by
-  rw [fidx.hidx, fidx.harr, coveredCsOf]
-  exact CoveredIndex.coveredIdx_eq_filter dedupVarsOf cs.algebraicConstraints (coveredBy xs) xs
-    (fun i _hi hQ => by
+  rw [fidx.harr, coveredCsOf]
+  exact CoveredIndex.coveredIdx_eq_filter_of_complete fidx.idx cs.algebraicConstraints
+    (coveredBy xs) xs
+    (fun i hi hQ => by
       obtain ⟨v, hv, hvxs⟩ := coveredBy_shares_var xs cs.algebraicConstraints[i] hQ
-      exact ⟨v, by
-        rw [dedupVarsOf, HashedDedup.hashedEraseDups_eq]
-        exact List.mem_eraseDups.2 hv, hvxs⟩)
+      exact CoveredIndex.mem_candidates fidx.idx xs v i hvxs (fidx.hidx i hi v hv))
+
+/-! ### The sparse fold
+
+`foldOut` maps `foldRewrite` over the *whole* system, so each accepted fold pays a full
+gate walk (`anyVarIn`) over every expression node in the system — the dominant per-accept cost on
+fold-heavy circuits. But `foldRewrite` is the identity on any expression sharing no variable with
+`xs` (`foldRewrite_eq_self`), and by bucket completeness every item sharing a variable with `xs`
+is bucketed under it — so only the bucketed candidate positions can change. `foldOutIdx` walks
+the system once by position, passing every non-candidate item through untouched (one O(1)
+`Nat`-set probe each, no expression walk), and is provably equal to `foldOut`
+(`foldOutIdx_eq`). -/
+
+/-- The deduplicating position set of every bucket entry for a variable of `xs` — the positions
+    an accepted fold can possibly touch. -/
+def touchedSet (idx : CoveredIndex.CovIndex) (xs : List Variable) : Std.HashSet Nat :=
+  (xs.flatMap (fun v => idx.buckets.getD v [])).foldl (·.insert ·) ∅
+
+/-- Membership in the touched set is membership in some bucket of `xs`. -/
+theorem touchedSet_contains_iff (idx : CoveredIndex.CovIndex) (xs : List Variable) (i : Nat) :
+    (touchedSet idx xs).contains i = true ↔ ∃ v ∈ xs, i ∈ idx.buckets.getD v [] := by
+  rw [← Std.HashSet.mem_iff_contains, touchedSet, CoveredIndex.mem_foldl_insert,
+    List.mem_flatMap]
+  simp [Std.HashSet.not_mem_empty]
+
+/-- `foldOut`, computed sparsely through the index: only candidate positions (bucketed under a
+    variable of `xs`) are rewritten; all others are passed through by position. -/
+def foldOutIdx {cs : ConstraintSystem p} (fidx : FoldIdx cs) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) : ConstraintSystem p :=
+  let touchedCs : Std.HashSet Nat := touchedSet fidx.idx xs
+  let touchedBis : Std.HashSet Nat := touchedSet fidx.bisIdx xs
+  { algebraicConstraints := cs.algebraicConstraints.zipIdx.map (fun ci =>
+      if touchedCs.contains ci.2 then
+        (if coveredBy xs ci.1 then ci.1 else foldRewrite xs survs ci.1)
+      else ci.1),
+    busInteractions := cs.busInteractions.zipIdx.map (fun bii =>
+      if touchedBis.contains bii.2 then bii.1.mapExpr (foldRewrite xs survs) else bii.1) }
+
+/-- An untouched interaction maps to itself under a rewrite that fixes each of its expressions. -/
+theorem mapExpr_eq_self {bi : BusInteraction (Expression p)} {g : Expression p → Expression p}
+    (hm : g bi.multiplicity = bi.multiplicity) (hp : ∀ e ∈ bi.payload, g e = e) :
+    bi.mapExpr g = bi := by
+  have hpl : bi.payload.map g = bi.payload :=
+    (List.map_congr_left (g := id) hp).trans (List.map_id _)
+  cases bi with
+  | mk busId mult payload =>
+    simp only [BusInteraction.mapExpr] at *
+    rw [hm, hpl]
+
+/-- The positional pass-through map equals the plain map when the function fixes the item at
+    every position outside `mem`. -/
+theorem zipIdx_map_sparse {α : Type _} (l : List α) (f : α → α) (mem : Nat → Bool)
+    (hfix : ∀ (i : Nat) (hi : i < l.length), mem i = false → f l[i] = l[i]) :
+    l.zipIdx.map (fun ai => if mem ai.2 then f ai.1 else ai.1) = l.map f := by
+  rw [show l.map f = l.zipIdx.map (f ∘ Prod.fst) by rw [← List.map_map, List.zipIdx_map_fst]]
+  refine List.map_congr_left ?_
+  rintro ⟨a, i⟩ hp
+  obtain ⟨_, hlt, heq⟩ := List.mem_zipIdx (k := 0) hp
+  have hlt' : i < l.length := by simpa using hlt
+  have heq' : l[i]'hlt' = a := by simpa using heq.symm
+  dsimp only [Function.comp_apply]
+  by_cases hm : mem i = true
+  · rw [if_pos hm]
+  · rw [if_neg hm]
+    have := hfix i hlt' (by simpa using hm)
+    rw [heq'] at this
+    exact this.symm
+
+/-- **The sparse fold is the fold.** Every non-candidate position holds an item sharing no
+    variable with `xs` (bucket completeness, contraposed), on which `foldRewrite` is the
+    identity — so skipping it is exact. -/
+theorem foldOutIdx_eq {cs : ConstraintSystem p} (fidx : FoldIdx cs) (xs : List Variable)
+    (survs : List (List (Variable × ZMod p))) :
+    foldOutIdx fidx xs survs = foldOut cs xs survs := by
+  show ConstraintSystem.mk
+      (cs.algebraicConstraints.zipIdx.map (fun ci =>
+        if (touchedSet fidx.idx xs).contains ci.2 then
+          (if coveredBy xs ci.1 then ci.1 else foldRewrite xs survs ci.1)
+        else ci.1))
+      (cs.busInteractions.zipIdx.map (fun bii =>
+        if (touchedSet fidx.bisIdx xs).contains bii.2 then
+          bii.1.mapExpr (foldRewrite xs survs)
+        else bii.1)) = foldOut cs xs survs
+  unfold foldOut
+  congr 1
+  · -- constraint side
+    refine zipIdx_map_sparse cs.algebraicConstraints
+      (fun c => if coveredBy xs c then c else foldRewrite xs survs c)
+      (fun i => (touchedSet fidx.idx xs).contains i) ?_
+    intro i hi hm
+    have hm' : (touchedSet fidx.idx xs).contains i = false := hm
+    -- `i` is in no bucket of `xs`, so the constraint shares no variable with `xs`.
+    have hnb : ¬ ∃ v ∈ xs, i ∈ fidx.idx.buckets.getD v [] := by
+      rw [← touchedSet_contains_iff fidx.idx xs i, hm']
+      simp
+    have hnav : cs.algebraicConstraints[i].anyVarIn xs = false := by
+      by_contra hav
+      obtain ⟨v, hvc, hvxs⟩ := Expression.anyVarIn_exists (Bool.ne_false_iff.mp hav)
+      exact hnb ⟨v, hvxs, fidx.hidx i hi v hvc⟩
+    show (if coveredBy xs cs.algebraicConstraints[i] then cs.algebraicConstraints[i]
+        else foldRewrite xs survs cs.algebraicConstraints[i]) = cs.algebraicConstraints[i]
+    rw [foldRewrite_eq_self hnav, ite_self]
+  · -- interaction side
+    refine zipIdx_map_sparse cs.busInteractions
+      (fun bi => bi.mapExpr (foldRewrite xs survs))
+      (fun i => (touchedSet fidx.bisIdx xs).contains i) ?_
+    intro i hi hm
+    have hm' : (touchedSet fidx.bisIdx xs).contains i = false := hm
+    have hnb : ¬ ∃ v ∈ xs, i ∈ fidx.bisIdx.buckets.getD v [] := by
+      rw [← touchedSet_contains_iff fidx.bisIdx xs i, hm']
+      simp
+    have hnoshare : ∀ v ∈ (cs.busInteractions[i]).vars, v ∉ xs := by
+      intro v hvbi hvxs
+      exact hnb ⟨v, hvxs, fidx.hbis i hi v hvbi⟩
+    have hfix : ∀ e : Expression p, (∀ v ∈ e.vars, v ∈ (cs.busInteractions[i]).vars) →
+        foldRewrite xs survs e = e := by
+      intro e hsub
+      refine foldRewrite_eq_self ?_
+      by_contra hav
+      obtain ⟨v, hvc, hvxs⟩ := Expression.anyVarIn_exists (Bool.ne_false_iff.mp hav)
+      exact hnoshare v (hsub v hvc) hvxs
+    show (cs.busInteractions[i]).mapExpr (foldRewrite xs survs) = cs.busInteractions[i]
+    exact mapExpr_eq_self
+      (hfix (cs.busInteractions[i]).multiplicity (fun v hv => by
+        rw [BusInteraction.vars]; exact List.mem_append_left _ hv))
+      (fun e he => hfix e (fun v hv => by
+        rw [BusInteraction.vars]
+        exact List.mem_append_right _ (List.mem_flatMap.2 ⟨e, he, hv⟩)))
 
 /-- One checked fold for a candidate group (identity unless the group has a bounded domain, at least
     one survivor, and some foldable subexpression). The per-target covered scan is served from the
     prebuilt index (`coveredCsIdx_eq`) — and reused for the survivor filter
     (`groupSurvivorsE es`, provably `groupSurvivors cs xs doms` via `hes`) and for the
     index-local no-op gate (`systemHasFoldableIdx`), so no full-system scan remains on the
-    per-target path. The index is rebuilt only when a fold rewrites `cs`. Prime `p`; the caller
+    per-target path. An accepted fold is computed sparsely (`foldOutIdx`, provably the full fold)
+    and the index is *refreshed*, never rebuilt (`FoldIdx.refresh`). Prime `p`; the caller
     supplies `Fact p.Prime`. -/
 def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fidx : FoldIdx cs)
     (xs : List Variable) : Σ' (r : PassResult cs bs), FoldIdx r.out :=
@@ -630,13 +811,13 @@ def foldStep [Fact p.Prime] (bs : BusSemantics p) (cs : ConstraintSystem p) (fid
         have hsurv : groupSurvivors cs xs doms = survs := by
           show groupSurvivors cs xs doms = groupSurvivorsE es doms
           rw [hes]; rfl
-        -- Compute the rewritten system once (it was built twice: as the output and as the index
-        -- refresh argument). `foldOut` maps `foldRewrite` over the whole system, so this halves the
-        -- per-accepted-fold cost; the `let` zeta-reduces, so the correctness term is unchanged.
-        let ro := foldOut cs xs survs
-        ⟨⟨ro, [], (hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms) :
+        -- Compute the rewritten system once, sparsely; correctness and the index refresh both
+        -- transport along `hro` to the computed value, so nothing is evaluated twice.
+        let ro := foldOutIdx fidx xs survs
+        have hro : ro = foldOut cs xs survs := foldOutIdx_eq fidx xs survs
+        ⟨⟨ro, [], hro ▸ (hsurv ▸ foldOut_correct cs bs xs doms (hes ▸ hdoms) :
             PassCorrect cs (foldOut cs xs survs) [] bs)⟩,
-         fidx.refresh ro⟩
+         fidx.refresh xs survs ro hro⟩
       else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
     else ⟨⟨cs, [], PassCorrect.refl cs bs⟩, fidx⟩
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FactPass.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FactPass.lean
@@ -66,6 +66,22 @@ def ConstraintSystem.varCount (cs : ConstraintSystem p) : Nat :=
 def ConstraintSystem.sizeKey (cs : ConstraintSystem p) : Nat ×ₗ Nat ×ₗ Nat :=
   toLex (cs.varCount, toLex (cs.busInteractions.length, cs.algebraicConstraints.length))
 
+/-- The fixpoint worker, with the input's already-computed size key threaded through (`hk`):
+    each cycle computes only the *output*'s key — the old loop recomputed the input's key as well,
+    one redundant occurrence-list walk and hash-set build per cycle (`varCount` flat-maps every
+    variable occurrence in the system). Same comparisons, same results. -/
+def iterateToFixpointFrom (f : VerifiedPassW p) (cs : ConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (k : Nat ×ₗ Nat ×ₗ Nat) (_hk : cs.sizeKey = k) : PassResult cs bs :=
+  let r := f cs bs facts
+  let k' := r.out.sizeKey
+  if _h : k' < k then
+    let r2 := iterateToFixpointFrom f r.out bs facts k' rfl
+    ⟨r2.out, r.derivs ++ r2.derivs, r.correct.andThen r2.correct⟩
+  else
+    ⟨cs, [], PassCorrect.refl cs bs⟩
+  termination_by cs.sizeKey
+  decreasing_by rw [_hk]; exact _h
+
 /-- Iterate a fact-aware pass to a fixpoint, with **no** iteration budget: apply `f`; if the result
     is strictly smaller (lexicographically in `sizeKey`), recurse from it; otherwise stop and return
     the input unchanged. Terminates because every recursive step strictly decreases the well-founded
@@ -73,14 +89,7 @@ def ConstraintSystem.sizeKey (cs : ConstraintSystem p) : Nat ×ₗ Nat ×ₗ Nat
     stopping returns the input, correct by reflexivity). -/
 def iterateToFixpoint (f : VerifiedPassW p) (cs : ConstraintSystem p) (bs : BusSemantics p)
     (facts : BusFacts p bs) : PassResult cs bs :=
-  let r := f cs bs facts
-  if _h : r.out.sizeKey < cs.sizeKey then
-    let r2 := iterateToFixpoint f r.out bs facts
-    ⟨r2.out, r.derivs ++ r2.derivs, r.correct.andThen r2.correct⟩
-  else
-    ⟨cs, [], PassCorrect.refl cs bs⟩
-  termination_by cs.sizeKey
-  decreasing_by exact _h
+  iterateToFixpointFrom f cs bs facts cs.sizeKey rfl
 
 /-! ## Degree guarding
 
@@ -126,31 +135,47 @@ theorem VerifiedPassW.iterate_respectsDeg {b : DegreeBound} {f : VerifiedPassW p
 theorem sizeKey_wf : WellFounded (fun a b : ConstraintSystem p => a.sizeKey < b.sizeKey) :=
   InvImage.wf ConstraintSystem.sizeKey wellFounded_lt
 
-/-- `iterateToFixpoint` preserves the degree bound: every kept step is `f` (which respects the
-    bound) and the stopping case returns the unchanged input. Proved by strong induction on the
-    `sizeKey` measure the loop recurses on. -/
-theorem iterateToFixpoint_respectsDeg {b : DegreeBound} {f : VerifiedPassW p}
-    (hf : RespectsDeg b f) : RespectsDeg b (iterateToFixpoint f) := by
-  intro cs
+/-- `iterateToFixpointFrom` preserves the degree bound: every kept step is `f` (which respects
+    the bound) and the stopping case returns the unchanged input. Proved by strong induction on
+    the `sizeKey` measure the loop recurses on, generalizing the threaded key. -/
+theorem iterateToFixpointFrom_respectsDeg {b : DegreeBound} {f : VerifiedPassW p}
+    (hf : RespectsDeg b f) (cs : ConstraintSystem p) :
+    ∀ (bs : BusSemantics p) (facts : BusFacts p bs) (k : Nat ×ₗ Nat ×ₗ Nat)
+      (hk : cs.sizeKey = k), cs.withinDegree b →
+      (iterateToFixpointFrom f cs bs facts k hk).out.withinDegree b := by
   induction cs using sizeKey_wf.induction with
   | _ cs ih =>
-    intro bs facts hcs
-    rw [iterateToFixpoint]
+    intro bs facts k hk hcs
+    rw [iterateToFixpointFrom]
     split
     · rename_i h
-      exact ih _ h bs facts (hf cs bs facts hcs)
+      exact ih _ (by rw [hk]; exact h) bs facts _ rfl (hf cs bs facts hcs)
     · exact hcs
+
+/-- `iterateToFixpoint` preserves the degree bound. -/
+theorem iterateToFixpoint_respectsDeg {b : DegreeBound} {f : VerifiedPassW p}
+    (hf : RespectsDeg b f) : RespectsDeg b (iterateToFixpoint f) :=
+  fun cs bs facts hcs => iterateToFixpointFrom_respectsDeg hf cs bs facts _ rfl hcs
+
+/-- `iterateToFixpointFrom` never grows the size key (strong induction, key generalized). -/
+theorem iterateToFixpointFrom_monotone {f : VerifiedPassW p} (cs : ConstraintSystem p) :
+    ∀ (bs : BusSemantics p) (facts : BusFacts p bs) (k : Nat ×ₗ Nat ×ₗ Nat)
+      (hk : cs.sizeKey = k),
+      (iterateToFixpointFrom f cs bs facts k hk).out.sizeKey ≤ cs.sizeKey := by
+  induction cs using sizeKey_wf.induction with
+  | _ cs ih =>
+    intro bs facts k hk
+    rw [iterateToFixpointFrom]
+    split
+    · rename_i h
+      exact le_trans (ih _ (by rw [hk]; exact h) bs facts _ rfl)
+        (le_of_lt (by rw [hk]; exact h))
+    · exact le_refl _
 
 /-- **The cleanup loop can only improve the circuit.** `iterateToFixpoint f`'s output never has a
     larger lexicographic `sizeKey` (distinct vars, then bus interactions, then constraints) than its
     input: every recursive step strictly lowers the key, and the stopping case returns the input. -/
 theorem iterateToFixpoint_monotone {f : VerifiedPassW p}
     (cs : ConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs) :
-    (iterateToFixpoint f cs bs facts).out.sizeKey ≤ cs.sizeKey := by
-  induction cs using sizeKey_wf.induction with
-  | _ cs ih =>
-    rw [iterateToFixpoint]
-    split
-    · rename_i h
-      exact le_trans (ih _ h) (le_of_lt h)
-    · exact le_refl _
+    (iterateToFixpoint f cs bs facts).out.sizeKey ≤ cs.sizeKey :=
+  iterateToFixpointFrom_monotone cs bs facts _ rfl

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -557,13 +557,6 @@ def pdDropSet (bs : BusSemantics p) (singles : List (Expression p))
     pos := pos + 1
   return drops
 
-/-- Was `bi` flagged by the sweep? (`false` = flagged as a drop candidate.) -/
-def pdFastKeep (drops : Std.HashMap UInt64 (List (BusInteraction (Expression p))))
-    (bi : BusInteraction (Expression p)) : Bool :=
-  match drops[pdValHash bi]? with
-  | some l => !(l.any (fun b => decide (b = bi)))
-  | none => true
-
 /-- Part C as a standalone (unguarded) pass: drop stateless interactions pointwise-equal to an
     earlier first-of-class one. Stated over an arbitrary *prefilter* `fast`: the kept set is
     `fast bi || pdKeep … bi`, so a drop requires `pdKeep … = false` (the certified condition)

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -22,9 +22,12 @@ variable {p : ℕ}
 
 /-! ## Part B: box-tautology replacement -/
 
-/-- The single-variable constraints of a list (the only `findDomainAlg` sources). -/
+/-- The single-variable constraints of a list (the only `findDomainAlg` sources). The
+    distinct-variable count uses the bucketed dedup (`hashedEraseDups_eq` — the identical list,
+    so the filter and everything downstream is value-unchanged); occurrence-heavy constraints
+    made the plain quadratic `eraseDups` measurable here. -/
 def singleVarCs (all : List (Expression p)) : List (Expression p) :=
-  all.filter (fun c => c.vars.eraseDups.length == 1)
+  all.filter (fun c => (HashedDedup.hashedEraseDups (hash ·) c.vars).length == 1)
 
 /-- Certificate: `c` mentions ≥ 2 distinct variables, every one carries a proven finite domain
     (from the single-variable constraints), the joint box is small, and `c` vanishes on all of
@@ -112,8 +115,9 @@ theorem ConstraintSystem.boxTautoReplace_correct [Fact p.Prime]
       intro c' hc'
       simp only [singleVarCs] at hc'
       have hmem := List.mem_of_mem_filter hc'
-      have hsingle : (c'.vars.eraseDups.length == 1) = true :=
-        (List.mem_filter.1 hc').2
+      have hsingle : (c'.vars.eraseDups.length == 1) = true := by
+        have h := (List.mem_filter.1 hc').2
+        rwa [HashedDedup.hashedEraseDups_eq] at h
       exact hsat.1 c' (singleVar_mem_boxTautoReplace cs domOf c' hmem hsingle)
     have hmemdoms : ∀ vd ∈ c.vars.eraseDups.filterMap (fun v =>
         (findDomainAlg (singleVarCs cs.algebraicConstraints) v).map (fun d => (v, d))),
@@ -179,6 +183,16 @@ def boxTautoDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let singles := singleVarCs cs.algebraicConstraints
+    -- Bucket the single-variable constraints by their variable once: `findDomainAlg singles v`
+    -- skips every constraint not mentioning `v`, and a single-variable constraint mentions
+    -- exactly its one variable — so scanning `v`'s own bucket (original order preserved) yields
+    -- the identical domain without the O(#singles) `mentions` walk per distinct variable (the
+    -- pass's dominant cost on large circuits).
+    let singlesBy : Std.HashMap Variable (List (Expression p)) :=
+      singles.reverse.foldl (fun m c =>
+        match HashedDedup.hashedEraseDups (hash ·) c.vars with
+        | [v] => m.insert v (c :: m.getD v [])
+        | _ => m) ∅
     -- Build the per-variable domain cache in one linear pass over all occurrences, skipping
     -- variables already seen (a `contains` guard) rather than pre-deduplicating with the quadratic
     -- `List.eraseDups` over the whole ~10⁵-entry occurrence list. `findDomainAlg` is deterministic,
@@ -186,7 +200,8 @@ def boxTautoDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
     -- theorem takes the oracle as an arbitrary function, so this rebuild is proof-transparent.
     let cache : Std.HashMap Variable (Option (List (ZMod p))) :=
       (cs.algebraicConstraints.flatMap Expression.vars).foldl
-        (fun m v => if m.contains v then m else m.insert v (findDomainAlg singles v)) ∅
+        (fun m v => if m.contains v then m
+         else m.insert v (findDomainAlg (singlesBy.getD v []) v)) ∅
     ⟨cs.boxTautoReplaceWith singles (fun v => cache.getD v none), [],
      cs.boxTautoReplace_correct bs (fun v => cache.getD v none)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
@@ -557,23 +572,20 @@ def pdFastKeep (drops : Std.HashMap UInt64 (List (BusInteraction (Expression p))
     on the few genuine drops. -/
 theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
     (cs : ConstraintSystem p) (bs : BusSemantics p)
-    (fast : BusInteraction (Expression p) → Bool) :
-    PassCorrect cs
-      (cs.filterBus
-        (fun bi => fast bi || pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions bi))
-      [] bs :=
+    (keep : BusInteraction (Expression p) → Bool)
+    (hkeep : ∀ bi ∈ cs.busInteractions, keep bi = false →
+      pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions bi = false) :
+    PassCorrect cs (cs.filterBus keep) [] bs :=
   cs.filterBusEntailed_correct bs _
        (by
-         intro bi _ hkf
-         rw [Bool.or_eq_false_iff] at hkf
-         have hkf' := hkf.2
+         intro bi hbimem hkf
+         have hkf' := hkeep bi hbimem hkf
          unfold pdKeep at hkf'
          rw [Bool.or_eq_false_iff] at hkf'
          simpa using hkf'.1)
        (by
          intro bi hbimem hkf env hsat hm
-         rw [Bool.or_eq_false_iff] at hkf
-         have hkf' := hkf.2
+         have hkf' := hkeep bi hbimem hkf
          unfold pdKeep at hkf'
          rw [Bool.or_eq_false_iff] at hkf'
          obtain ⟨_hst, hmatch⟩ := hkf'
@@ -589,10 +601,13 @@ theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
            have hbkeep : pdKeep bs (singleVarCs cs.algebraicConstraints)
                cs.busInteractions b = true :=
              pdFirst_keep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions b hfirst
-           have hbout : b ∈ (cs.filterBus
-               (fun bi => fast bi || pdKeep bs (singleVarCs cs.algebraicConstraints)
-                 cs.busInteractions bi)).busInteractions :=
-             List.mem_filter.2 ⟨hbcs, by simp [hbkeep]⟩
+           have hbkept : keep b = true := by
+             by_contra hkb
+             have := hkeep b hbcs (by simpa using hkb)
+             rw [this] at hbkeep
+             exact absurd hbkeep (by simp)
+           have hbout : b ∈ (cs.filterBus keep).busInteractions :=
+             List.mem_filter.2 ⟨hbcs, hbkept⟩
            have hdom : ∀ c ∈ singleVarCs cs.algebraicConstraints, c.eval env = 0 := by
              intro c hc
              exact hsat.1 c (List.mem_of_mem_filter hc)
@@ -602,15 +617,47 @@ theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
            rw [heq] at hob
            exact hob hm)
 
+/-- The verdict-map keep test: drop `bi` iff its value bucket holds a *certified* dropped twin
+    (an entry provably `pdKeep = false`, structurally equal to `bi`). -/
+def pdVerdictKeep {p : ℕ} {P : BusInteraction (Expression p) → Prop}
+    (verdicts : Std.HashMap UInt64 (List { b : BusInteraction (Expression p) // P b }))
+    (bi : BusInteraction (Expression p)) : Bool :=
+  match verdicts[pdValHash bi]? with
+  | some l => !(l.any (fun b => decide (b.val = bi)))
+  | none => true
+
+/-- A `pdVerdictKeep` drop carries its certificate: the bucket entry is structurally equal to
+    `bi`, so its stored property transports. -/
+theorem pdVerdictKeep_false {p : ℕ} {P : BusInteraction (Expression p) → Prop}
+    (verdicts : Std.HashMap UInt64 (List { b : BusInteraction (Expression p) // P b }))
+    (bi : BusInteraction (Expression p)) (h : pdVerdictKeep verdicts bi = false) : P bi := by
+  unfold pdVerdictKeep at h
+  cases hv : verdicts[pdValHash bi]? with
+  | none => rw [hv] at h; simp at h
+  | some l =>
+    rw [hv] at h
+    simp only [Bool.not_eq_false'] at h
+    obtain ⟨b, _hb, hbe⟩ := List.any_eq_true.1 h
+    exact of_decide_eq_true hbe ▸ b.property
+
 def pointwiseDupDropPass (pw : PrimeWitness p) : VerifiedPass p := fun cs bs =>
   if hpB : pw.isPrime = true then
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
     let singles := singleVarCs cs.algebraicConstraints
-    -- The fast sweep flags exactly `pdKeep`'s drop set; the certified `pdKeep` re-verifies each
-    -- flagged drop (short-circuited away for the unflagged rest by the `||`).
+    -- The fast sweep flags exactly `pdKeep`'s drop set; the certified `pdKeep` then re-verifies
+    -- each flagged drop **once per distinct value** — `pdKeep` is value-determined (its
+    -- `findIdx?` locates the value's first occurrence), so equal interactions share one run
+    -- instead of paying the deep-equality scan and prefix certificates per occurrence.
     let drops := pdDropSet bs singles cs.busInteractions
-    ⟨cs.filterBus (fun bi => pdFastKeep drops bi || pdKeep bs singles cs.busInteractions bi), [],
-     cs.pointwiseDupDrop_correct bs (pdFastKeep drops)⟩
+    let verdicts : Std.HashMap UInt64 (List { b : BusInteraction (Expression p) //
+        pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions b = false }) :=
+      drops.fold (init := ∅) fun m h l =>
+        m.insert h (l.eraseDups.filterMap (fun b =>
+          if hpd : pdKeep bs (singleVarCs cs.algebraicConstraints) cs.busInteractions b = false
+          then some ⟨b, hpd⟩ else none))
+    ⟨cs.filterBus (pdVerdictKeep verdicts), [],
+     cs.pointwiseDupDrop_correct bs (pdVerdictKeep verdicts)
+       (fun bi _ hkf => pdVerdictKeep_false verdicts bi hkf)⟩
   else ⟨cs, [], PassCorrect.refl cs bs⟩
 
 /-! ## Part A: the entailed nonlinear substitution -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFold.lean
@@ -557,12 +557,11 @@ def pdDropSet (bs : BusSemantics p) (singles : List (Expression p))
     pos := pos + 1
   return drops
 
-/-- Part C as a standalone (unguarded) pass: drop stateless interactions pointwise-equal to an
-    earlier first-of-class one. Stated over an arbitrary *prefilter* `fast`: the kept set is
-    `fast bi || pdKeep … bi`, so a drop requires `pdKeep … = false` (the certified condition)
-    and keeping more is always sound. `pointwiseDupDropPass` instantiates `fast` with the sweep
-    above, which flags exactly `pdKeep`'s drop set — the expensive certified scan then runs only
-    on the few genuine drops. -/
+/-- Part C's correctness, stated over an **arbitrary keep-predicate** that only ever drops
+    certified-droppable interactions (`hkeep`: dropped ⟹ `pdKeep … = false`) — keeping more is
+    always sound, and a dropped interaction's first-of-class twin is kept because `pdKeep` would
+    keep it (the contrapositive of `hkeep`). `pointwiseDupDropPass` instantiates `keep` with the
+    verdict map (`pdVerdictKeep`), whose entries carry their `pdKeep = false` proofs. -/
 theorem ConstraintSystem.pointwiseDupDrop_correct [Fact p.Prime]
     (cs : ConstraintSystem p) (bs : BusSemantics p)
     (keep : BusInteraction (Expression p) → Bool)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -397,8 +397,78 @@ theorem Expression.normalize_vars (e : Expression p) : ∀ x ∈ e.normalize.var
       · simp only [Expression.vars, List.mem_append] at hx ⊢
         exact hx.imp (iha x) (ihb x)
 
-/-- The affine-normalization pass. Correct via `mapExpr_correct` (only `normalize_eval`). -/
+/-- Fused normalization: one bottom-up pass returning the normalized expression *and* the node's
+    linear form (`linearize`'s value). `Expression.normalize` re-runs `linearize` — a full
+    subtree walk — at every `add`/`mul` node along non-affine paths (O(size × depth) on the deep
+    sum spines circuits are full of); threading the linear form up removes the re-walks.
+    `normalizeFused_eq` pins both components to the original functions, so consumers are provably
+    unchanged. -/
+def normalizeFused : Expression p → Expression p × Option (LinExpr p)
+  | .const n => (.const n, some ⟨n, []⟩)
+  | .var x => (.var x, some ⟨0, [(x, 1)]⟩)
+  | .add a b =>
+      let ra := normalizeFused a
+      let rb := normalizeFused b
+      match ra.2, rb.2 with
+      | some la, some lb =>
+          let l := la.add lb
+          (l.norm.toExpr, some l)
+      | _, _ => (.add ra.1 rb.1, none)
+  | .mul a b =>
+      let ra := normalizeFused a
+      let rb := normalizeFused b
+      match ra.2, rb.2 with
+      | some la, some lb =>
+          if la.terms.isEmpty then
+            let l := lb.scale la.const
+            (l.norm.toExpr, some l)
+          else if lb.terms.isEmpty then
+            let l := la.scale lb.const
+            (l.norm.toExpr, some l)
+          else (.mul ra.1 rb.1, none)
+      | _, _ => (.mul ra.1 rb.1, none)
+
+/-- The fused pass computes exactly (`normalize`, `linearize`). -/
+theorem normalizeFused_eq (e : Expression p) :
+    normalizeFused e = (e.normalize, linearize e) := by
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      simp only [normalizeFused, iha, ihb]
+      cases hla : linearize a with
+      | none => simp [Expression.normalize, linearize, hla]
+      | some la =>
+        cases hlb : linearize b with
+        | none => simp [Expression.normalize, linearize, hla, hlb]
+        | some lb => simp [Expression.normalize, linearize, hla, hlb]
+  | mul a b iha ihb =>
+      simp only [normalizeFused, iha, ihb]
+      cases hla : linearize a with
+      | none => simp [Expression.normalize, linearize, hla]
+      | some la =>
+        cases hlb : linearize b with
+        | none => simp [Expression.normalize, linearize, hla, hlb]
+        | some lb =>
+          by_cases h1 : la.terms.isEmpty
+          · simp [Expression.normalize, linearize, hla, hlb, h1]
+          · by_cases h2 : lb.terms.isEmpty
+            · simp [Expression.normalize, linearize, hla, hlb, h1, h2]
+            · simp [Expression.normalize, linearize, hla, hlb, h1, h2]
+
+theorem normalizeFused_fst (e : Expression p) : (normalizeFused e).1 = e.normalize := by
+  rw [normalizeFused_eq]
+
+/-- The affine-normalization pass, computing through the fused walk (provably the same output).
+    Correct via `mapExpr_correct` (only `normalize_eval`, transported along
+    `normalizeFused_fst`). -/
 def normalizePass : VerifiedPass p := fun cs bs =>
-  ⟨cs.mapExpr Expression.normalize, [],
-   ConstraintSystem.mapExpr_correct (g := Expression.normalize)
-     (fun e env => Expression.normalize_eval e env) cs bs Expression.normalize_vars⟩
+  ⟨cs.mapExpr (fun e => (normalizeFused e).1), [],
+   ConstraintSystem.mapExpr_correct (g := fun e => (normalizeFused e).1)
+     (fun e env => by
+       show ((normalizeFused e).1).eval env = e.eval env
+       rw [normalizeFused_fst]
+       exact Expression.normalize_eval e env) cs bs
+     (fun e x hx => Expression.normalize_vars e x (by
+       have hx' : x ∈ ((normalizeFused e).1).vars := hx
+       rwa [normalizeFused_fst] at hx'))⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1520,6 +1520,37 @@ def buildReencode (useIdx : Bool) (csIdx : CoveredIndex.CovIndex) (arrCs : Array
       else none
     else none
 
+/-- Does the expression share a variable with `xs`? (No allocation; the `foldRewrite`-gate test,
+    local to this file because `DomainFold` imports it.) -/
+def Expression.sharesVarIn (xs : List Variable) : Expression p → Bool
+  | .const _ => false
+  | .var y => containsFast xs y
+  | .add a b => a.sharesVarIn xs || b.sharesVarIn xs
+  | .mul a b => a.sharesVarIn xs || b.sharesVarIn xs
+
+/-- **Degree pre-gate** (untrusted, necessary-condition — measured on keccak: *every one* of the
+    1276 `checkReencode`-passing groups per run was then rejected by the output degree check,
+    each after paying the whole-system freshness scan, the full `reencodeOut` rewrite, and a full
+    degree walk, re-tried every cycle). This walks the system once with an early-exit `any`,
+    rewriting **only** the items that share a variable with the group, and fires when such a
+    rewritten item already exceeds the bound. Firing is exact: a violating non-covered rewritten
+    constraint (or any rewritten interaction expression) appears verbatim in `reencodeOut`, so
+    the full `withinDegreeB` check would reject the same candidate — the pass's output is
+    unchanged; only the three whole-system walks are skipped. -/
+def degPreReject (b : DegreeBound) (cs : ConstraintSystem p)
+    (xs bits : List Variable) (hm : Std.HashMap Variable (Expression p)) : Bool :=
+  let σ := groupSubst xs hm
+  let patts := assignments (bitBox (p := p) bits)
+  cs.algebraicConstraints.any (fun c =>
+    c.sharesVarIn xs && !coveredBy xs c &&
+      decide (b.identities < (groupRewrite xs bits σ patts c).degree)) ||
+  cs.busInteractions.any (fun bi =>
+    (bi.multiplicity.sharesVarIn xs &&
+      decide (b.busInteractions < (groupRewrite xs bits σ patts bi.multiplicity).degree)) ||
+    bi.payload.any (fun e =>
+      e.sharesVarIn xs &&
+        decide (b.busInteractions < (groupRewrite xs bits σ patts e).degree)))
+
 /-- One checked re-encoding step (identity if construction or certificate fails). The expensive
     filter — `buildReencode` — runs first, so the remaining side conditions (all cheap: the group
     is all input columns and disjoint from the fresh bits, the bits carry no powdr ID) are only
@@ -1547,6 +1578,10 @@ def reencodeStep [Fact p.Prime] (bsem : BusSemantics p) (b : DegreeBound) (useId
   match hb : buildReencode useIdx csIdx arrCs xs freshBase with
   | none => ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
   | some (bits, hm) =>
+    -- Degree pre-gate: reject (exactly the candidates the final `withinDegreeB` would reject)
+    -- before the certificate's whole-system freshness scan and the output materialization.
+    if degPreReject b cs xs bits hm then ⟨⟨cs, [], PassCorrect.refl cs bsem⟩, csIdx, arrCs, varSet⟩
+    else
     if hxsCs : xs.all (fun x => varSet.val.contains x) = true then
     if hxsB : xs.all (fun x => decide (x ∉ bits)) = true then
     if hbn : bits.all (fun b => decide (b.powdrId? = none)) = true then

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -192,10 +192,12 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
    - **Variable interning-lite, `Implementation/`-only**: parse-time interning is **done (entry
-     106)**. Still open: swap the `Hashable Variable` instance (`Implementation/Variable.lean`,
-     unaudited) to hash `powdrId?` first — O(1) vs O(name length) on almost every key. Caution:
-     hash values leak into `Std.HashMap`/`HashSet` **iteration orders**; audit (or
-     export-verify) every `toList`/`fold` whose order reaches the output before landing.
+     106)**. The `powdrId?`-first `Hashable Variable` swap was **tried and reverted (entry
+     116)**: hash values leak into `Std.HashMap`/`HashSet` iteration orders, and *some* consumer
+     lets that order reach the output — sp1 apc_030's export changed (openvm-eth apc_100 was
+     identical). Before re-proposing, find and order-normalize the leaking `toList`/`fold`
+     (suspects: gauss's `Solved` reverse-dependency buckets, the pdDropSet sweep buckets) — the
+     swap itself is otherwise sound and cheap.
    - ~~`identitySubst`~~ **done (entry 106)**: the 2.8 s was an **arity-expansion bug** — a
      `def … : X → Y := let heavy := …; fun y => …` re-evaluates `heavy` per call (the map was
      rebuilt per queried occurrence). 2827 ms → 9 ms on apc_030. **Working rule: bind heavy

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -106,6 +106,13 @@ keccak, so anything superlinear is fatal there.
 - keccak per-pass (254 s profile): domainFold 48 s, domainBatch 48 s, reencode 42 s,
   busPairCancel 26 s, intervalForce 21 s, flagFold 16 s, busUnify 12.5 s, rootPairUnify 9.4 s,
   dedup 6.6 s, bytePack 5.5 s, gauss 4.5 s — no single villain; the cost is systemic.
+- **Post entries 109–113** (same container, serial): keccak 215 s → ~150 s expected — domainFold
+  47 → 14.2 s, busUnify 12.7 → 10.5 s, reencode's ~49 s was **1276-of-1276 degree-rejected
+  re-encodings per run** (each paying the freshness scan + full `reencodeOut` + degree walk,
+  retried every cycle) — killed by the `degPreReject` necessary-condition pre-gate. Remaining
+  big rocks: domainBatch ~50 s (productive enumeration + per-target gathers), flagFold ~20 s
+  (samples: `pdKeep` re-verification `findIdx?` deep-eq scans + boxTauto `mentions`/
+  `findDomainAlg`), rootPairUnify ~7.6 s, busPairCancel ~7.4 s.
 - keccak per-cycle (10 cycles): **cycles 0–2 are ~80 % of the total** (system still 28k→9.7k
   constraints there); the tail cycles 6–9 are ~1 % each. Fixing the big-system per-pass
   quadratics matters more than fixing the fixpoint tail.
@@ -124,21 +131,22 @@ entry-90 discipline: *untrusted, re-checked-at-use* candidate indexes (`buildFor
 `recvIndexAll`, `CoveredIndex`) — a wrong index entry costs time, never soundness, so most of
 these need no new proof.
 
-**R1. Kill the true O(N²) loops that dominate the big early cycles**  ·  *high value, mostly
-proof-free*. Confirmed quadratics, in rough per-case cost order:
-   - `busUnify.findConsumer` scans forward through the whole tail per send, and `checkPair`
-     re-scans the mid region `findConsumer` just stepped over (`BusUnify.lean:217/146`); each
-     step can hit `addrNonzeroNeq` = O(2^A·C) (`AddrDiseq.lean:519`). Fix: `(busId, addrHash)`
-     position buckets (port `recvIndexAll`), and thunk the eager `TwoRootMap`/`NonzeroWits`
-     builds (`BusUnify.lean:309-311`) so no-op invocations skip them. **Still open.** Note the
-     scan semantics are load-bearing: every stepped-over message must be *excluded*, so an
-     address-bucketed jump cannot skip the blocker checks — the win is bounding the scan via
-     per-position precomputed address forms, or a per-address-key incremental fold (complex; the
-     left-fold reformulation `ok' = (pr m ∨ ok) ∧ ref m` is exact but pairwise in `S`).
+**R1. Kill the true O(N²) loops that dominate the big early cycles**  ·  mostly **done**:
+   - ~~`busUnify.findConsumer` per-send forward scans~~ **done (entries 111–112)**: single
+     left-to-right sweep per bus with canonical-address-keyed open windows (`sweepGo` —
+     all-constant messages are provably invisible to other constant keys, so they cost one map
+     probe; `checkPair` re-verifies every emitted candidate, so the sweep is untrusted beyond
+     the split equations, which are recovered by drop arithmetic). `TwoRootMap`/`NonzeroWits`
+     thunked; the pass body's per-invocation `HashSet.ofList cs.vars` replaced by the
+     by-construction variable guarantee (`memEqConstraints_vars`) and the hash-bucket build
+     gated on nonempty candidates. Output byte-identical.
    - `busPairCancel`: `shieldOk` re-scans (and `liveArr` **materializes**) the whole before-region
-     per candidate send (`BusPairCancel.lean:1861/2428`) — O(B²) time *and* allocation on the long
-     same-address chains the pass exists for; in coda mode the `addrHash` bucket is O(B) per hot
-     address (`:1255`) — add a position cursor. **Still open.** ~~`dropWits` from-0 array scan per
+     per candidate send (`BusPairCancel.lean` `shieldOk`/`findCancelGoIdx`) — O(B²) time *and*
+     allocation on the long same-address chains the pass exists for; in coda mode the `addrHash`
+     bucket is O(B) per hot address — add a position cursor. **Still open**, but whole-run
+     samples put busPairCancel at only ~4 % on keccak post-111; the same per-key sweep pattern
+     as busUnify applies (`shieldOk` left-folds to a single per-key `pending` bit), complicated
+     by the tombstone-drop restarts. ~~`dropWits` from-0 array scan per
      queried variable~~ **done (entry 105)**: per-variable position index (`buildBoundIdx`),
      re-checked at use.
    - ~~`dedup` constraint-side `List.dedup` O(C²·E)~~ **done (entry 104)**: bucketed

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -191,24 +191,26 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      (`Reencode.lean:852/858`); rarely reached (post-gates), so low value now.
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
-   - **Variable interning-lite, `Implementation/`-only**: the parser mints a fresh `String` per
-     occurrence (`Variable.ofPowdrName`, `JsonParser.lean:101`); intern one shared object per
-     distinct name so the runtime's pointer fast-path (`lean_string_eq`: `s1 == s2 || …`) makes
-     every hit-comparison O(1). Swap the `Hashable Variable` instance
-     (`Implementation/Variable.lean:19`, unaudited) to hash `powdrId?` first — O(1) vs O(name
-     length) on almost every key. `Spec.lean`'s `Variable` stays untouched.
+   - **Variable interning-lite, `Implementation/`-only**: parse-time interning is **done (entry
+     106)**. Still open: swap the `Hashable Variable` instance (`Implementation/Variable.lean`,
+     unaudited) to hash `powdrId?` first — O(1) vs O(name length) on almost every key. Caution:
+     hash values leak into `Std.HashMap`/`HashSet` **iteration orders**; audit (or
+     export-verify) every `toList`/`fold` whose order reaches the output before landing.
    - ~~`identitySubst`~~ **done (entry 106)**: the 2.8 s was an **arity-expansion bug** — a
      `def … : X → Y := let heavy := …; fun y => …` re-evaluates `heavy` per call (the map was
      rebuilt per queried occurrence). 2827 ms → 9 ms on apc_030. **Working rule: bind heavy
      values in the fully-applied pass body and pass them as parameters** (the `FlagFold`
      comment's pattern); when a pass's profile makes no sense relative to its work, suspect this
      first and bisect with a skip-the-body experiment.
-   - `normalize`: `linearize` re-runs on the whole subtree at every node along non-affine paths
-     (O(E·depth), `Normalize.lean:306`); fuse into one bottom-up pass returning per-node linear
-     forms. Also feeds gauss's per-constraint reduce.
-   - `gauss`: skip `c.substF σ.fn |> normalize` for constraints mentioning no solved key, and skip
-     sweep 2 when sweep 1 adopted nothing (`Gauss.lean:592`). (PR #156 has a proven dirty-sweep
-     variant of this — check its status before redoing.)
+   - ~~`normalize` linearize fusion~~ **done (entry 115)** for `normalizePass`
+     (`normalizeFused`, proven equal). Gauss's per-constraint `substF |> normalize` still walks
+     the old way — left alone deliberately: open PR #156 rewrites gauss's sweeps (dirty second
+     sweep, allocation-free pivots) and should not be conflicted with.
+   - ~~`iterateToFixpoint` sizeKey recomputation~~ **done (entry 115)**: the input's key is
+     threaded (`iterateToFixpointFrom`), halving the per-cycle occurrence-list walks (~6 % of
+     whole-run samples).
+   - `gauss`: covered by open **PR #156** (proven dirty second sweep + allocation-free pivot
+     selection, 0.78× on eth) — do not duplicate here.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs
@@ -235,11 +237,25 @@ remaining cost is *productive first-time enumeration*; the levers there are effe
 (replace enumeration classes with algebra, cf. the quadratic-roots effectiveness idea 1) or
 intra-enumeration (survivor-scan compilation is already tuned).
 
-**R7. Intra-pass parallelism**  ·  *wall-clock lever, orthogonal*. The per-target enumeration in
-domainBatch/reencode/domainFold is embarrassingly parallel and pure; `Task.spawn`/`Task.get` with
-ordered joins keeps the output deterministic. CI runners have 32 cores; the serial Runtime Bench
-would show the win directly. Worth it only after the algorithmic waste is gone (parallelizing a
-triple-redundant gather is throwing cores at garbage).
+**R7. Intra-pass parallelism**  ·  partially **done (entry 114)**: domainBatch's per-target
+enumerations are `Task`-parallel with ordered joins (byte-identical σ; keccak domainBatch
+55 → 18 s on 4 cores — CI's 32 cores have more headroom). Still open: domainFold's and
+reencode's per-target *gating* work is also independent between accepts, but their loops rewrite
+`cs` on accept, so parallelizing needs a speculative gather-then-replay structure — only worth it
+if their serial remainder grows relative to the rest. busPairCancel/busUnify are inherently
+sequential scans (window state).
+
+**R8. busPairCancel residual quadratics** (formerly part of R1)  ·  ~7 % of the post-114 keccak
+profile. `shieldOk` re-scans (and `liveArr` materializes) the whole live before-region per
+candidate send; `midRefuted` likewise materializes the between-region. Two designs, in
+increasing effort: (a) fuse the materialization away — array-index twins of
+`liveArr`+`shieldScan`/`List.all` with `…_eq` lemmas (the `liveArr_eq` pattern), removing the
+O(i) allocation per candidate but keeping the O(i) scan; (b) the busUnify entry-111 treatment —
+`shieldOk` left-folds to a single per-address-key `pending` bit, maintainable across one sweep,
+but the pass's tombstone-and-restart structure (drops invalidate prefix state: removing a
+consumed receive un-shields earlier messages) forces a recompute-on-drop scheme, bounded by
+#drops × O(B). The whole-run sample share (~5 %) says (a) first, (b) only if SHA-scale profiles
+promote it.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -161,7 +161,7 @@ enumeration core itself (SP1 apc_030's 19 s single-cycle spike) is untouched: th
 substrate), not setup cost.
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
-index gate**  ·  *high value at eth/mid-keccak scale*. Partially **done (entry 105)**:
+index gate**  ·  mostly **done (entries 105/107/109)**:
    - reencode: the pruned index (`CoveredIndex.buildPruned`, entry 105 — items with more than 8
      distinct variables can never be covered by a ≤8-variable target, so pruning keeps covered
      sets identical) stays, but **behind the 8192 gate again** (entry 107): CI measured
@@ -170,20 +170,15 @@ index gate**  ·  *high value at eth/mid-keccak scale*. Partially **done (entry 
    - ~~domainFold's direct-path double `coveredBy` sweep~~ **done**: one `partition` per target
      feeds both the covered set and the no-op gate (`systemHasFoldableW`).
    - ~~both passes' doubled `c.vars.dedup` setup~~ **done** (`hashedDedup`, computed once).
-   - **Still open — domainFold's per-accept rebuild** (instrumented on keccak: 830 doms-bearing
-     targets, **482 accepts**, each paying `foldOut` + a constraint-index rebuild; entry 107
-     already removed the two per-accept const-foldable refilters and made all builds insert per
-     distinct variable). The remaining rebuild exists because `foldOut` *reorders* constraints
-     (rewritten-uncovered ++ covered-verbatim), invalidating bucket positions. Candidate fixes,
-     hardest-but-best first: (a) position-remap refresh — the reorder is a computable stable
-     partition, so buckets can be remapped in O(entries) integer work without re-hashing (needs
-     the completeness proof restated over the remap); (b) generalize `foldOut_correct` to any
-     covered *subset* (soundness only needs survivor supersets), making the gather untrusted —
-     but `systemHasFoldableIdx` must never under-approximate (a false negative skips a real fold
-     and changes output; a false positive triggers a no-op `foldOut` which *also* changes output
-     via the reorder), so the gate needs exact, current buckets either way; (c) make `foldOut`
-     order-preserving — simplest and fixes everything, but changes output order, so it needs a
-     full effectiveness re-validation rather than byte-identity.
+   - ~~domainFold's per-accept rebuild~~ **done (entry 109)**: `foldOut` is order-preserving
+     (in-place rewrite), `FoldIdx` carries bucket-completeness invariants (stale supersets fine,
+     re-checked at use), `refresh` keeps the buckets with no rebuild, and the fold itself is
+     computed sparsely over candidate positions (`foldOutIdx`). keccak domainFold 47 s → 10.4 s.
+     The **pattern generalizes**: any pass that rewrites items in place (shrinking variable
+     sets) can keep one inverted index for its whole run via
+     `coveredIdx_eq_filter_of_complete`; reencode is the next candidate (its rewrite *adds* bit
+     columns and drops covered constraints, so it needs the remap or a pruned-completeness
+     argument).
    - **Still open — reencode's `checkReencode`** re-runs the covered scan after `buildReencode`
      (`Reencode.lean:852/858`); rarely reached (post-gates), so low value now.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -4145,3 +4145,26 @@ cost (12.6 s on keccak). Replaced by a single left-to-right sweep per bus (`swee
 
 **Verification**: output byte-identical on {openvm keccak, sp1 rsp apc_024/apc_030} exports vs
 the pre-sweep binary; keccak in-pipeline cycle sizes identical at every cycle. Within-run share: busUnify 5.9% of the pre-sweep baseline run → 5.4% after — the scan is no longer the pass's floor; what remains is the pass body's eager per-invocation table builds (csVarSet over the ~10⁵-entry occurrence list, csHashes over every constraint), addressed next. **Worked: yes (exactness verified; modest wall-clock until the table builds are gated).**
+
+### 112. Runtime: busUnify body gating + by-construction variable check; domainFold fast membership tests (keccak 215 s → 193 s)
+
+Follow-ups from the gdb-sampled attribution (200 whole-run stack samples, function→pass mapped):
+
+- **busUnify's floor was its own body, not the scan**: every invocation eagerly built
+  `Std.HashSet.ofList cs.vars` (the ~10⁵-entry occurrence list) for the "no new variable" filter
+  and the structural-hash bucket map for the already-present filter — even with zero collected
+  equalities. Now: the equalities' variables come from payload slots of `cs`'s own interactions
+  **by construction** (`memEqConstraints_vars`, threaded through `collectForBus`/
+  `collectAllBuses`), so the occurrence-list HashSet is gone entirely — with the filter provably
+  unchanged — and the bucket map is built only when `eqs` is nonempty.
+- **domainFold's remaining direct-path cost was the slow spec-side `varsIn`** — a `List.elem`
+  running the full `Variable` `DecidableEq` (name-`String` compare first) per AST node inside
+  `foldRewriteGo`'s gates and `hasFoldable` — 26 % of all whole-run samples. Swapped for the
+  `containsFast`-backed `varsInF` (`powdrId?` compared first; `varsInF_eq` proves the value
+  unchanged, so the output is provably identical). Both fold paths share the fix.
+
+**Verification**: keccak and sp1 apc_030/apc_024 exports byte-identical across all of entries
+111–112; proof integrity green. **Measured** (this container, serial): keccak profile
+**215 s → 192.7 s** — domainFold **47.0 → 14.2 s (0.30×)**, busUnify 12.7 → 10.5 s. Remaining:
+domainBatch 55.1 s, reencode 49.4 s (per-accept `groupRewrite` full-system walks — next),
+flagFold 21.9 s, rootPairUnify 7.6 s, busPairCancel 7.4 s. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4220,3 +4220,23 @@ identical. **Measured** (this container, serial, 4 cores): keccak profile **147.
 domainBatch 55.0 → 18.2 s, flagFold 20.8 → 17.1 s. Session total so far: **215 → 111 s
 (0.52×)**. CI matrix for `73d732c` (through entry 113): identical per-case sizes on all five
 sets; contended runtime rows keccak −37 %, wasm-eth −17 %. **Worked: yes.**
+
+### 115. Runtime: fixpoint sizeKey threading + fused normalization (small, output-identical)
+
+Two R4/R5-slice items from the round-2 sample attribution:
+
+- **`iterateToFixpoint` recomputed the input's `sizeKey` every cycle** alongside the output's —
+  `varCount` flat-maps every variable occurrence into a fresh list and hash-set (~6 % of
+  whole-run thread samples). `iterateToFixpointFrom` threads the previously computed key with
+  its proof, so each cycle computes only the output's key. Same comparisons, same results; the
+  degree/monotonicity theorems restate over the threaded variant.
+- **`normalizePass` computes through `normalizeFused`**: one bottom-up walk returning the
+  normalized expression *and* the node's linear form, instead of re-running `linearize` (a full
+  subtree walk) at every `add`/`mul` node along non-affine paths. `normalizeFused_eq` pins both
+  components to (`Expression.normalize`, `linearize`), so the pass output is provably unchanged.
+  Gauss's `substF |> normalize` sites are deliberately untouched — open PR #156 rewrites gauss
+  and should not be conflicted with.
+
+**Verification**: keccak and sp1 apc_030 exports byte-identical; proof integrity green; keccak
+profile steady at **111.0 s** (both items are a few-percent class on this container; they also
+shrink every future cycle-heavy case). **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4191,3 +4191,32 @@ violating item, typically within a few candidates).
 profile total **215 s (session baseline) → 147.4 s**; reencode **49.4 → 5.1 s (0.10×)**.
 Remaining: domainBatch 55.0 s, flagFold 20.8 s, domainFold 14.0 s, busUnify 10.5 s,
 rootPairUnify 8.0 s, busPairCancel 7.4 s. **Worked: yes.**
+
+### 114. Runtime: parallel domainBatch enumeration (R7) + flagFold verdict memoization and domain-cache bucketing (keccak 147 s → 111 s)
+
+- **domainBatch enumerations are now `Task`-parallel** (the R7 lever, now that the algorithmic
+  waste elsewhere is gone and domainBatch was the dominant pass at 55 s): every per-target
+  `forcedOver` is independent — the same `cs`, domain table, and index — so `collectForced`
+  spawns one task per deduplicated target and joins the results **in target order**; `σ`
+  receives exactly the sequential fold's insertions, so the pass output is byte-identical and
+  only wall-clock changes. The target dedup is split out (`dedupTargets`, same `seen`
+  threading). keccak domainBatch **55.0 → 18.2 s on 4 cores**; CI's 32-core runners have more
+  headroom.
+- **flagFold, part C**: `pointwiseDupDropPass` re-verified every flagged drop through `pdKeep` —
+  a `findIdx?` deep-equality scan plus prefix certificates **per occurrence**. `pdKeep` is
+  value-determined (its `findIdx?` locates the value's *first* occurrence), so the certified
+  verdicts are now computed once per distinct flagged value (`pdVerdictKeep`, entries carrying
+  their `pdKeep = false` proofs; `pointwiseDupDrop_correct` generalized to any keep-predicate
+  that implies `pdKeep = false` — the twin-keep argument recovers via the contrapositive).
+- **flagFold, part B**: `boxTautoDropPass` built its per-variable domain cache with
+  `findDomainAlg singles v` per distinct variable — an O(#singles) `mentions` walk each. A
+  single-variable constraint mentions exactly its one variable, so the singles are bucketed by
+  variable once and each lookup scans only its own bucket (original order preserved — identical
+  domains). `singleVarCs`'s per-constraint `eraseDups` swapped for the bucketed twin
+  (`hashedEraseDups_eq`, value-identical).
+
+**Verification**: keccak and sp1 apc_030 exports byte-identical; keccak per-cycle sizes
+identical. **Measured** (this container, serial, 4 cores): keccak profile **147.4 → 111.0 s** —
+domainBatch 55.0 → 18.2 s, flagFold 20.8 → 17.1 s. Session total so far: **215 → 111 s
+(0.52×)**. CI matrix for `73d732c` (through entry 113): identical per-case sizes on all five
+sets; contended runtime rows keccak −37 %, wasm-eth −17 %. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4261,3 +4261,16 @@ super-linear terms that mattered for the openvm-SHA scale (~8× keccak): the rem
 (domainBatch enumeration, flagFold's certified sweeps) are linear-ish per cycle or parallel.
 Remaining runtime ideas live in the rewritten R-sections of `docs/ideas.md` (R8 busPairCancel
 sweep, the hash-order leak hunt, reencode/domainFold direct-path gathers at mid scale).
+
+### 117. Runtime follow-up: gate domainBatch's fan-out on system size
+
+The full CI matrix for the session (all sizes identical on all five sets) showed the runtime
+rows at keccak **−52 %** and wasm-eth **−25 %**, but sp1/rsp at **+15 %** — the effectiveness
+matrix runs whole cases in parallel, and entry 114's unconditional per-target fan-out
+oversubscribes the runner on the many-small-cases sets (spawn overhead + scheduler contention
+per case, multiplied by 100 parallel cases). `collectForced` now fans out only when the system
+has ≥ 8192 constraints (the established big-case gate): below it the sequential fold is
+byte-for-byte the same computation without spawns, so sp1/rsp and openvm-eth behave exactly as
+before entry 114 while keccak/SHA-scale invocations keep the parallel win (keccak's ≥8192
+cycles carry ~90 % of its domainBatch cost). keccak and sp1 apc_030 exports byte-identical;
+keccak total steady at ~111 s locally. **Worked: yes (CI re-run pending).**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4098,3 +4098,24 @@ reproduce identical counts. CI matrix pending for the full five-set per-case com
 **47.0 s → 10.4 s (0.22×)**. Remaining keccak: domainBatch 47.9 s, reencode 43.2 s, flagFold
 16.2 s, busUnify 12.6 s, domainFold 10.4 s, busPairCancel 8.2 s, rootPairUnify 8.2 s.
 **Worked: yes.**
+
+### 110. Runtime follow-up: keep the historical fold on domainFold's direct path (fixes the sp1 +2-constraint drift)
+
+Entry 109's CI matrix: **+0.000× with identical per-case sizes on openvm-eth (100), wasm-eth
+(100), openvm keccak, and sp1 keccak** — but sp1/rsp changed on 2 of 100 cases (apc_024/040:
+175 → 177 constraints, vars/bus identical; aggregate −0.008× on the lowest axis). Export diff
+(canonical, modulo a positional `rnc*` rename) pinned it to two `lower_limb`↔bitwise-result
+product constraints that main's pipeline collapsed and the reworked direct path didn't — i.e.
+the drift came from the direct (unindexed) path's behavior change (in-place order and/or the
+dropped disjoint-item const-compound folding), not from the indexed path.
+
+Fix: the **direct path now runs the historical fold verbatim** — `foldRewriteC` (the old
+`anyVarIn ∨ hasConstFoldableNode` gate), `foldOutC` (the old rewritten-uncovered ++
+covered-verbatim output), the old `systemHasFoldableW` gate, and the old correctness proof —
+so every system below `domainFoldIndexThreshold` (8192; everything in the corpus except openvm
+keccak, and SHA when it lands) is **bit-for-bit unchanged from main**. apc_024 verified
+byte-identical (175 constraints). The order-preserving in-place fold + persistent index +
+sparse rewrite (entry 109) remain on the indexed path only, where the reorder would invalidate
+the index positions — keccak re-verified: identical final circuit, domainFold stays ~0.2× of
+its pre-109 cost. The survivor-pinning argument is shared (`groupSurvivors_mem_agree`), so the
+duplicated fold carries only its own thin agreement/output lemmas. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4240,3 +4240,24 @@ Two R4/R5-slice items from the round-2 sample attribution:
 **Verification**: keccak and sp1 apc_030 exports byte-identical; proof integrity green; keccak
 profile steady at **111.0 s** (both items are a few-percent class on this container; they also
 shrink every future cycle-heavy case). **Worked: yes.**
+
+### 116. Runtime: `Hashable Variable` powdrId?-first — tried, leaks, reverted (no code change)
+
+The R4 idea (hash the O(1) `powdrId?` discriminator instead of walking the name string on every
+hash-map probe) was implemented and export-checked: **openvm-eth apc_100 byte-identical, sp1
+apc_030 NOT** — some consumer lets a `Std.HashMap`/`HashSet` iteration order (which the hash
+values determine) reach the output. Reverted; recorded in `docs/ideas.md` with the leak-hunting
+prerequisite (order-normalize the offending `toList`/`fold` first — suspects: gauss's `Solved`
+reverse-dependency buckets, `pdDropSet`'s sweep buckets). **Worked: no (reverted, documented).**
+
+---
+
+**Session summary (entries 109–116, PR #165)**: keccak profile **215 s → 111 s (0.52×)** on the
+4-core dev container, with every step either provably output-identical, byte-identical on the
+export set, or (R3's order change) validated by the CI matrix at identical per-case sizes on
+all five benchmark sets. The structural wins — the index-preserving order-preserving fold, the
+busUnify sweep, the reencode degree pre-gate, and the parallel enumeration — are exactly the
+super-linear terms that mattered for the openvm-SHA scale (~8× keccak): the remaining top passes
+(domainBatch enumeration, flagFold's certified sweeps) are linear-ish per cycle or parallel.
+Remaining runtime ideas live in the rewritten R-sections of `docs/ideas.md` (R8 busPairCancel
+sweep, the hash-order leak hunt, reencode/domainFold direct-path gathers at mid scale).

--- a/docs/log.md
+++ b/docs/log.md
@@ -4119,3 +4119,29 @@ sparse rewrite (entry 109) remain on the indexed path only, where the reorder wo
 the index positions — keccak re-verified: identical final circuit, domainFold stays ~0.2× of
 its pre-109 cost. The survivor-pinning argument is shared (`groupSurvivors_mem_agree`), so the
 duplicated fold carries only its own thin agreement/output lemmas. **Worked: yes.**
+
+### 111. Runtime: busUnify single-sweep consumer matching (findConsumer O(B²) → per-key windows)
+
+R1's biggest open item. `findConsumer` scanned forward through the bus tail once per send —
+every position crossed by every open window that spans it, each step evaluating up to four
+address-disequality certificates (`addrNonzeroNeq` worst-case O(2^A·C)) — the dominant busUnify
+cost (12.6 s on keccak). Replaced by a single left-to-right sweep per bus (`sweepGo`):
+
+- **Canonical address keys** (`addrKey?`): each present address slot, constant-valued slots
+  normalized to their literal constant. Key equality is provably equivalent to `addrConstsEq`,
+  so the consumer test for an incoming message is one hash-map probe.
+- **Constant-address transparency**: an all-constant message is `addrConstsNeq`-excluded at
+  every open window with a *different* all-constant key — zero work — and runs the full
+  `findConsumer` branch test (`stepTest`, same arms, same order) only against the one window at
+  its own key. Windows with symbolic key components (`symOpen`) and messages with symbolic
+  address slots are tested literally — exactly the pairs the per-send scans also paid for.
+- **Split equations by drop arithmetic** (`split_of_positions`): an open window stores its send
+  position and suffix; `mid` is recovered as a `take` at consume time, so windows carry no
+  per-step bookkeeping. Candidates are sorted back into send-position order — the emitted list
+  is the one the per-send scans produced (the sweep is untrusted beyond the split equations:
+  `checkPair` re-verifies every pair condition on every candidate).
+- **`TwoRootMap`/`NonzeroWits` are `Thunk`ed**: invocations whose pairs are all decided by the
+  constant/affine certificates never pay the two O(#constraints) table builds.
+
+**Verification**: output byte-identical on {openvm keccak, sp1 rsp apc_024/apc_030} exports vs
+the pre-sweep binary; keccak in-pipeline cycle sizes identical at every cycle. Within-run share: busUnify 5.9% of the pre-sweep baseline run → 5.4% after — the scan is no longer the pass's floor; what remains is the pass body's eager per-invocation table builds (csVarSet over the ~10⁵-entry occurrence list, csHashes over every constraint), addressed next. **Worked: yes (exactness verified; modest wall-clock until the table builds are gated).**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4168,3 +4168,26 @@ Follow-ups from the gdb-sampled attribution (200 whole-run stack samples, functi
 **215 s → 192.7 s** — domainFold **47.0 → 14.2 s (0.30×)**, busUnify 12.7 → 10.5 s. Remaining:
 domainBatch 55.1 s, reencode 49.4 s (per-accept `groupRewrite` full-system walks — next),
 flagFold 21.9 s, rootPairUnify 7.6 s, busPairCancel 7.4 s. **Worked: yes.**
+
+### 113. Runtime: reencode degree pre-gate — 100 % of keccak's accepted re-encodings were degree-rejected (reencode 49.4 s → 5.1 s)
+
+Instrumenting the reencode funnel on keccak: **1276 groups per run pass `checkReencode` and
+every single one is then rejected by the output degree check** (`reencodeOut … |>.withinDegreeB`)
+— the interpolations of the 7–8-variable flag groups are degree-3 polynomials in the bits, and
+any multiplicative use overshoots the openvm bound. Each rejection paid three whole-system
+walks — the certificate's freshness scan (`bits × system` `mentionsF`), the full `reencodeOut`
+rewrite, and the `withinDegreeB` walk — and the same groups were re-tried every cycle (nothing
+memoizes the rejection). That was essentially all of reencode's 49 s.
+
+Fix: `degPreReject`, a **necessary-condition pre-gate** right after `buildReencode` — one
+early-exit `any` over the system that rewrites *only* items sharing a variable with the group
+(`sharesVarIn`) and fires when a rewritten non-covered constraint (or any rewritten interaction
+expression) already exceeds the bound. Firing is exact: such an item appears verbatim in
+`reencodeOut`, so the full check would reject the same candidate — the pass output is unchanged,
+only the three whole-system walks are skipped (and on kill-cases the `any` exits at the first
+violating item, typically within a few candidates).
+
+**Verification**: keccak export byte-identical. **Measured** (this container, serial): keccak
+profile total **215 s (session baseline) → 147.4 s**; reencode **49.4 → 5.1 s (0.10×)**.
+Remaining: domainBatch 55.0 s, flagFold 20.8 s, domainFold 14.0 s, busUnify 10.5 s,
+rootPairUnify 8.0 s, busPairCancel 7.4 s. **Worked: yes.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4061,3 +4061,40 @@ figure does not translate to target-level reuse). domainBatch's remaining cost i
 first-time enumeration; its levers are effectiveness-side (quadratic-root algebra replacing
 enumeration classes). Instrumentation reverted; no behavioral change. **Worked: n/a
 (measurement; saved the refactor).**
+
+### 109. Runtime: domainFold order-preserving in-place fold — the per-accept rebuild is gone (keccak domainFold 47 s → 10.4 s)
+
+The R3 leftover from entry 107: 482 accepted folds on keccak each paid a full `foldOut` map
+(an `anyVarIn` gate walk over every expression node in the system) plus a constraint-side
+index rebuild (`CoveredIndex.build` over all ~28k constraints), because the old `foldOut`
+*reordered* constraints (rewritten-uncovered ++ covered-verbatim), invalidating bucket
+positions. This entry removes the reorder and, with it, every per-accept full-system cost:
+
+- **`foldOut` is now order-preserving**: each constraint is rewritten (or, if covered, kept
+  verbatim) **in place** — one `map` over the original list. Positions never move, and
+  `foldRewrite` only ever shrinks a variable set, so the inverted index survives an accept.
+- **`FoldIdx` carries bucket-completeness invariants instead of build-equalities** (`hidx`,
+  `hbis`: every item position is bucketed under each of its variables). Stale supersets are
+  fine — every consumer re-checks candidates — and completeness is monotone under in-place
+  variable-shrinking rewrites, so `FoldIdx.refresh` keeps both bucket maps **with no rebuild**
+  (only the O(n)-pointer item arrays are re-materialized). `CoveredIndex.coveredIdx_eq_filter`
+  is generalized to `coveredIdx_eq_filter_of_complete` (any index whose candidate set is
+  complete), which the covered-set equality `coveredCsIdx_eq` now consumes.
+- **The fold itself is computed sparsely** (`foldOutIdx`, proven equal to `foldOut` via the
+  completeness invariants): only bucketed candidate positions are walked; every other item is
+  passed through by position with one O(1) `Nat`-set probe — no expression walk at all.
+- `foldRewrite`'s gate drops the `hasConstFoldableNode` arm (and `FoldIdx` its cf lists): items
+  sharing no variable with the group are never rewritten now; purely variable-free compound
+  nodes are the constant-fold pass's job (they only arise transiently mid-cycle, and folding
+  them is size-neutral so it never extended the fixpoint).
+
+**Not byte-identical** (the old fold moved covered constraints to the end of the list; the new
+one leaves them in place), so this is validated by effectiveness counts, not export diffs:
+keccak reproduces **identical per-cycle sizes at every one of the 10 cycles** and the identical
+final circuit (2021 vars / 2022 bus / 186 constraints); openvm-eth apc_001 and apc_100
+reproduce identical counts. CI matrix pending for the full five-set per-case comparison.
+
+**Measured** (this container, serial): keccak `profile` total 215 s → 172 s, domainFold
+**47.0 s → 10.4 s (0.22×)**. Remaining keccak: domainBatch 47.9 s, reencode 43.2 s, flagFold
+16.2 s, busUnify 12.6 s, domainFold 10.4 s, busPairCancel 8.2 s, rootPairUnify 8.2 s.
+**Worked: yes.**


### PR DESCRIPTION
## Goal

Continue #164: make the optimizer's runtime scale acceptably on large cases (openvm SHA ≈ 8× keccak, so anything superlinear is fatal). This session works through the unfinished runtime ideas from `docs/ideas.md`, in priority order, plus what fresh gdb-sample attribution surfaced along the way.

## Results

- **Serial Runtime Bench (same-runner A/B, the authoritative number): keccak 93.0 s → 45.9 s (0.49×)** — reencode **0.09×**, domainFold **0.24×**, domainBatch **0.37×**, bytePack 0.69×, flagFold 0.90×.
- Contended effectiveness-matrix runtime rows: wasm-eth **−20 %** (676 → 543 s), sp1/rsp −6 %, openvm-eth −4 %.
- **Effectiveness: identical per-case circuit sizes on all five benchmark sets, +0.000× on every axis.** Every step was additionally verified byte-identical on an export set (openvm keccak, sp1 apc_024/apc_030, openvm-eth apc_100) except R3's order-preserving fold, which the CI matrix validated at identical sizes.
- Local dev container (4 cores, serial): keccak `profile` 215 s → 111 s.

## Landed (log entries 109–117)

- **R3 — domainFold's per-accept rebuild is gone** (109–110): on the ≥8192 (keccak/SHA-scale) path the fold is order-preserving and computed sparsely (`foldOutIdx`), and the inverted index carries bucket-completeness invariants that survive accepts — **no rebuild**. The direct path keeps the historical fold verbatim (bit-for-bit main behavior below the gate).
- **R1 — busUnify single-sweep consumer matching** (111–112): per-send O(B²) `findConsumer` scans → one sweep per bus with canonical-address-keyed open windows (constant-address messages are provably invisible to other constant keys); `checkPair` re-verifies every emitted candidate, so the sweep is untrusted beyond the split equations (drop arithmetic). The "no new variable" filter is now **by construction** (`memEqConstraints_vars`) — the per-invocation ~10⁵-entry occurrence HashSet is gone; `TwoRootMap`/`NonzeroWits` are thunked.
- **domainFold fast membership tests** (112): the slow spec-side `varsIn` (`List.elem` with name-string `decEq` per AST node — 26 % of whole-run samples) → proven-equal `varsInF`.
- **reencode degree pre-gate** (113): instrumentation showed **1276 of 1276** `checkReencode`-passing keccak groups get degree-rejected — each after a whole-system freshness scan, a full `reencodeOut` rewrite, and a degree walk, re-tried every cycle. `degPreReject` (necessary-condition, early-exit) rejects them first; firing is exact.
- **R7 — domainBatch enumerations are Task-parallel at ≥8192 constraints** (114, 117): per-target `forcedOver` is independent; results join in target order → byte-identical σ. Small systems keep the plain sequential fold (the unconditional fan-out oversubscribed CI's contended matrix runners on the many-small-cases sets — caught and gated).
- **flagFold** (114): `pdKeep` verdicts memoized per distinct flagged value (`pointwiseDupDrop_correct` generalized to any keep-predicate implying `pdKeep = false`); `boxTautoDropPass`'s domain cache bucketed by variable (no O(#singles) `mentions` walk per distinct variable).
- **Fixpoint sizeKey threading + fused normalization** (115): `iterateToFixpointFrom` threads the input's key; `normalizePass` computes through `normalizeFused` (one bottom-up walk), proven equal. Gauss left untouched deliberately — open **PR #156** covers it.
- **`Hashable Variable` powdrId?-first: tried and reverted** (116) — hash values reach some consumer's iteration order (sp1 apc_030's export changed); documented with the leak-hunt prerequisite.

Remaining ideas (R8 busPairCancel per-key sweep with its measure-first prerequisite, the hash-order leak hunt, mid-scale direct-path gathers) are recorded in `docs/ideas.md`.

## Verification

- `lake build` warning-free at every commit; proof integrity green ({propext, Classical.choice, Quot.sound} only); no `sorry`/`admit`/`native_decide`/new axioms.
- No audited-surface changes; the pass framework's only change is the (proof-carrying) `iterateToFixpointFrom` key threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kBUetMTzfLpkumqFrigv3