### PR TITLE
Runtime: tighten Gauss hot paths

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -19,6 +19,22 @@ def DenseExpr.varCount : DenseExpr p → Nat
   | .add a b => a.varCount + b.varCount
   | .mul a b => a.varCount + b.varCount
 
+/-- Fold variable leaves in left-to-right order without materializing `vars`. -/
+def DenseExpr.foldVars {α : Type} (e : DenseExpr p) (f : α → VarId → α) (init : α) : α :=
+  match e with
+  | .const _ => init
+  | .var x => f init x
+  | .add a b => b.foldVars f (a.foldVars f init)
+  | .mul a b => b.foldVars f (a.foldVars f init)
+
+theorem DenseExpr.foldVars_eq {α : Type} (e : DenseExpr p) (f : α → VarId → α) (init : α) :
+    e.foldVars f init = e.vars.foldl f init := by
+  induction e generalizing init with
+  | const => rfl
+  | var => rfl
+  | add a b iha ihb => simp only [foldVars, DenseExpr.vars, List.foldl_append, iha, ihb]
+  | mul a b iha ihb => simp only [foldVars, DenseExpr.vars, List.foldl_append, iha, ihb]
+
 def DenseExpr.isVar : DenseExpr p → Bool
   | .var _ => true
   | _ => false
@@ -284,18 +300,18 @@ theorem denseCoeffIdxWith_eq (ops : DenseZModOps p) (terms : List (VarId × ZMod
 def densePm1DescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
     (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
     Option (VarId × Nat) :=
-  if ((idx[v]?).getD (ops.zero, 0)).1 = ops.one ∨
-      ((idx[v]?).getD (ops.zero, 0)).1 = ops.negOne then
-    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (ops.zero, 0)).2))
+  let cv := (idx[v]?).getD (ops.zero, 0)
+  if cv.1 = ops.one ∨ cv.1 = ops.negOne then
+    some (v, denseGaussScore occ prot v (total - cv.2))
   else none
 
 def denseUnitDescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
     (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
     Option (VarId × Nat) :=
-  if ¬(((idx[v]?).getD (ops.zero, 0)).1 = ops.one ∨
-      ((idx[v]?).getD (ops.zero, 0)).1 = ops.negOne) ∧
-      ops.mul ((idx[v]?).getD (ops.zero, 0)).1 (((idx[v]?).getD (ops.zero, 0)).1)⁻¹ = ops.one then
-    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (ops.zero, 0)).2))
+  let cv := (idx[v]?).getD (ops.zero, 0)
+  if ¬(cv.1 = ops.one ∨ cv.1 = ops.negOne) ∧
+      ops.mul cv.1 cv.1⁻¹ = ops.one then
+    some (v, denseGaussScore occ prot v (total - cv.2))
   else none
 
 def densePivotDescsWith (ops : DenseZModOps p) (l : DenseLinExpr p)
@@ -404,7 +420,7 @@ theorem denseFastBest_eq (c : DenseExpr p) (occ : Std.HashMap VarId Nat)
 /-- Occurrence counts of every variable across the dense system (one traversal). -/
 def denseOccurrenceMap (d : DenseConstraintSystem p) : Std.HashMap VarId Nat :=
   let addE := fun (m : Std.HashMap VarId Nat) (e : DenseExpr p) =>
-    e.vars.foldl (fun m x => m.insert x (m.getD x 0 + 1)) m
+    e.foldVars (fun m x => m.insert x (m.getD x 0 + 1)) m
   let m := d.algebraicConstraints.foldl addE ∅
   d.busInteractions.foldl (fun m bi => bi.payload.foldl addE (addE m bi.multiplicity)) m
 
@@ -434,7 +450,7 @@ def insertAll (dσ : DenseSolved p) : List (VarId × DenseExpr p) → DenseSolve
   | (x, t) :: rest =>
       DenseSolved.insertAll
         { map := dσ.map.insert x t,
-          revDeps := t.vars.foldl (fun rd z => rd.insert z (((rd[z]?).getD ∅).insert x)) dσ.revDeps }
+          revDeps := t.foldVars (fun rd z => rd.insert z (((rd[z]?).getD ∅).insert x)) dσ.revDeps }
         rest
 
 theorem insertAll_map :
@@ -504,18 +520,22 @@ theorem denseTrySolveUnit_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarI
     pivot is chosen per constraint over two sweeps, then the whole solution map is substituted
     through the system in one pass. -/
 def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
-  let dσ := denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-    (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty
-  if dσ.map.isEmpty then d else d.substF dσ.fn
+  let occ := denseOccurrenceMap d
+  let prot := denseProtectedVars d bs
+  let first := denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty
+  if first.map.isEmpty then d
+  else d.substF (denseGaussLoop occ prot d.algebraicConstraints first).fn
 
 /-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
 theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     denseGaussElim bs d =
       if (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty).map.isEmpty
+          d.algebraicConstraints DenseSolved.empty).map.isEmpty
       then d
       else d.substF (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty).fn := rfl
+          d.algebraicConstraints
+          (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
+            d.algebraicConstraints DenseSolved.empty)).fn := rfl
 
 /-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -217,18 +217,24 @@ theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
 theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
         (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty).fn i = some t →
