### PR TITLE
Runtime: skip domainBatch no-filter boxes

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -297,6 +297,7 @@ structure DenseBusPlan (p : ℕ) where
   vars : List VarId
   usable : Bool
   informative : Bool
+  domainRedundant : Bool
 
 /-- The per-target index bundle (plain data; correctness via correspondence). -/
 structure DenseForcedIdx (p : ℕ) where

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -158,6 +158,86 @@ def denseConstraintRedundantV (T : DenseDomainTable p) (c : DenseExpr p) : Bool 
         denseAllBoxV (fun a => decide (c.eval (denseEnvOfKeysV (d.map Prod.fst) a) = 0))
           (d.map Prod.snd)
 
+def denseDomainBelowV (d : FiniteDomain p) (bound : Nat) : Bool :=
+  match d with
+  | .explicit vs => vs.all (fun v => decide (v.val < bound))
+  | .range size => decide (size ≤ bound)
+
+def denseExprDomainBelowV (T : DenseDomainTable p) (e : DenseExpr p) (bound : Nat) : Bool :=
+  match e.constValue? with
+  | some c => decide (c.val < bound)
+  | none =>
+    match e with
+    | .var i => match T.map[i]? with | some d => denseDomainBelowV d bound | none => false
+    | _ => false
+
+def denseRangeCheckDomainRedundantV {bs : BusSemantics p} (facts : BusFacts p bs)
+    (T : DenseDomainTable p)
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
+  match bi.multiplicity.constValue? with
+  | some mult =>
+    if mult = 0 then true
+    else if mult = 1 then
+      match facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+      | some (slot, bound) =>
+        match bi.payload[slot]? with
+        | some e => denseExprDomainBelowV T e bound
+        | none => false
+      | none => false
+    else false
+  | none => false
+
+def denseConstBiV? (bi : BusInteraction (DenseExpr p)) : Option (BusInteraction (ZMod p)) := do
+  let mult ← bi.multiplicity.constValue?
+  let payload ← bi.payload.mapM DenseExpr.constValue?
+  pure { busId := bi.busId, multiplicity := mult, payload }
+
+def denseBytePairDomainRedundantV {bs : BusSemantics p} (facts : BusFacts p bs)
+    (T : DenseDomainTable p) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  match facts.byteXorSpec bi.busId with
+  | none => false
+  | some spec =>
+    match spec.decode bi.payload with
+    | none => false
+    | some (op, o1, o2, result) =>
+      match op.constValue?, result.constValue? with
+      | some opValue, some resultValue =>
+        opValue = spec.pairOp && resultValue = 0 &&
+          denseExprDomainBelowV T o1 spec.bound && denseExprDomainBelowV T o2 spec.bound
+      | _, _ => false
+
+def denseBiDomainRedundantV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomainTable p)
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
+  match denseConstBiV? bi with
+  | some value => value.multiplicity = 0 || !bs.violatesConstraint value
+  | none =>
+    if facts.neverViolates bi.busId then true
+    else
+      match bi.payload with
+      | [x, b] =>
+        if facts.varRangeBus bi.busId then
+          match b.constValue? with
+          | some width =>
+            if width.val ≤ 17 then denseExprDomainBelowV T x (2 ^ width.val) else false
+          | none => false
+        else
+          match facts.tupleRangeBus bi.busId with
+          | some (boundX, boundB) =>
+            denseExprDomainBelowV T x boundX && denseExprDomainBelowV T b boundB
+          | none => denseRangeCheckDomainRedundantV facts T bi ||
+              denseBytePairDomainRedundantV facts T bi
+      | _ => denseRangeCheckDomainRedundantV facts T bi ||
+          denseBytePairDomainRedundantV facts T bi
+
+def denseDomainConstantValueV? (d : FiniteDomain p) : Option (ZMod p) :=
+  match d with
+  | .explicit [] => none
+  | .explicit (v :: vs) => if vs.all (fun w => decide (w = v)) then some v else none
+  | .range size => if size = 1 then some 0 else none
+
+def denseConstantDomainsV (fdoms : List (VarId × FiniteDomain p)) : List (VarId × ZMod p) :=
+  fdoms.filterMap fun xd => (denseDomainConstantValueV? xd.2).map (fun c => (xd.1, c))
+
 /-! ## `forcedOver`, value-only -/
 
 structure DenseConstraintGatherV (p : ℕ) where
@@ -184,6 +264,7 @@ def denseGatherConstraintsV (fidx : DenseForcedIdx p) (xs : List VarId) :
 structure DenseBusGatherV (p : ℕ) where
   count : Nat
   informative : Bool
