### PR TITLE
Remove unused theorems and add an unused-theorem linter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,12 @@ Keep the implementation lean; don't let comments regrow.
 ## Pushing work
 
 - All commits have to compile without warnings.
+- `Scripts/check-proof-integrity.sh` (run in CI) must pass: no `sorry`/`admit`/`axiom`/
+  `native_decide`, the correctness theorems rest only on Lean's three standard axioms, and no
+  human-written theorem is unused. The last is `Scripts/UnusedTheorems.lean`, which flags any
+  theorem/lemma unreachable from the correctness roots in `Scripts/unused-theorems.txt`; if you
+  orphan a lemma (e.g. by deleting its last use) either delete it too or, for a genuine
+  false-positive, add it to that file's `[ignore]` section.
 - Changes should be committed in incremental commits if possible. Rebases are fine.
 - The agent can always open a draft PR.
 - Opening a PR triggers a CI run with benchmark results posted as a sticky comment. Agents may

--- a/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
@@ -115,22 +115,6 @@ theorem PassCorrect.andThen {cs mid out : ConstraintSystem p} {bs : BusSemantics
   have := hr2 inputVars hmidIn (dsIn ++ df) (hr1 inputVars hpowIn dsIn hrec)
   rwa [List.append_assoc] at this
 
-/-- `PassCorrect` for a pass whose completeness witness is the input assignment itself and which
-    introduces no new variables (`out.vars ⊆ cs.vars`); emits no derivations. -/
-theorem PassCorrect.ofEnvEq {cs out : ConstraintSystem p} {bs : BusSemantics p}
-    (hsound : out.implies cs bs)
-    (hinv : cs.guaranteesInvariants bs → out.guaranteesInvariants bs)
-    (hsub : ∀ v ∈ out.vars, v ∈ cs.vars)
-    (hcomp : ∀ env, cs.admissible bs env → cs.satisfies bs env →
-      out.satisfies bs env ∧ out.admissible bs env ∧
-        cs.sideEffects bs env ≈ out.sideEffects bs env) :
-    PassCorrect cs out [] bs := by
-  refine ⟨hsound, hinv, fun v hv _ => hsub v hv, fun env hadm hsat => ?_⟩
-  obtain ⟨ho1, ho2, ho3⟩ := hcomp env hadm hsat
-  refine ⟨env, ho1, ho2, ho3, ⟨fun _ _ => rfl, fun _ _ dsIn hrec => ?_⟩⟩
-  rw [List.append_nil]
-  exact fun v hvout hvnone => hrec v (hsub v hvout) hvnone
-
 /-- A `PassCorrect` gives the audited `isSoundReplacementOf`. The completeness half is discharged
     at the pipeline top (`Implementation/Optimizer.lean`). -/
 theorem PassCorrect.toSound {cs out : ConstraintSystem p} {ds : Derivations p}

--- a/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
@@ -791,20 +791,6 @@ def DenseVerifiedPassW.of
       correct := DensePassCorrect.lift hcovd (hcov reg bs facts d hcovd)
         (hdcov reg bs facts d hcovd) (hcorrect reg bs facts d hcovd) }
 
-/-- `of` respects the degree bound whenever its dense output stays within bound. -/
-theorem DenseVerifiedPassW.of_respectsDeg {b : DegreeBound}
-    {denseF : (bs : BusSemantics p) → BusFacts p bs → DenseConstraintSystem p →
-      DenseConstraintSystem p}
-    {denseDerivsF : (bs : BusSemantics p) → BusFacts p bs → DenseConstraintSystem p →
-      DenseDerivations p}
-    {hcov hdcov hcorrect}
-    (hdeg : ∀ (reg : VarRegistry) (bs : BusSemantics p) (facts : BusFacts p bs)
-      (d : DenseConstraintSystem p), d.CoveredBy reg →
-      (reg.decodeCS d).withinDegree b → (reg.decodeCS (denseF bs facts d)).withinDegree b) :
-    DenseRespectsDeg b (of denseF denseDerivsF hcov hdcov hcorrect) := by
-  intro reg d hcovd bs facts hin
-  exact hdeg reg bs facts d hcovd hin
-
 /-! ## The registry-extending dense-pass builder
 
 `ofExtending` is the sibling of `of` for fresh-variable passes: the transform returns the extended
