### PR TITLE
Runtime: compact domainBatch gathers

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -299,11 +299,22 @@ structure DenseBusPlan (p : ℕ) where
   informative : Bool
   domainRedundant : Bool
 
+/-- Compact anchor buckets used by the read-only per-target gathers. -/
+structure DenseArrayCovIndex where
+  buckets : Std.HashMap VarId (Array Nat)
+  varless : Array Nat
+
+/-- Constraint anchors with inactive variable-free plans summarized once. -/
+structure DenseConstraintCovIndex where
+  buckets : Std.HashMap VarId (Array Nat)
+  inactiveVarlessCount : Nat
+  activeVarless : Array Nat
+
 /-- The per-target index bundle (plain data; correctness via correspondence). -/
 structure DenseForcedIdx (p : ℕ) where
-  csIdx : DenseCovIndex
+  csIdx : DenseConstraintCovIndex
   arrCs : Array (DenseConstraintPlan p)
-  bisIdx : DenseCovIndex
+  bisIdx : DenseArrayCovIndex
   arrBis : Array (DenseBusPlan p)
 
 /-- The dense domain-table `doms` list has keys `xs`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -244,22 +244,26 @@ structure DenseConstraintGatherV (p : ℕ) where
   fullCount : Nat
   active : List (DenseExpr p)
 
-def denseGatherConstraintsLoopV (arr : Array (DenseConstraintPlan p)) (xs : List VarId) :
-    List Nat → DenseConstraintGatherV p → DenseConstraintGatherV p
-  | [], acc => acc
-  | i :: rest, acc =>
-    if h : i < arr.size then
-      let plan := arr[i]
-      if denseVarsInListF xs plan.vars then
-        denseGatherConstraintsLoopV arr xs rest
-          { fullCount := acc.fullCount + 1,
-            active := if plan.active then plan.expr :: acc.active else acc.active }
-      else denseGatherConstraintsLoopV arr xs rest acc
-    else denseGatherConstraintsLoopV arr xs rest acc
+def denseGatherConstraintAtV (arr : Array (DenseConstraintPlan p)) (xs : List VarId)
+    (acc : DenseConstraintGatherV p) (i : Nat) : DenseConstraintGatherV p :=
+  if h : i < arr.size then
+    let plan := arr[i]
+    if denseVarsInListF xs plan.vars then
+      { fullCount := acc.fullCount + 1,
+        active := if plan.active then plan.expr :: acc.active else acc.active }
+    else acc
+  else acc
+
+def denseGatherConstraintArrayV (arr : Array (DenseConstraintPlan p)) (xs : List VarId)
+    (positions : Array Nat) (acc : DenseConstraintGatherV p) : DenseConstraintGatherV p :=
+  positions.foldl (denseGatherConstraintAtV arr xs) acc
 
 def denseGatherConstraintsV (fidx : DenseForcedIdx p) (xs : List VarId) :
     DenseConstraintGatherV p :=
