### PR TITLE
Runtime: fuse domainBatch target planning

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -224,9 +224,9 @@ def DenseExpr.varsInF (xs : List VarId) : DenseExpr p → Bool
   | .add a b => a.varsInF xs && b.varsInF xs
   | .mul a b => a.varsInF xs && b.varsInF xs
 
-/-- Whether every variable of the bus interaction's multiplicity and payload lies in `xs`. -/
-def denseBIVarsInF (xs : List VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
-  bi.multiplicity.varsInF xs && bi.payload.all (fun e => e.varsInF xs)
+def denseVarsInListF (xs : List VarId) : List VarId → Bool
+  | [] => true
+  | v :: vs => denseContainsFast xs v && denseVarsInListF xs vs
 
 /-! ## Dense `biInformative` -/
 
@@ -257,15 +257,19 @@ def denseBuildStep {α : Type} (varsOf : α → List VarId) (ai : α × Nat) (id
 def denseCovBuild {α : Type} (varsOf : α → List VarId) (items : List α) : DenseCovIndex :=
   items.zipIdx.foldr (denseBuildStep varsOf) ⟨∅, []⟩
 
+/-- Build an index with each non-variable-less item stored under one anchor variable. -/
+def denseAnchorBuildStep {α : Type} (varsOf : α → List VarId) (ai : α × Nat)
+    (idx : DenseCovIndex) : DenseCovIndex :=
+  match varsOf ai.1 with
+  | [] => ⟨idx.buckets, ai.2 :: idx.varless⟩
+  | v :: _ => ⟨idx.buckets.insert v (ai.2 :: idx.buckets.getD v []), idx.varless⟩
+
+def denseAnchorCovBuild {α : Type} (varsOf : α → List VarId) (items : List α) : DenseCovIndex :=
+  items.zipIdx.foldr (denseAnchorBuildStep varsOf) ⟨∅, []⟩
+
 /-- The dense candidate positions for target `xs`. -/
 def denseCandidates (idx : DenseCovIndex) (xs : List VarId) : List Nat :=
   (xs.flatMap (fun v => idx.buckets.getD v [])) ++ idx.varless
-
-/-- The dense covered items for target `xs`, unordered. -/
-def denseCoveredIdxUnord {α : Type} (idx : DenseCovIndex) (arr : Array α) (Q : α → Bool)
-    (xs : List VarId) : List α :=
-  (((denseCandidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList).filterMap
-    (fun i => if h : i < arr.size then (if Q arr[i] then some arr[i] else none) else none)
 
 /-! ### `buildStep` bucket projection helpers -/
 
@@ -281,14 +285,25 @@ theorem denseBuildStep_buckets_cons {α : Type} (varsOf : α → List VarId) (ai
 
 /-! ### Dense `ForcedIdx` and its correspondence -/
 
+/-- A constraint and the target-planning data reused by every enumeration. -/
+structure DenseConstraintPlan (p : ℕ) where
+  expr : DenseExpr p
+  vars : List VarId
+  active : Bool
+
+/-- A bus interaction and the target-planning data reused by every enumeration. -/
+structure DenseBusPlan (p : ℕ) where
+  interaction : BusInteraction (DenseExpr p)
+  vars : List VarId
+  usable : Bool
+  informative : Bool
+
 /-- The per-target index bundle (plain data; correctness via correspondence). -/
 structure DenseForcedIdx (p : ℕ) where
   csIdx : DenseCovIndex
-  arrCs : Array (DenseExpr p)
+  arrCs : Array (DenseConstraintPlan p)
   bisIdx : DenseCovIndex
-  arrBis : Array (BusInteraction (DenseExpr p))
-  activeIdx : DenseCovIndex
-  arrActive : Array (DenseExpr p)
+  arrBis : Array (DenseBusPlan p)
 
 /-- The dense domain-table `doms` list has keys `xs`. -/
 theorem DenseDomainTable.doms_fst (T : DenseDomainTable p) :
@@ -310,31 +325,6 @@ theorem DenseDomainTable.doms_fst (T : DenseDomainTable p) :
               simp only [Option.some.injEq] at h
               subst h
               simp [ih ds' hr]
-
-/-! ### Dense covered-index soundness (membership of an enumerated item is a real covered item) -/
-
-theorem denseCoveredIdxUnord_mem {α : Type} (idx : DenseCovIndex) (arr : Array α) (Q : α → Bool)
-    (xs : List VarId) {e : α} (he : e ∈ denseCoveredIdxUnord idx arr Q xs) :
-    ∃ i, ∃ _h : i < arr.size, arr[i] = e ∧ Q e = true := by
-  rw [denseCoveredIdxUnord, List.mem_filterMap] at he
-  obtain ⟨i, _hi, hfe⟩ := he
-  by_cases h : i < arr.size
-  · rw [dif_pos h] at hfe
-    by_cases hq : Q arr[i]
-    · rw [if_pos hq] at hfe
-      have hei : arr[i] = e := Option.some.inj hfe
-      exact ⟨i, h, hei, by rw [← hei]; exact hq⟩
-    · rw [if_neg hq] at hfe; exact absurd hfe (by simp)
-  · rw [dif_neg h] at hfe; exact absurd hfe (by simp)
-
-theorem denseCoveredIdxUnord_mem_of_eq {α : Type} (idx : DenseCovIndex) (l : List α) (arr : Array α)
-    (harr : arr = l.toArray) (Q : α → Bool) (xs : List VarId)
-    {e : α} (he : e ∈ denseCoveredIdxUnord idx arr Q xs) : e ∈ l ∧ Q e = true := by
-  subst harr
-  obtain ⟨i, hi, hei, hq⟩ := denseCoveredIdxUnord_mem idx l.toArray Q xs he
-  subst hei
-  have hi' : i < l.length := by simpa using hi
-  exact ⟨by simp [l.getElem_mem hi'], hq⟩
 
 /-- Canonical dedup key of a variable set: the sorted, duplicate-free `List VarId`, so the key is
     invariant under the order and multiplicity of `xs` and distinct variables never collide. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -160,24 +160,65 @@ def denseConstraintRedundantV (T : DenseDomainTable p) (c : DenseExpr p) : Bool 
 
 /-! ## `forcedOver`, value-only -/
 
+structure DenseConstraintGatherV (p : ℕ) where
+  fullCount : Nat
+  active : List (DenseExpr p)
+
+def denseGatherConstraintsLoopV (arr : Array (DenseConstraintPlan p)) (xs : List VarId) :
+    List Nat → DenseConstraintGatherV p → DenseConstraintGatherV p
+  | [], acc => acc
+  | i :: rest, acc =>
+    if h : i < arr.size then
+      let plan := arr[i]
+      if denseVarsInListF xs plan.vars then
+        denseGatherConstraintsLoopV arr xs rest
+          { fullCount := acc.fullCount + 1,
+            active := if plan.active then plan.expr :: acc.active else acc.active }
+      else denseGatherConstraintsLoopV arr xs rest acc
+    else denseGatherConstraintsLoopV arr xs rest acc
+
+def denseGatherConstraintsV (fidx : DenseForcedIdx p) (xs : List VarId) :
+    DenseConstraintGatherV p :=
+  denseGatherConstraintsLoopV fidx.arrCs xs (denseCandidates fidx.csIdx xs) ⟨0, []⟩
+
+structure DenseBusGatherV (p : ℕ) where
+  count : Nat
+  informative : Bool
+  interactions : List (BusInteraction (DenseExpr p))
+
+def denseGatherBusesLoopV (arr : Array (DenseBusPlan p)) (xs : List VarId) :
+    List Nat → DenseBusGatherV p → DenseBusGatherV p
+  | [], acc => acc
+  | i :: rest, acc =>
+    if h : i < arr.size then
+      let plan := arr[i]
+      if plan.usable && denseVarsInListF xs plan.vars then
+        denseGatherBusesLoopV arr xs rest
+          { count := acc.count + 1,
+            informative := acc.informative || plan.informative,
+            interactions := plan.interaction :: acc.interactions }
+      else denseGatherBusesLoopV arr xs rest acc
+    else denseGatherBusesLoopV arr xs rest acc
+
+def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGatherV p :=
+  denseGatherBusesLoopV fidx.arrBis xs (denseCandidates fidx.bisIdx xs) ⟨0, false, []⟩
+
 /-- All checked forced constants over the variable set `xs`. `keys` drives the compiler and the
     final zip; the unkeyed `doms` drives the value-only scan. -/
-def denseForcedOverV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomainTable p)
+def denseForcedOverV (bs : BusSemantics p) (_facts : BusFacts p bs) (T : DenseDomainTable p)
     (fidx : DenseForcedIdx p) (xs : List VarId) : List (VarId × ZMod p) :=
   match T.doms xs with
   | none => []
   | some fdoms =>
     let boxSize := (fdoms.map (fun yd => yd.2.size)).prod
     if boxSize ≤ maxEnumSize then
-      let esFull := denseCoveredIdxUnord fidx.csIdx fidx.arrCs (fun c => c.varsInF xs) xs
-      let bis := denseCoveredIdxUnord fidx.bisIdx fidx.arrBis
-        (fun bi => denseBIVarsInF xs bi && !bs.isStateful bi.busId) xs
-      let es := denseCoveredIdxUnord fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs
-      let informative := !esFull.isEmpty || bis.any (denseBiInformative bs facts)
-      if informative && boxSize * (esFull.length + bis.length) ≤ maxEnumWork then
+      let cs := denseGatherConstraintsV fidx xs
+      let bis := denseGatherBusesV fidx xs
+      let informative := cs.fullCount != 0 || bis.informative
+      if informative && boxSize * (cs.fullCount + bis.count) ≤ maxEnumWork then
         let keys := fdoms.map Prod.fst
         let doms := fdoms.map Prod.snd
-        let survC := denseCompiledSurvV bs es bis keys
+        let survC := denseCompiledSurvV bs cs.active bis.interactions keys
         match denseScanBoxV survC.run doms with
         | none =>
           -- no surviving point: the box has no solutions, so everything is vacuously forced
@@ -228,6 +269,33 @@ def denseCollectForcedV (bs : BusSemantics p) (facts : BusFacts p bs)
 
 /-! ## The pass transform, value-only -/
 
+def denseConstraintPlansV (T : DenseDomainTable p) (cs : List (DenseExpr p)) :
+    List (DenseConstraintPlan p) :=
+  cs.map fun c =>
+    { expr := c,
+      vars := HashedDedup.hashedDedup (hash ·) c.vars,
+      active := !denseConstraintRedundantV T c }
+
+def denseBusPlansV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) : List (DenseBusPlan p) :=
+  bis.map fun bi =>
+    let usable := !bs.isStateful bi.busId
+    { interaction := bi,
+      vars := HashedDedup.hashedDedup (hash ·) (denseBIVars bi),
+      usable,
+      informative := usable && denseBiInformative bs facts bi }
+
+def densePlanTargetsV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
+    List (List VarId) :=
+  cs.map (fun c => c.vars) ++ bis.map (fun bi => bi.vars)
+
+def denseForcedIdxV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
+    DenseForcedIdx p :=
+  { csIdx := denseAnchorCovBuild (fun c => c.vars) cs,
+    arrCs := cs.toArray,
+    bisIdx := denseAnchorCovBuild (fun bi => bi.vars) bis,
+    arrBis := bis.toArray }
+
 /-- Domain-batch: builds a finite domain per variable (from constraints like `x*(x-1)=0` giving
     `x ∈ {0,1}`, and from bus range checks), enumerates the small Cartesian product of those
     domains, and for each variable that takes the same value in every surviving assignment infers
@@ -237,16 +305,10 @@ def denseDomainBatchσV (bs : BusSemantics p) (facts : BusFacts p bs)
   let T : DenseDomainTable p :=
     denseAddBusDoms bs facts d.busInteractions
       (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty)
-  let targets := d.algebraicConstraints.map (fun e => HashedDedup.hashedDedup (hash ·) e.vars) ++
-    d.busInteractions.map (fun bi => HashedDedup.hashedDedup (hash ·) (denseBIVars bi))
-  let activeCs := d.algebraicConstraints.filter (fun c => !denseConstraintRedundantV T c)
-  let fidx : DenseForcedIdx p :=
-    { csIdx := denseCovBuild DenseExpr.vars d.algebraicConstraints,
-      arrCs := d.algebraicConstraints.toArray,
-      bisIdx := denseCovBuild denseBIVars d.busInteractions,
-      arrBis := d.busInteractions.toArray,
-      activeIdx := denseCovBuild DenseExpr.vars activeCs,
-      arrActive := activeCs.toArray }
+  let csPlans := denseConstraintPlansV T d.algebraicConstraints
+  let busPlans := denseBusPlansV bs facts d.busInteractions
+  let targets := densePlanTargetsV csPlans busPlans
+  let fidx := denseForcedIdxV csPlans busPlans
   -- Fan out only at keccak/SHA scale; below it the sequential fold avoids spawn overhead.
   denseCollectForcedV bs facts T fidx (8192 ≤ d.algebraicConstraints.length) targets ∅
     DenseSolved.empty

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -929,15 +929,113 @@ theorem mem_zip_filterMap {α : Type} (keys : List α) (cands : DenseCandsV p) (
           · obtain ⟨n, hn1, hn2⟩ := ih ocs hf'
             exact ⟨n + 1, by simpa using hn1, by simpa using hn2⟩
 
+theorem denseGatherConstraintsLoopV_active_mem (arr : Array (DenseConstraintPlan p))
+    (xs : List VarId) (candidates : List Nat) (acc : DenseConstraintGatherV p)
+    (hacc : ∀ e ∈ acc.active, ∃ i, ∃ h : i < arr.size,
+      arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true) :
+    ∀ e ∈ (denseGatherConstraintsLoopV arr xs candidates acc).active,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true := by
+  induction candidates generalizing acc with
+  | nil => simpa [denseGatherConstraintsLoopV] using hacc
+  | cons i rest ih =>
+      by_cases hi : i < arr.size
+      · by_cases hvars : denseVarsInListF xs arr[i].vars = true
+        · simp only [denseGatherConstraintsLoopV, hi, ↓reduceDIte, hvars, ↓reduceIte]
+          apply ih
+          intro e he
+          by_cases hactive : arr[i].active = true
+          · simp only [hactive, ↓reduceIte] at he
+            rcases List.mem_cons.1 he with he | he
+            · subst e; exact ⟨i, hi, rfl, hvars, hactive⟩
+            · exact hacc e he
+          · simp [hactive] at he
+            exact hacc e he
+        · simpa [denseGatherConstraintsLoopV, hi, hvars] using ih acc hacc
+      · simpa [denseGatherConstraintsLoopV, hi] using ih acc hacc
+
+theorem denseGatherConstraintsV_active_mem (fidx : DenseForcedIdx p) (xs : List VarId)
+    {e : DenseExpr p} (he : e ∈ (denseGatherConstraintsV fidx xs).active) :
+    ∃ i, ∃ h : i < fidx.arrCs.size,
+      fidx.arrCs[i].expr = e ∧ denseVarsInListF xs fidx.arrCs[i].vars = true ∧
+        fidx.arrCs[i].active = true := by
+  apply denseGatherConstraintsLoopV_active_mem fidx.arrCs xs (denseCandidates fidx.csIdx xs)
+    ⟨0, []⟩ (by simp) e
+  exact he
+
+theorem denseGatherConstraintsV_plan_mem (fidx : DenseForcedIdx p)
+    (plans : List (DenseConstraintPlan p)) (harr : fidx.arrCs = plans.toArray)
+    (xs : List VarId) {e : DenseExpr p} (he : e ∈ (denseGatherConstraintsV fidx xs).active) :
+    ∃ plan ∈ plans, plan.expr = e ∧ denseVarsInListF xs plan.vars = true ∧
+      plan.active = true := by
+  obtain ⟨i, hi, hie, hvars, hactive⟩ := denseGatherConstraintsV_active_mem fidx xs he
+  let plan := fidx.arrCs[i]
+  have hmemA : plan ∈ fidx.arrCs := by
+    simp [plan]
+  have hmem : plan ∈ plans := by
+    rw [harr] at hmemA
+    simpa using hmemA
+  exact ⟨plan, hmem, by simpa [plan] using hie, by simpa [plan] using hvars,
+    by simpa [plan] using hactive⟩
+
+theorem denseGatherBusesLoopV_interactions_mem (arr : Array (DenseBusPlan p))
+    (xs : List VarId) (candidates : List Nat) (acc : DenseBusGatherV p)
+    (hacc : ∀ bi ∈ acc.interactions, ∃ i, ∃ h : i < arr.size,
+      arr[i].interaction = bi ∧ arr[i].usable = true ∧
+        denseVarsInListF xs arr[i].vars = true) :
+    ∀ bi ∈ (denseGatherBusesLoopV arr xs candidates acc).interactions,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].interaction = bi ∧ arr[i].usable = true ∧
+          denseVarsInListF xs arr[i].vars = true := by
+  induction candidates generalizing acc with
+  | nil => simpa [denseGatherBusesLoopV] using hacc
+  | cons i rest ih =>
+      by_cases hi : i < arr.size
+      · by_cases husable : arr[i].usable = true
+        · by_cases hvars : denseVarsInListF xs arr[i].vars = true
+          · simp only [denseGatherBusesLoopV, hi, ↓reduceDIte, husable, hvars,
+              Bool.and_self, ↓reduceIte]
+            apply ih
+            intro bi hbi
+            rcases List.mem_cons.1 hbi with hbi | hbi
+            · subst bi; exact ⟨i, hi, rfl, husable, hvars⟩
+            · exact hacc bi hbi
+          · simpa [denseGatherBusesLoopV, hi, husable, hvars] using ih acc hacc
+        · simpa [denseGatherBusesLoopV, hi, husable] using ih acc hacc
+      · simpa [denseGatherBusesLoopV, hi] using ih acc hacc
+
+theorem denseGatherBusesV_interactions_mem (fidx : DenseForcedIdx p) (xs : List VarId)
+    {bi : BusInteraction (DenseExpr p)} (hbi : bi ∈ (denseGatherBusesV fidx xs).interactions) :
+    ∃ i, ∃ h : i < fidx.arrBis.size,
+      fidx.arrBis[i].interaction = bi ∧ fidx.arrBis[i].usable = true ∧
+        denseVarsInListF xs fidx.arrBis[i].vars = true := by
+  apply denseGatherBusesLoopV_interactions_mem fidx.arrBis xs (denseCandidates fidx.bisIdx xs)
+    ⟨0, false, []⟩ (by simp) bi
+  exact hbi
+
+theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (DenseBusPlan p))
+    (harr : fidx.arrBis = plans.toArray) (xs : List VarId)
+    {bi : BusInteraction (DenseExpr p)} (hbi : bi ∈ (denseGatherBusesV fidx xs).interactions) :
+    ∃ plan ∈ plans, plan.interaction = bi ∧ plan.usable = true ∧
+      denseVarsInListF xs plan.vars = true := by
+  obtain ⟨i, hi, hbi', husable, hvars⟩ := denseGatherBusesV_interactions_mem fidx xs hbi
+  let plan := fidx.arrBis[i]
+  have hmemA : plan ∈ fidx.arrBis := by
+    simp [plan]
+  have hmem : plan ∈ plans := by
+    rw [harr] at hmemA
+    simpa using hmemA
+  exact ⟨plan, hmem, by simpa [plan] using hbi', by simpa [plan] using husable,
+    by simpa [plan] using hvars⟩
+
 /-- **Value-only `forcedOver` entailment.** Every forced pair `(x, c)` is entailed by `denv`, given
     the domain table is sound at `denv` and the covered items evaluate/oblige correctly. -/
 theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     (T : DenseDomainTable p) (fidx : DenseForcedIdx p) (xs : List VarId) (denv : VarId → ZMod p)
     (hTs : DenseTableSoundAt denv T)
-    (hes : ∀ e ∈ denseCoveredIdxUnord fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs,
+    (hes : ∀ e ∈ (denseGatherConstraintsV fidx xs).active,
       e.eval denv = 0 ∧ ∀ i ∈ e.vars, i ∈ xs)
-    (hbis : ∀ bi ∈ denseCoveredIdxUnord fidx.bisIdx fidx.arrBis
-        (fun bi => denseBIVarsInF xs bi && !bs.isStateful bi.busId) xs,
+    (hbis : ∀ bi ∈ (denseGatherBusesV fidx xs).interactions,
       ((denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false)
         ∧ ∀ i ∈ denseBIVars bi, i ∈ xs) :
     ∀ f ∈ denseForcedOverV bs facts T fidx xs, denv f.1 = f.2 := by
@@ -953,9 +1051,8 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     dsimp only
     split_ifs with hbox hwork
     · have hsurv : (denseCompiledSurvV bs
-          (denseCoveredIdxUnord fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs)
-          (denseCoveredIdxUnord fidx.bisIdx fidx.arrBis
-            (fun bi => denseBIVarsInF xs bi && !bs.isStateful bi.busId) xs)
+          (denseGatherConstraintsV fidx xs).active
+          (denseGatherBusesV fidx xs).interactions
           (fdoms.map Prod.fst)).run ((fdoms.map Prod.fst).map denv) = true := by
         apply denseCompiledSurvV_restriction
         · exact fun e he => (hes e he).1
@@ -963,9 +1060,8 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
         · intro e he i hi; rw [hkeys]; exact (hes e he).2 i hi
         · intro bi hbi i hi; rw [hkeys]; exact (hbis bi hbi).2 i hi
       cases hscan : denseScanBoxV (denseCompiledSurvV bs
-          (denseCoveredIdxUnord fidx.activeIdx fidx.arrActive (fun c => c.varsInF xs) xs)
-          (denseCoveredIdxUnord fidx.bisIdx fidx.arrBis
-            (fun bi => denseBIVarsInF xs bi && !bs.isStateful bi.busId) xs)
+          (denseGatherConstraintsV fidx xs).active
+          (denseGatherBusesV fidx xs).interactions
           (fdoms.map Prod.fst)).run (fdoms.map Prod.snd) with
       | none =>
           intro f hf
@@ -994,38 +1090,16 @@ theorem denseContainsFast_mem (xs : List VarId) (y : VarId) (h : denseContainsFa
       exact this ▸ List.mem_cons_self ..
     · exact List.mem_cons_of_mem _ (ih h)
 
-theorem denseExpr_varsInF_mem (xs : List VarId) :
-    ∀ (e : DenseExpr p), e.varsInF xs = true → ∀ i ∈ e.vars, i ∈ xs := by
-  intro e
-  induction e with
-  | const n => intro _ i hi; simp [DenseExpr.vars] at hi
-  | var y =>
-      intro h i hi
-      simp only [DenseExpr.vars, List.mem_singleton] at hi
-      rw [hi]; exact denseContainsFast_mem xs y h
-  | add a b iha ihb =>
-      intro h i hi
-      rw [DenseExpr.varsInF, Bool.and_eq_true] at h
-      simp only [DenseExpr.vars, List.mem_append] at hi
-      rcases hi with hi | hi
-      · exact iha h.1 i hi
-      · exact ihb h.2 i hi
-  | mul a b iha ihb =>
-      intro h i hi
-      rw [DenseExpr.varsInF, Bool.and_eq_true] at h
-      simp only [DenseExpr.vars, List.mem_append] at hi
-      rcases hi with hi | hi
-      · exact iha h.1 i hi
-      · exact ihb h.2 i hi
-
-theorem denseBIVarsInF_mem (xs : List VarId) (bi : BusInteraction (DenseExpr p))
-    (h : denseBIVarsInF xs bi = true) : ∀ i ∈ denseBIVars bi, i ∈ xs := by
-  rw [denseBIVarsInF, Bool.and_eq_true] at h
-  intro i hi
-  simp only [denseBIVars, List.mem_append, List.mem_flatMap] at hi
-  rcases hi with hi | ⟨e, he, hie⟩
-  · exact denseExpr_varsInF_mem xs bi.multiplicity h.1 i hi
-  · exact denseExpr_varsInF_mem xs e (List.all_eq_true.1 h.2 e he) i hie
+theorem denseVarsInListF_mem (xs vs : List VarId) (h : denseVarsInListF xs vs = true) :
+    ∀ i ∈ vs, i ∈ xs := by
+  induction vs with
+  | nil => intro i hi; simp at hi
+  | cons v rest ih =>
+      rw [denseVarsInListF, Bool.and_eq_true] at h
+      intro i hi
+      rcases List.mem_cons.mp hi with hi | hi
+      · subst i; exact denseContainsFast_mem xs _ h.1
+      · exact ih h.2 i hi
 
 /-! ## The entailment invariant on the collected solution map -/
 
@@ -1135,38 +1209,36 @@ def dbT (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem
   denseAddBusDoms bs facts d.busInteractions
     (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty)
 
-/-- The non-redundant active-constraint set built by `denseDomainBatchσV`. -/
-def dbActiveCs (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
-    List (DenseExpr p) :=
-  d.algebraicConstraints.filter (fun c => !denseConstraintRedundantV (dbT bs facts d) c)
+def dbConstraintPlans (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : List (DenseConstraintPlan p) :=
+  denseConstraintPlansV (dbT bs facts d) d.algebraicConstraints
+
+def dbBusPlans (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : List (DenseBusPlan p) :=
+  denseBusPlansV bs facts d.busInteractions
 
 /-- The target list built by `denseDomainBatchσV`. -/
-def dbTargets (d : DenseConstraintSystem p) : List (List VarId) :=
-  d.algebraicConstraints.map (fun e => HashedDedup.hashedDedup (hash ·) e.vars) ++
-    d.busInteractions.map (fun bi => HashedDedup.hashedDedup (hash ·) (denseBIVars bi))
+def dbTargets (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : List (List VarId) :=
+  densePlanTargetsV (dbConstraintPlans bs facts d) (dbBusPlans bs facts d)
 
 /-- The inverted index built by `denseDomainBatchσV`. -/
 def dbFidx (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseForcedIdx p :=
-  { csIdx := denseCovBuild DenseExpr.vars d.algebraicConstraints,
-    arrCs := d.algebraicConstraints.toArray,
-    bisIdx := denseCovBuild denseBIVars d.busInteractions,
-    arrBis := d.busInteractions.toArray,
-    activeIdx := denseCovBuild DenseExpr.vars (dbActiveCs bs facts d),
-    arrActive := (dbActiveCs bs facts d).toArray }
+  denseForcedIdxV (dbConstraintPlans bs facts d) (dbBusPlans bs facts d)
 
 theorem denseDomainBatchσV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     denseDomainBatchσV bs facts d
       = denseCollectForcedV bs facts (dbT bs facts d) (dbFidx bs facts d)
-          (8192 ≤ d.algebraicConstraints.length) (dbTargets d) ∅ DenseSolved.empty := rfl
+          (8192 ≤ d.algebraicConstraints.length) (dbTargets bs facts d) ∅ DenseSolved.empty := rfl
 
 theorem denseDomainBatchσV_entailed [Fact p.Prime] [NeZero p]
     (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     EntailedMap d bs (denseDomainBatchσV bs facts d).map := by
   rw [denseDomainBatchσV_eq]
   refine denseCollectForcedV_entailed bs facts (dbT bs facts d) (dbFidx bs facts d) d
-    ?hforced (8192 ≤ d.algebraicConstraints.length) (dbTargets d) ∅ DenseSolved.empty ?hbase
+    ?hforced (8192 ≤ d.algebraicConstraints.length) (dbTargets bs facts d) ∅ DenseSolved.empty ?hbase
   case hbase =>
     intro i t h
     rw [DenseSolved.empty, Std.HashMap.getElem?_empty] at h
@@ -1177,15 +1249,30 @@ theorem denseDomainBatchσV_entailed [Fact p.Prime] [NeZero p]
       ?_ ?_ ?_ f hf
     · exact denseDomainTable_soundAt bs facts d denv hsat
     · intro e he
-      obtain ⟨hmem, hQ⟩ := denseCoveredIdxUnord_mem_of_eq (dbFidx bs facts d).activeIdx
-        (dbActiveCs bs facts d) (dbFidx bs facts d).arrActive rfl (fun c => c.varsInF xs) xs he
-      exact ⟨hsat.1 e (List.mem_of_mem_filter hmem), denseExpr_varsInF_mem xs e hQ⟩
+      obtain ⟨plan, hplan, hpe, hpvars, _⟩ := denseGatherConstraintsV_plan_mem
+        (dbFidx bs facts d) (dbConstraintPlans bs facts d) rfl xs he
+      rw [dbConstraintPlans, denseConstraintPlansV] at hplan
+      obtain ⟨c, hc, rfl⟩ := List.mem_map.mp hplan
+      simp only at hpe hpvars
+      subst e
+      refine ⟨hsat.1 c hc, ?_⟩
+      intro i hi
+      apply denseVarsInListF_mem xs (HashedDedup.hashedDedup (hash ·) c.vars) hpvars i
+      rw [HashedDedup.hashedDedup_eq]
+      simpa using hi
     · intro bi hbi
-      obtain ⟨hmem, hQ⟩ := denseCoveredIdxUnord_mem_of_eq (dbFidx bs facts d).bisIdx
-        d.busInteractions (dbFidx bs facts d).arrBis rfl
-        (fun bi => denseBIVarsInF xs bi && !bs.isStateful bi.busId) xs hbi
-      rw [Bool.and_eq_true] at hQ
-      exact ⟨hsat.2 bi hmem, denseBIVarsInF_mem xs bi hQ.1⟩
+      obtain ⟨plan, hplan, hpbi, _, hpvars⟩ := denseGatherBusesV_plan_mem
+        (dbFidx bs facts d) (dbBusPlans bs facts d) rfl xs hbi
+      rw [dbBusPlans, denseBusPlansV] at hplan
+      obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.mp hplan
+      simp only at hpbi hpvars
+      subst bi
+      refine ⟨hsat.2 bi0 hbi0, ?_⟩
+      intro i hi
+      apply denseVarsInListF_mem xs
+        (HashedDedup.hashedDedup (hash ·) (denseBIVars bi0)) hpvars i
+      rw [HashedDedup.hashedDedup_eq]
+      simpa using hi
 
 /-! ## The value-only domain-batch pass -/
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -4473,3 +4473,28 @@ future pass: `denseXorEq?`/`denseBoolEq?` (XorEqExtract) and `denseIdentityPairA
 (IdentitySubst) could share the classifier's shape dispatch but keep bespoke conclusions
 (entailed equality / var-equality); the seqz build-and-compare path shares only the encode
 layout and should stay put.
+
+### 128. Runtime: anchor-indexed domainBatch planning and fused gathers
+
+domainBatch now builds one reusable plan per constraint and bus interaction. Each plan caches its
+deduplicated variable scope and the active/stateless/informative decisions that were previously
+recomputed or represented by separate indices. Constraints and interactions are indexed under one
+anchor variable: any item covered by a target necessarily has that anchor in the target, so the
+per-target candidate stream needs neither duplicate bucket entries nor a position `HashSet`.
+
+Two direct tail-recursive gathers replace the three generic `denseCoveredIdxUnord` traversals. The
+constraint gather computes the full covered count and active expression list together; the bus
+gather computes the covered count, informative bit, and interaction list together. A direct scope
+predicate also avoids allocating a `List.all` closure for each candidate. The soundness proof traces
+every gathered item through its plan-array position to an original constraint or interaction and
+proves that its cached deduplicated scope contains every actual variable. The planner remains plain
+untrusted data.
+
+On `SP1/keccak/apc_001_pc0x78007bbc`, two runs averaged 34.079 s in domainBatch versus a same-session
+`origin/main` average of 52.345 s: **34.90% lower runtime (1.536x speedup)**. Whole-optimizer time
+averaged 127.568 s versus 145.092 s: **12.08% lower (1.137x speedup)**. Every run used five cleanup
+iterations and finished at the same 2773 variables, 2370 bus interactions, and 313 constraints.
+`lake build` is warning-free, generated C uses direct gather loops without per-candidate scope
+closures, and the proof-integrity and unused-theorem checks pass.
+
+**Worked: yes (effectiveness unchanged on the measured case; large domainBatch runtime win).**


### PR DESCRIPTION
## Summary

- precompute one reusable plan per constraint and bus interaction, including its deduplicated variable scope and active/stateless/informative decisions
- index every item under one anchor variable, eliminating duplicate postings and the per-target position `HashSet`
- gather constraint counts/active expressions and bus counts/informative state/interactions in two direct tail-recursive scans
- reuse the planned scopes as enumeration targets and evaluate them with a direct closure-free loop

## Correctness

The planner and indices remain untrusted data. The proof traces every gathered item through its checked array position to an original constraint or interaction, then proves that its cached deduplicated scope contains every variable of that original item before using it in the survivor argument. The audited specification is unchanged.

## Validation

- `lake build` (warning-free)
- `Scripts/check-proof-integrity.sh`
- generated-C inspection confirms direct gather loops and no per-candidate scope closure or position-set construction on the domainBatch path
- all measured runs retained five cleanup iterations and the same final size: 2773 variables, 2370 bus interactions, 313 constraints

On `Benchmarks/SP1/keccak/apc_001_pc0x78007bbc.json.gz`, two runs averaged 34.079 s in domainBatch versus a same-session `origin/main` average of 52.345 s: **34.90% lower runtime (1.536x speedup)**. Whole-optimizer time averaged 127.568 s versus 145.092 s: **12.08% lower (1.137x speedup)**.
