### PR TITLE
Runtime: compile DenseExpr.vars with an accumulator

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -88,6 +88,26 @@ def DenseExpr.vars : DenseExpr p → List VarId
   | .add a b => a.vars ++ b.vars
   | .mul a b => a.vars ++ b.vars
 
+def DenseExpr.varsAcc : DenseExpr p → List VarId → List VarId
+  | .const _, acc => acc
+  | .var i, acc => i :: acc
+  | .add a b, acc => a.varsAcc (b.varsAcc acc)
+  | .mul a b, acc => a.varsAcc (b.varsAcc acc)
+
+def DenseExpr.varsFast (e : DenseExpr p) : List VarId := e.varsAcc []
+
+theorem DenseExpr.varsAcc_eq (e : DenseExpr p) (acc : List VarId) :
+    e.varsAcc acc = e.vars ++ acc := by
+  induction e generalizing acc with
+  | const => rfl
+  | var => rfl
+  | add a b iha ihb => simp only [varsAcc, iha, ihb, vars, List.append_assoc]
+  | mul a b iha ihb => simp only [varsAcc, iha, ihb, vars, List.append_assoc]
+
+@[csimp] theorem DenseExpr.vars_eq_fast : @DenseExpr.vars = @DenseExpr.varsFast := by
+  funext p e
+  simp only [varsFast, varsAcc_eq, List.append_nil]
+
 /-- All `VarId`s of a dense bus interaction (multiplicity then payload). -/
 def denseBIVars (bi : BusInteraction (DenseExpr p)) : List VarId :=
   bi.multiplicity.vars ++ bi.payload.flatMap DenseExpr.vars

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -219,6 +219,9 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      empty first solution map returns immediately, while productive runs retain both sweeps;
      occurrence and reverse-dependency construction fold expression leaves directly without
      building `DenseExpr.vars` and its append chains.
+   - ~~shared `DenseExpr.vars` append traversal~~ **done (entry 121)**: the proof-facing
+     left-to-right list definition stays unchanged, while a proved `@[csimp]` twin compiles every
+     remaining runtime consumer through `varsAcc`, eliminating per-node list appends.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/log.md
+++ b/docs/log.md
@@ -4344,3 +4344,20 @@ productive branch preserve the previous circuit result, so variable, bus-interac
 constraint effectiveness are unchanged. The full build and proof-integrity checks pass; runtime
 A/B and export comparison are deferred to the draft PR's CI matrix. **Worked: implementation/proofs
 yes; runtime result pending CI.**
+
+### 121. Runtime: compile `DenseExpr.vars` through an accumulator
+
+The proof-facing `DenseExpr.vars` remains the simple left-to-right definition with
+`a.vars ++ b.vars`, but compiled execution now uses `DenseExpr.varsFast`. Its `varsAcc` traversal
+threads the suffix through the expression tree and allocates only the final variable list, avoiding
+`List.appendTR` at every binary node. `varsAcc_eq` proves the stronger accumulator invariant
+`e.varsAcc acc = e.vars ++ acc`; the `@[csimp]` theorem derives exact list equality at `acc = []`,
+so all existing proofs and every order-sensitive consumer retain precisely the same value.
+
+The full build and proof-integrity checks pass. Generated C shows current consumers use
+`DenseExpr.varsFast`; the accumulator loop contains no list append, including the domain,
+reencode, flag-fold, disconnected-component, hint-collapse, and bus-cancellation call sites.
+The output is provably unchanged through the compiler rewrite, so variable,
+bus-interaction, and constraint effectiveness are unchanged. Runtime A/B and export comparison are
+deferred to the draft PR's CI matrix. **Worked: implementation/proof/codegen yes; runtime result
+pending CI.**


### PR DESCRIPTION
## Summary

- add an accumulator implementation of `DenseExpr.vars`
- prove the stronger invariant `e.varsAcc acc = e.vars ++ acc`
- install the exact `vars = varsFast` equality as a `@[csimp]` compiler rewrite

## Why

The proof-facing definition recursively computes `a.vars ++ b.vars`. Generated code therefore allocated child lists and ran `List.appendTR` at every binary expression node, becoming quadratic on the left-associated expression chains produced by affine reconstruction.

The accumulator traverses the right subtree into the suffix and then the left subtree, preserving the exact left-to-right list order while allocating only the final result. Existing proofs continue to use the simple definition; compiled runtime consumers use the proved fast twin.

## Impact

This is shared by the domain passes, reencode, flag folding, disconnected-component analysis, hint collapse, bus cancellation, and other dense passes. Circuit output and all three effectiveness axes are unchanged by the proved equality.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection confirms current consumers call `DenseExpr.varsFast`
- the accumulator loop contains no `List.appendTR`
- runtime A/B and export comparison are intentionally left to PR CI
