### PR TITLE
Runtime: streamline domainBatch box evaluation

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -147,11 +147,41 @@ def denseScanStopV : Option (DenseCandsV p) → Bool
   | none => false
   | some cands => cands.all Option.isNone
 
+mutual
+  /-- Specialized box traversal for the forced-value scan. -/
+  def denseScanBoxLoopV (surv : List (ZMod p) → Bool) :
+      List (FiniteDomain p) → List (ZMod p) → Option (DenseCandsV p) → Option (DenseCandsV p)
+    | [], pt, acc =>
+      if denseScanStopV acc then acc else denseScanStepV surv acc pt
+    | .explicit values :: rest, pt, acc => denseScanExplicitV surv rest pt values acc
+    | .range bound :: rest, pt, acc => denseScanRangeV surv rest pt 0 bound acc
+  termination_by doms _ _ => (doms.length + 1, 0, 0)
+
+  def denseScanExplicitV (surv : List (ZMod p) → Bool) (rest : List (FiniteDomain p))
+      (pt : List (ZMod p)) :
+      List (ZMod p) → Option (DenseCandsV p) → Option (DenseCandsV p)
+    | [], acc => acc
+    | v :: vs, acc =>
+      if denseScanStopV acc then acc
+      else denseScanExplicitV surv rest pt vs (denseScanBoxLoopV surv rest (v :: pt) acc)
+  termination_by values _ => (rest.length + 1, 1, values.length)
+
+  def denseScanRangeV (surv : List (ZMod p) → Bool) (rest : List (FiniteDomain p))
+      (pt : List (ZMod p)) (start : Nat) :
+      Nat → Option (DenseCandsV p) → Option (DenseCandsV p)
+    | 0, acc => acc
+    | n + 1, acc =>
+      if denseScanStopV acc then acc
+      else denseScanRangeV surv rest pt (start + 1) n
+        (denseScanBoxLoopV surv rest (((start : Nat) : ZMod p) :: pt) acc)
+  termination_by count _ => (rest.length + 1, 2, count)
+end
+
 /-- The value-only box scan, streamed lazily over the symbolic domains; the caller
     (`denseForcedOverV`) zips the final mask with `keys` once, after the scan finishes. -/
 def denseScanBoxV (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p)) :
     Option (DenseCandsV p) :=
-  denseBoxFoldV (denseScanStepV surv) denseScanStopV doms none
+  denseScanBoxLoopV surv doms.reverse [] none
 
 /-! ## Redundancy check, value-only -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -39,15 +39,32 @@ def denseCBiEvalWithV (ops : DenseZModOps p) (cbi : CBi p) (pt : List (ZMod p)) 
     multiplicity := denseIExprEvalWithV ops pt cbi.mult,
     payload := cbi.payload.map (fun ie => denseIExprEvalWithV ops pt ie) }
 
+/-- Check that every compiled constraint vanishes, stopping at the first failure. -/
+def denseAllZeroCWV (ops : DenseZModOps p) (pt : List (ZMod p)) : List (IExpr p) → Bool
+  | [] => true
+  | ie :: rest =>
+    if denseIExprEvalWithV ops pt ie = ops.zero then denseAllZeroCWV ops pt rest else false
+
+/-- Check every compiled bus obligation, skipping payload evaluation when multiplicity is zero. -/
+def denseAllBusCWV (ops : DenseZModOps p) (bs : BusSemantics p)
+    (pt : List (ZMod p)) : List (CBi p) → Bool
+  | [] => true
+  | cbi :: rest =>
+    let mult := denseIExprEvalWithV ops pt cbi.mult
+    if mult = ops.zero then denseAllBusCWV ops bs pt rest
+    else
+      let v : BusInteraction (ZMod p) :=
+        { busId := cbi.busId,
+          multiplicity := mult,
+          payload := cbi.payload.map (fun ie => denseIExprEvalWithV ops pt ie) }
+      if bs.violatesConstraint v then false else denseAllBusCWV ops bs pt rest
+
 /-- `survivesAllCW`, over a value-only point: compiled items' zero test plus interactions'
     obligation check. -/
