### PR TITLE
Proofs: finish the grind sweep (24 lemmas → one-liners, −190 lines, output-identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -322,12 +322,7 @@ theorem denseAddrTwoRootNeq_sound (reg : VarRegistry) (shape : MemoryBusShape)
 /-- A form recognized as identically zero evaluates to `0`. -/
 theorem denseIsZeroLin_sound (l : DenseLinExpr p) (h : denseIsZeroLin l = true)
     (denv : VarId → ZMod p) : l.eval denv = 0 := by
-  unfold denseIsZeroLin at h
-  simp only [Bool.and_eq_true, decide_eq_true_eq] at h
-  obtain ⟨hterms, hconst⟩ := h
-  have hz : l.norm.eval denv = l.norm.const := by
-    simp only [DenseLinExpr.eval, List.isEmpty_iff.1 hterms, List.map_nil, List.sum_nil, add_zero]
-  rw [← DenseLinExpr.norm_eval, hz, hconst]
+  grind [denseIsZeroLin, DenseLinExpr.eval, DenseLinExpr.norm_eval l denv, List.isEmpty_iff]
 
 /-- Each recognized factor of a reciprocal product `a·b + r` (`r` a nonzero constant) is nonzero. -/
 theorem denseReciprocalWitsProd_sound (a b r : DenseExpr p) (g : DenseLinExpr p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelIndex.lean
@@ -157,16 +157,7 @@ theorem DenseEqConstraintMap.test_sound {constraints : List (DenseExpr p)}
     (M : DenseEqConstraintMap p) (hM : M.Sound constraints) (d : DenseExpr p)
     (h : M.test d = true) (denv : VarId → ZMod p)
     (hcon : ∀ c ∈ constraints, c.eval denv = 0) : d.eval denv = 0 := by
-  unfold DenseEqConstraintMap.test at h
-  cases hb : M.map[d.bHash]? with
-  | none => rw [hb] at h; exact absurd h (by simp)
-  | some ns =>
-      rw [hb] at h
-      obtain ⟨n, hn, heq⟩ := List.any_eq_true.1 h
-      obtain ⟨c, hc, hcn⟩ := hM d.bHash ns hb n hn
-      have hnd : n = d := of_decide_eq_true heq
-      rw [← hnd, ← hcn, DenseExpr.normalize_eval]
-      exact hcon c hc
+  grind [DenseEqConstraintMap.test, DenseEqConstraintMap.Sound, DenseExpr.normalize_eval]
 
 /-- A passing entailed-payload match makes the *evaluated* payloads equal whenever the constraints
     hold — the `hpayEval` hypothesis `denseDropPair_correct` takes. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
@@ -66,12 +66,7 @@ theorem denseMkBytePair_operand_mem (spec : ByteXorSpec p) (busId : Nat) (e₁ e
 theorem denseMkBytePair_payload_vars (spec : ByteXorSpec p) (busId : Nat) (e₁ e₂ : DenseExpr p)
     {x : VarId} (pe : DenseExpr p) (hpe : pe ∈ (denseMkBytePair spec busId e₁ e₂).payload)
     (hx : x ∈ pe.vars) : x ∈ e₁.vars ∨ x ∈ e₂.vars := by
-  simp only [denseMkBytePair] at hpe
-  rcases spec.encode_mem _ _ _ _ pe hpe with h | h | h | h <;> rw [h] at hx
-  · simp only [DenseExpr.vars, List.not_mem_nil] at hx
-  · exact Or.inl hx
-  · exact Or.inr hx
-  · simp only [DenseExpr.vars, List.not_mem_nil] at hx
+  grind [denseMkBytePair, ByteXorSpec.encode_mem, DenseExpr.vars]
 
 /-! ## Decoded-field acceptance characterizations -/
 
@@ -413,12 +408,8 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
 theorem denseMkBytePair_covered (reg : VarRegistry) (spec : ByteXorSpec p) (busId : Nat)
     (e₁ e₂ : DenseExpr p) (he₁ : e₁.CoveredBy reg) (he₂ : e₂.CoveredBy reg) :
     denseBICovered reg (denseMkBytePair spec busId e₁ e₂) := by
-  refine ⟨?_, ?_⟩
-  · intro i hi; simp only [denseMkBytePair, DenseExpr.vars, List.not_mem_nil] at hi
-  · intro pe hpe i hi
-    rcases denseMkBytePair_payload_vars spec busId e₁ e₂ pe hpe hi with h | h
-    · exact he₁ i h
-    · exact he₂ i h
+  grind [denseBICovered, denseMkBytePair, DenseExpr.CoveredBy, DenseExpr.vars,
+    denseMkBytePair_payload_vars]
 
 /-! ## Scan invariants: reconstructing the split equation -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
@@ -81,13 +81,7 @@ theorem denseIntervalCert_sound (hp : 0 < p) (B : Std.HashMap VarId Nat) (l : De
     (h : denseIntervalCert B l = true) (denv : VarId → ZMod p)
     (hB : ∀ v bound, B[v]? = some bound → (denv v).val < bound) :
     l.eval denv ≠ 0 := by
-  unfold denseIntervalCert at h
-  split at h
-  · exact absurd h (by simp)
-  · rename_i acc hacc
-    obtain ⟨mp, mn⟩ := acc
-    rw [Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq] at h
-    exact denseLinNeverZeroSplit B l mp mn hp hacc h.1 h.2 denv hB
+  grind [denseIntervalCert, denseLinNeverZeroSplit]
 
 /-- Checked never-zero certificate for an expression (over the candidate rescalings). -/
 theorem denseNeverZeroB_sound (hp : 0 < p) (B : Std.HashMap VarId Nat) (e : DenseExpr p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -299,16 +299,7 @@ theorem denseInteractionDomainF_sound [NeZero p] (bs : BusSemantics p) (facts : 
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval bi denv) = false) :
     denv i ∈ dm.toList := by
-  unfold denseInteractionDomainF at h
-  split at h
-  · exact absurd h (by simp)
-  · rename_i bound hB
-    split_ifs at h with hcap
-    simp only [Option.some.injEq] at h
-    subst h
-    show denv i ∈ (List.range bound).map (Nat.cast : Nat → ZMod p)
-    exact mem_range_cast (denv i) bound
-      (denseInteractionBound_sound bs facts bi i bound hB denv hob)
+  grind [denseInteractionDomainF, FiniteDomain.toList, denseInteractionBound_sound, mem_range_cast]
 
 /-! ## Domain-table soundness -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
@@ -107,30 +107,7 @@ theorem mem_denseGroupSurvivorsEV (es : List (DenseExpr p)) (xs : List VarId)
 theorem denseConstOnSurvsV_sound (xs : List VarId) (survsV : List (List (ZMod p)))
     (e : DenseExpr p) (c : ZMod p) (h : denseConstOnSurvsV xs survsV e = some c) :
     ∀ s ∈ survsV, e.eval (denseEnvOfKeysV xs s) = c := by
-  intro s hs
-  cases survsV with
-  | nil => simp at hs
-  | cons s₀ rest =>
-      cases hce : denseCompileE xs e with
-      | some ie =>
-          simp only [denseConstOnSurvsV, hce] at h
-          split at h
-          · rename_i hall
-            simp only [Option.some.injEq] at h
-            have hthis := List.all_eq_true.mp hall s hs
-            rw [decide_eq_true_eq] at hthis
-            have hev := denseCompileE_evalV denseZModOps xs s e ie hce
-            rw [← hev, hthis]; exact h
-          · exact absurd h (by simp)
-      | none =>
-          simp only [denseConstOnSurvsV, hce] at h
-          split at h
-          · rename_i hall
-            simp only [Option.some.injEq] at h
-            have hthis := List.all_eq_true.mp hall s hs
-            rw [decide_eq_true_eq] at hthis
-            rw [hthis]; exact h
-          · exact absurd h (by simp)
+  rcases survsV with _ | ⟨s₀, rest⟩ <;> grind [denseConstOnSurvsV, denseCompileE_evalV]
 
 /-! ## The fold rewrite: agreement and variable containment (value-only) -/
 
@@ -871,12 +848,7 @@ theorem denseMapExpr_vars_subset (g : DenseExpr p → DenseExpr p)
     (bi : BusInteraction (DenseExpr p)) :
     ∀ i ∈ denseBIVars { bi with multiplicity := g bi.multiplicity, payload := bi.payload.map g },
       i ∈ denseBIVars bi := by
-  intro i hi
-  simp only [denseBIVars, List.mem_append, List.mem_flatMap] at hi ⊢
-  rcases hi with hi | ⟨e, he, hi⟩
-  · exact Or.inl (hg _ i hi)
-  · obtain ⟨e0, he0, rfl⟩ := List.mem_map.1 he
-    exact Or.inr ⟨e0, he0, hg e0 i hi⟩
+  grind [denseBIVars]
 
 /-- The sparse fold is the in-place fold: every non-candidate position holds an item sharing no
     variable with `xs` (bucket completeness, contraposed), on which `denseFoldRewriteIdxV` is the

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -65,29 +65,13 @@ theorem DenseLinExpr.trySolveUnit_sound (l : DenseLinExpr p) (v x : VarId) (t : 
 theorem densePm1PivotsOf_sound (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
     (h : (x, t) ∈ densePm1PivotsOf c) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
     denv x = t.eval denv := by
-  unfold densePm1PivotsOf at h
-  split at h
-  · exact absurd h (by simp)
-  · rename_i l hlin
-    have hl : l.eval denv = 0 := by rw [← denseLinearize_eval c l hlin denv]; exact hc
-    obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-    exact DenseLinExpr.trySolve_sound l v x t hv denv hl
+  grind [densePm1PivotsOf, denseLinearize_eval, DenseLinExpr.trySolve_sound]
 
 /-- Every unit-pivot of a dense constraint entails its equality. -/
 theorem denseUnitPivotsOf_sound (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
     (h : (x, t) ∈ denseUnitPivotsOf c) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
     denv x = t.eval denv := by
-  unfold denseUnitPivotsOf at h
-  split at h
-  · exact absurd h (by simp)
-  · rename_i l hlin
-    have hl : l.eval denv = 0 := by rw [← denseLinearize_eval c l hlin denv]; exact hc
-    obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-    cases htr : l.trySolve v with
-    | some r => rw [htr] at hv; exact absurd hv (by simp)
-    | none =>
-        rw [htr] at hv
-        exact DenseLinExpr.trySolveUnit_sound l v x t hv denv hl
+  grind [denseUnitPivotsOf, denseLinearize_eval, DenseLinExpr.trySolveUnit_sound]
 
 /-! ## Pivot-vars bounds -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
@@ -399,13 +399,7 @@ theorem denseSqCoeffsOK_sound (reg : VarRegistry) (B : Std.HashMap VarId Nat) (D
 theorem denseOccursOnlyInTarget_constr {d : DenseConstraintSystem p} {E : DenseExpr p} {v : VarId}
     (h : denseOccursOnlyInTarget d E v = true) :
     ∀ c ∈ d.algebraicConstraints, v ∈ c.vars → c = E := by
-  intro c hc hvc
-  simp only [denseOccursOnlyInTarget, Bool.and_eq_true, List.all_eq_true] at h
-  have hc' := h.1 c hc
-  simp only [Bool.or_eq_true, decide_eq_true_eq, Bool.not_eq_true'] at hc'
-  rcases hc' with h1 | h2
-  · exact h1
-  · exact absurd hvc (denseMentions_false_not_mem v c h2)
+  grind [denseOccursOnlyInTarget, denseMentions_false_not_mem]
 
 theorem denseOccursOnlyInTarget_bus {d : DenseConstraintSystem p} {E : DenseExpr p} {v : VarId}
     (h : denseOccursOnlyInTarget d E v = true) : ∀ bi ∈ d.busInteractions,
@@ -434,11 +428,7 @@ theorem register_snd_eq_of_idOf {reg : VarRegistry} {v : Variable} {i : VarId}
 /-- For an unregistered variable, `register` allocates the trailing (fresh) `VarId`. -/
 theorem register_snd_eq_of_none {reg : VarRegistry} {v : Variable}
     (h : reg.idOf? v = none) : (reg.register v).2 = ⟨reg.byId.size⟩ := by
-  unfold VarRegistry.register
-  split
-  · rename_i i hlook
-    rw [show reg.idOf? v = some i from hlook] at h; exact absurd h (by simp)
-  · rfl
+  grind [VarRegistry.register, VarRegistry.idOf?]
 
 /-- Registering a `powdrId? = none` variable preserves `isInput` pointwise. -/
 theorem hcRegisterIsInputEq (reg : VarRegistry) (v : Variable) (hv : v.powdrId? = none)
@@ -687,12 +677,8 @@ theorem dense_collapse_correct [Fact p.Prime] (isInput : VarId → Bool)
 /-- Occurrence-validity gives coverage. -/
 theorem hcCoveredByOfOcc {r : VarRegistry} {d : DenseConstraintSystem p}
     (h : ∀ i ∈ d.occ, r.Valid i) : d.CoveredBy r := by
-  refine ⟨fun e he i hi => h i ?_, fun bi hbi => ⟨fun i hi => h i ?_, fun e he i hi => h i ?_⟩⟩
-  · exact DenseConstraintSystem.mem_occ_of_constraint he hi
-  · refine DenseConstraintSystem.mem_occ_of_bi hbi ?_
-    simp only [denseBIVars, List.mem_append]; exact Or.inl hi
-  · refine DenseConstraintSystem.mem_occ_of_bi hbi ?_
-    simp only [denseBIVars, List.mem_append, List.mem_flatMap]; exact Or.inr ⟨e, he, hi⟩
+  grind [DenseConstraintSystem.CoveredBy, DenseExpr.CoveredBy, denseBICovered, denseBIVars,
+    DenseConstraintSystem.mem_occ_of_constraint, DenseConstraintSystem.mem_occ_of_bi]
 
 /-- An occurrence of the collapse output is either a variable of the replacement `E'` or an
     occurrence of the input system. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/MonicScale.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/MonicScale.lean
@@ -32,15 +32,7 @@ theorem denseMonicScaleAffine_eval (e : DenseExpr p) (denv : VarId → ZMod p) :
 /-- The affine scaling's certificate is a genuine unit. -/
 theorem denseMonicScaleAffine_unit (e : DenseExpr p) :
     (denseMonicScaleAffine e).2.1 * (denseMonicScaleAffine e).2.2 = 1 := by
-  unfold denseMonicScaleAffine
-  split
-  · simp
-  · split
-    · rename_i y k rest ht
-      split_ifs with hk
-      · simpa [mul_comm] using hk.1
-      · simp
-    · simp
+  grind [denseMonicScaleAffine, mul_comm]
 
 /-- Monic scaling of an affine expression introduces no new variable. -/
 theorem denseMonicScaleAffine_vars (e : DenseExpr p) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/OneHotAnnihilate.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/OneHotAnnihilate.lean
@@ -18,19 +18,7 @@ theorem denseAffineCloser_spec (a : DenseExpr p) (la : DenseLinExpr p)
     (h : denseAffineCloser a = some la) :
     denseLinearize a = some la ∧
       ((la.const = -1 ∧ ∀ t ∈ la.terms, t.2 = 1) ∨ (la.const = 1 ∧ ∀ t ∈ la.terms, t.2 = -1)) := by
-  unfold denseAffineCloser at h
-  split at h
-  · rename_i l hl
-    split at h
-    · rename_i hcond
-      obtain ⟨hc, _⟩ := hcond
-      obtain rfl : l = la := by simpa using h
-      refine ⟨hl, ?_⟩
-      rcases hc with ⟨hc1, hc2⟩ | ⟨hc1, hc2⟩
-      · exact Or.inl ⟨hc1, fun t ht => eq_of_beq (List.all_eq_true.1 hc2 t ht)⟩
-      · exact Or.inr ⟨hc1, fun t ht => eq_of_beq (List.all_eq_true.1 hc2 t ht)⟩
-    · exact absurd h (by simp)
-  · exact absurd h (by simp)
+  grind [denseAffineCloser, List.all_eq_true]
 
 /-- `denseReadCloser` succeeds only on `A · x` with `A` linearizing to `la`, `la.const = −1` and
     every coefficient `1` (or the flipped sign). -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RangeBool.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RangeBool.lean
@@ -28,22 +28,7 @@ theorem denseBoolCheck?_spec {bs : BusSemantics p} (facts : BusFacts p bs)
     ∃ valSlot x, facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?)
         = some (valSlot, 2) ∧ bi.multiplicity = DenseExpr.const 1 ∧
         bi.payload[valSlot]? = some (DenseExpr.var x) ∧ c = denseBoolC (DenseExpr.var x) := by
-  unfold denseBoolCheck? at h
-  split at h
-  · rename_i vs bd hrc
-    split_ifs at h with hcond
-    obtain ⟨hmc, rfl⟩ := hcond
-    cases hp : bi.payload[vs]? with
-    | none => simp only [hp] at h; simp at h
-    | some ex =>
-      cases ex with
-      | var x =>
-        simp only [hp] at h; simp only [Option.some.injEq] at h
-        exact ⟨vs, x, hrc, hmc, hp, h.symm⟩
-      | const _ => simp only [hp] at h; simp at h
-      | add _ _ => simp only [hp] at h; simp at h
-      | mul _ _ => simp only [hp] at h; simp at h
-  · exact absurd h (by simp)
+  grind [denseBoolCheck?]
 
 /-- A recognised width-1 check lives on a stateless bus. -/
 theorem denseBoolCheck?_stateless {bs : BusSemantics p} (facts : BusFacts p bs)
@@ -105,12 +90,8 @@ theorem denseRangeBoolNew_vars {bs : BusSemantics p} (facts : BusFacts p bs)
 theorem denseRangeBoolAddF_covered (reg : VarRegistry) {bs : BusSemantics p} (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
     (denseRangeBoolAddF facts d).CoveredBy reg := by
-  unfold denseRangeBoolAddF
-  refine ⟨fun e he => ?_, hcov.2⟩
-  rcases List.mem_append.1 he with h' | h'
-  · exact hcov.1 e h'
-  · intro i hi
-    exact DenseConstraintSystem.occ_valid hcov i (denseRangeBoolNew_vars facts d e h' i hi)
+  grind [denseRangeBoolAddF, denseRangeBoolNew_vars, DenseConstraintSystem.occ_valid,
+    DenseConstraintSystem.CoveredBy, DenseExpr.CoveredBy]
 
 theorem denseRangeBoolF_covered (pw : PrimeWitness p) (reg : VarRegistry) (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1162,12 +1162,8 @@ theorem denseBuildReencode_props (reg : VarRegistry) (useIdx : Bool) (csIdx : De
 
 theorem coveredBy_of_occ {r : VarRegistry} {d : DenseConstraintSystem p}
     (h : ∀ i ∈ d.occ, r.Valid i) : d.CoveredBy r := by
-  refine ⟨fun e he i hi => h i ?_, fun bi hbi => ⟨fun i hi => h i ?_, fun e he i hi => h i ?_⟩⟩
-  · exact DenseConstraintSystem.mem_occ_of_constraint he hi
-  · refine DenseConstraintSystem.mem_occ_of_bi hbi ?_
-    simp only [denseBIVars, List.mem_append]; exact Or.inl hi
-  · refine DenseConstraintSystem.mem_occ_of_bi hbi ?_
-    simp only [denseBIVars, List.mem_append, List.mem_flatMap]; exact Or.inr ⟨e, he, hi⟩
+  grind [DenseConstraintSystem.CoveredBy, DenseExpr.CoveredBy, denseBICovered, denseBIVars,
+    DenseConstraintSystem.mem_occ_of_constraint, DenseConstraintSystem.mem_occ_of_bi]
 
 theorem csCoveredBy_mono {r r' : VarRegistry} (h : r.Extends r') {d : DenseConstraintSystem p}
     (hc : d.CoveredBy r) : d.CoveredBy r' :=
@@ -1224,13 +1220,7 @@ theorem stepIdentityPost (reg reg' : VarRegistry) (d : DenseConstraintSystem p)
 theorem denseCheckReencode_polyVars (d : DenseConstraintSystem p) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) (hchk : denseCheckReencode d xs bits hm = true) :
     ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs hm)).vars, v ∈ bits := by
-  unfold denseCheckReencode at hchk
-  split at hchk
-  · exact absurd hchk (by simp)
-  · simp only [Bool.and_eq_true] at hchk
-    obtain ⟨⟨⟨⟨⟨⟨⟨_, _⟩, _⟩, _⟩, hvarsB⟩, _⟩, _⟩, _⟩ := hchk
-    intro y hy v hv
-    exact List.contains_iff_mem.mp (List.all_eq_true.mp (List.all_eq_true.mp hvarsB y hy) v hv)
+  grind [denseCheckReencode, List.contains_iff_mem]
 
 theorem denseBuildReencode_ext_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
     {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)} {xs : List VarId} {freshBase : String}

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
@@ -22,25 +22,7 @@ theorem denseAsBytePair_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (h : denseAsBytePair bs facts bi = some (busId, spec, a, b)) :
     bi = denseMkBytePair spec busId a b ∧ facts.byteXorSpec busId = some spec := by
   obtain ⟨biBus, biMul, biPay⟩ := bi
-  unfold denseAsBytePair at h
-  split at h
-  · exact absurd h (by simp)
-  · rename_i spec' hspec
-    split at h
-    · rename_i op o1 o2 r hdec
-      split_ifs at h with hc
-      obtain ⟨hm, hop, hr⟩ := hc
-      simp only [Option.some.injEq, Prod.mk.injEq] at h
-      obtain ⟨rfl, rfl, rfl, rfl⟩ := h
-      have hpay : biPay = spec'.encode (DenseExpr.const spec'.pairOp) o1 o2 (DenseExpr.const 0) := by
-        have he := spec'.decode_eq_encode biPay op o1 o2 r hdec
-        rw [hop, hr] at he; exact he
-      refine ⟨?_, hspec⟩
-      have hm' : biMul = DenseExpr.const 1 := hm
-      show ({ busId := biBus, multiplicity := biMul, payload := biPay } : BusInteraction (DenseExpr p))
-        = denseMkBytePair spec' biBus o1 o2
-      rw [hm', hpay]; rfl
-    · exact absurd h (by simp)
+  grind [denseAsBytePair, denseMkBytePair, ByteXorSpec.decode_eq_encode]
 
 /-- The obligation predicate appearing in dense `satisfies`. -/
 private def denseP (bs : BusSemantics p) (denv : VarId → ZMod p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/XorEqExtract.lean
@@ -209,22 +209,12 @@ def denseXorEqExtractNew (bs : BusSemantics p) (facts : BusFacts p bs) (d : Dens
 theorem denseXorEqExtractNew_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     ∀ c ∈ denseXorEqExtractNew bs facts d, ∀ z ∈ c.vars, z ∈ d.occ := by
-  intro c hc z hz
-  rcases List.mem_append.1 hc with hc | hc
-  · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-    exact denseXorEq?_vars bs facts d bi c hbc hbi z hz
-  · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-    exact denseBoolEq?_vars bs facts d bi c hbc hbi z hz
+  grind [denseXorEqExtractNew, denseXorEq?_vars, denseBoolEq?_vars]
 
 theorem denseXorEqExtractNew_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (h1ne : (1 : ZMod p) ≠ 0) (denv : VarId → ZMod p)
     (hsat : d.satisfies bs denv) : ∀ c ∈ denseXorEqExtractNew bs facts d, c.eval denv = 0 := by
-  intro c hc
-  rcases List.mem_append.1 hc with hc | hc
-  · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-    exact denseXorEq?_eval bs facts d bi c denv h1ne hbc hbi hsat
-  · obtain ⟨bi, hbi, hbc⟩ := List.mem_filterMap.1 hc
-    exact denseBoolEq?_eval bs facts d bi c denv h1ne hbc hbi hsat
+  grind [denseXorEqExtractNew, denseXorEq?_eval, denseBoolEq?_eval]
 
 theorem denseXorEqExtractF_covered (reg : VarRegistry) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ZeroWidthRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ZeroWidthRange.lean
@@ -21,17 +21,7 @@ theorem denseRangeEq?_spec (one : Bool) (bs : BusSemantics p) (facts : BusFacts 
       ∃ v, ((facts.zeroRangeEq bi.busId = true ∧ bi.payload = [v, DenseExpr.const 0] ∧ e = v)
         ∨ (one = true ∧ facts.varRangeBus bi.busId = true
             ∧ bi.payload = [v, DenseExpr.const 1] ∧ e = denseBoolC v)) := by
-  unfold denseRangeEq? at h
-  split at h
-  · rename_i v' c hpay
-    split_ifs at h with hm hA hB
-    · obtain ⟨hz, hc⟩ := hA
-      simp only [Option.some.injEq] at h
-      exact ⟨hm, e, Or.inl ⟨hz, by rw [hpay, hc, h], rfl⟩⟩
-    · obtain ⟨hone, hv, hc, _⟩ := hB
-      simp only [Option.some.injEq] at h
-      exact ⟨hm, v', Or.inr ⟨hone, hv, by rw [hpay, hc], h.symm⟩⟩
-  · exact absurd h (by simp)
+  grind [denseRangeEq?]
 
 /-- A recognised degenerate range check lives on a stateless bus. -/
 theorem denseRangeEq?_stateless (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -71,15 +61,8 @@ theorem denseRangeEq?_vars (one : Bool) (bs : BusSemantics p) (facts : BusFacts 
     (d : DenseConstraintSystem p) (bi : BusInteraction (DenseExpr p)) (e : DenseExpr p)
     (h : denseRangeEq? one bs facts bi = some e) (hbi : bi ∈ d.busInteractions) :
     ∀ z ∈ e.vars, z ∈ d.occ := by
-  obtain ⟨hm, v, hcase⟩ := denseRangeEq?_spec one bs facts bi e h
-  intro z hz
-  refine DenseConstraintSystem.mem_occ_of_bi hbi ?_
-  simp only [denseBIVars, List.mem_append, List.mem_flatMap]
-  refine Or.inr ⟨v, ?_, ?_⟩
-  · rcases hcase with ⟨_, hp', _⟩ | ⟨_, _, hp', _⟩ <;> rw [hp'] <;> simp
-  · rcases hcase with ⟨_, _, rfl⟩ | ⟨_, _, _, rfl⟩
-    · exact hz
-    · exact denseBoolC_vars v z hz
+  grind [denseRangeEq?, DenseConstraintSystem.mem_occ_of_bi, denseBIVars, denseBoolC,
+    DenseExpr.vars]
 
 /-- A recognised check's constraint holds on every satisfying dense assignment. -/
 theorem denseRangeEq?_eval (one : Bool) (hone : one = true → Nat.Prime p) (bs : BusSemantics p)

--- a/docs/log.md
+++ b/docs/log.md
@@ -4344,3 +4344,21 @@ productive branch preserve the previous circuit result, so variable, bus-interac
 constraint effectiveness are unchanged. The full build and proof-integrity checks pass; runtime
 A/B and export comparison are deferred to the draft PR's CI matrix. **Worked: implementation/proofs
 yes; runtime result pending CI.**
+### 121. Structure: finish the `grind` sweep across the proof corpus
+
+Follow-up to entry 119's grind adoption: swept the remaining recognizer-spec / structural
+destructuring proofs. 24 lemmas across 15 `Proofs/` files collapse to `grind [<def>]` one-liners
+(net −190 lines): `AddrDiseq`, `BusPairCancelIndex`, `ByteCheckPack`, `CarryBranch`,
+`DomainBatch`, `DomainFold`, `Gauss`, `HintCollapse`, `MonicScale`, `OneHotAnnihilate`,
+`RangeBool`, `Reencode`, `SplitBytePair`, `XorEqExtract`, `ZeroWidthRange`.
+
+Proof-body-only edits (no statement / def / import touched), so the optimizer is unchanged by
+construction — `lake build` green, proof integrity passes, and the 6-case OpenVM/SP1 output
+snapshot is byte-identical. Left alone (grind does not close them): the hypothesis-heavy semantic
+soundness lemmas that dispatch to another `_sound` lemma (`denseSolveOperand_sound` and the
+`BusPairCancelCheck`/`ZeroRegister` family), `_covered`/`_vars` lemmas built on `filterBus_covered`
+/ structural recursion, and `linear_combination` / `induction` proofs. Two quirks worth recording:
+deeply nested matches can hit grind's `maximum term generation` gate (leave those), and boolean
+recognizers want an existing `_iff` lemma in the bracket rather than the raw `def`.
+
+**Worked: yes (net −190 lines, effectiveness and runtime unchanged by construction).**


### PR DESCRIPTION
Follow-up to #171, completing the `grind` sweep it started. #171 flagged that the recognizer-spec
proof shape recurs across the whole `Proofs/` corpus; this PR converts the rest.

## What changed

24 mechanical destructuring proofs — the `unfold X at h; split at h; …; Option/Prod injEq` shape —
collapse to `grind [<def>]` one-liners across 15 files:

`AddrDiseq`, `BusPairCancelIndex`, `ByteCheckPack`, `CarryBranch`, `DomainBatch`, `DomainFold`,
`Gauss`, `HintCollapse`, `MonicScale`, `OneHotAnnihilate`, `RangeBool`, `Reencode`, `SplitBytePair`,
`XorEqExtract`, `ZeroWidthRange`.

**Net −190 lines**, all in tactic proof bodies.

## Left alone (grind does not close these)

- Hypothesis-heavy semantic soundness lemmas that dispatch to another `_sound` lemma
  (`denseSolveOperand_sound`, the `BusPairCancelCheck` / `ZeroRegister` families).
- `_covered` / `_vars` lemmas built on `filterBus_covered` or structural recursion.
- `linear_combination` / `induction` / `ring` arithmetic proofs.

Two quirks recorded in `docs/log.md` entry 121: deeply nested matches can hit grind's
`maximum term generation` gate, and boolean recognizers want an existing `_iff` lemma in the
bracket rather than the raw `def`.

## Verification

- **No theorem statement, `def`, or `import` changed** — only proof bodies. The optimizer is
  therefore unchanged *by construction*.
- `lake build` green (2538 jobs); `Scripts/check-proof-integrity.sh` passes (no sorry/axioms;
  correctness theorems depend only on the three standard axioms).
- 6-case OpenVM/SP1 output snapshot byte-identical to the pre-sweep binary (sanity check on top of
  the by-construction argument).
- Rebased on current `main` (includes the Gauss hot-path PR); my `Proofs/Gauss.lean` grind edits
  compile cleanly against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGGcmzs9AFx2THDQUyNSEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGGcmzs9AFx2THDQUyNSEA)_