+  allDomainRedundant : Bool
   interactions : List (BusInteraction (DenseExpr p))
 
 def denseGatherBusesLoopV (arr : Array (DenseBusPlan p)) (xs : List VarId) :
@@ -196,12 +277,13 @@ def denseGatherBusesLoopV (arr : Array (DenseBusPlan p)) (xs : List VarId) :
         denseGatherBusesLoopV arr xs rest
           { count := acc.count + 1,
             informative := acc.informative || plan.informative,
+            allDomainRedundant := acc.allDomainRedundant && plan.domainRedundant,
             interactions := plan.interaction :: acc.interactions }
       else denseGatherBusesLoopV arr xs rest acc
     else denseGatherBusesLoopV arr xs rest acc
 
 def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGatherV p :=
-  denseGatherBusesLoopV fidx.arrBis xs (denseCandidates fidx.bisIdx xs) ⟨0, false, []⟩
+  denseGatherBusesLoopV fidx.arrBis xs (denseCandidates fidx.bisIdx xs) ⟨0, false, true, []⟩
 
 /-- All checked forced constants over the variable set `xs`. `keys` drives the compiler and the
     final zip; the unkeyed `doms` drives the value-only scan. -/
@@ -218,14 +300,18 @@ def denseForcedOverV (bs : BusSemantics p) (_facts : BusFacts p bs) (T : DenseDo
       if informative && boxSize * (cs.fullCount + bis.count) ≤ maxEnumWork then
         let keys := fdoms.map Prod.fst
         let doms := fdoms.map Prod.snd
-        let survC := denseCompiledSurvV bs cs.active bis.interactions keys
-        match denseScanBoxV survC.run doms with
-        | none =>
-          -- no surviving point: the box has no solutions, so everything is vacuously forced
-          keys.map (fun x => (x, (0 : ZMod p)))
-        | some cands =>
-          -- recover the forced `(x, c)` pairs by zipping the mask with `keys` once, at the end
-          (keys.zip cands).filterMap (fun xc => xc.2.map (fun c => (xc.1, c)))
+        if cs.active.isEmpty && bis.allDomainRedundant &&
+            doms.all (fun d => d.size != 0) then
+          denseConstantDomainsV fdoms
+        else
+          let survC := denseCompiledSurvV bs cs.active bis.interactions keys
+          match denseScanBoxV survC.run doms with
+          | none =>
+            -- no surviving point: the box has no solutions, so everything is vacuously forced
+            keys.map (fun x => (x, (0 : ZMod p)))
+          | some cands =>
+            -- recover the forced `(x, c)` pairs by zipping the mask with `keys` once, at the end
+            (keys.zip cands).filterMap (fun xc => xc.2.map (fun c => (xc.1, c)))
       else []
     else []
 
@@ -276,14 +362,15 @@ def denseConstraintPlansV (T : DenseDomainTable p) (cs : List (DenseExpr p)) :
       vars := HashedDedup.hashedDedup (hash ·) c.vars,
       active := !denseConstraintRedundantV T c }
 
-def denseBusPlansV (bs : BusSemantics p) (facts : BusFacts p bs)
+def denseBusPlansV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomainTable p)
     (bis : List (BusInteraction (DenseExpr p))) : List (DenseBusPlan p) :=
   bis.map fun bi =>
     let usable := !bs.isStateful bi.busId
     { interaction := bi,
       vars := HashedDedup.hashedDedup (hash ·) (denseBIVars bi),
       usable,
-      informative := usable && denseBiInformative bs facts bi }
+      informative := usable && denseBiInformative bs facts bi,
+      domainRedundant := usable && denseBiDomainRedundantV bs facts T bi }
 
 def densePlanTargetsV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
     List (List VarId) :=
@@ -306,7 +393,7 @@ def denseDomainBatchσV (bs : BusSemantics p) (facts : BusFacts p bs)
     denseAddBusDoms bs facts d.busInteractions
       (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty)
   let csPlans := denseConstraintPlansV T d.algebraicConstraints
-  let busPlans := denseBusPlansV bs facts d.busInteractions
+  let busPlans := denseBusPlansV bs facts T d.busInteractions
   let targets := densePlanTargetsV csPlans busPlans
   let fidx := denseForcedIdxV csPlans busPlans
   -- Fan out only at keccak/SHA scale; below it the sequential fold avoids spawn overhead.

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -903,6 +903,48 @@ theorem DenseDomainTable.doms_getElem (T : DenseDomainTable p) :
         · exact hd
         · exact ih ds' hr kd hkd'
 
