### PR TITLE
Runtime: hoist ZMod operations from hot loops

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -65,7 +65,8 @@ structure DenseDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p)
     `denseCheckCancel_sound`. -/
 def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
-    (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
+    (ops : DenseZModOps p) (busId : Nat) (shape : MemoryBusShape)
+    (hshape : facts.memShape busId = some shape)
     (T : Thunk (DenseAddrCerts p))
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
@@ -87,9 +88,9 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (hSalive : alive[iP]?.getD false = true) (hRalive : alive[jP]?.getD false = true)
     (hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) = some (slots, bound))
     (hmid : ∀ m0 ∈ denseLiveSeg arr alive (iP + 1) (jP - iP - 1),
-      denseMidRefuted shape T busId S m0 = true)
-    (hshield : denseShieldOk shape T busId S (denseLiveSeg arr alive 0 iP) = true)
-    (hchk : denseCheckCancel deep bs facts M domCs candsOf
+      denseMidRefuted ops shape T busId S m0 = true)
+    (hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 iP) = true)
+    (hchk : denseCheckCancel ops deep bs facts M domCs candsOf
       (denseDropWits facts bidx arr alive S R checksOld checks) (denseDropFormWits fidx arr alive S R)
       busId shape slots bound S R checks = true) :
     DenseDropResult cs0 bs arr alive checksOld := by
@@ -128,7 +129,7 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     dropPos := dropPos
     sizeNew := by simp only [aliveNew, Array.size_setIfInBounds]; exact hsz
     step := fun isInput reg hsys => heq ▸