-  denseGatherConstraintsLoopV fidx.arrCs xs (denseCandidates fidx.csIdx xs) ⟨0, []⟩
+  let acc := xs.foldl (fun acc v =>
+    denseGatherConstraintArrayV fidx.arrCs xs (fidx.csIdx.buckets.getD v #[]) acc)
+    ⟨fidx.csIdx.inactiveVarlessCount, []⟩
+  denseGatherConstraintArrayV fidx.arrCs xs fidx.csIdx.activeVarless acc
 
 structure DenseBusGatherV (p : ℕ) where
   count : Nat
@@ -267,23 +271,27 @@ structure DenseBusGatherV (p : ℕ) where
   allDomainRedundant : Bool
   interactions : List (BusInteraction (DenseExpr p))
 
-def denseGatherBusesLoopV (arr : Array (DenseBusPlan p)) (xs : List VarId) :
-    List Nat → DenseBusGatherV p → DenseBusGatherV p
-  | [], acc => acc
-  | i :: rest, acc =>
-    if h : i < arr.size then
-      let plan := arr[i]
-      if plan.usable && denseVarsInListF xs plan.vars then
-        denseGatherBusesLoopV arr xs rest
-          { count := acc.count + 1,
-            informative := acc.informative || plan.informative,
-            allDomainRedundant := acc.allDomainRedundant && plan.domainRedundant,
-            interactions := plan.interaction :: acc.interactions }
-      else denseGatherBusesLoopV arr xs rest acc
-    else denseGatherBusesLoopV arr xs rest acc
+def denseGatherBusAtV (arr : Array (DenseBusPlan p)) (xs : List VarId)
+    (acc : DenseBusGatherV p) (i : Nat) : DenseBusGatherV p :=
+  if h : i < arr.size then
+    let plan := arr[i]
+    if plan.usable && denseVarsInListF xs plan.vars then
+      { count := acc.count + 1,
+        informative := acc.informative || plan.informative,
+        allDomainRedundant := acc.allDomainRedundant && plan.domainRedundant,
+        interactions := plan.interaction :: acc.interactions }
+    else acc
+  else acc
+
+def denseGatherBusArrayV (arr : Array (DenseBusPlan p)) (xs : List VarId)
+    (positions : Array Nat) (acc : DenseBusGatherV p) : DenseBusGatherV p :=
+  positions.foldl (denseGatherBusAtV arr xs) acc
 
 def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGatherV p :=
-  denseGatherBusesLoopV fidx.arrBis xs (denseCandidates fidx.bisIdx xs) ⟨0, false, true, []⟩
+  let acc := xs.foldl (fun acc v =>
+    denseGatherBusArrayV fidx.arrBis xs (fidx.bisIdx.buckets.getD v #[]) acc)
+    ⟨0, false, true, []⟩
+  denseGatherBusArrayV fidx.arrBis xs fidx.bisIdx.varless acc
 
 /-- All checked forced constants over the variable set `xs`. `keys` drives the compiler and the
     final zip; the unkeyed `doms` drives the value-only scan. -/
@@ -376,11 +384,30 @@ def densePlanTargetsV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusP
     List (List VarId) :=
   cs.map (fun c => c.vars) ++ bis.map (fun bi => bi.vars)
 
+def denseFreezeBuckets (buckets : Std.HashMap VarId (List Nat)) :
+    Std.HashMap VarId (Array Nat) :=
+  buckets.fold (fun out v positions => out.insert v positions.toArray) ∅
+
+def denseFreezeCovIndex (idx : DenseCovIndex) : DenseArrayCovIndex :=
+  { buckets := denseFreezeBuckets idx.buckets,
+    varless := idx.varless.toArray }
+
+def denseConstraintCovIndexV (cs : List (DenseConstraintPlan p)) : DenseConstraintCovIndex :=
+  let arr := cs.toArray
+  let idx := denseAnchorCovBuild (fun c => c.vars) cs
+  let summary := idx.varless.foldl (init := (0, #[])) fun acc i =>
+    if h : i < arr.size then
+      if arr[i].active then (acc.1, acc.2.push i) else (acc.1 + 1, acc.2)
+    else acc
+  { buckets := denseFreezeBuckets idx.buckets,
+    inactiveVarlessCount := summary.1,
+    activeVarless := summary.2 }
+
 def denseForcedIdxV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
     DenseForcedIdx p :=
-  { csIdx := denseAnchorCovBuild (fun c => c.vars) cs,
+  { csIdx := denseConstraintCovIndexV cs,
     arrCs := cs.toArray,
-    bisIdx := denseAnchorCovBuild (fun bi => bi.vars) bis,
+    bisIdx := denseFreezeCovIndex (denseAnchorCovBuild (fun bi => bi.vars) bis),
     arrBis := bis.toArray }
 
 /-- Domain-batch: builds a finite domain per variable (from constraints like `x*(x-1)=0` giving

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -971,39 +971,67 @@ theorem mem_zip_filterMap {α : Type} (keys : List α) (cands : DenseCandsV p) (
           · obtain ⟨n, hn1, hn2⟩ := ih ocs hf'
             exact ⟨n + 1, by simpa using hn1, by simpa using hn2⟩
 
-theorem denseGatherConstraintsLoopV_active_mem (arr : Array (DenseConstraintPlan p))
-    (xs : List VarId) (candidates : List Nat) (acc : DenseConstraintGatherV p)
+theorem denseGatherConstraintAtV_active_mem (arr : Array (DenseConstraintPlan p))
+    (xs : List VarId) (acc : DenseConstraintGatherV p) (i : Nat)
     (hacc : ∀ e ∈ acc.active, ∃ i, ∃ h : i < arr.size,
       arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true) :
-    ∀ e ∈ (denseGatherConstraintsLoopV arr xs candidates acc).active,
+    ∀ e ∈ (denseGatherConstraintAtV arr xs acc i).active,
       ∃ i, ∃ h : i < arr.size,
         arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true := by
-  induction candidates generalizing acc with
-  | nil => simpa [denseGatherConstraintsLoopV] using hacc
+  intro e he
+  by_cases hi : i < arr.size
+  · by_cases hvars : denseVarsInListF xs arr[i].vars = true
+    · simp only [denseGatherConstraintAtV, hi, ↓reduceDIte, hvars, ↓reduceIte] at he
+      by_cases hactive : arr[i].active = true
+      · simp only [hactive, ↓reduceIte] at he
+        rcases List.mem_cons.1 he with he | he
+        · subst e; exact ⟨i, hi, rfl, hvars, hactive⟩
+        · exact hacc e he
+      · simp [hactive] at he
+        exact hacc e he
+    · apply hacc e
+      simpa [denseGatherConstraintAtV, hi, hvars] using he
+  · apply hacc e
+    simpa [denseGatherConstraintAtV, hi] using he
+
+theorem denseGatherConstraintArrayV_active_mem (arr : Array (DenseConstraintPlan p))
+    (xs : List VarId) (positions : Array Nat) (acc : DenseConstraintGatherV p)
+    (hacc : ∀ e ∈ acc.active, ∃ i, ∃ h : i < arr.size,
+      arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true) :
+    ∀ e ∈ (denseGatherConstraintArrayV arr xs positions acc).active,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true := by
+  rw [denseGatherConstraintArrayV, ← Array.foldl_toList]
+  induction positions.toList generalizing acc with
+  | nil => simpa using hacc
   | cons i rest ih =>
-      by_cases hi : i < arr.size
-      · by_cases hvars : denseVarsInListF xs arr[i].vars = true
-        · simp only [denseGatherConstraintsLoopV, hi, ↓reduceDIte, hvars, ↓reduceIte]
-          apply ih
-          intro e he
-          by_cases hactive : arr[i].active = true
-          · simp only [hactive, ↓reduceIte] at he
-            rcases List.mem_cons.1 he with he | he
-            · subst e; exact ⟨i, hi, rfl, hvars, hactive⟩
-            · exact hacc e he
-          · simp [hactive] at he
-            exact hacc e he
-        · simpa [denseGatherConstraintsLoopV, hi, hvars] using ih acc hacc
-      · simpa [denseGatherConstraintsLoopV, hi] using ih acc hacc
+      simp only [List.foldl_cons]
+      exact ih (denseGatherConstraintAtV arr xs acc i)
+        (denseGatherConstraintAtV_active_mem arr xs acc i hacc)
+
+theorem denseGatherConstraintBucketsV_active_mem (arr : Array (DenseConstraintPlan p))
+    (idx : DenseConstraintCovIndex) (xs vs : List VarId) (acc : DenseConstraintGatherV p)
+    (hacc : ∀ e ∈ acc.active, ∃ i, ∃ h : i < arr.size,
+      arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true) :
+    ∀ e ∈ (vs.foldl (fun acc v =>
+        denseGatherConstraintArrayV arr xs (idx.buckets.getD v #[]) acc) acc).active,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].expr = e ∧ denseVarsInListF xs arr[i].vars = true ∧ arr[i].active = true := by
+  induction vs generalizing acc with
+  | nil => simpa using hacc
+  | cons v rest ih =>
+      simp only [List.foldl_cons]
+      exact ih _ (denseGatherConstraintArrayV_active_mem arr xs _ acc hacc)
 
 theorem denseGatherConstraintsV_active_mem (fidx : DenseForcedIdx p) (xs : List VarId)
     {e : DenseExpr p} (he : e ∈ (denseGatherConstraintsV fidx xs).active) :
     ∃ i, ∃ h : i < fidx.arrCs.size,
       fidx.arrCs[i].expr = e ∧ denseVarsInListF xs fidx.arrCs[i].vars = true ∧
         fidx.arrCs[i].active = true := by
-  apply denseGatherConstraintsLoopV_active_mem fidx.arrCs xs (denseCandidates fidx.csIdx xs)
-    ⟨0, []⟩ (by simp) e
-  exact he
+  rw [denseGatherConstraintsV] at he
+  apply denseGatherConstraintArrayV_active_mem fidx.arrCs xs fidx.csIdx.activeVarless _
+    (denseGatherConstraintBucketsV_active_mem fidx.arrCs fidx.csIdx xs xs
+      ⟨fidx.csIdx.inactiveVarlessCount, []⟩ (by simp)) e he
 
 theorem denseGatherConstraintsV_plan_mem (fidx : DenseForcedIdx p)
     (plans : List (DenseConstraintPlan p)) (harr : fidx.arrCs = plans.toArray)
@@ -1020,40 +1048,73 @@ theorem denseGatherConstraintsV_plan_mem (fidx : DenseForcedIdx p)
   exact ⟨plan, hmem, by simpa [plan] using hie, by simpa [plan] using hvars,
     by simpa [plan] using hactive⟩
 
-theorem denseGatherBusesLoopV_interactions_mem (arr : Array (DenseBusPlan p))
-    (xs : List VarId) (candidates : List Nat) (acc : DenseBusGatherV p)
+theorem denseGatherBusAtV_interactions_mem (arr : Array (DenseBusPlan p))
+    (xs : List VarId) (acc : DenseBusGatherV p) (i : Nat)
     (hacc : ∀ bi ∈ acc.interactions, ∃ i, ∃ h : i < arr.size,
       arr[i].interaction = bi ∧ arr[i].usable = true ∧
         denseVarsInListF xs arr[i].vars = true) :
-    ∀ bi ∈ (denseGatherBusesLoopV arr xs candidates acc).interactions,
+    ∀ bi ∈ (denseGatherBusAtV arr xs acc i).interactions,
       ∃ i, ∃ h : i < arr.size,
         arr[i].interaction = bi ∧ arr[i].usable = true ∧
           denseVarsInListF xs arr[i].vars = true := by
-  induction candidates generalizing acc with
-  | nil => simpa [denseGatherBusesLoopV] using hacc
+  intro bi hbi
+  by_cases hi : i < arr.size
+  · by_cases husable : arr[i].usable = true
+    · by_cases hvars : denseVarsInListF xs arr[i].vars = true
+      · simp only [denseGatherBusAtV, hi, ↓reduceDIte, husable, hvars, Bool.and_self,
+          ↓reduceIte] at hbi
+        rcases List.mem_cons.1 hbi with hbi | hbi
+        · subst bi; exact ⟨i, hi, rfl, husable, hvars⟩
+        · exact hacc bi hbi
+      · apply hacc bi
+        simpa [denseGatherBusAtV, hi, husable, hvars] using hbi
+    · apply hacc bi
+      simpa [denseGatherBusAtV, hi, husable] using hbi
+  · apply hacc bi
+    simpa [denseGatherBusAtV, hi] using hbi
+
+theorem denseGatherBusArrayV_interactions_mem (arr : Array (DenseBusPlan p))
+    (xs : List VarId) (positions : Array Nat) (acc : DenseBusGatherV p)
+    (hacc : ∀ bi ∈ acc.interactions, ∃ i, ∃ h : i < arr.size,
+      arr[i].interaction = bi ∧ arr[i].usable = true ∧
+        denseVarsInListF xs arr[i].vars = true) :
+    ∀ bi ∈ (denseGatherBusArrayV arr xs positions acc).interactions,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].interaction = bi ∧ arr[i].usable = true ∧
+          denseVarsInListF xs arr[i].vars = true := by
+  rw [denseGatherBusArrayV, ← Array.foldl_toList]
+  induction positions.toList generalizing acc with
+  | nil => simpa using hacc
   | cons i rest ih =>
-      by_cases hi : i < arr.size
-      · by_cases husable : arr[i].usable = true
-        · by_cases hvars : denseVarsInListF xs arr[i].vars = true
-          · simp only [denseGatherBusesLoopV, hi, ↓reduceDIte, husable, hvars,
-              Bool.and_self, ↓reduceIte]
-            apply ih
-            intro bi hbi
-            rcases List.mem_cons.1 hbi with hbi | hbi
-            · subst bi; exact ⟨i, hi, rfl, husable, hvars⟩
-            · exact hacc bi hbi
-          · simpa [denseGatherBusesLoopV, hi, husable, hvars] using ih acc hacc
-        · simpa [denseGatherBusesLoopV, hi, husable] using ih acc hacc
-      · simpa [denseGatherBusesLoopV, hi] using ih acc hacc
+      simp only [List.foldl_cons]
+      exact ih (denseGatherBusAtV arr xs acc i)
+        (denseGatherBusAtV_interactions_mem arr xs acc i hacc)
+
+theorem denseGatherBusBucketsV_interactions_mem (arr : Array (DenseBusPlan p))
+    (idx : DenseArrayCovIndex) (xs vs : List VarId) (acc : DenseBusGatherV p)
+    (hacc : ∀ bi ∈ acc.interactions, ∃ i, ∃ h : i < arr.size,
+      arr[i].interaction = bi ∧ arr[i].usable = true ∧
+        denseVarsInListF xs arr[i].vars = true) :
+    ∀ bi ∈ (vs.foldl (fun acc v =>
+        denseGatherBusArrayV arr xs (idx.buckets.getD v #[]) acc) acc).interactions,
+      ∃ i, ∃ h : i < arr.size,
+        arr[i].interaction = bi ∧ arr[i].usable = true ∧
+          denseVarsInListF xs arr[i].vars = true := by
+  induction vs generalizing acc with
+  | nil => simpa using hacc
+  | cons v rest ih =>
+      simp only [List.foldl_cons]
+      exact ih _ (denseGatherBusArrayV_interactions_mem arr xs _ acc hacc)
 
 theorem denseGatherBusesV_interactions_mem (fidx : DenseForcedIdx p) (xs : List VarId)
     {bi : BusInteraction (DenseExpr p)} (hbi : bi ∈ (denseGatherBusesV fidx xs).interactions) :
     ∃ i, ∃ h : i < fidx.arrBis.size,
       fidx.arrBis[i].interaction = bi ∧ fidx.arrBis[i].usable = true ∧
         denseVarsInListF xs fidx.arrBis[i].vars = true := by
-  apply denseGatherBusesLoopV_interactions_mem fidx.arrBis xs (denseCandidates fidx.bisIdx xs)
-    ⟨0, false, true, []⟩ (by simp) bi
-  exact hbi
+  rw [denseGatherBusesV] at hbi
+  apply denseGatherBusArrayV_interactions_mem fidx.arrBis xs fidx.bisIdx.varless _
+    (denseGatherBusBucketsV_interactions_mem fidx.arrBis fidx.bisIdx xs xs
+      ⟨0, false, true, []⟩ (by simp)) bi hbi
 
 theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (DenseBusPlan p))
     (harr : fidx.arrBis = plans.toArray) (xs : List VarId)

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -188,10 +188,12 @@ these need no new proof.
      unfold them — rework only if they show up in profiles).
 
 **R2. domainBatch setup: stop re-gathering and re-dedup-ing**  ·  **mostly done (entries 104,
-128–129)**. Entry 129 skips the Cartesian scan when every active filter is already discharged by
-constant evaluation or exact `BusFacts` and extracts constant domains directly. Remaining:
-`constraintRedundant` full-box scans (they pay once to save per-target work), and hot-variable
-bucket capping (not byte-identical — the gates read `esFull`).
+128–130)**. Entry 129 skips the Cartesian scan when every active filter is already discharged by
+constant evaluation or exact `BusFacts` and extracts constant domains directly. Entry 130 stores
+anchor buckets as arrays and summarizes inactive variable-free constraints once, so targets no
+longer materialize candidate lists or walk the same inactive tail. Remaining: `constraintRedundant`
+full-box scans (they pay once to save per-target work), and hot-variable bucket capping (not byte-
+identical — the gates read `esFull`).
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
 index gate**  ·  mostly **done (entries 105/107/109)**:

--- a/docs/log.md
+++ b/docs/log.md
@@ -4520,3 +4520,32 @@ is delegated to the draft PR's CI workflows.
 
 **Worked locally: yes (verified shortcut, representative domainBatch runtime win; full-set result
 pending CI).**
+
+### 130. Runtime: compact direct domainBatch gathers and one variable-free summary
+
+`domainBatch` now freezes its anchor buckets into arrays and folds those arrays directly for each
+target variable. The constraint index keeps only active variable-free positions and one count for
+all inactive variable-free plans; the latter therefore contributes to the work heuristic without
+being appended to and traversed in every target's candidate stream. Bus gathers use the same direct
+array-bucket traversal. Bounds, scope, activity, and usability are still rechecked at use, so the
+compact indexes remain untrusted planning data.
+
+The generated C contains tight `Array.foldl` loops using borrowed array reads; the former
+`denseCandidates` list construction and its shared list-spine consumption are absent from both
+gathers. The gather proofs now establish provenance through each checked array position and compose
+that invariant across the target's bucket arrays and the exceptional variable-free arrays.
+
+Local profiles used the five representatives from `domainBatchProposals.md`. Against entry 129's
+merged measurements, `domainBatch` changed from 2725 → 2376 ms on OpenVM keccak (−12.8%),
+228 → 202 ms on `openvm-eth/apc_044` (−11.4%), and 2325 → 2094 ms on
+`wasm-eth/apc_063` (−9.9%); `openvm-eth/apc_094` and `wasm-eth/apc_065` were flat within
+millisecond noise at 179 → 180 and 132 → 133 ms. The five-case sum was 5589 → 4985 ms
+(−10.8%). Relative to revision `498092b` in the checked-in `openvm-profile.csv`, the cumulative
+five-case reduction is 6163 → 4985 ms (−19.1%). No `origin/main` binary was rebuilt. Cleanup
+iteration counts matched the CSV on all five cases; full same-runner runtime and effectiveness
+evaluation is delegated to the draft PR's CI workflows.
+
+`lake build` is warning-free, generated C was inspected, and the proof-integrity and unused-theorem
+checks pass.
+
+**Worked locally: yes (representative domainBatch runtime win; full-set result pending CI).**


### PR DESCRIPTION
## Summary

- summarize inactive variable-free constraint plans once instead of appending and visiting them for every target
- freeze anchor buckets as compact arrays and fold them directly, removing per-target `denseCandidates` list materialization for both constraint and bus gathers
- retain defensive bounds, scope, activity, and usability checks, with updated provenance proofs for the array traversal

## Local runtime

Representative `domainBatch` profiles, compared with the merged entry-129 implementation (without rebuilding `origin/main`):

| representative | merged | PR | change |
|---|---:|---:|---:|
| OpenVM keccak | 2725 ms | 2376 ms | -12.8% |
| openvm-eth/apc_044 | 228 ms | 202 ms | -11.4% |
| wasm-eth/apc_063 | 2325 ms | 2094 ms | -9.9% |
| openvm-eth/apc_094 | 179 ms | 180 ms | noise |
| wasm-eth/apc_065 | 132 ms | 133 ms | noise |
| **sum** | **5589 ms** | **4985 ms** | **-10.8%** |

Relative to revision `498092b` in the checked-in CSV, the cumulative five-case result is 6163 → 4985 ms (-19.1%). Cleanup iteration counts matched on all five representatives. Full effectiveness and same-runner runtime evaluation are delegated to triggered PR CI.

## Verification

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection: direct `Array.foldl` loops use borrowed array reads; the gathers no longer build candidate lists