+theorem denseDomainConstantValueV?_mem_eq (d : FiniteDomain p) (c x : ZMod p)
+    (hc : denseDomainConstantValueV? d = some c) (hx : x ∈ d.toList) : x = c := by
+  cases d with
+  | explicit values =>
+      cases values with
+      | nil => simp [denseDomainConstantValueV?] at hc
+      | cons v vs =>
+          simp only [denseDomainConstantValueV?] at hc
+          split at hc
+          · rename_i hall
+            simp only [Option.some.injEq] at hc
+            subst c
+            simp only [FiniteDomain.toList, List.mem_cons] at hx
+            rcases hx with rfl | hx
+            · rfl
+            · have hdec := (List.all_eq_true.mp hall) x hx
+              exact of_decide_eq_true hdec
+          · simp at hc
+  | range size =>
+      simp only [denseDomainConstantValueV?] at hc
+      split at hc
+      · rename_i hsize
+        subst size
+        simp only [Option.some.injEq] at hc
+        subst c
+        simpa [FiniteDomain.toList] using hx
+      · simp at hc
+
+theorem denseConstantDomainsV_entails (fdoms : List (VarId × FiniteDomain p))
+    (denv : VarId → ZMod p)
+    (hmem : ∀ kd ∈ fdoms, denv kd.1 ∈ kd.2.toList) :
+    ∀ f ∈ denseConstantDomainsV fdoms, denv f.1 = f.2 := by
+  intro f hf
+  obtain ⟨xd, hxd, hmap⟩ := List.mem_filterMap.1 hf
+  cases hc : denseDomainConstantValueV? xd.2 with
+  | none => rw [hc] at hmap; simp at hmap
+  | some c =>
+      rw [hc] at hmap
+      simp only [Option.map_some, Option.some.injEq] at hmap
+      subst f
+      exact denseDomainConstantValueV?_mem_eq xd.2 c (denv xd.1) hc (hmem xd hxd)
+
 /-- A pair produced by `(keys.zip cands).filterMap (·.2.map …)` sits at a common index with a
     `some`-masked candidate. -/
 theorem mem_zip_filterMap {α : Type} (keys : List α) (cands : DenseCandsV p) (f : α × ZMod p)
@@ -1010,7 +1052,7 @@ theorem denseGatherBusesV_interactions_mem (fidx : DenseForcedIdx p) (xs : List 
       fidx.arrBis[i].interaction = bi ∧ fidx.arrBis[i].usable = true ∧
         denseVarsInListF xs fidx.arrBis[i].vars = true := by
   apply denseGatherBusesLoopV_interactions_mem fidx.arrBis xs (denseCandidates fidx.bisIdx xs)
-    ⟨0, false, []⟩ (by simp) bi
+    ⟨0, false, true, []⟩ (by simp) bi
   exact hbi
 
 theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (DenseBusPlan p))
@@ -1049,7 +1091,8 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     have hinbox : (fdoms.map Prod.fst).map denv ∈ assignmentsV (fdoms.map Prod.snd) := by
       rw [List.map_map]; exact mem_assignmentsV denv fdoms hmem
     dsimp only