-      denseCheckCancel_sound isInput (denseMkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep
+      denseCheckCancel_sound isInput (denseMkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep ops
         reg hsys busId shape hshape slots bound T hTtworoot hTnonzero M hM domCs candsOf
         (denseDropWits facts bidx arr alive S R checksOld checks)
         (denseDropFormWits fidx arr alive S R)
@@ -164,7 +165,7 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     scan stops once a pair is accepted. -/
 def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
-    (aggressive : Bool)
+    (aggressive : Bool) (ops : DenseZModOps p)
     (busId : Nat) (shape : MemoryBusShape)
     (hshape : facts.memShape busId = some shape)
     (T : Thunk (DenseAddrCerts p))
@@ -182,11 +183,12 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (i : Nat) : Option (DenseDropResult cs0 bs arr alive checksOld) :=
   if hi : i < arr.size then
     let S := arr[i]
-    let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive busId
+    let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
       shape hshape T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? fidx bidx arr alive
       checksOld hsz idx (i + 1)
     if haliveS : alive[i]?.getD false = true then
-    if decide (denseMultConst S = some shape.setNewMult) && decide (S.busId = busId) then
+    if decide (S.busId = busId) &&
+        decide (denseMultConst S = some (denseSetNewMult ops shape)) then
       match hfm : denseFirstMatchAt M arr alive busId S i (idx.getD
           (mixHash (hash busId)
             (if aggressive then denseAddrHash shape S.payload else densePayloadHash S.payload)) []) with
@@ -201,24 +203,24 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
             rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hR; simp at hR
           have hSget : arr[i]? = some S := Array.getElem?_eq_getElem hi
           let B := denseLiveArr arr alive hsz (i + 1) (j - i - 1) (by omega)
-          if hmidB : B.all (denseMidRefuted shape T busId S) = true then
+          if hmidB : B.all (denseMidRefuted ops shape T busId S) = true then
           let A := denseLiveArr arr alive hsz 0 i (by omega)
-          if hshieldA : denseShieldOk shape T busId S A = true then
+          if hshieldA : denseShieldOk ops shape T busId S A = true then
           have hBeq : B = denseLiveSeg arr alive (i + 1) (j - i - 1) :=
             denseLiveArr_eq arr alive hsz (i + 1) (j - i - 1) (by omega)
           have hAeq : A = denseLiveSeg arr alive 0 i := denseLiveArr_eq arr alive hsz 0 i (by omega)
           have hmid : ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
-              denseMidRefuted shape T busId S m0 = true := by
+              denseMidRefuted ops shape T busId S m0 = true := by
             rw [← hBeq]; exact fun m0 hm0 => List.all_eq_true.mp hmidB m0 hm0
-          have hshield : denseShieldOk shape T busId S (denseLiveSeg arr alive 0 i) = true := by
+          have hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
             rw [← hAeq]; exact hshieldA
           match hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) with
           | none => next ()
           | some (slots, bound) =>
-          if hchk0 : denseCheckCancel deep bs facts M domCsT.get.val candsT.get.lookup
+          if hchk0 : denseCheckCancel ops deep bs facts M domCsT.get.val candsT.get.lookup
               (denseDropWits facts bidx arr alive S R checksOld []) (denseDropFormWits fidx arr alive S R)
               busId shape slots bound S R [] = true then
-            some (denseMkDropResult cs0 bs facts hp1 deep hdeep busId shape hshape T hTtworoot
+            some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
               hTnonzero M hM domCsT.get.val domCsT.get.property candsT.get.lookup hcands
               fidx bidx arr alive checksOld hsz i j S R slots bound [] checksOld
               (List.append_nil checksOld).symm (fun reg _ bi hbi => absurd hbi (by simp))
@@ -233,11 +235,11 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
                 [denseMkByteCheck spec bcBus e])
             | _, _ => []
           if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
-            if hchk : denseCheckCancel deep bs facts M domCsT.get.val candsT.get.lookup
+            if hchk : denseCheckCancel ops deep bs facts M domCsT.get.val candsT.get.lookup
                 (denseDropWits facts bidx arr alive S R checksOld checks)
                 (denseDropFormWits fidx arr alive S R)
                 busId shape slots bound S R checks = true then
-              some (denseMkDropResult cs0 bs facts hp1 deep hdeep busId shape hshape T hTtworoot
+              some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
                 hTnonzero M hM domCsT.get.val domCsT.get.property candsT.get.lookup hcands
                 fidx bidx arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
                 (fun reg hRpay bi hbi => denseEmittedChecks_covered unjust bcBus? R reg hRpay bi hbi)
@@ -257,7 +259,7 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     hint. -/
 def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
-    (aggressive : Bool)
+    (aggressive : Bool) (ops : DenseZModOps p)
     (T : Thunk (DenseAddrCerts p))
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
@@ -274,20 +276,20 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
   | _, [] => none
   | curIdx, busId :: rest =>
     if curIdx < resumeIdx then
-      denseFindCancel cs0 bs facts hp1 deep hdeep aggressive T hTtworoot hTnonzero M hM domCsT candsT
+      denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT candsT
         hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
-        match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive busId shape hshape
+        match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
             T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? fidx bidx arr alive checksOld
             hsz idx startPos with
         | some dr => some { dr with dropIdx := curIdx }
-        | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive T hTtworoot hTnonzero M hM
+        | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
             domCsT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
             (curIdx + 1) rest
-      | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive T hTtworoot hTnonzero M hM
+      | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
           domCsT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
           (curIdx + 1) rest
 
@@ -304,7 +306,7 @@ structure DenseCancelBundle (cs0 : DenseConstraintSystem p) (bs : BusSemantics p
     compose via `DensePassCorrect.andThen`, coverage via `DenseDropResult.covNew`. -/
 def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
-    (aggressive : Bool)
+    (aggressive : Bool) (ops : DenseZModOps p)
     (T : Thunk (DenseAddrCerts p))
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
@@ -323,7 +325,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hsyscov : ∀ (reg : VarRegistry), cs0.CoveredBy reg →
       (denseMkCs cs0 arr alive checksOld).CoveredBy reg) :
     DenseCancelBundle cs0 bs :=
-  match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive T hTtworoot hTnonzero M hM domCsT
+  match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT
       candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 busIds with
   | none =>
     { out := { cs0 with
@@ -341,7 +343,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
   | some dr =>
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
-    denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive T hTtworoot hTnonzero M hM domCsT candsT
+    denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT candsT
       hcands bcBus? busIds fidx bidx arr idx dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos
       (fun isInput reg hcs0 => (hcur isInput reg hcs0).andThen (dr.step isInput reg (hsyscov reg hcs0)))
       (fun reg hcs0 => dr.covNew reg (hsyscov reg hcs0))
@@ -356,7 +358,8 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     let busIds := (d.busInteractions.map (fun bi => bi.busId)).dedup
     let deep : Bool := pw.isPrime
     let arr := d.busInteractions.toArray
-    let idx := denseRecvIndexAll facts aggressive arr
+    let ops : DenseZModOps p := denseZModOps
+    let idx := denseRecvIndexAll facts aggressive ops arr
     let alive : Array Bool := Array.replicate arr.size true
     let T : Thunk (DenseAddrCerts p) :=
       Thunk.mk fun _ => DenseAddrCerts.build d.algebraicConstraints
@@ -396,7 +399,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     have hsyscov0 : ∀ (reg : VarRegistry), d.CoveredBy reg →
         (denseMkCs d arr alive []).CoveredBy reg :=
       fun _ hcs0 => by rw [denseMkCs_all d arr rfl alive halltrue]; exact hcs0
-    let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive
+    let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive ops
       T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? busIds fidx bidx arr idx alive [] hsz 0 0
       hcur0 hsyscov0
     { reg' := reg

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -31,42 +31,50 @@ def denseFirstMatchAt (M : Thunk (DenseEqConstraintMap p)) (arr : Array (BusInte
 /-- Refute `m` as an active same-address message on `busId` (the "between" region test). The two-root
     disequality (`denseAddrTwoRootNeq`) lets it step over interleaved accesses whose addresses are
     pointer expressions rather than constants. -/
-def denseMidRefuted (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+def denseMidRefuted (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S m : BusInteraction (DenseExpr p)) : Bool :=
-  decide (m.busId ≠ busId) || decide (denseMultConst m = some 0) || denseAddrConstsNeq shape S m
+  decide (m.busId ≠ busId) || decide (denseMultConst m = some ops.zero) || denseAddrConstsNeq shape S m
     || denseAddrAffineNeq shape S m || denseAddrTwoRootNeq shape T.get.tworoot S m
     || denseAddrNonzeroNeq shape T.get.nonzero S m
 
 /-- Refute `m` as an active same-address *send* on `busId` (the "before" region test:
     earliest-send). -/
-def densePreRefuted (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+def densePreRefuted (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S m : BusInteraction (DenseExpr p)) : Bool :=
-  denseMidRefuted shape T busId S m ||
-    (match denseMultConst m with | some c => decide (c ≠ shape.setNewMult) | none => false)
+  denseMidRefuted ops shape T busId S m ||
+    (match denseMultConst m with
+     | some c => decide (c ≠ denseSetNewMult ops shape)
+     | none => false)
 
 /-- `m` is a *provable* active same-address receive on `busId`: on-bus, constant `-1`
     multiplicity, and a constant address equal to `S`'s. -/
-def denseProvRecv (shape : MemoryBusShape) (busId : Nat) (S m : BusInteraction (DenseExpr p)) : Bool :=
+def denseProvRecv (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
+    (S m : BusInteraction (DenseExpr p)) : Bool :=
   decide (m.busId = busId) && denseAddrConstsEq shape S m &&
-    decide (denseMultConst m = some (-shape.setNewMult))
+    decide (denseMultConst m = some (denseGetPreviousMult ops shape))
 
 /-- Single right-to-left pass returning `(hasRecvSoFar, ok)`: `hasRecvSoFar` is whether the tail
     processed so far (everything to the right) contains a provable active same-address receive; `ok`
     is whether every not-`densePreRefuted` message so far is followed by such a receive. O(n). -/
-def denseShieldScan (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+def denseShieldScan (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S : BusInteraction (DenseExpr p)) :
     List (BusInteraction (DenseExpr p)) → Bool × Bool
   | [] => (false, true)
   | m0 :: rest =>
-    let r := denseShieldScan shape T busId S rest
-    (r.1 || denseProvRecv shape busId S m0, r.2 && (densePreRefuted shape T busId S m0 || r.1))
+    let r := denseShieldScan ops shape T busId S rest
+    (r.1 || denseProvRecv ops shape busId S m0,
+      r.2 && (densePreRefuted ops shape T busId S m0 || r.1))
 
 /-- The *shield* check on the before-region: every message that is **not** provably a
     non-(active-same-address-send) (`¬densePreRefuted`) is followed by a provable active
     same-address receive (`denseProvRecv`). Computed in one O(n) pass (`denseShieldScan`). -/
-def denseShieldOk (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+def denseShieldOk (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S : BusInteraction (DenseExpr p)) (l : List (BusInteraction (DenseExpr p))) : Bool :=
-  (denseShieldScan shape T busId S l).2
+  (denseShieldScan ops shape T busId S l).2
 
 /-- Single-value byte check on `e`, emitted through `spec` (multiplicity `1`). -/
 def denseMkByteCheck (spec : ByteXorSpec p) (busId : Nat) (e : DenseExpr p) :
@@ -83,20 +91,22 @@ def denseMkBytePair (spec : ByteXorSpec p) (busId : Nat) (e₁ e₂ : DenseExpr 
 /-- Certificate that an emitted check faithfully carries `R`'s byte obligation: on a `byteXorSpec`
     bus (bound `256`), multiplicity 1, self-check payload `(xorOp, e, e, 0)` for an `e` that is a
     declared byte slot of `R`. -/
-def denseEmitOk (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat) (shape : MemoryBusShape)
-    (slots : List Nat) (R ck : BusInteraction (DenseExpr p)) : Bool :=
+def denseEmitOk (ops : DenseZModOps p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (busId : Nat) (shape : MemoryBusShape) (slots : List Nat)
+    (R ck : BusInteraction (DenseExpr p)) : Bool :=
   match facts.byteXorSpec ck.busId with
   | none => false
   | some spec =>
     decide (spec.bound = 256) &&
-    decide (ck.multiplicity = (.const 1 : DenseExpr p)) &&
+    decide (ck.multiplicity = (.const ops.one : DenseExpr p)) &&
     (match spec.decode ck.payload with
      | some (op, o1, o2, r) =>
        decide (op = (.const spec.xorOp : DenseExpr p)) && decide (o1 = o2) &&
-       decide (r = (.const 0 : DenseExpr p)) &&
+       decide (r = (.const ops.zero : DenseExpr p)) &&
        slots.any (fun slot =>
          decide (R.payload[slot]? = some o1) &&
-         (match facts.slotBound busId (-shape.setNewMult) (R.payload.map DenseExpr.constValue?) slot with
+         (match facts.slotBound busId (denseGetPreviousMult ops shape)
+              (R.payload.map DenseExpr.constValue?) slot with
           | some b => decide (b ≤ 256)
           | none => false))
      | none => false)
@@ -115,7 +125,7 @@ def denseUnjustifiedSlots (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p
     certificates, and byte justification of `R`'s declared slots. The split equation and region
     tests are not re-checked here (the scan established them); the justification scan is last, so it
     only runs for already-matching candidates. -/
-def denseCheckCancel (deep : Bool) (bs : BusSemantics p)
+def denseCheckCancel (ops : DenseZModOps p) (deep : Bool) (bs : BusSemantics p)
     (facts : BusFacts p bs)
     (M : Thunk (DenseEqConstraintMap p))
     (domCs : List (DenseExpr p)) (candsOf : VarId → List (DenseExpr p))
@@ -124,10 +134,10 @@ def denseCheckCancel (deep : Bool) (bs : BusSemantics p)
     (S R : BusInteraction (DenseExpr p))
     (checks : List (BusInteraction (DenseExpr p))) : Bool :=
   decide (S.busId = busId) && decide (R.busId = busId) &&
-  decide (denseMultConst S = some shape.setNewMult) &&
-    decide (denseMultConst R = some (-shape.setNewMult)) &&
+  decide (denseMultConst S = some (denseSetNewMult ops shape)) &&
+    decide (denseMultConst R = some (denseGetPreviousMult ops shape)) &&
   densePayloadEntailedEq M S.payload R.payload &&
-  checks.all (denseEmitOk bs facts busId shape slots R) &&
+  checks.all (denseEmitOk ops bs facts busId shape slots R) &&
   denseRecvSlotsJustified bound deep domCs candsOf bs facts wits fwits slots R
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheckProof.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheckProof.lean
@@ -39,18 +39,19 @@ theorem denseFirstMatchAt_spec (M : Thunk (DenseEqConstraintMap p))
     · exact ih h
 
 /-- No active same-address message on `busId` survives the between-region test. -/
-theorem denseMidRefuted_sound (reg : VarRegistry) (shape : MemoryBusShape)
+theorem denseMidRefuted_sound (reg : VarRegistry) (ops : DenseZModOps p) (shape : MemoryBusShape)
     {dcs : List (DenseExpr p)} (T : Thunk (DenseAddrCerts p))
     (hTtworoot : T.get.tworoot.Sound dcs)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build dcs)
     (hdcov : ∀ c ∈ dcs, c.CoveredBy reg)
     (busId : Nat) (S m : BusInteraction (DenseExpr p))
     (hScov : denseBICovered reg S) (hmcov : denseBICovered reg m)
-    (h : denseMidRefuted shape T busId S m = true) (denv : VarId → ZMod p)
+    (h : denseMidRefuted ops shape T busId S m = true) (denv : VarId → ZMod p)
     (hcon : ∀ c ∈ dcs, c.eval denv = 0)
     (hbid : (denseBIEval m denv).busId = busId) (hmne : (denseBIEval m denv).multiplicity ≠ 0)
     (hmaddr : shape.address (denseBIEval m denv) = shape.address (denseBIEval S denv)) : False := by
   unfold denseMidRefuted at h
+  rw [ops.zero_eq] at h
   rw [Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true, Bool.or_eq_true] at h
   rcases h with ((((h | h) | h) | h) | h) | h
   · exact absurd hbid (of_decide_eq_true h)
@@ -64,22 +65,23 @@ theorem denseMidRefuted_sound (reg : VarRegistry) (shape : MemoryBusShape)
 
 /-- An active same-address message on `busId` not refuted by the before-region test has multiplicity
     `≠ shape.setNewMult` (it is not a `setNew` send). -/
-theorem densePreRefuted_sound (reg : VarRegistry) (shape : MemoryBusShape)
+theorem densePreRefuted_sound (reg : VarRegistry) (ops : DenseZModOps p) (shape : MemoryBusShape)
     {dcs : List (DenseExpr p)} (T : Thunk (DenseAddrCerts p))
     (hTtworoot : T.get.tworoot.Sound dcs)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build dcs)
     (hdcov : ∀ c ∈ dcs, c.CoveredBy reg)
     (busId : Nat) (S m : BusInteraction (DenseExpr p))
     (hScov : denseBICovered reg S) (hmcov : denseBICovered reg m)
-    (h : densePreRefuted shape T busId S m = true) (denv : VarId → ZMod p)
+    (h : densePreRefuted ops shape T busId S m = true) (denv : VarId → ZMod p)
     (hcon : ∀ c ∈ dcs, c.eval denv = 0)
     (hbid : (denseBIEval m denv).busId = busId) (hmne : (denseBIEval m denv).multiplicity ≠ 0)
     (hmaddr : shape.address (denseBIEval m denv) = shape.address (denseBIEval S denv)) :
     (denseBIEval m denv).multiplicity ≠ shape.setNewMult := by
   unfold densePreRefuted at h
+  rw [denseSetNewMult_eq ops shape] at h
   rw [Bool.or_eq_true] at h
   rcases h with h | h
-  · exact (denseMidRefuted_sound reg shape T hTtworoot hTnonzero hdcov busId S m hScov hmcov h denv
+  · exact (denseMidRefuted_sound reg ops shape T hTtworoot hTnonzero hdcov busId S m hScov hmcov h denv
       hcon hbid hmne hmaddr).elim
   · cases hc : denseMultConst m with
     | none => rw [hc] at h; exact absurd h (by simp)
@@ -91,13 +93,15 @@ theorem densePreRefuted_sound (reg : VarRegistry) (shape : MemoryBusShape)
 
 /-- A provable active same-address receive on `busId` really is on-bus, active, same-address, and
     multiplicity `-shape.setNewMult`. -/
-theorem denseProvRecv_sound (shape : MemoryBusShape) (busId : Nat) (hp1 : (1 : ZMod p) ≠ 0)
-    (S m : BusInteraction (DenseExpr p)) (h : denseProvRecv shape busId S m = true)
+theorem denseProvRecv_sound (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
+    (hp1 : (1 : ZMod p) ≠ 0)
+    (S m : BusInteraction (DenseExpr p)) (h : denseProvRecv ops shape busId S m = true)
     (denv : VarId → ZMod p) :
     (denseBIEval m denv).busId = busId ∧ (denseBIEval m denv).multiplicity ≠ 0 ∧
     shape.address (denseBIEval m denv) = shape.address (denseBIEval S denv) ∧
       (denseBIEval m denv).multiplicity = -shape.setNewMult := by
   unfold denseProvRecv at h
+  rw [denseGetPreviousMult_eq ops shape] at h
   rw [Bool.and_eq_true, Bool.and_eq_true] at h
   obtain ⟨⟨hbid, haddr⟩, hmult⟩ := h
   have hmult' : (denseBIEval m denv).multiplicity = -shape.setNewMult :=
@@ -106,27 +110,29 @@ theorem denseProvRecv_sound (shape : MemoryBusShape) (busId : Nat) (hp1 : (1 : Z
   rw [hmult']; exact neg_ne_zero.mpr (shape.setNewMult_ne_zero hp1)
 
 /-- If the scan's `hasRecv` flag is set, the list contains a provable receive. -/
-theorem denseShieldScan_hasRecv (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+theorem denseShieldScan_hasRecv (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S : BusInteraction (DenseExpr p)) :
-    ∀ (l : List (BusInteraction (DenseExpr p))), (denseShieldScan shape T busId S l).1 = true →
-      ∃ Rp ∈ l, denseProvRecv shape busId S Rp = true
+    ∀ (l : List (BusInteraction (DenseExpr p))), (denseShieldScan ops shape T busId S l).1 = true →
+      ∃ Rp ∈ l, denseProvRecv ops shape busId S Rp = true
   | [], h => by simp [denseShieldScan] at h
   | m0 :: rest, h => by
       rw [denseShieldScan] at h
       dsimp only at h
       rcases Bool.or_eq_true _ _ |>.mp h with h1 | h1
-      · obtain ⟨Rp, hRp, hprov⟩ := denseShieldScan_hasRecv shape T busId S rest h1
+      · obtain ⟨Rp, hRp, hprov⟩ := denseShieldScan_hasRecv ops shape T busId S rest h1
         exact ⟨Rp, List.mem_cons_of_mem _ hRp, hprov⟩
       · exact ⟨m0, List.mem_cons_self .., h1⟩
 
 /-- From a passing `denseShieldOk` and a split `A_pre ++ m0 :: A_suf` whose `m0` is not provably
     excluded (`¬densePreRefuted`), `A_suf` carries a provable active same-address receive. -/
-theorem denseShieldOk_sound (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+theorem denseShieldOk_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S m0 : BusInteraction (DenseExpr p)) (A_suf : List (BusInteraction (DenseExpr p))) :
     ∀ (A_pre : List (BusInteraction (DenseExpr p))),
-      denseShieldOk shape T busId S (A_pre ++ m0 :: A_suf) = true →
-      densePreRefuted shape T busId S m0 = false →
-      ∃ Rp ∈ A_suf, denseProvRecv shape busId S Rp = true
+      denseShieldOk ops shape T busId S (A_pre ++ m0 :: A_suf) = true →
+      densePreRefuted ops shape T busId S m0 = false →
+      ∃ Rp ∈ A_suf, denseProvRecv ops shape busId S Rp = true
   | [], h, hpre => by
       unfold denseShieldOk at h
       rw [List.nil_append, denseShieldScan] at h
@@ -134,13 +140,13 @@ theorem denseShieldOk_sound (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts 
       rw [Bool.and_eq_true] at h
       obtain ⟨_, h2⟩ := h
       rw [hpre, Bool.false_or] at h2
-      exact denseShieldScan_hasRecv shape T busId S A_suf h2
+      exact denseShieldScan_hasRecv ops shape T busId S A_suf h2
   | a :: A_pre', h, hpre => by
       unfold denseShieldOk at h
       rw [List.cons_append, denseShieldScan] at h
       dsimp only at h
       rw [Bool.and_eq_true] at h
-      exact denseShieldOk_sound shape T busId S m0 A_suf A_pre' h.1 hpre
+      exact denseShieldOk_sound ops shape T busId S m0 A_suf A_pre' h.1 hpre
 
 /-- The evaluation of an emitted single-value byte check. -/
 theorem denseMkByteCheck_eval (spec : ByteXorSpec p) (busId : Nat) (e : DenseExpr p)
@@ -185,9 +191,10 @@ theorem denseMkByteCheck_payload_vars (spec : ByteXorSpec p) (busId : Nat) (e : 
 
 /-- A passing emit certificate makes the check stateless, implied by `R`'s own accepted receive,
     invariant-free, and adding no `VarId`s — `denseDropPair_correct`'s per-check `hchecks` element. -/
-theorem denseEmitOk_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId : Nat)
+theorem denseEmitOk_sound (ops : DenseZModOps p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (busId : Nat)
     (shape : MemoryBusShape) (slots : List Nat) (R ck : BusInteraction (DenseExpr p))
-    (h : denseEmitOk bs facts busId shape slots R ck = true)
+    (h : denseEmitOk ops bs facts busId shape slots R ck = true)
     (hRbus : R.busId = busId)
     (hRmEv : ∀ denv, (denseBIEval R denv).multiplicity = -shape.setNewMult) :
     bs.isStateful ck.busId = false ∧
@@ -196,6 +203,7 @@ theorem denseEmitOk_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId :
     (∀ denv, bs.breaksInvariant (denseBIEval ck denv) = false) ∧
     (∀ v ∈ denseBIVars ck, v ∈ denseBIVars R) := by
   unfold denseEmitOk at h
+  rw [ops.one_eq, ops.zero_eq, denseGetPreviousMult_eq ops shape] at h
   split at h
   · exact absurd h (by simp)
   · rename_i spec hspec
@@ -275,6 +283,7 @@ theorem denseEmitOk_sound (bs : BusSemantics p) (facts : BusFacts p bs) (busId :
 theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (d : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
+    (ops : DenseZModOps p)
     (reg : VarRegistry) (hcov : d.CoveredBy reg)
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
     (slots : List Nat) (bound : Nat)
@@ -294,12 +303,13 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ d.algebraicConstraints)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ A ++ B ++ C ++ checks)
     (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ A ++ B ++ C ++ checks)
-    (hmid : ∀ m0 ∈ B, denseMidRefuted shape T busId S m0 = true)
-    (hshield : denseShieldOk shape T busId S A = true)
-    (h : denseCheckCancel deep bs facts M domCs candsOf wits fwits busId shape slots bound S R checks
+    (hmid : ∀ m0 ∈ B, denseMidRefuted ops shape T busId S m0 = true)
+    (hshield : denseShieldOk ops shape T busId S A = true)
+    (h : denseCheckCancel ops deep bs facts M domCs candsOf wits fwits busId shape slots bound S R checks
       = true) :
     DensePassCorrect isInput d { d with busInteractions := A ++ B ++ C ++ checks } [] bs := by
   unfold denseCheckCancel at h
+  rw [denseSetNewMult_eq ops shape, denseGetPreviousMult_eq ops shape] at h
   simp only [Bool.and_eq_true] at h
   obtain ⟨⟨⟨⟨⟨⟨hSb, hRb⟩, hSm⟩, hRm⟩, hpay⟩, hemit⟩, hjust⟩ := h
   have hRmEv : ∀ denv, (denseBIEval R denv).multiplicity = -shape.setNewMult :=
@@ -310,7 +320,7 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
   refine denseDropPair_correct isInput d bs facts hp1 A B C S R busId shape hshape
     (R.payload.map DenseExpr.constValue?) slots bound hslots
     (fun denv => denseMatches_evalPattern R.payload denv) checks
-    (fun ck hck => denseEmitOk_sound bs facts busId shape slots R ck
+    (fun ck hck => denseEmitOk_sound ops bs facts busId shape slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
     (fun denv hall hbus => denseRecvSlotsJustified_sound bound deep d.algebraicConstraints domCs
       candsOf bs facts (A ++ B ++ C ++ checks) wits fwits slots R hdeep hdomCs hcands hwits hfwits
@@ -323,7 +333,7 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     intro denv hcon m0 hm0 hbid hmne hmaddr
     have hm0mem : m0 ∈ d.busInteractions := by
       rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto
-    exact denseMidRefuted_sound reg shape T hTtworoot hTnonzero hcov.1 busId S m0 hScov
+    exact denseMidRefuted_sound reg ops shape T hTtworoot hTnonzero hcov.1 busId S m0 hScov
       (hcov.2 m0 hm0mem) (hmid m0 hm0) denv hcon hbid hmne hmaddr
   ·
     intro denv hcon A_pre m0 A_suf hAeq hbid hmne hmaddr hmult
@@ -332,13 +342,13 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     have hm0mem : m0 ∈ d.busInteractions := by
       rw [hsplit]; simp only [List.mem_append, List.mem_cons]; tauto
     have hm0cov : denseBICovered reg m0 := hcov.2 m0 hm0mem
-    have hnp : densePreRefuted shape T busId S m0 = false := by
+    have hnp : densePreRefuted ops shape T busId S m0 = false := by
       by_contra hp'
       rw [Bool.not_eq_false] at hp'
-      exact (densePreRefuted_sound reg shape T hTtworoot hTnonzero hcov.1 busId S m0 hScov hm0cov
+      exact (densePreRefuted_sound reg ops shape T hTtworoot hTnonzero hcov.1 busId S m0 hScov hm0cov
         hp' denv hcon hbid hmne hmaddr) hmult
     obtain ⟨Rp, hRpmem, hRpprov⟩ :=
-      denseShieldOk_sound shape T busId S m0 A_suf A_pre (hAeq ▸ hshield) hnp
-    exact ⟨Rp, hRpmem, denseProvRecv_sound shape busId hp1 S Rp hRpprov denv⟩
+      denseShieldOk_sound ops shape T busId S m0 A_suf A_pre (hAeq ▸ hshield) hnp
+    exact ⟨Rp, hRpmem, denseProvRecv_sound ops shape busId hp1 S Rp hRpprov denv⟩
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
@@ -29,12 +29,12 @@ def denseAddrHash (shape : MemoryBusShape) (pl : List (DenseExpr p)) : UInt64 :=
     memory-shaped bus, keyed by bus id mixed with the payload hash (`densePayloadHash`, or
     `denseAddrHash` when `aggressive`). One build serves the whole sweep. -/
 def denseRecvIndexAll {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
-    (arr : Array (BusInteraction (DenseExpr p))) :
+    (ops : DenseZModOps p) (arr : Array (BusInteraction (DenseExpr p))) :
     Std.HashMap UInt64 (List Nat) :=
   (arr.toList.zipIdx).foldr (fun bij m =>
     match facts.memShape bij.1.busId with
     | some shape =>
-      if decide (denseMultConst bij.1 = some (-shape.setNewMult)) then
+      if decide (denseMultConst bij.1 = some (denseGetPreviousMult ops shape)) then
         let h := mixHash (hash bij.1.busId)
           (if aggressive then denseAddrHash shape bij.1.payload else densePayloadHash bij.1.payload)
         m.insert h (bij.2 :: m.getD h [])

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -21,6 +21,28 @@ def denseEqExpr (e2 e1 : DenseExpr p) : DenseExpr p := .add e2 (.mul (.const (-1
 def denseMultConst (bi : BusInteraction (DenseExpr p)) : Option (ZMod p) :=
   bi.multiplicity.constValue?
 
+def denseSetNewMult (ops : DenseZModOps p) (shape : MemoryBusShape) : ZMod p :=
+  match shape.direction with
+  | .receiveThenSend => ops.one
+  | .sendThenReceive => ops.negOne
+
+def denseGetPreviousMult (ops : DenseZModOps p) (shape : MemoryBusShape) : ZMod p :=
+  match shape.direction with
+  | .receiveThenSend => ops.negOne
+  | .sendThenReceive => ops.one
+
+theorem denseSetNewMult_eq (ops : DenseZModOps p) (shape : MemoryBusShape) :
+    denseSetNewMult ops shape = shape.setNewMult := by
+  cases shape with
+  | mk addressFields direction => cases direction <;> simp [denseSetNewMult,
+      MemoryBusShape.setNewMult, ops.one_eq, ops.negOne_eq]
+
+theorem denseGetPreviousMult_eq (ops : DenseZModOps p) (shape : MemoryBusShape) :
+    denseGetPreviousMult ops shape = -shape.setNewMult := by
+  cases shape with
+  | mk addressFields direction => cases direction <;> simp [denseGetPreviousMult,
+      MemoryBusShape.setNewMult, ops.one_eq, ops.negOne_eq]
+
 /-- Do the two sends carry equal constant address entries? -/
 def denseAddrConstsEq (shape : MemoryBusShape) (S S' : BusInteraction (DenseExpr p)) : Bool :=
   shape.addressFields.all (fun slot =>
@@ -90,12 +112,14 @@ inductive DenseStepRes
 /-- Classify message `m` against an open send window `S` (consumer / excluded / blocker). The
     certificate tables are `Thunk`s, forced only if a pair reaches the two-root / nonzero-witness
     arms, and call the same certificates `denseCheckPair`'s `mid` arms re-verify. -/
-def denseStepTest (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p))
+def denseStepTest (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p))
     (S m : BusInteraction (DenseExpr p)) : DenseStepRes :=
-  if decide (denseMultConst m = some (-shape.setNewMult)) && denseAddrConstsEq shape S m then .consumer
+  if decide (denseMultConst m = some (denseGetPreviousMult ops shape)) &&
+      denseAddrConstsEq shape S m then .consumer
   else if denseAddrConstsNeq shape S m || denseAddrAffineNeq shape S m
       || denseAddrTwoRootNeq shape T.get S m || denseAddrNonzeroNeq shape nw.get S m
-      || decide (denseMultConst m = some 0) then .excluded
+      || decide (denseMultConst m = some ops.zero) then .excluded
   else .blocker
 
 /-- A canonical address key. -/
@@ -140,7 +164,8 @@ def denseEmitCand (w : DenseOpenRec p) (j : Nat) (R : BusInteraction (DenseExpr 
 
 /-- The sweep: one pass over the interaction list. `acc` collects `(sendPosition, candidate)` pairs,
     order restored by the caller's sort. -/
-def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p)) :
+def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p)) :
     (revSeen rest : List (BusInteraction (DenseExpr p))) → (j : Nat) →
     (constOpen : Std.HashMap (DenseAddrKey p) (DenseOpenRec p)) →
     (symOpen : List (DenseOpenRec p)) →
@@ -160,7 +185,7 @@ def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : 
         | some k =>
           match constOpen[k]? with
           | some w =>
-            match denseStepTest shape T nw w.S m with
+            match denseStepTest ops shape T nw w.S m with
             | .consumer =>
               (constOpen.erase k,
                match denseEmitCand w j m rest' with
@@ -173,7 +198,7 @@ def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : 
       else
         let (drops, acc) := constOpen.toList.foldl (init := (([] : List (DenseAddrKey p)), acc))
           fun (ds, a) kw =>
-            match denseStepTest shape T nw kw.2.S m with
+            match denseStepTest ops shape T nw kw.2.S m with
             | .consumer =>
               (kw.1 :: ds,
                match denseEmitCand kw.2 j m rest' with
@@ -186,7 +211,7 @@ def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : 
     let (symOpen, acc) :=
       if symOpen.isEmpty then (symOpen, acc) else
       symOpen.foldr (init := (([] : List (DenseOpenRec p)), acc)) fun w (so, a) =>
-        match denseStepTest shape T nw w.S m with
+        match denseStepTest ops shape T nw w.S m with
         | .consumer =>
           (so,
            match denseEmitCand w j m rest' with
@@ -197,7 +222,7 @@ def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : 
     -- (3) a send opens its window; a same-key window that survived (1) as excluded moves to the
     --     literally-tested `symOpen` list.
     let (constOpen, symOpen) :=
-      if decide (denseMultConst m = some shape.setNewMult) then
+      if decide (denseMultConst m = some (denseSetNewMult ops shape)) then
         match mKey? with
         | some k =>
           let w : DenseOpenRec p := ⟨revSeen, m, rest', j⟩
@@ -208,13 +233,14 @@ def denseSweepGo (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p)) (nw : 
           else (constOpen, w :: symOpen)
         | none => (constOpen, symOpen)
       else (constOpen, symOpen)
-    denseSweepGo shape T nw (m :: revSeen) rest' (j + 1) constOpen symOpen acc
+    denseSweepGo ops shape T nw (m :: revSeen) rest' (j + 1) constOpen symOpen acc
 
 /-- All consumer candidates of one bus, in send-position order. -/
 def denseCandidateSplitsSweep (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p))
     (nw : Thunk (DenseNonzeroWits p)) (L : List (BusInteraction (DenseExpr p))) :
     List (DenseSplitCand p) :=
-  ((denseSweepGo shape T nw [] L 0 ∅ [] []).mergeSort
+  let ops : DenseZModOps p := denseZModOps
+  ((denseSweepGo ops shape T nw [] L 0 ∅ [] []).mergeSort
     (fun a b => decide (a.1 ≤ b.1))).map (·.2)
 
 /-- Collect the entailed equalities for one bus: for each candidate, `denseCheckPair` and, when it

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnifyProof.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnifyProof.lean
@@ -290,7 +290,8 @@ private theorem eraseFold_ow {L : List (BusInteraction (DenseExpr p))}
     exact ih (cO.erase d) (erase_ow cO hcO d)
 
 
-theorem denseSweepGo_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap p)}
+theorem denseSweepGo_split {ops : DenseZModOps p} {shape : MemoryBusShape}
+    {T : Thunk (DenseTwoRootMap p)}
     {nw : Thunk (DenseNonzeroWits p)} (L : List (BusInteraction (DenseExpr p)))
     (revSeen rest : List (BusInteraction (DenseExpr p))) (j : Nat)
     (constOpen : Std.HashMap (DenseAddrKey p) (DenseOpenRec p))
@@ -299,9 +300,9 @@ theorem denseSweepGo_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap 
     (hcO : ∀ (k : DenseAddrKey p) (w : DenseOpenRec p), constOpen[k]? = some w → OpenWF L w)
     (hsO : ∀ w ∈ symOpen, OpenWF L w)
     (hacc : ∀ ic ∈ acc, SplitEqC L ic.2) :
-    ∀ ic ∈ denseSweepGo shape T nw revSeen rest j constOpen symOpen acc, SplitEqC L ic.2 := by
+    ∀ ic ∈ denseSweepGo ops shape T nw revSeen rest j constOpen symOpen acc, SplitEqC L ic.2 := by
   revert hsplit hj hcO hsO hacc
-  fun_induction denseSweepGo shape T nw revSeen rest j constOpen symOpen acc with
+  fun_induction denseSweepGo ops shape T nw revSeen rest j constOpen symOpen acc with
   | case1 revSeen j constOpen symOpen acc =>
     intro hsplit hj hcO hsO hacc ic hic
     exact hacc ic hic
@@ -344,7 +345,7 @@ theorem denseSweepGo_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap 
         intro dsa hdsa kw hkw
         obtain ⟨ds, a2⟩ := dsa
         intro ic hic
-        cases hst : denseStepTest shape T nw kw.2.S m with
+        cases hst : denseStepTest ops shape T nw kw.2.S m with
         | consumer =>
           simp only [hst] at hic
           exact denseEmitCand_cons_split kw.2 (hlst kw hkw) j hj m rest' hnow a2 hdsa ic hic
@@ -364,7 +365,7 @@ theorem denseSweepGo_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap 
           intro soa hsoa w hw
           obtain ⟨so2, a2⟩ := soa
           obtain ⟨hso2, ha2⟩ := hsoa
-          cases hst : denseStepTest shape T nw w.S m with
+          cases hst : denseStepTest ops shape T nw w.S m with
           | consumer => exact ⟨hso2, denseEmitCand_cons_split w (hsO w hw) j hj m rest' hnow a2 ha2⟩
           | excluded =>
             exact ⟨List.forall_mem_cons.mpr ⟨hsO w hw, hso2⟩, ha2⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchProof.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchProof.lean
@@ -670,7 +670,7 @@ theorem denseEnvOfKeysV_map (denv : VarId → ZMod p) :
 /-- Positional lookup on a value-only point matches the keyed environment lookup. -/
 theorem denseVarIx_lookupV_env (keys : List VarId) (pt : List (ZMod p)) (y : VarId) (idx : Nat)
     (h : denseVarIx keys y = some idx) :
-    denseLookupIxV pt idx = denseEnvOfKeysV keys pt y := by
+    denseLookupIxV 0 pt idx = denseEnvOfKeysV keys pt y := by
   induction keys generalizing pt idx with
   | nil => simp [denseVarIx] at h
   | cons x rest ih =>
@@ -680,20 +680,18 @@ theorem denseVarIx_lookupV_env (keys : List VarId) (pt : List (ZMod p)) (y : Var
     | cons v vs =>
       split_ifs at h with hyx
       · simp only [Option.some.injEq] at h; subst h
-        show denseLookupIxV (v :: vs) 0 = denseEnvOfKeysV (x :: rest) (v :: vs) y
+        show denseLookupIxV 0 (v :: vs) 0 = denseEnvOfKeysV (x :: rest) (v :: vs) y
         rw [denseLookupIxV, denseEnvOfKeysV, if_pos hyx]
       · rw [Option.map_eq_some_iff] at h
         obtain ⟨j, hj, rfl⟩ := h
-        show denseLookupIxV (v :: vs) (j + 1) = denseEnvOfKeysV (x :: rest) (v :: vs) y
+        show denseLookupIxV 0 (v :: vs) (j + 1) = denseEnvOfKeysV (x :: rest) (v :: vs) y
         rw [denseLookupIxV, denseEnvOfKeysV, if_neg hyx]
         exact ih vs j hj
 
 /-- Compiled value-only evaluation agrees with the keyed-environment evaluation of the source. -/
-theorem denseCompileE_evalV (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b)
-    (keys : List VarId) (pt : List (ZMod p)) :
+theorem denseCompileE_evalV (ops : DenseZModOps p) (keys : List VarId) (pt : List (ZMod p)) :
     ∀ (e : DenseExpr p) (ic : IExpr p), denseCompileE keys e = some ic →
-      denseIExprEvalWithV add mul pt ic = e.eval (denseEnvOfKeysV keys pt) := by
+      denseIExprEvalWithV ops pt ic = e.eval (denseEnvOfKeysV keys pt) := by
   intro e
   induction e with
   | const n => intro ic h; simp only [denseCompileE, Option.some.injEq] at h; subst h; rfl
@@ -701,8 +699,9 @@ theorem denseCompileE_evalV (add mul : ZMod p → ZMod p → ZMod p)
       intro ic h
       rw [denseCompileE, Option.map_eq_some_iff] at h
       obtain ⟨idx, hidx, rfl⟩ := h
-      show denseIExprEvalWithV add mul pt (.ix idx) = denseEnvOfKeysV keys pt y
+      show denseIExprEvalWithV ops pt (.ix idx) = denseEnvOfKeysV keys pt y
       rw [denseIExprEvalWithV]
+      rw [ops.zero_eq]
       exact denseVarIx_lookupV_env keys pt y idx hidx
   | add a b iha ihb =>
       intro ic h
@@ -713,8 +712,8 @@ theorem denseCompileE_evalV (add mul : ZMod p → ZMod p → ZMod p)
         | none => rw [denseCompileE, ha, hb] at h; simp at h
         | some ib =>
           rw [denseCompileE, ha, hb] at h; simp only [Option.some.injEq] at h; subst h
-          show denseIExprEvalWithV add mul pt (.add ia ib) = (a.add b).eval (denseEnvOfKeysV keys pt)
-          rw [denseIExprEvalWithV, DenseExpr.eval, hadd, iha ia ha, ihb ib hb]
+          show denseIExprEvalWithV ops pt (.add ia ib) = (a.add b).eval (denseEnvOfKeysV keys pt)
+          rw [denseIExprEvalWithV, DenseExpr.eval, ops.add_eq, iha ia ha, ihb ib hb]
   | mul a b iha ihb =>
       intro ic h
       cases ha : denseCompileE keys a with
@@ -724,15 +723,14 @@ theorem denseCompileE_evalV (add mul : ZMod p → ZMod p → ZMod p)
         | none => rw [denseCompileE, ha, hb] at h; simp at h
         | some ib =>
           rw [denseCompileE, ha, hb] at h; simp only [Option.some.injEq] at h; subst h
-          show denseIExprEvalWithV add mul pt (.mul ia ib) = (a.mul b).eval (denseEnvOfKeysV keys pt)
-          rw [denseIExprEvalWithV, DenseExpr.eval, hmul, iha ia ha, ihb ib hb]
+          show denseIExprEvalWithV ops pt (.mul ia ib) = (a.mul b).eval (denseEnvOfKeysV keys pt)
+          rw [denseIExprEvalWithV, DenseExpr.eval, ops.mul_eq, iha ia ha, ihb ib hb]
 
 /-- Compiled-list zero-check agrees with the source list's (value-only). -/
-theorem denseCompileEs_allV (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b) (isZero : ZMod p → Bool)
+theorem denseCompileEs_allV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (hz : ∀ v, isZero v = decide (v = 0)) (keys : List VarId) (pt : List (ZMod p)) :
     ∀ (es : List (DenseExpr p)) (ces : List (IExpr p)), denseCompileEs keys es = some ces →
-      ces.all (fun ie => isZero (denseIExprEvalWithV add mul pt ie))
+      ces.all (fun ie => isZero (denseIExprEvalWithV ops pt ie))
         = es.all (fun e => decide (e.eval (denseEnvOfKeysV keys pt) = 0)) := by
   intro es
   induction es with
@@ -747,14 +745,12 @@ theorem denseCompileEs_allV (add mul : ZMod p → ZMod p → ZMod p)
       | some irest =>
         rw [denseCompileEs, he, hr] at h; simp only [Option.some.injEq] at h; subst h
         rw [List.all_cons, List.all_cons, ih irest hr,
-          denseCompileE_evalV add mul hadd hmul keys pt e ie he, hz]
+          denseCompileE_evalV ops keys pt e ie he, hz]
 
 /-- Compiled payload evaluation agrees with the fallback payload (value-only). -/
-theorem denseCompileEs_mapV (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b)
-    (keys : List VarId) (pt : List (ZMod p)) :
+theorem denseCompileEs_mapV (ops : DenseZModOps p) (keys : List VarId) (pt : List (ZMod p)) :
     ∀ (es : List (DenseExpr p)) (ces : List (IExpr p)), denseCompileEs keys es = some ces →
-      ces.map (fun ie => denseIExprEvalWithV add mul pt ie)
+      ces.map (fun ie => denseIExprEvalWithV ops pt ie)
         = es.map (fun e => e.eval (denseEnvOfKeysV keys pt)) := by
   intro es
   induction es with
@@ -769,14 +765,13 @@ theorem denseCompileEs_mapV (add mul : ZMod p → ZMod p → ZMod p)
       | some irest =>
         rw [denseCompileEs, he, hr] at h; simp only [Option.some.injEq] at h; subst h
         rw [List.map_cons, List.map_cons, ih irest hr,
-          denseCompileE_evalV add mul hadd hmul keys pt e ie he]
+          denseCompileE_evalV ops keys pt e ie he]
 
 /-- Compiled interaction evaluation agrees with the fallback message (value-only). -/
-theorem denseCompileBi_evalWithV (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b)
-    (keys : List VarId) (pt : List (ZMod p)) (bi : BusInteraction (DenseExpr p)) (cbi : CBi p)
+theorem denseCompileBi_evalWithV (ops : DenseZModOps p) (keys : List VarId)
+    (pt : List (ZMod p)) (bi : BusInteraction (DenseExpr p)) (cbi : CBi p)
     (h : denseCompileBi keys bi = some cbi) :
-    denseCBiEvalWithV add mul cbi pt
+    denseCBiEvalWithV ops cbi pt
       = { busId := bi.busId,
           multiplicity := bi.multiplicity.eval (denseEnvOfKeysV keys pt),
           payload := bi.payload.map (fun e => e.eval (denseEnvOfKeysV keys pt)) } := by
@@ -789,17 +784,16 @@ theorem denseCompileBi_evalWithV (add mul : ZMod p → ZMod p → ZMod p)
       rw [denseCompileBi, hm, hpl] at h; simp only [Option.some.injEq] at h; subst h
       unfold denseCBiEvalWithV
       dsimp only
-      rw [denseCompileE_evalV add mul hadd hmul keys pt bi.multiplicity m hm,
-        denseCompileEs_mapV add mul hadd hmul keys pt bi.payload pl hpl]
+      rw [denseCompileE_evalV ops keys pt bi.multiplicity m hm,
+        denseCompileEs_mapV ops keys pt bi.payload pl hpl]
 
 /-- Compiled-list obligation check agrees with the source list's (value-only). -/
-theorem denseCompileBis_allV (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b) (isZero : ZMod p → Bool)
+theorem denseCompileBis_allV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p) (keys : List VarId)
     (pt : List (ZMod p)) :
     ∀ (bis : List (BusInteraction (DenseExpr p))) (cbis : List (CBi p)),
       denseCompileBis keys bis = some cbis →
-      cbis.all (fun cbi => let v := denseCBiEvalWithV add mul cbi pt;
+      cbis.all (fun cbi => let v := denseCBiEvalWithV ops cbi pt;
           isZero v.multiplicity || !bs.violatesConstraint v)
         = bis.all (fun bi =>
           let v : BusInteraction (ZMod p) :=
@@ -820,20 +814,19 @@ theorem denseCompileBis_allV (add mul : ZMod p → ZMod p → ZMod p)
       | some crest =>
         rw [denseCompileBis, hb, hr] at h; simp only [Option.some.injEq] at h; subst h
         rw [List.all_cons, List.all_cons, ih crest hr]
-        simp only [denseCompileBi_evalWithV add mul hadd hmul keys pt bi cbi hb, hz]
+        simp only [denseCompileBi_evalWithV ops keys pt bi cbi hb, hz]
 
 /-- The value-only compiled survivor predicate under compile success agrees with the uncompiled one. -/
-theorem denseSurvivesAllCWV_eq (add mul : ZMod p → ZMod p → ZMod p)
-    (hadd : ∀ a b, add a b = a + b) (hmul : ∀ a b, mul a b = a * b) (isZero : ZMod p → Bool)
+theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p) (es : List (DenseExpr p))
     (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (ces : List (IExpr p))
     (cbis : List (CBi p)) (pt : List (ZMod p))
     (hce : denseCompileEs keys es = some ces) (hcb : denseCompileBis keys bis = some cbis) :
-    denseSurvivesAllCWV add mul isZero bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt := by
+    denseSurvivesAllCWV ops isZero bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt := by
   unfold denseSurvivesAllCWV denseSurvivesAllMV
   congr 1
-  · exact denseCompileEs_allV add mul hadd hmul isZero hz keys pt es ces hce
-  · exact denseCompileBis_allV add mul hadd hmul isZero hz bs keys pt bis cbis hcb
+  · exact denseCompileEs_allV ops isZero hz keys pt es ces hce
+  · exact denseCompileBis_allV ops isZero hz bs keys pt bis cbis hcb
 
 /-- The value-only compiled survivor predicate agrees with the uncompiled one on every point. -/
 theorem denseCompiledSurvV_eq (bs : BusSemantics p) (es : List (DenseExpr p))
@@ -846,7 +839,9 @@ theorem denseCompiledSurvV_eq (bs : BusSemantics p) (es : List (DenseExpr p))
     cases hcb : denseCompileBis keys bis with
     | none => rfl
     | some cbis =>
-      exact denseSurvivesAllCWV_eq _ _ (fun _ _ => rfl) (fun _ _ => rfl) _ (fun _ => rfl)
+      change denseSurvivesAllCWV denseZModOps (fun v => decide (v = denseZModOps.zero))
+          bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt
+      exact denseSurvivesAllCWV_eq denseZModOps _ (fun _ => rfl)
         bs es bis keys ces cbis pt hce hcb
 
 /-- The restriction of a satisfying `denv` survives the covered-item predicate (value-only). -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -19,34 +19,34 @@ variable {p : ℕ}
 /-! ## Value-only positional lookup and compiled evaluation -/
 
 /-- Positional lookup in a value-only point (position alone determines the value). -/
-def denseLookupIxV : List (ZMod p) → Nat → ZMod p
-  | [], _ => 0
+def denseLookupIxV (zero : ZMod p) : List (ZMod p) → Nat → ZMod p
+  | [], _ => zero
   | v :: _, 0 => v
-  | _ :: rest, i + 1 => denseLookupIxV rest i
+  | _ :: rest, i + 1 => denseLookupIxV zero rest i
 
 /-- `IExpr.evalWith`, over a value-only point (hoisted `add`/`mul`). -/
-def denseIExprEvalWithV (add mul : ZMod p → ZMod p → ZMod p) (pt : List (ZMod p)) :
+def denseIExprEvalWithV (ops : DenseZModOps p) (pt : List (ZMod p)) :
     IExpr p → ZMod p
   | .const n => n
-  | .ix i => denseLookupIxV pt i
-  | .add a b => add (denseIExprEvalWithV add mul pt a) (denseIExprEvalWithV add mul pt b)
-  | .mul a b => mul (denseIExprEvalWithV add mul pt a) (denseIExprEvalWithV add mul pt b)
+  | .ix i => denseLookupIxV ops.zero pt i
+  | .add a b => ops.add (denseIExprEvalWithV ops pt a) (denseIExprEvalWithV ops pt b)
+  | .mul a b => ops.mul (denseIExprEvalWithV ops pt a) (denseIExprEvalWithV ops pt b)
 
 /-- `CBi.evalWith`, over a value-only point. -/
-def denseCBiEvalWithV (add mul : ZMod p → ZMod p → ZMod p) (cbi : CBi p) (pt : List (ZMod p)) :
+def denseCBiEvalWithV (ops : DenseZModOps p) (cbi : CBi p) (pt : List (ZMod p)) :
     BusInteraction (ZMod p) :=
   { busId := cbi.busId,
-    multiplicity := denseIExprEvalWithV add mul pt cbi.mult,
-    payload := cbi.payload.map (fun ie => denseIExprEvalWithV add mul pt ie) }
+    multiplicity := denseIExprEvalWithV ops pt cbi.mult,
+    payload := cbi.payload.map (fun ie => denseIExprEvalWithV ops pt ie) }
 
 /-- `survivesAllCW`, over a value-only point: compiled items' zero test plus interactions'
     obligation check. -/
-def denseSurvivesAllCWV (add mul : ZMod p → ZMod p → ZMod p) (isZero : ZMod p → Bool)
+def denseSurvivesAllCWV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (bs : BusSemantics p) (ces : List (IExpr p)) (cbis : List (CBi p))
     (pt : List (ZMod p)) : Bool :=
-  ces.all (fun ie => isZero (denseIExprEvalWithV add mul pt ie)) &&
+  ces.all (fun ie => isZero (denseIExprEvalWithV ops pt ie)) &&
     cbis.all (fun cbi =>
-      let v := denseCBiEvalWithV add mul cbi pt
+      let v := denseCBiEvalWithV ops cbi pt
       isZero v.multiplicity || !bs.violatesConstraint v)
 
 /-! ### The uncompiled fallback
@@ -87,13 +87,10 @@ def denseCompiledSurvV (bs : BusSemantics p) (es : List (DenseExpr p))
     DenseSurvV p :=
   match denseCompileEs keys es, denseCompileBis keys bis with
   | some ces, some cbis =>
-    let addI : Add (ZMod p) := inferInstance
-    let mulI : Mul (ZMod p) := inferInstance
+    let ops : DenseZModOps p := denseZModOps
     let dec : DecidableEq (ZMod p) := inferInstance
-    let add := addI.add
-    let mul := mulI.mul
-    let isZero : ZMod p → Bool := fun v => @decide (v = 0) (dec v 0)
-    ⟨fun pt => denseSurvivesAllCWV add mul isZero bs ces cbis pt⟩
+    let isZero : ZMod p → Bool := fun v => @decide (v = ops.zero) (dec v ops.zero)
+    ⟨fun pt => denseSurvivesAllCWV ops isZero bs ces cbis pt⟩
   | _, _ => ⟨denseSurvivesAllMV bs es bis keys⟩
 
 /-! ## Value-only lazy box enumeration -/
@@ -152,12 +149,10 @@ def denseConstraintRedundantV (T : DenseDomainTable p) (c : DenseExpr p) : Bool 
     (d.map (fun yd => yd.2.size)).prod ≤ maxEnumSize &&
       match denseCompileE (d.map Prod.fst) c with
       | some ic =>
-        let addI : Add (ZMod p) := inferInstance
-        let mulI : Mul (ZMod p) := inferInstance
+        let ops : DenseZModOps p := denseZModOps
         let dec : DecidableEq (ZMod p) := inferInstance
-        let add := addI.add
-        let mul := mulI.mul
-        denseAllBoxV (fun a => @decide (denseIExprEvalWithV add mul a ic = 0) (dec _ 0))
+        denseAllBoxV
+          (fun a => @decide (denseIExprEvalWithV ops a ic = ops.zero) (dec _ ops.zero))
           (d.map Prod.snd)
       | none =>
         denseAllBoxV (fun a => decide (c.eval (denseEnvOfKeysV (d.map Prod.fst) a) = 0))

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldProof.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldProof.lean
@@ -88,11 +88,10 @@ theorem denseGroupSurvivorsEV_eq (es : List (DenseExpr p)) (xs : List VarId)
   | some ces =>
       apply List.filter_congr
       intro a _
-      show denseSurvZeroCWV (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul ces a
+      show denseSurvZeroCWV denseZModOps (fun v => decide (v = denseZModOps.zero)) ces a
         = es.all (fun c => decide (c.eval (denseEnvOfKeysV xs a) = 0))
       unfold denseSurvZeroCWV
-      exact denseCompileEs_allV (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul
-        (fun _ _ => rfl) (fun _ _ => rfl) (fun v => decide (v = 0)) (fun _ => rfl) xs a es ces hce
+      exact denseCompileEs_allV denseZModOps _ (fun _ => rfl) xs a es ces hce
 
 theorem mem_denseGroupSurvivorsEV (es : List (DenseExpr p)) (xs : List VarId)
     (domVals : List (List (ZMod p))) (pt : List (ZMod p)) (hmem : pt ∈ denseAssignmentsV domVals)
@@ -120,8 +119,7 @@ theorem denseConstOnSurvsV_sound (xs : List VarId) (survsV : List (List (ZMod p)
             simp only [Option.some.injEq] at h
             have hthis := List.all_eq_true.mp hall s hs
             rw [decide_eq_true_eq] at hthis
-            have hev := denseCompileE_evalV (inferInstance : Add (ZMod p)).add
-              (inferInstance : Mul (ZMod p)).mul (fun _ _ => rfl) (fun _ _ => rfl) xs s e ie hce
+            have hev := denseCompileE_evalV denseZModOps xs s e ie hce
             rw [← hev, hthis]; exact h
           · exact absurd h (by simp)
       | none =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
@@ -25,11 +25,10 @@ def denseAssignmentsV : List (List (ZMod p)) → List (List (ZMod p))
 
 /-! ## The group's survivor filter, compiled once per target -/
 
-/-- Whether every compiled covered constraint `ces` zeroes at point `pt`; `add`/`mul` are the ring
-    ops hoisted out of the `ZMod p` instances once by the caller. -/
-def denseSurvZeroCWV (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr p))
+/-- Whether every compiled covered constraint `ces` zeroes at point `pt`. -/
+def denseSurvZeroCWV (ops : DenseZModOps p) (isZero : ZMod p → Bool) (ces : List (IExpr p))
     (pt : List (ZMod p)) : Bool :=
-  ces.all (fun ie => decide (denseIExprEvalWithV add mul pt ie = 0))
+  ces.all (fun ie => isZero (denseIExprEvalWithV ops pt ie))
 
 /-- The surviving group values, value-only: covered constraints `es` compiled once over key list
     `xs`, every enumerated point checked by index. Falls back to the uncompiled filter only if
@@ -38,9 +37,11 @@ def denseGroupSurvivorsEV (es : List (DenseExpr p)) (xs : List VarId)
     (domVals : List (List (ZMod p))) : List (List (ZMod p)) :=
   match denseCompileEs xs es with
   | some ces =>
-    let addI : Add (ZMod p) := inferInstance
-    let mulI : Mul (ZMod p) := inferInstance
-    (denseAssignmentsV domVals).filter (denseSurvZeroCWV addI.add mulI.mul ces)
+    let ops : DenseZModOps p := denseZModOps
+    let dec : DecidableEq (ZMod p) := inferInstance
+    let isZero : ZMod p → Bool := fun v => @decide (v = ops.zero) (dec v ops.zero)
+    let surv : DenseSurvV p := ⟨fun pt => denseSurvZeroCWV ops isZero ces pt⟩
+    (denseAssignmentsV domVals).filter surv.run
   | none =>
     (denseAssignmentsV domVals).filter
       (fun a => es.all (fun c => decide (c.eval (denseEnvOfKeysV xs a) = 0)))
@@ -57,10 +58,9 @@ def denseConstOnSurvsV (xs : List VarId) (survsV : List (List (ZMod p))) (e : De
   | s₀ :: rest =>
     match denseCompileE xs e with
     | some ie =>
-      let addI : Add (ZMod p) := inferInstance
-      let mulI : Mul (ZMod p) := inferInstance
-      let v₀ := denseIExprEvalWithV addI.add mulI.mul s₀ ie
-      if (s₀ :: rest).all (fun s => decide (denseIExprEvalWithV addI.add mulI.mul s ie = v₀))
+      let ops : DenseZModOps p := denseZModOps
+      let v₀ := denseIExprEvalWithV ops s₀ ie
+      if (s₀ :: rest).all (fun s => decide (denseIExprEvalWithV ops s ie = v₀))
       then some v₀ else none
     | none =>
       let v₀ := e.eval (denseEnvOfKeysV xs s₀)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -40,6 +40,31 @@ structure DenseConstraintSystem (p : ℕ) where
   algebraicConstraints : List (DenseExpr p)
   busInteractions : List (BusInteraction (DenseExpr p))
 
+/-- Boxed field operations and constants, built once outside hot recursive traversals. -/
+structure DenseZModOps (p : ℕ) where
+  add : ZMod p → ZMod p → ZMod p
+  mul : ZMod p → ZMod p → ZMod p
+  zero : ZMod p
+  one : ZMod p
+  negOne : ZMod p
+  add_eq : ∀ a b, add a b = a + b
+  mul_eq : ∀ a b, mul a b = a * b
+  zero_eq : zero = 0
+  one_eq : one = 1
+  negOne_eq : negOne = -1
+
+def denseZModOps : DenseZModOps p where
+  add := (inferInstance : Add (ZMod p)).add
+  mul := (inferInstance : Mul (ZMod p)).mul
+  zero := 0
+  one := 1
+  negOne := -1
+  add_eq := fun _ _ => rfl
+  mul_eq := fun _ _ => rfl
+  zero_eq := rfl
+  one_eq := rfl
+  negOne_eq := rfl
+
 /-! ## Dense expression operations (runtime; specified against decode below) -/
 
 /-- Multiplicative degree, mirroring `Expression.degree`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -248,6 +248,89 @@ theorem densePivotDescs_eq (c : DenseExpr p) (l : DenseLinExpr p) (hlin : denseL
   · exact List.filterMap_congr (fun v _ => densePm1Desc_eq l occ prot v)
   · exact List.filterMap_congr (fun v _ => denseUnitDesc_eq l occ prot v)
 
+/-! ## Boxed runtime twins -/
+
+def denseIdxStepWith (ops : DenseZModOps p) (m : Std.HashMap VarId (ZMod p × Nat))
+    (t : VarId × ZMod p) : Std.HashMap VarId (ZMod p × Nat) :=
+  let old := (m[t.1]?).getD (ops.zero, 0)
+  m.insert t.1 (ops.add old.1 t.2, old.2 + 1)
+
+def denseCoeffIdxWith (ops : DenseZModOps p) :
+    List (VarId × ZMod p) → Std.HashMap VarId (ZMod p × Nat) →
+      Std.HashMap VarId (ZMod p × Nat)
+  | [], m => m
+  | t :: rest, m => denseCoeffIdxWith ops rest (denseIdxStepWith ops m t)
+
+def denseCoeffIdxFast (terms : List (VarId × ZMod p)) : Std.HashMap VarId (ZMod p × Nat) :=
+  let ops : DenseZModOps p := denseZModOps
+  denseCoeffIdxWith ops terms ∅
+
+theorem denseIdxStepWith_eq (ops : DenseZModOps p) (m : Std.HashMap VarId (ZMod p × Nat))
+    (t : VarId × ZMod p) : denseIdxStepWith ops m t = denseIdxStep m t := by
+  simp only [denseIdxStepWith, denseIdxStep, ops.zero_eq, ops.add_eq]
+
+theorem denseCoeffIdxWith_eq (ops : DenseZModOps p) (terms : List (VarId × ZMod p))
+    (m : Std.HashMap VarId (ZMod p × Nat)) :
+    denseCoeffIdxWith ops terms m = terms.foldl denseIdxStep m := by
+  induction terms generalizing m with
+  | nil => rfl
+  | cons t rest ih =>
+    rw [denseCoeffIdxWith, denseIdxStepWith_eq, List.foldl_cons, ih]
+
+@[csimp] theorem denseCoeffIdx_eq_fast : @denseCoeffIdx = @denseCoeffIdxFast := by
+  funext p terms
+  simp only [denseCoeffIdx, denseCoeffIdxFast, denseCoeffIdxWith_eq]
+
+def densePm1DescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
+    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    Option (VarId × Nat) :=
+  if ((idx[v]?).getD (ops.zero, 0)).1 = ops.one ∨
+      ((idx[v]?).getD (ops.zero, 0)).1 = ops.negOne then
+    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (ops.zero, 0)).2))
+  else none
+
+def denseUnitDescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
+    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    Option (VarId × Nat) :=
+  if ¬(((idx[v]?).getD (ops.zero, 0)).1 = ops.one ∨
+      ((idx[v]?).getD (ops.zero, 0)).1 = ops.negOne) ∧
+      ops.mul ((idx[v]?).getD (ops.zero, 0)).1 (((idx[v]?).getD (ops.zero, 0)).1)⁻¹ = ops.one then
+    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (ops.zero, 0)).2))
+  else none
+
+def densePivotDescsWith (ops : DenseZModOps p) (l : DenseLinExpr p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : List (VarId × Nat) :=
+  let idx := denseCoeffIdxWith ops l.terms ∅
+  let total := l.terms.length
+  (l.terms.map Prod.fst).filterMap (densePm1DescWith ops idx total occ prot) ++
+    (l.terms.map Prod.fst).filterMap (denseUnitDescWith ops idx total occ prot)
+
+def densePivotDescsFast (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : List (VarId × Nat) :=
+  let ops : DenseZModOps p := denseZModOps
+  densePivotDescsWith ops l occ prot
+
+theorem densePm1DescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
+    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    densePm1DescWith ops idx total occ prot v = densePm1Desc idx total occ prot v := by
+  simp only [densePm1DescWith, densePm1Desc, ops.zero_eq, ops.one_eq, ops.negOne_eq]
+
+theorem denseUnitDescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
+    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    denseUnitDescWith ops idx total occ prot v = denseUnitDesc idx total occ prot v := by
+  simp only [denseUnitDescWith, denseUnitDesc, ops.zero_eq, ops.one_eq, ops.negOne_eq, ops.mul_eq]
+
+theorem densePivotDescsWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    densePivotDescsWith ops l occ prot = densePivotDescs l occ prot := by
+  unfold densePivotDescsWith densePivotDescs denseCoeffIdx
+  rw [denseCoeffIdxWith_eq]
+  simp only [densePm1DescWith_eq, denseUnitDescWith_eq]
+
+@[csimp] theorem densePivotDescs_eq_fast : @densePivotDescs = @densePivotDescsFast := by
+  funext p l occ prot
+  exact (densePivotDescsWith_eq denseZModOps l occ prot).symm
+
 /-! ## Fast pivot selection -/
 
 /-- The cheapest solvable dense pivot of a constraint, building the solution only for the winner. -/

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -206,13 +206,15 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      first and bisect with a skip-the-body experiment.
    - ~~`normalize` linearize fusion~~ **done (entry 115)** for `normalizePass`
      (`normalizeFused`, proven equal). Gauss's per-constraint `substF |> normalize` still walks
-     the old way — left alone deliberately: open PR #156 rewrites gauss's sweeps (dirty second
-     sweep, allocation-free pivots) and should not be conflicted with.
+     the old way. PR #156's wider gauss sweep rewrite was closed after too little whole-run
+     benefit, so this remains available only if a fresh profile justifies it.
    - ~~`iterateToFixpoint` sizeKey recomputation~~ **done (entry 115)**: the input's key is
      threaded (`iterateToFixpointFrom`), halving the per-cycle occurrence-list walks (~6 % of
      whole-run samples).
-   - `gauss`: covered by open **PR #156** (proven dirty second sweep + allocation-free pivot
-     selection, 0.78× on eth) — do not duplicate here.
+   - ~~gauss descriptor field-operation setup~~ **done (entry 118)**: proven `@[csimp]` fast
+     twins box the canonical operations once for coefficient indexing and pivot descriptors,
+     while the logical definitions and proofs stay unchanged. The broader dirty-sweep and
+     allocation-free-pivot experiment in PR #156 was closed after too little whole-run benefit.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/log.md
+++ b/docs/log.md
@@ -4274,3 +4274,21 @@ byte-for-byte the same computation without spawns, so sp1/rsp and openvm-eth beh
 before entry 114 while keccak/SHA-scale invocations keep the parallel win (keccak's ≥8192
 cycles carry ~90 % of its domainBatch cost). keccak and sp1 apc_030 exports byte-identical;
 keccak total steady at ~111 s locally. **Worked: yes (CI re-run pending).**
+
+### 118. Runtime: hoist boxed `ZMod` operations out of hot pass loops
+
+Several hot helpers obtained field constants and operations through fresh `ZMod` typeclass
+projections inside recursive, per-point, or per-window traversals. `DenseZModOps` now boxes the
+canonical operations and constants once and is threaded through domain evaluation and memory-bus
+scans. DomainFold also boxes its survivor predicate so setup remains outside the generated loop;
+Gauss keeps its logical definitions and installs proven `@[csimp]` fast twins for coefficient
+indexing and pivot descriptors. Bus multiplicity selectors have equality theorems tying the
+runtime functions to `MemoryBusShape.setNewMult` and its negation.
+
+`lake build` and proof-integrity checks pass. Generated-C inspection confirms that the targeted
+domain evaluators, gauss fast paths, bus-unify step, receive-index fold, cancellation scan, and
+refutation/check helpers no longer construct `ZMod.commRing` in their inner loops. The remaining
+calls are in colder constructors, pass guards, or logical fallbacks. Every runtime replacement is
+proven equal to the original helper, so variable, bus-interaction, and constraint effectiveness
+are unchanged. Local A/B timing and export comparison are intentionally deferred to the draft
+PR's CI matrix. **Worked: implementation/proofs yes; runtime result pending CI.**


### PR DESCRIPTION
## Summary

- box canonical `ZMod` operations/constants once and thread them through hot domain and memory-bus traversals
- add proven `@[csimp]` fast twins for Gauss coefficient indexing and pivot descriptors
- preserve the original semantics with operation and multiplicity-selector equality proofs

## Motivation

Generated C was reconstructing `ZMod.commRing` through typeclass projections inside recursive, per-point, and per-window loops. A source-level `let` is not sufficient in every higher-order path because code generation can arity-expand it. The boxed bundle, boxed DomainFold predicate, and Gauss fast twins keep setup outside the generated loops.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- inspected generated C: the targeted domain evaluators, Gauss fast paths, bus-unify step, receive-index fold, cancellation scan, and refutation/check helpers no longer construct `ZMod.commRing` in their inner loops
- output/effectiveness semantics are unchanged by the proved helper equalities
- runtime A/B and export comparison intentionally left to PR CI