+          d.algebraicConstraints
+          (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
+            d.algebraicConstraints DenseSolved.empty)).fn i = some t →
           denv i = t.eval denv) ∧
     (∀ i t, (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-        (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty).fn i = some t →
+        d.algebraicConstraints
+        (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
+          d.algebraicConstraints DenseSolved.empty)).fn i = some t →
         ∀ z ∈ t.vars, z ∈ d.occ) := by
-  refine denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
-    (d.algebraicConstraints ++ d.algebraicConstraints) DenseSolved.empty
-    (fun _c hc => (List.mem_append.1 hc).elim id id) ?_ ?_
-  · intro denv _ i t hti
-    exact absurd hti (by simp [DenseSolved.fn, DenseSolved.empty])
-  · intro i t hti
-    exact absurd hti (by simp [DenseSolved.fn, DenseSolved.empty])
+  have hfirst := denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
+    d.algebraicConstraints DenseSolved.empty (fun _c hc => hc)
+    (fun _ _ _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
+    (fun _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
+  exact denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
+    d.algebraicConstraints
+    (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
+      d.algebraicConstraints DenseSolved.empty)
+    (fun _c hc => hc) hfirst.1 hfirst.2
 
 /-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
     occurrence-closed solution map, whose solutions are covered because their variables occur in a

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -211,10 +211,14 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
    - ~~`iterateToFixpoint` sizeKey recomputation~~ **done (entry 115)**: the input's key is
      threaded (`iterateToFixpointFrom`), halving the per-cycle occurrence-list walks (~6 % of
      whole-run samples).
-   - ~~gauss descriptor field-operation setup~~ **done (entry 118)**: proven `@[csimp]` fast
-     twins box the canonical operations once for coefficient indexing and pivot descriptors,
-     while the logical definitions and proofs stay unchanged. The broader dirty-sweep and
+   - ~~gauss descriptor field-operation setup and repeated index reads~~ **done (entries
+     118–119)**: proven `@[csimp]` fast twins box the canonical operations once and each pivot
+     descriptor now reads its coefficient/count entry once. The broader dirty-sweep and
      allocation-free-pivot experiment in PR #156 was closed after too little whole-run benefit.
+   - ~~gauss empty second sweep and variable-list materialization~~ **done (entry 119)**: an
+     empty first solution map returns immediately, while productive runs retain both sweeps;
+     occurrence and reverse-dependency construction fold expression leaves directly without
+     building `DenseExpr.vars` and its append chains.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/log.md
+++ b/docs/log.md
@@ -4324,3 +4324,23 @@ sp1/rsp (100 ranked) sets plus both keccak stress sets against the pre-refactor 
   `dedup` (size-neutral but ~9% slower keccak without it).
 
 **Worked: yes (net −655 lines at unchanged effectiveness; runtime within noise on all sets).**
+
+### 120. Runtime: three contained Gauss hot-path cleanups
+
+- Gauss now runs the first constraint sweep separately and returns the input immediately when its
+  solution map is empty. Productive invocations still run the same constraints twice with the
+  first solution state threaded into the second; steady-state fixpoint calls avoid the duplicate
+  no-op sweep and the temporary `constraints ++ constraints` list.
+- The boxed pivot-descriptor twins read each variable's coefficient/count index entry once and
+  reuse the pair for the `±1`, unit, and score checks.
+- `DenseExpr.foldVars` visits leaves in the same left-to-right order as `vars.foldl` (proved by
+  `foldVars_eq`) without allocating variable lists or append chains. Gauss occurrence counting
+  and `DenseSolved` reverse-dependency insertion use the direct fold.
+
+The Gauss proof composes `denseGaussLoop_sound` across the two productive sweeps. The targeted
+build succeeds, and generated C confirms an empty-map branch before the second loop call, one raw
+index lookup per descriptor, and direct expression folds in both consumers. The empty branch and
+productive branch preserve the previous circuit result, so variable, bus-interaction, and
+constraint effectiveness are unchanged. The full build and proof-integrity checks pass; runtime
+A/B and export comparison are deferred to the draft PR's CI matrix. **Worked: implementation/proofs
+yes; runtime result pending CI.**


### PR DESCRIPTION
## Summary

- return after the first Gauss sweep when it produced no solutions, avoiding the duplicate steady-state sweep
- read each boxed pivot descriptor's coefficient/count index entry once
- fold expression variable leaves directly for occurrence counts and reverse dependencies instead of materializing `DenseExpr.vars` lists

## Why

Gauss always traversed `constraints ++ constraints`, including at the fixpoint where the first sweep could not solve anything. Its pivot descriptors also repeated hash-map lookups, while occurrence and reverse-dependency construction allocated variable lists and append chains for every expression.

The productive path still threads the first sweep's solution state into the same second sweep. `DenseExpr.foldVars_eq` proves the direct traversal has the same left-to-right behavior as `vars.foldl`, and the existing boxed-descriptor equality proofs cover the lookup hoist.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection confirms:
  - the first-map emptiness branch precedes the second `denseGaussLoop` call
  - each boxed descriptor performs one raw coefficient-index lookup
  - occurrence and reverse-dependency construction call the direct expression fold
- runtime A/B and export comparison are intentionally left to PR CI
