### PR TITLE
monicScale: evaluate l.norm once per affine factor

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/MonicScale.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/MonicScale.lean
@@ -36,17 +36,22 @@ variable {p : ℕ}
 
 /-! ## Scaling with a unit certificate -/
 
+/-- The core of `denseMonicScaleAffine`, over the already-normalized linear form `n` (taking it
+    as an argument evaluates the normalization once for both its uses below). -/
+def denseMonicScaleNormed (e : DenseExpr p) (n : DenseLinExpr p) :
+    DenseExpr p × ZMod p × ZMod p :=
+  match n.terms with
+  | (_, k) :: _ =>
+      if k * k⁻¹ = 1 ∧ k ≠ 1 then ((n.scale k⁻¹).toExpr, k⁻¹, k)
+      else (e, 1, 1)
+  | [] => (e, 1, 1)
+
 /-- Scale an affine dense expression to monic form. Returns `(e', u, v)` with the intended
     invariants `e'.eval denv = u * e.eval denv` and `u * v = 1`; `(e, 1, 1)` when not applicable. -/
 def denseMonicScaleAffine (e : DenseExpr p) : DenseExpr p × ZMod p × ZMod p :=
   match denseLinearize e with
   | none => (e, 1, 1)
-  | some l =>
-    match l.norm.terms with
-    | (_, k) :: _ =>
-        if k * k⁻¹ = 1 ∧ k ≠ 1 then ((l.norm.scale k⁻¹).toExpr, k⁻¹, k)
-        else (e, 1, 1)
-    | [] => (e, 1, 1)
+  | some l => denseMonicScaleNormed e l.norm
 
 /-- Scale the affine factors of a product tree to monic form, with the accumulated unit
     certificate. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/MonicScaleProof.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/MonicScaleProof.lean
@@ -28,7 +28,7 @@ variable {p : ℕ}
 /-- The monic-scaled affine expression evaluates to its unit multiplier times the original. -/
 theorem denseMonicScaleAffine_eval (e : DenseExpr p) (denv : VarId → ZMod p) :
     (denseMonicScaleAffine e).1.eval denv = (denseMonicScaleAffine e).2.1 * e.eval denv := by
-  unfold denseMonicScaleAffine
+  unfold denseMonicScaleAffine denseMonicScaleNormed
   split
   · simp
   · rename_i l hlin
@@ -44,7 +44,7 @@ theorem denseMonicScaleAffine_eval (e : DenseExpr p) (denv : VarId → ZMod p) :
 /-- The affine scaling's certificate is a genuine unit. -/
 theorem denseMonicScaleAffine_unit (e : DenseExpr p) :
     (denseMonicScaleAffine e).2.1 * (denseMonicScaleAffine e).2.2 = 1 := by
-  unfold denseMonicScaleAffine
+  unfold denseMonicScaleAffine denseMonicScaleNormed
   split
   · simp
   · split
@@ -58,7 +58,7 @@ theorem denseMonicScaleAffine_unit (e : DenseExpr p) :
 theorem denseMonicScaleAffine_vars (e : DenseExpr p) :
     ∀ z ∈ (denseMonicScaleAffine e).1.vars, z ∈ e.vars := by
   intro z hz
-  unfold denseMonicScaleAffine at hz
+  unfold denseMonicScaleAffine denseMonicScaleNormed at hz
   split at hz
   · exact hz
   · rename_i l hlin


### PR DESCRIPTION
## Summary

Runtime-only fix for item 1 of the pass-improvement findings from the VarId migration audits: `denseMonicScaleAffine` recomputed the linearized form's normalization `l.norm` twice per constraint factor — once for the monic-gate test (`l.norm.terms`) and once for the rescale (`(l.norm.scale k⁻¹).toExpr`).

The normalization is now hoisted into a helper, `denseMonicScaleNormed`, which takes the normalized form as an argument, so it is evaluated once. A helper argument (rather than a `let` in the match) keeps the three `unfold` + `split` proof scripts in `MonicScaleProof.lean` working unchanged apart from unfolding the new name.

## Output-neutrality

The change is pure hoisting — no behavior change. Verified locally: `opt-export` output is byte-identical (`cmp`) on openvm-eth cases 001, 003, 010, 025, 050, 075, 100. `lake build` completes warning-free.

While auditing this file, two further output-neutral runtime inefficiencies were spotted in `denseMonicScale` (its recursive results are written out three times each — no CSE, so 3^depth recursive work — and accepted `.mul` factors are linearized twice); they are recorded in the local findings notes as follow-up candidates, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)