-    split_ifs with hbox hwork
+    split_ifs with hbox hwork hfast
+    · exact denseConstantDomainsV_entails fdoms denv hmem
     · have hsurv : (denseCompiledSurvV bs
           (denseGatherConstraintsV fidx xs).active
           (denseGatherBusesV fidx xs).interactions
@@ -1215,7 +1258,7 @@ def dbConstraintPlans (bs : BusSemantics p) (facts : BusFacts p bs)
 
 def dbBusPlans (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : List (DenseBusPlan p) :=
-  denseBusPlansV bs facts d.busInteractions
+  denseBusPlansV bs facts (dbT bs facts d) d.busInteractions
 
 /-- The target list built by `denseDomainBatchσV`. -/
 def dbTargets (bs : BusSemantics p) (facts : BusFacts p bs)

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -187,12 +187,11 @@ these need no new proof.
      still recompute per-constraint `eraseDups`, but only on gate-passing constraints (proofs
      unfold them — rework only if they show up in profiles).
 
-**R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  **done (entry 104)** except:
-(c) `constraintRedundant` full-box scans (`:899`) remain (they pay once to save per-target work);
-hot-variable bucket capping remains open (not byte-identical — the gates read `esFull`). The
-enumeration core itself (SP1 apc_030's 19 s single-cycle spike) is untouched: that lever is
-**cross-cycle memoization of enumeration negatives** (needs pass-state threading — R6's
-substrate), not setup cost.
+**R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  **mostly done (entries 104,
+128–129)**. Entry 129 skips the Cartesian scan when every active filter is already discharged by
+constant evaluation or exact `BusFacts` and extracts constant domains directly. Remaining:
+`constraintRedundant` full-box scans (they pay once to save per-target work), and hot-variable
+bucket capping (not byte-identical — the gates read `esFull`).
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
 index gate**  ·  mostly **done (entries 105/107/109)**:
@@ -266,10 +265,10 @@ inputs (0.4 %), apc_030 257 of 1,641 (16 %, and its expensive cycle-5 enumeratio
 cross-cycle scheme must therefore be *finer* than whole-target skipping (powdr-style dirty
 worklists where a substitution dirties only the items mentioning substituted variables — the full
 #146 architecture), and its payoff must be re-estimated per pass first: at target granularity the
-~61 % invocation-level no-op measurement does **not** translate into reusable work. domainBatch's
-remaining cost is *productive first-time enumeration*; the levers there are effectiveness-side
-(replace enumeration classes with algebra, cf. the quadratic-roots effectiveness idea 1) or
-intra-enumeration (survivor-scan compilation is already tuned).
+~61 % invocation-level no-op measurement does **not** translate into reusable work. After entry
+129's no-effective-filter skip, domainBatch's remaining enumeration is relational first-time work;
+the levers there are effectiveness-side (replace enumeration classes with algebra, cf. the
+quadratic-roots effectiveness idea 1) or intra-enumeration.
 
 **R7. Intra-pass parallelism**  ·  partially **done (entry 114)**: domainBatch's per-target
 enumerations are `Task`-parallel with ordered joins (byte-identical σ; keccak domainBatch

--- a/docs/log.md
+++ b/docs/log.md
@@ -4498,3 +4498,25 @@ iterations and finished at the same 2773 variables, 2370 bus interactions, and 3
 closures, and the proof-integrity and unused-theorem checks pass.
 
 **Worked: yes (effectiveness unchanged on the measured case; large domainBatch runtime win).**
+
+### 129. Runtime: skip domainBatch boxes with no effective filter
+
+`domainBatch` now records whether each stateless bus interaction is already accepted throughout
+the stored finite domains. The recognizer handles fully constant messages directly and uses exact
+`BusFacts` for variable/tuple range checks, layout-independent single-slot range checks, and byte
+pair checks. When every gathered algebraic constraint is redundant and every gathered bus has
+that certificate, the pass extracts constant coordinates from the symbolic domains instead of
+enumerating the Cartesian product. The emitted constants are independently justified by domain-
+table soundness in `Proofs/DomainBatch.lean`; empty domains retain the existing scan path.
+
+Targeted local profiles used revision `498092b`'s values from `openvm-profile.csv` as the baseline.
+`domainBatch` changed from 3159 → 2725 ms on OpenVM keccak (−13.7%), 255 → 228 ms on
+`openvm-eth/apc_044` (−10.6%), 188 → 179 ms on `openvm-eth/apc_094` (−4.8%), and 2430 → 2325 ms
+on `wasm-eth/apc_063` (−4.3%); `wasm-eth/apc_065` was flat at 131 → 132 ms. The five-case sum was
+6163 → 5589 ms (−9.3%). Cleanup iteration counts were unchanged; the three locally rechecked small
+cases retained their output sizes, so relative effectiveness was 1.000× / 1.000× / 1.000× on
+variables / bus interactions / constraints. Full same-runner runtime and effectiveness evaluation
+is delegated to the draft PR's CI workflows.
+
+**Worked locally: yes (verified shortcut, representative domainBatch runtime win; full-set result
+pending CI).**


### PR DESCRIPTION
## Summary

- cache whether each stateless bus interaction is already accepted throughout the stored finite domains
- recognize fully constant interactions and exact `BusFacts` cases for variable/tuple range checks, layout-independent range checks, and byte-pair checks
- skip Cartesian enumeration when no active algebraic or bus filter remains, extracting constant coordinates directly from symbolic domains
- prove every fast-path substitution from domain-table soundness

## Local validation

- `lake build apc-optimizer`
- `Scripts/check-proof-integrity.sh`
- inspected generated `DomainBatchRuntime.c`; the fast branch precedes survivor compilation and `denseScanBoxV`

Representative `domainBatch` profiles use revision `498092b` values from `openvm-profile.csv` as the baseline:

| APC | main CSV | branch | change |
|---|---:|---:|---:|
| OpenVM keccak | 3159 ms | 2725 ms | -13.7% |
| `openvm-eth/apc_044` | 255 ms | 228 ms | -10.6% |
| `openvm-eth/apc_094` | 188 ms | 179 ms | -4.8% |
| `wasm-eth/apc_063` | 2430 ms | 2325 ms | -4.3% |
| `wasm-eth/apc_065` | 131 ms | 132 ms | flat |

Five-case sum: 6163 -> 5589 ms (-9.3%). Cleanup iteration counts were unchanged. Full same-runner runtime and effectiveness evaluation is delegated to PR CI.