@@ -854,19 +840,6 @@ def DenseVerifiedPassW.ofExtending
         have hcovd' : d.CoveredBy t.1 := denseCS_coveredBy_mono hext' hcovd
         have hlift := DensePassCorrect.lift hcovd' hcov' hdcov' hcorrect'
         rwa [hext'.decodeCS_eq hcovd] at hlift }
-
-/-- `ofExtending` respects the degree bound whenever its dense output stays within bound. -/
-theorem DenseVerifiedPassW.ofExtending_respectsDeg {b : DegreeBound}
-    {transform : VarRegistry → (bs : BusSemantics p) → BusFacts p bs → DenseConstraintSystem p →
-      VarRegistry × DenseConstraintSystem p × DenseDerivations p}
-    {hext hcov hdcov hcorrect}
-    (hdeg : ∀ (reg : VarRegistry) (bs : BusSemantics p) (facts : BusFacts p bs)
-      (d : DenseConstraintSystem p), d.CoveredBy reg →
-      (reg.decodeCS d).withinDegree b →
-      ((transform reg bs facts d).1.decodeCS (transform reg bs facts d).2.1).withinDegree b) :
-    DenseRespectsDeg b (ofExtending transform hext hcov hdcov hcorrect) := by
-  intro reg d hcovd bs facts hin
-  exact hdeg reg bs facts d hcovd hin
 
 /-! ### Sanity check: a trivial registry-minting stub composes through the builder -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -355,9 +355,6 @@ def denseBICovered (r : VarRegistry) (bi : BusInteraction (DenseExpr p)) : Prop 
 theorem VarRegistry.encodeBI_fst (r : VarRegistry) (bi : BusInteraction (Expression p)) :
     (r.encodeBI bi).1 = ((r.encodeExpr bi.multiplicity).1.encodeExprs bi.payload).1 := rfl
 
-theorem VarRegistry.encodeBI_busId (r : VarRegistry) (bi : BusInteraction (Expression p)) :
-    (r.encodeBI bi).2.busId = bi.busId := rfl
-
 theorem VarRegistry.encodeBI_mult (r : VarRegistry) (bi : BusInteraction (Expression p)) :
     (r.encodeBI bi).2.multiplicity = (r.encodeExpr bi.multiplicity).2 := rfl
 
@@ -385,7 +382,7 @@ theorem VarRegistry.encodeBI_covered (r : VarRegistry) (bi : BusInteraction (Exp
 
 theorem VarRegistry.decodeBI_encodeBI (r : VarRegistry) (bi : BusInteraction (Expression p)) :
     (r.encodeBI bi).1.decodeBI (r.encodeBI bi).2 = bi := by
-  simp only [VarRegistry.decodeBI, encodeBI_fst, encodeBI_busId, encodeBI_mult, encodeBI_payload]
+  simp only [VarRegistry.decodeBI, encodeBI_fst, encodeBI_mult, encodeBI_payload]
   obtain ⟨busId, mult, payload⟩ := bi
   congr 1
   · rw [((r.encodeExpr mult).1.encodeExprs_extends payload).decodeExpr_eq

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -27,14 +27,6 @@ def DenseExpr.foldVars {α : Type} (e : DenseExpr p) (f : α → VarId → α) (
   | .add a b => b.foldVars f (a.foldVars f init)
   | .mul a b => b.foldVars f (a.foldVars f init)
 
-theorem DenseExpr.foldVars_eq {α : Type} (e : DenseExpr p) (f : α → VarId → α) (init : α) :
-    e.foldVars f init = e.vars.foldl f init := by
-  induction e generalizing init with
-  | const => rfl
-  | var => rfl
-  | add a b iha ihb => simp only [foldVars, DenseExpr.vars, List.foldl_append, iha, ihb]
-  | mul a b iha ihb => simp only [foldVars, DenseExpr.vars, List.foldl_append, iha, ihb]
-
 def DenseExpr.isVar : DenseExpr p → Bool
   | .var _ => true
   | _ => false

--- a/ApcOptimizer/Implementation/OptimizerPasses/Measure.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Measure.lean
@@ -177,25 +177,10 @@ theorem DenseConstraintSystem.occ_valid {r : VarRegistry} {d : DenseConstraintSy
     · exact hm i him
     · exact hp e hemem i hie
 
-/-- On a covered system, the dense variable count equals the spec variable count of the decode. -/
-theorem VarRegistry.decodeCS_varCount (r : VarRegistry) (d : DenseConstraintSystem p)
-    (hc : d.CoveredBy r) : (r.decodeCS d).varCount = d.varCount := by
-  unfold ConstraintSystem.varCount DenseConstraintSystem.varCount
-  rw [r.decodeCS_occ d]
-  exact size_fold_map_resolve r d.occ ∅ ∅ (by simp) (by simp) (DenseConstraintSystem.occ_valid hc)
-
-/-! ## sizeKey correspondence -/
+/-! ## The dense lexicographic size key -/
 
 /-- The dense lexicographic size key `(distinct vars, bus interactions, constraints)`. -/
 def DenseConstraintSystem.sizeKey (d : DenseConstraintSystem p) : Nat ×ₗ Nat ×ₗ Nat :=
   toLex (d.varCount, toLex (d.busInteractions.length, d.algebraicConstraints.length))
-
-/-- The dense size key equals the spec size key on the decode, so the fixpoint driver makes
-    identical stopping decisions. -/
-theorem VarRegistry.decodeCS_sizeKey (r : VarRegistry) (d : DenseConstraintSystem p)
-    (hc : d.CoveredBy r) : (r.decodeCS d).sizeKey = d.sizeKey := by
-  unfold ConstraintSystem.sizeKey DenseConstraintSystem.sizeKey
-  rw [r.decodeCS_varCount d hc]
-  simp only [VarRegistry.decodeCS, List.length_map]
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
@@ -196,29 +196,4 @@ theorem denseIterateToFixpoint_respectsDeg {b : DegreeBound} {f : DenseVerifiedP
   intro reg d hcov bs facts hin
   exact denseIterateToFixpointFrom_respectsDeg hf reg d hcov bs facts d.sizeKey rfl hin
 
-/-- `denseIterateToFixpointFrom` never grows the size key (strong induction, key generalized). -/
-theorem denseIterateToFixpointFrom_monotone {f : DenseVerifiedPassW p} (reg : VarRegistry)
-    (d : DenseConstraintSystem p) :
-    ∀ (hcov : d.CoveredBy reg) (bs : BusSemantics p) (facts : BusFacts p bs)
-      (k : Nat ×ₗ Nat ×ₗ Nat) (hk : d.sizeKey = k),
-      (denseIterateToFixpointFrom f reg d hcov bs facts k hk).out.sizeKey ≤ d.sizeKey := by
-  induction d using denseSizeKey_wf.induction generalizing reg with
-  | _ d ih =>
-    intro hcov bs facts k hk
-    rw [denseIterateToFixpointFrom]
-    split
-    · rename_i h
-      exact le_trans
-        (ih _ (by rw [hk]; exact h) _ (f reg d hcov bs facts).covered bs facts _ rfl)
-        (le_of_lt (by rw [hk]; exact h))
-    · exact le_refl _
-
-/-- The dense cleanup loop can only improve the circuit: the output's `sizeKey` never exceeds the
-    input's. -/
-theorem denseIterateToFixpoint_monotone {f : DenseVerifiedPassW p} (reg : VarRegistry)
-    (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) (bs : BusSemantics p)
-    (facts : BusFacts p bs) :
-    (denseIterateToFixpoint f reg d hcov bs facts).out.sizeKey ≤ d.sizeKey :=
-  denseIterateToFixpointFrom_monotone reg d hcov bs facts d.sizeKey rfl
-
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Registry.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Registry.lean
@@ -67,10 +67,6 @@ theorem idOf_resolve {r : VarRegistry} {i : VarId} (h : r.Valid i) :
   rw [resolve_eq h, idOf?]
   simpa using this
 
-theorem idOf_inj {r : VarRegistry} {x y : Variable} {i : VarId}
-    (hx : r.idOf? x = some i) (hy : r.idOf? y = some i) : x = y := by
-  rw [← r.resolve_idOf hx, ← r.resolve_idOf hy]
-
 theorem resolve_inj {r : VarRegistry} {i j : VarId} (hi : r.Valid i) (hj : r.Valid j)
     (h : r.resolve i = r.resolve j) : i = j := by
   have := r.idOf_resolve hi

--- a/Scripts/UnusedTheorems.lean
+++ b/Scripts/UnusedTheorems.lean
@@ -1,0 +1,134 @@
+import ApcOptimizer
+import Main
+
+/-! CI helper: flag human-written theorems that no longer contribute to the audited correctness
+    theorems in `ApcOptimizer/Optimizer.lean`.
+
+    A theorem is "used" iff it is reachable, through proof terms and types, from the roots seeded in
+    `Scripts/unused-theorems.txt` (the correctness statements), together with every `@[csimp]`
+    theorem — those are referenced by the compiler, not by any proof term, so a term walk cannot see
+    the use. Auto-generated declarations (structure projections, `injEq`, equation lemmas, …) are
+    excluded: they carry no source range and are not something a human wrote.
+
+    `Scripts/check-proof-integrity.sh` runs this from the repo root and fails CI if anything is
+    flagged. To resolve a flag: delete the dead theorem, or — if it really is used through a channel
+    the term walk cannot see (see the `[ignore]` section of the seed) — record it there. -/
+
+open Lean Elab Command
+
+namespace UnusedTheorems
+
+def seedPath : System.FilePath := "Scripts/unused-theorems.txt"
+
+structure Seed where
+  roots : Array Name := #[]
+  ignore : Std.HashSet Name := {}
+
+-- `String.trim` (String → String) is deprecated in favour of a Slice-returning variant.
+set_option linter.deprecated false in
+/-- Parse the seed file: `#` comments, blank lines, and `[roots]` / `[ignore]` section headers. -/
+def parseSeed (content : String) : Seed := Id.run do
+  let mut seed : Seed := {}
+  let mut sect := "roots"
+  for rawLine in content.splitOn "\n" do
+    let line := rawLine.trim
+    if line.isEmpty || line.startsWith "#" then continue
+    if line == "[roots]" then sect := "roots"; continue
+    if line == "[ignore]" then sect := "ignore"; continue
+    let n := line.toName
+    if sect == "roots" then seed := { seed with roots := seed.roots.push n }
+    else seed := { seed with ignore := seed.ignore.insert n }
+  return seed
+
+def isProjectModule (m : Name) : Bool :=
+  let s := m.toString
+  s == "Main" || "ApcOptimizer".isPrefixOf s
+
+def projectModuleIdxs (env : Environment) : Std.HashSet Nat := Id.run do
+  let mut s : Std.HashSet Nat := {}
+  for i in [0:env.header.moduleNames.size] do
+    if isProjectModule env.header.moduleNames[i]! then s := s.insert i
+  return s
+
+def isProjectConst (env : Environment) (idxs : Std.HashSet Nat) (n : Name) : Bool :=
+  match env.getModuleIdxFor? n with
+  | some i => idxs.contains i.toNat
+  | none => false
+
+/-- The defining term of a constant. `ConstantInfo.value?` omits theorem bodies in this Lean
+    version, so read the field directly — the whole point is to walk into proofs. -/
+def valueOf (ci : ConstantInfo) : Option Expr :=
+  match ci with
+  | .defnInfo v => some v.value
+  | .thmInfo v => some v.value
+  | .opaqueInfo v => some v.value
+  | _ => none
+
+def refsOf (env : Environment) (n : Name) : Array Name :=
+  match env.find? n with
+  | none => #[]
+  | some ci => ci.type.getUsedConstants ++ ((valueOf ci).map Expr.getUsedConstants).getD #[]
+
+/-- Reachable project constants from `roots`. Restricted to project constants: Mathlib and core
+    never reference the project, so the boundary can be cut there without missing anything. -/
+def closure (env : Environment) (idxs : Std.HashSet Nat) (roots : Array Name) :
+    Std.HashSet Name := Id.run do
+  let mut visited : Std.HashSet Name := {}
+  let mut stack : Array Name := roots
+  while stack.size > 0 do
+    let n := stack.back!
+    stack := stack.pop
+    if visited.contains n then continue
+    visited := visited.insert n
+    for r in refsOf env n do
+      if isProjectConst env idxs r && !visited.contains r then
+        stack := stack.push r
+  return visited
+
+/-- `@[csimp]` theorems in project modules: compiler-referenced, hence implicit roots. -/
+def csimpRoots (env : Environment) (idxs : Std.HashSet Nat) : Array Name :=
+  (Lean.Compiler.CSimp.ext.getState env).map.fold
+    (fun acc _ v => if isProjectConst env idxs v.thmName then acc.push v.thmName else acc) #[]
+
+/-- Every human-written theorem in a project module: a `thmInfo` that is not internal, not a
+    structure projection, and carries a source declaration range. -/
+def deadTheorems (env : Environment) (idxs : Std.HashSet Nat) (cl : Std.HashSet Name)
+    (ignore : Std.HashSet Name) : CommandElabM (Array (Name × Name × Nat)) := do
+  let mut out : Array (Name × Name × Nat) := #[]
+  for i in idxs do
+    for ci in env.header.moduleData[i]!.constants do
+      match ci with
+      | .thmInfo _ =>
+        let n := ci.name
+        if n.isInternalDetail || cl.contains n || ignore.contains n then continue
+        if (env.getProjectionFnInfo? n).isSome then continue
+        match ← Lean.findDeclarationRanges? n with
+        | some dr => out := out.push (env.header.moduleNames[i]!, n, dr.range.pos.line)
+        | none => pure ()
+      | _ => pure ()
+  return out
+
+elab "#checkUnusedTheorems" : command => do
+  let env ← getEnv
+  let content ← IO.FS.readFile seedPath
+  let seed := parseSeed content
+  let idxs := projectModuleIdxs env
+  let csimp := csimpRoots env idxs
+  let cl := closure env idxs (seed.roots ++ csimp)
+  let dead := (← deadTheorems env idxs cl seed.ignore).qsort
+    (fun a b => if a.1 == b.1 then a.2.2 < b.2.2 else a.1.toString < b.1.toString)
+  logInfo m!"checked {cl.size} reachable constants from {seed.roots.size} seeded roots \
+    + {csimp.size} @[csimp] theorems; {seed.ignore.size} ignored"
+  if dead.isEmpty then
+    logInfo "OK: no unused theorems."
+  else
+    let mut msg := m!"found {dead.size} unused theorem(s) — not reachable from the roots in \
+      {seedPath}. Delete them, or add to that file's [ignore] section if genuinely used:"
+    for (m, n, line) in dead do
+      let file := m.toString.replace "." "/" ++ ".lean"
+      msg := msg ++ m!"\n  {file}:{line}  {n}"
+    throwError msg
+
+#checkUnusedTheorems
+
+end UnusedTheorems

--- a/Scripts/check-proof-integrity.sh
+++ b/Scripts/check-proof-integrity.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Fails if the optimizer's correctness proof is not fully machine-checked:
-#   1. no `sorry` / `admit` / `native_decide` / `axiom` in the Lean sources, and
-#   2. the top-level correctness theorems depend only on Lean's three standard axioms.
+#   1. no `sorry` / `admit` / `native_decide` / `axiom` in the Lean sources,
+#   2. the top-level correctness theorems depend only on Lean's three standard axioms, and
+#   3. no human-written theorem is unused (unreachable from the correctness theorems).
 # Run from the repo root (CI runs it after `lake build`).
 set -euo pipefail
 
@@ -19,5 +20,8 @@ if echo "$out" | grep -qE 'sorryAx|ofReduceBool|trustCompiler'; then
   echo "ERROR: a correctness theorem depends on a forbidden axiom." >&2
   exit 1
 fi
+
+echo "==> Checking for unused theorems (seeded by Scripts/unused-theorems.txt)"
+lake env lean Scripts/UnusedTheorems.lean
 
 echo "OK: proof integrity checks passed."

--- a/Scripts/unused-theorems.txt
+++ b/Scripts/unused-theorems.txt
@@ -1,0 +1,24 @@
+# Seed file for the unused-theorem linter (`Scripts/UnusedTheorems.lean`).
+#
+# The linter flags every human-written theorem/lemma in the project that is NOT reachable,
+# through proof terms and types, from the roots below (plus every `@[csimp]` theorem, which is
+# auto-detected: the compiler references it, so a proof-term walk cannot see the use).
+#
+# Format: `#` starts a comment; blank lines are ignored; `[roots]` / `[ignore]` switch sections.
+# Names are fully qualified.
+
+# The theorems we ultimately care about: the audited correctness statements in
+# `ApcOptimizer/Optimizer.lean`. Everything a correct optimizer needs is reachable from these.
+[roots]
+optimizerWithBusFacts_maintainsCorrectness
+simpleOptimizer_maintainsCorrectness
+ApcOptimizer.OpenVM.openVmOptimizer_maintainsCorrectness
+ApcOptimizer.SP1.sp1Optimizer_maintainsCorrectness
+
+# Theorems the closure cannot see are used, so they must be listed by hand. The only class so far:
+# a `rfl`-lemma named in a `simp only`/`rw` list whose rewrite step collapses to `Eq.refl`, leaving
+# no reference to the lemma in the resulting proof term.
+[ignore]
+# `(Task.spawn f).get = f ()`, used in `denseCollectForcedV_eq_serial` (Proofs/DomainBatch.lean);
+# `Task.get` is opaque, so the `simp only` needs the lemma even though it rewrites by `rfl`.
+ApcOptimizer.Dense.get_spawn

--- a/docs/log.md
+++ b/docs/log.md
@@ -4362,3 +4362,32 @@ deeply nested matches can hit grind's `maximum term generation` gate (leave thos
 recognizers want an existing `_iff` lemma in the bracket rather than the raw `def`.
 
 **Worked: yes (net −190 lines, effectiveness and runtime unchanged by construction).**
+
+### 122. Tooling: unused-theorem linter + dead-lemma sweep
+
+Maintainability pass; no runtime or proof-content change, effectiveness untouched.
+
+- **Linter** (`Scripts/UnusedTheorems.lean`, seeded by `Scripts/unused-theorems.txt`): walks the
+  proof-term + type dependency closure of the audited correctness theorems in
+  `ApcOptimizer/Optimizer.lean` and flags every human-written theorem/lemma not reachable from
+  them. Wired into `check-proof-integrity.sh`, so CI now fails on a newly-orphaned lemma. Two
+  subtleties the walk handles: `ConstantInfo.value?` omits imported theorem bodies (read the
+  `.thmInfo`/`.defnInfo` value field directly, else the closure sees only types and looks 883/1370
+  "dead"), and `@[csimp]` theorems are compiler-referenced, not term-referenced, so they are
+  auto-detected as implicit roots. Auto-generated names (projections, `injEq`, equation lemmas)
+  are excluded by requiring a source declaration range and no `getProjectionFnInfo?`. The seed
+  file also carries an `[ignore]` list for the one residual false-positive class: a `rfl`-lemma
+  named in a `simp only`/`rw` whose rewrite collapses to `Eq.refl`, leaving no reference in the
+  term (`get_spawn`, needed because `Task.get` is opaque).
+- **Sweep**: the 10 theorems the linter flagged, all orphaned by earlier refactors, removed —
+  `PassCorrect.ofEnvEq` (Basic); `DenseVerifiedPassW.{of,ofExtending}_respectsDeg` (Bridge, dead
+  since #119's guard-once pipeline); `DenseExpr.foldVars_eq` (Gauss, #120's runtime `foldVars`
+  feeds only heuristic occ/revDeps bookkeeping, which no correctness proof reasons about);
+  `VarRegistry.encodeBI_busId` (Encoding, a `rfl` projection `congr` already discharges);
+  `VarRegistry.{decodeCS_varCount,decodeCS_sizeKey}` (Measure, the dense/spec size-key
+  correspondence, unused since the driver runs on the dense key);
+  `denseIterateToFixpoint{,From}_monotone` (Pass, the size never-grows property, unused by
+  correctness); `VarRegistry.idOf_inj` (Registry).
+
+**Worked: yes (−10 dead theorems; `lake build` warning-free; proof integrity green, correctness
+axioms `{propext, Classical.choice, Quot.sound}`-only).**


### PR DESCRIPTION
## What

Two things:

1. **Remove 10 unused theorems** — theorems that no longer contribute to the audited correctness theorems in `ApcOptimizer/Optimizer.lean` and aren't referenced anywhere else (proof term, compiled runtime, or tactic block).
2. **Add an unused-theorem linter** (`Scripts/UnusedTheorems.lean`, seeded by `Scripts/unused-theorems.txt`) that keeps them from creeping back in. Wired into `check-proof-integrity.sh`, so CI now fails on a newly-orphaned lemma.

Effectiveness is untouched (no runtime or proof-content change); the correctness theorems still rest only on `{propext, Classical.choice, Quot.sound}`.

## How the linter works

Starting from the roots seeded in `Scripts/unused-theorems.txt` (the four `*_maintainsCorrectness` theorems), it walks the transitive dependency closure through both **types and proof terms** and flags every human-written theorem/lemma in a project module that isn't reachable. The closure is restricted to project constants (Mathlib/core never reference the project, so the boundary can be cut there), which keeps it fast.

Three subtleties it handles, each of which is why a naive "grep for the name" approach is wrong:

- **Imported theorem bodies.** In this Lean version `ConstantInfo.value?` returns `none` for imported theorems, so the walk reads the `.thmInfo`/`.defnInfo` value field directly. Without this the closure sees only *types*, and ~883/1370 theorems look "dead".
- **`@[csimp]` theorems.** These are referenced by the *compiler*, not by any proof term, so they're auto-detected from the csimp extension and added as implicit roots (this pulls their helper lemmas back in as live).
- **Auto-generated declarations** (structure projections, `injEq`, equation lemmas, …) are excluded by requiring a real source declaration range and no `getProjectionFnInfo?`.

The seed file also has an `[ignore]` section for the one residual false-positive class: a `rfl`-lemma named in a `simp only`/`rw` whose rewrite collapses to `Eq.refl`, leaving no reference in the proof term. Exactly one such lemma exists (`get_spawn`, needed because `Task.get` is opaque).

The seed file is the single knob: to resolve a future flag, either delete the dead theorem, add a new intentional root, or (for a genuine false-positive) add it to `[ignore]`.

## Theorems removed

| Theorem | File | Why dead |
|---|---|---|
| `PassCorrect.ofEnvEq` | Basic | no longer used |
| `DenseVerifiedPassW.of_respectsDeg` | Bridge | dead since the guard-once pipeline (#171) |
| `DenseVerifiedPassW.ofExtending_respectsDeg` | Bridge | dead since the guard-once pipeline (#171) |
| `DenseExpr.foldVars_eq` | Gauss | #172's `foldVars` feeds only heuristic occ/revDeps bookkeeping, which no correctness proof reasons about |
| `VarRegistry.encodeBI_busId` | Encoding | a `rfl` projection `congr` already discharges (dropped from the one `simp only` naming it) |
| `VarRegistry.decodeCS_varCount` | Measure | dense/spec size-key correspondence, unused since the driver runs on the dense key |
| `VarRegistry.decodeCS_sizeKey` | Measure | dense/spec size-key correspondence, unused since the driver runs on the dense key |
| `denseIterateToFixpointFrom_monotone` | Pass | "size never grows" property, unused by correctness |
| `denseIterateToFixpoint_monotone` | Pass | "size never grows" property, unused by correctness |
| `VarRegistry.idOf_inj` | Registry | no longer used |

The linter itself caught `foldVars_eq` (added by #172) during the rebase — a nice first live catch.

## Related finding (not in this PR)

The `BusFacts.neverViolates` field and its `neverViolates_sound` obligation are only ever *set* (in `openVmFacts`/`sp1Facts` and the trivial instance), never read by the correctness proof — dead data in the `BusFacts` structure. Removing it is a structure/API change rather than a theorem cleanup, so I left it out to keep this PR focused; happy to do it as a follow-up if wanted.

## Verification

- `lake build` green and warning-free.
- `Scripts/check-proof-integrity.sh` passes (no `sorry`/`admit`/`axiom`/`native_decide`; correctness axioms `{propext, Classical.choice, Quot.sound}`-only; **no unused theorems**).
- Linter failure path exercised (temporarily un-ignoring `get_spawn` → flagged with `file:line`, non-zero exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171UmqN4EexgE5DBCMYSD6T

---
_Generated by [Claude Code](https://claude.ai/code/session_0171UmqN4EexgE5DBCMYSD6T)_