### PR TITLE
Runtime: reverse Gauss sweeps to avoid fill-in

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -509,25 +509,26 @@ theorem denseTrySolveUnit_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarI
 
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
     assignment `x := 2*y + 3` and substitutes it everywhere, dropping `x`. The cheapest solvable
-    pivot is chosen per constraint over two sweeps, then the whole solution map is substituted
-    through the system in one pass. -/
+    pivot is chosen per constraint over two reverse-order sweeps, then the whole solution map is
+    substituted through the system in one pass. -/
 def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   let occ := denseOccurrenceMap d
   let prot := denseProtectedVars d bs
-  let first := denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty
+  let pending := d.algebraicConstraints.reverse
+  let first := denseGaussLoop occ prot pending DenseSolved.empty
   if first.map.isEmpty then d
-  else d.substF (denseGaussLoop occ prot d.algebraicConstraints first).fn
+  else d.substF (denseGaussLoop occ prot pending first).fn
 
 /-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
 theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     denseGaussElim bs d =
       if (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints DenseSolved.empty).map.isEmpty
+          d.algebraicConstraints.reverse DenseSolved.empty).map.isEmpty
       then d
       else d.substF (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints
+          d.algebraicConstraints.reverse
           (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-            d.algebraicConstraints DenseSolved.empty)).fn := rfl
+            d.algebraicConstraints.reverse DenseSolved.empty)).fn := rfl
 
 /-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -201,24 +201,24 @@ theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
 theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
         (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints
+          d.algebraicConstraints.reverse
           (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-            d.algebraicConstraints DenseSolved.empty)).fn i = some t →
+            d.algebraicConstraints.reverse DenseSolved.empty)).fn i = some t →
           denv i = t.eval denv) ∧
     (∀ i t, (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-        d.algebraicConstraints
+        d.algebraicConstraints.reverse
         (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints DenseSolved.empty)).fn i = some t →
+          d.algebraicConstraints.reverse DenseSolved.empty)).fn i = some t →
         ∀ z ∈ t.vars, z ∈ d.occ) := by
   have hfirst := denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
-    d.algebraicConstraints DenseSolved.empty (fun _c hc => hc)
+    d.algebraicConstraints.reverse DenseSolved.empty (fun _c hc => by simpa using hc)
     (fun _ _ _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
     (fun _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
   exact denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
-    d.algebraicConstraints
+    d.algebraicConstraints.reverse
     (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-      d.algebraicConstraints DenseSolved.empty)
-    (fun _c hc => hc) hfirst.1 hfirst.2
+      d.algebraicConstraints.reverse DenseSolved.empty)
+    (fun _c hc => by simpa using hc) hfirst.1 hfirst.2
 
 /-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
     occurrence-closed solution map, whose solutions are covered because their variables occur in a

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -245,6 +245,9 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      empty first solution map returns immediately, while productive runs retain both sweeps;
      occurrence and reverse-dependency construction fold expression leaves directly without
      building `DenseExpr.vars` and its append chains.
+   - ~~gauss constraint ordering~~ **done locally (entry 129)**: both sweeps visit constraints in
+     reverse source order, avoiding a large transient fill-in cascade on wasm-eth apc_036. Corpus
+     CI must still determine whether a fixed reverse order is a robust heuristic.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/log.md
+++ b/docs/log.md
@@ -4498,3 +4498,21 @@ iterations and finished at the same 2773 variables, 2370 bus interactions, and 3
 closures, and the proof-integrity and unused-theorem checks pass.
 
 **Worked: yes (effectiveness unchanged on the measured case; large domainBatch runtime win).**
+
+### 129. Runtime: reverse Gauss sweeps to avoid transient fill-in
+
+Gauss now visits algebraic constraints in reverse order during both elimination sweeps. Sweep order
+does not affect soundness: `denseGaussLoop_sound` only requires every pending constraint to belong
+to the input system, which follows directly through `List.reverse`. It does affect the elimination
+path and therefore the size of intermediate solution expressions.
+
+On `OpenVM/wasm-eth/apc_036_pc0x224240`, forward order built 111,005 live solution terms before a
+late 500-pivot block rewrote 60,976 older rows over 14.35 million input terms. Reverse order reaches
+the bridge variables first and avoids that transient fill-in. Two local full-pipeline profiles took
+46.944 s and 46.727 s, with Gauss at 3.748 s and 3.760 s, versus a representative `origin/main`
+profile of 84.826 s total and 42.064 s in Gauss: about **91% less Gauss time (11.2x)** and **45%
+less whole-optimizer time (1.81x)**. All runs used eight cleanup iterations, every reported cycle
+size matched, and the final size remained 1954 variables / 1201 bus interactions / 1895
+constraints. Full-set CI will determine whether the reverse-order heuristic generalizes.
+
+**Worked locally: yes (effectiveness unchanged on the measured case; corpus evaluation pending).**


### PR DESCRIPTION
## Summary

- run both Gauss elimination sweeps in reverse algebraic-constraint order
- adapt the Gauss loop invariant proof using membership preservation under `List.reverse`
- record the local runtime experiment and leave corpus effectiveness to CI

## Why

Gauss elimination order controls transient fill-in. On `OpenVM/wasm-eth/apc_036_pc0x224240`, forward order grew the solution map to 111,005 terms before a late 500-pivot block rewrote 60,976 older rows over 14.35 million input terms. Reversing the sweep reaches those bridge variables first and avoids the rewrite cascade.

## Local impact

Two full reverse-order profiles:

- whole optimizer: 46.944 s and 46.727 s, versus 84.826 s on `origin/main`
- Gauss: 3.748 s and 3.760 s, versus 42.064 s
- about 91% less Gauss time (11.2x) and 45% less end-to-end time (1.81x)
- eight cleanup iterations in every run
- every reported cycle size matched; final size remained 1954 variables / 1201 bus interactions / 1895 constraints

The full benchmark CI should determine whether fixed reverse order preserves or improves effectiveness and runtime across all benchmark families.

## Validation

- `lake build`
- `./Scripts/check-proof-integrity.sh`
- two complete local `profile` runs on wasm-eth apc_036