-def denseSurvivesAllCWV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (bs : BusSemantics p) (ces : List (IExpr p)) (cbis : List (CBi p))
+def denseSurvivesAllCWV (ops : DenseZModOps p) (bs : BusSemantics p)
+    (ces : List (IExpr p)) (cbis : List (CBi p))
     (pt : List (ZMod p)) : Bool :=
-  ces.all (fun ie => isZero (denseIExprEvalWithV ops pt ie)) &&
-    cbis.all (fun cbi =>
-      let v := denseCBiEvalWithV ops cbi pt
-      isZero v.multiplicity || !bs.violatesConstraint v)
+  denseAllZeroCWV ops pt ces && denseAllBusCWV ops bs pt cbis
 
 /-! ### The uncompiled fallback
 
@@ -88,9 +105,7 @@ def denseCompiledSurvV (bs : BusSemantics p) (es : List (DenseExpr p))
   match denseCompileEs keys es, denseCompileBis keys bis with
   | some ces, some cbis =>
     let ops : DenseZModOps p := denseZModOps
-    let dec : DecidableEq (ZMod p) := inferInstance
-    let isZero : ZMod p → Bool := fun v => @decide (v = ops.zero) (dec v ops.zero)
-    ⟨fun pt => denseSurvivesAllCWV ops isZero bs ces cbis pt⟩
+    ⟨fun pt => denseSurvivesAllCWV ops bs ces cbis pt⟩
   | _, _ => ⟨denseSurvivesAllMV bs es bis keys⟩
 
 /-! ## Value-only lazy box enumeration -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -807,17 +807,46 @@ theorem denseCompileBis_allV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
         rw [List.all_cons, List.all_cons, ih crest hr]
         simp only [denseCompileBi_evalWithV ops keys pt bi cbi hb, hz]
 
+/-- The compiled constraint loop agrees with `List.all`. -/
+theorem denseAllZeroCWV_eq (ops : DenseZModOps p) (pt : List (ZMod p)) : ∀ ces,
+    denseAllZeroCWV ops pt ces =
+      ces.all (fun ie => decide (denseIExprEvalWithV ops pt ie = ops.zero)) := by
+  intro ces
+  induction ces with
+  | nil => rfl
+  | cons ie rest ih => simp [denseAllZeroCWV, List.all_cons, ih]
+
+/-- The multiplicity-first bus loop agrees with `List.all`. -/
+theorem denseAllBusCWV_eq (ops : DenseZModOps p) (bs : BusSemantics p)
+    (pt : List (ZMod p)) : ∀ cbis,
+    denseAllBusCWV ops bs pt cbis =
+      cbis.all (fun cbi =>
+        let v := denseCBiEvalWithV ops cbi pt
+        decide (v.multiplicity = ops.zero) || !bs.violatesConstraint v) := by
+  intro cbis
+  induction cbis with
+  | nil => rfl
+  | cons cbi rest ih =>
+      simp only [denseAllBusCWV, List.all_cons]
+      rw [ih]
+      unfold denseCBiEvalWithV
+      simp only
+      split <;> simp_all
+
 /-- The value-only compiled survivor predicate under compile success agrees with the uncompiled one. -/
-theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p) (es : List (DenseExpr p))
+theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (bs : BusSemantics p)
+    (es : List (DenseExpr p))
     (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (ces : List (IExpr p))
     (cbis : List (CBi p)) (pt : List (ZMod p))
     (hce : denseCompileEs keys es = some ces) (hcb : denseCompileBis keys bis = some cbis) :
-    denseSurvivesAllCWV ops isZero bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt := by
+    denseSurvivesAllCWV ops bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt := by
   unfold denseSurvivesAllCWV denseSurvivesAllMV
+  rw [denseAllZeroCWV_eq, denseAllBusCWV_eq]
   congr 1
-  · exact denseCompileEs_allV ops isZero hz keys pt es ces hce
-  · exact denseCompileBis_allV ops isZero hz bs keys pt bis cbis hcb
+  · exact denseCompileEs_allV ops (fun v => decide (v = ops.zero))
+      (fun v => by rw [ops.zero_eq]) keys pt es ces hce
+  · exact denseCompileBis_allV ops (fun v => decide (v = ops.zero))
+      (fun v => by rw [ops.zero_eq]) bs keys pt bis cbis hcb
 
 /-- The value-only compiled survivor predicate agrees with the uncompiled one on every point. -/
 theorem denseCompiledSurvV_eq (bs : BusSemantics p) (es : List (DenseExpr p))
@@ -830,10 +859,9 @@ theorem denseCompiledSurvV_eq (bs : BusSemantics p) (es : List (DenseExpr p))
     cases hcb : denseCompileBis keys bis with
     | none => rfl
     | some cbis =>
-      change denseSurvivesAllCWV denseZModOps (fun v => decide (v = denseZModOps.zero))
-          bs ces cbis pt = denseSurvivesAllMV bs es bis keys pt
-      exact denseSurvivesAllCWV_eq denseZModOps _ (fun _ => rfl)
-        bs es bis keys ces cbis pt hce hcb
+      change denseSurvivesAllCWV denseZModOps bs ces cbis pt =
+        denseSurvivesAllMV bs es bis keys pt
+      exact denseSurvivesAllCWV_eq denseZModOps bs es bis keys ces cbis pt hce hcb
 
 /-- The restriction of a satisfying `denv` survives the covered-item predicate (value-only). -/
 theorem denseSurvivesAllMV_restriction (bs : BusSemantics p) (es : List (DenseExpr p))

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -419,6 +419,96 @@ def assignmentsV : List (FiniteDomain p) → List (List (ZMod p))
   | [] => [[]]
   | d :: rest => (assignmentsV rest).flatMap (fun a => d.toList.map (fun v => v :: a))
 
+/-- Point order used by `denseScanBoxLoopV`, with the accumulated suffix explicit. -/
+def assignmentsRevV : List (FiniteDomain p) → List (ZMod p) → List (List (ZMod p))
+  | [], pt => [pt]
+  | d :: rest, pt => d.toList.flatMap (fun v => assignmentsRevV rest (v :: pt))
+
+/-- The specialized scanner is the early-stop fold over its direct traversal order. -/
+theorem denseScanBoxLoopV_eq (surv : List (ZMod p) → Bool) :
+    ∀ (doms : List (FiniteDomain p)) (pt : List (ZMod p)) (acc : Option (DenseCandsV p)),
+      denseScanBoxLoopV surv doms pt acc =
+        foldlStop (denseScanStepV surv) denseScanStopV (assignmentsRevV doms pt) acc := by
+  intro doms
+  induction doms with
+  | nil =>
+    intro pt acc
+    simp only [denseScanBoxLoopV, assignmentsRevV, foldlStop]
+  | cons d rest ih =>
+    intro pt acc
+    cases d with
+    | explicit values =>
+      rw [denseScanBoxLoopV, assignmentsRevV, FiniteDomain.toList,
+        ← foldlStop_flatMap]
+      induction values generalizing acc with
+      | nil => rw [denseScanExplicitV, foldlStop]
+      | cons v vs ihvs =>
+        rw [denseScanExplicitV, foldlStop]
+        by_cases hstop : denseScanStopV acc = true
+        · rw [if_pos hstop, if_pos hstop]
+        · rw [if_neg hstop, if_neg hstop, ih, ihvs]
+    | range bound =>
+      rw [denseScanBoxLoopV, assignmentsRevV, FiniteDomain.toList,
+        List.range_eq_range', ← foldlStop_flatMap]
+      have hrange : ∀ (start count : Nat) (acc : Option (DenseCandsV p)),
+          denseScanRangeV surv rest pt start count acc =
+            foldlStop
+              (fun acc v => foldlStop (denseScanStepV surv) denseScanStopV
+                (assignmentsRevV rest (v :: pt)) acc)
+              denseScanStopV ((List.range' start count).map (Nat.cast : Nat → ZMod p)) acc := by
+        intro start count
+        induction count generalizing start with
+        | zero => intro acc; rw [denseScanRangeV, List.range', List.map, foldlStop]
+        | succ n ihn =>
+          intro acc
+          rw [denseScanRangeV, List.range'_succ, List.map_cons, foldlStop]
+          by_cases hstop : denseScanStopV acc = true
+          · rw [if_pos hstop, if_pos hstop]
+          · rw [if_neg hstop, if_neg hstop, ih, ihn]
+      exact hrange 0 bound acc
+
+theorem assignmentsRevV_suffix (doms : List (FiniteDomain p)) (suffix : List (ZMod p)) :
+    assignmentsRevV doms suffix =
+      (assignmentsRevV doms []).map (fun pt => pt ++ suffix) := by
+  induction doms generalizing suffix with
+  | nil => simp only [assignmentsRevV, List.map, List.nil_append]
+  | cons d rest ih =>
+    simp only [assignmentsRevV, List.map_flatMap]
+    apply List.flatMap_congr
+    intro v _
+    rw [ih (v :: suffix), ih [v], List.map_map]
+    apply List.map_congr_left
+    intro pt _
+    simp only [Function.comp_apply, List.append_assoc, List.singleton_append]
+
+theorem assignmentsRevV_snoc (doms : List (FiniteDomain p)) (d : FiniteDomain p)
+    (suffix : List (ZMod p)) :
+    assignmentsRevV (doms ++ [d]) suffix =
+      (assignmentsRevV doms []).flatMap
+        (fun pt => d.toList.map (fun v => v :: (pt ++ suffix))) := by
+  induction doms generalizing suffix with
+  | nil =>
+    simp only [List.nil_append, assignmentsRevV, List.flatMap_singleton, List.nil_append]
+    exact (List.map_eq_flatMap (f := fun v => v :: suffix) (l := d.toList)).symm
+  | cons d' rest ih =>
+    simp only [List.cons_append, assignmentsRevV, List.flatMap_assoc]
+    apply List.flatMap_congr
+    intro v _
+    rw [ih (v :: suffix), assignmentsRevV_suffix rest [v], List.flatMap_map]
+    apply List.flatMap_congr
+    intro pt _
+    apply List.map_congr_left
+    intro w _
+    simp only [List.append_assoc, List.singleton_append]
+
+theorem assignmentsRevV_reverse_eq (doms : List (FiniteDomain p)) :
+    assignmentsRevV doms.reverse [] = assignmentsV doms := by
+  induction doms with
+  | nil => rfl
+  | cons d rest ih =>
+    rw [List.reverse_cons, assignmentsRevV_snoc, ih, assignmentsV]
+    simp only [List.append_nil]
+
 /-- `denseBoxFoldV` streams exactly the eager fold over `assignmentsV`. -/
 theorem denseBoxFoldV_eq {β : Type} (f : β → List (ZMod p) → β) (stop : β → Bool)
     (doms : List (FiniteDomain p)) (acc : β) :
@@ -438,6 +528,11 @@ theorem denseBoxFoldV_eq {β : Type} (f : β → List (ZMod p) → β) (stop : �
     show d.foldElts (fun acc'' v => f acc'' (v :: a)) stop acc'
       = foldlStop f stop (d.toList.map (fun v => v :: a)) acc'
     rw [FiniteDomain.foldElts_eq, foldlStop_map]
+
+theorem denseScanBoxV_eq (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p)) :
+    denseScanBoxV surv doms =
+      denseBoxFoldV (denseScanStepV surv) denseScanStopV doms none := by
+  rw [denseScanBoxV, denseScanBoxLoopV_eq, assignmentsRevV_reverse_eq, denseBoxFoldV_eq]
 
 /-- The restriction of a satisfying `denv` to a keyed domain list is one of the value-only
     enumerated assignments. -/
@@ -614,7 +709,7 @@ theorem foldlStop_denseScanStep_none (surv : List (ZMod p) → Bool) :
 /-- **Value-only scan `none` case.** No point of the box survives the scanned predicate. -/
 theorem denseScanBoxV_none_unsat (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p))
     (h : denseScanBoxV surv doms = none) : ∀ pt ∈ assignmentsV doms, surv pt = false := by
-  rw [denseScanBoxV, denseBoxFoldV_eq] at h
+  rw [denseScanBoxV_eq, denseBoxFoldV_eq] at h
   exact foldlStop_denseScanStep_none surv (assignmentsV doms) h
 
 /-- **Value-only scan `some` case.** A `some c` in the returned mask is agreed on by every surviving
@@ -623,7 +718,7 @@ theorem denseScanBoxV_forces (surv : List (ZMod p) → Bool) (doms : List (Finit
     (mask : DenseCandsV p) (h : denseScanBoxV surv doms = some mask) (n : Nat) (c : ZMod p)
     (hmask : mask[n]? = some (some c)) :
     ∀ pt ∈ assignmentsV doms, surv pt = true → pt[n]? = some c := by
-  rw [denseScanBoxV, denseBoxFoldV_eq] at h
+  rw [denseScanBoxV_eq, denseBoxFoldV_eq] at h
   have hne : denseScanStopV (some mask) = false := by
     rw [denseScanStopV, Bool.eq_false_iff]
     intro hall

--- a/docs/log.md
+++ b/docs/log.md
@@ -4391,3 +4391,18 @@ Maintainability pass; no runtime or proof-content change, effectiveness untouche
 
 **Worked: yes (−10 dead theorems; `lake build` warning-free; proof integrity green, correctness
 axioms `{propext, Classical.choice, Quot.sound}`-only).**
+
+### 123. Runtime: multiplicity-first domainBatch survivor loops
+
+The compiled domainBatch survivor predicate now traverses algebraic constraints and bus
+interactions with explicit recursive loops instead of allocating up to two `List.all` closures per box
+point. The bus loop evaluates multiplicity first; a zero multiplicity advances immediately without
+evaluating the payload or constructing a `BusInteraction`. The loops also compare directly with the
+hoisted zero value, removing the separately boxed per-target zero predicate and its per-value
+dispatch.
+
+Both loops have equality theorems back to the previous `List.all` predicates, preserving the exact
+survivor result and therefore the circuit output. The full build and proof-integrity checks pass.
+Generated C has direct recursive loops and `ZMod` equality calls, with payload mapping only in the
+nonzero branch. Runtime A/B is deferred to the draft PR's CI matrix. **Worked: implementation,
+proofs, and codegen yes; runtime result pending CI.**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4406,3 +4406,19 @@ survivor result and therefore the circuit output. The full build and proof-integ
 Generated C has direct recursive loops and `ZMod` equality calls, with payload mapping only in the
 nonzero branch. Runtime A/B is deferred to the draft PR's CI matrix. **Worked: implementation,
 proofs, and codegen yes; runtime result pending CI.**
+
+### 124. Runtime: specialized domainBatch box scan
+
+The forced-value box scan now traverses explicit and range domains with dedicated recursive loops
+instead of carrying generic step and stop callbacks through `denseBoxFoldV`. Reversing the domain
+list once preserves the previous point order while letting the traversal build each point by
+prepending values. The generated C contains direct calls throughout the scan, with no closure
+allocation or `lean_apply_*` dispatch in the domain traversal.
+
+The specialized traversal is proved equal to the previous early-stop fold, so optimizer output is
+unchanged. On SP1 keccak `apc_001`, two serial runs averaged 48.975 s in `domainBatch`, versus
+49.307 s for three runs of the survivor-loop implementation (0.67% faster); whole-run averages
+were 141.509 s and 141.505 s respectively, so the incremental end-to-end effect was noise. Against
+the exact `origin/main` parent in a fresh ABBA run, the combined changes reduced `domainBatch`
+52.345 s → 48.975 s (6.44%) and total time 145.092 s → 141.509 s (2.47%). The full build and proof
+integrity checks pass. **Worked: pass-level marginal; incremental whole-run neutral.**


### PR DESCRIPTION
## Summary

- replace the compiled survivor predicate's per-point `List.all` closures with explicit recursive constraint and bus loops
- evaluate each bus multiplicity before its payload, skipping payload evaluation, message construction, and semantic validation when multiplicity is zero
- specialize domain-box enumeration with direct explicit/range loops instead of the generic callback-based fold

## Correctness

The survivor loops and specialized scanner have equality theorems back to the previous implementations. The compiled survivor predicate therefore remains exactly equal to the existing uncompiled specification, so circuit output and effectiveness are unchanged.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated-C inspection confirms direct recursive survivor and scanner loops, no per-point survivor-list closures, and payload mapping only in the nonzero-multiplicity branch

On `Benchmarks/SP1/keccak/apc_001_pc0x78007bbc.json.gz`, an interleaved main/new/new/main run measured domainBatch at 52.345 s on main and 48.975 s here: 6.44% lower runtime (1.069x speedup). Whole-optimizer runtime fell from 145.092 s to 141.509 s: 2.47% lower (1.025x speedup). The scanner specialization alone was a smaller 0.67% domainBatch improvement and had no measurable whole-run effect; CI remains the deciding benchmark.
