### PR TITLE
Runtime: bound domainBatch parallel fan-out

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -457,12 +457,30 @@ def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGath
     ⟨0, false, true, []⟩
   denseGatherBusArrayV fidx.arrBis xs fidx.bisIdx.varless acc
 
-/-- All checked forced constants over the variable set `xs`. `keys` drives the compiler and the
-    final zip; the unkeyed `doms` drives the value-only scan. -/
-def denseForcedOverV (bs : BusSemantics p) (_facts : BusFacts p bs) (T : DenseDomainTable p)
-    (fidx : DenseForcedIdx p) (xs : List VarId) : List (VarId × ZMod p) :=
+structure DenseForcedScanV (p : ℕ) where
+  keys : List VarId
+  doms : List (FiniteDomain p)
+  active : List (DenseExpr p)
+  interactions : List (BusInteraction (DenseExpr p))
+  work : Nat
+
+inductive DenseForcedPlanV (p : ℕ) where
+  | done (forced : List (VarId × ZMod p))
+  | scan (job : DenseForcedScanV p)
+
+def DenseForcedPlanV.work : DenseForcedPlanV p → Nat
+  | .done _ => 0
+  | .scan job => job.work
+
+def DenseForcedPlanV.needsScan : DenseForcedPlanV p → Bool
+  | .done _ => false
+  | .scan _ => true
+
+/-- Apply every per-target gate before scheduling and retain only immediate results or real scans. -/
+def denseForcedPreflightV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
+    (xs : List VarId) : Option (DenseForcedPlanV p) :=
   match T.doms xs with
-  | none => []
+  | none => none
   | some fdoms =>
     let boxSize := (fdoms.map (fun yd => yd.2.size)).prod
     if boxSize ≤ maxEnumSize then
@@ -474,18 +492,36 @@ def denseForcedOverV (bs : BusSemantics p) (_facts : BusFacts p bs) (T : DenseDo
         let doms := fdoms.map Prod.snd
         if cs.active.isEmpty && bis.allDomainRedundant &&
             doms.all (fun d => d.size != 0) then
-          denseConstantDomainsV fdoms
+          some (.done (denseConstantDomainsV fdoms))
         else
-          let survC := denseCompiledSurvV bs _facts cs.active bis.interactions keys
-          match denseScanBoxV survC.run doms with
-          | none =>
-            -- no surviving point: the box has no solutions, so everything is vacuously forced
-            keys.map (fun x => (x, (0 : ZMod p)))
-          | some cands =>
-            -- recover the forced `(x, c)` pairs by zipping the mask with `keys` once, at the end
-            (keys.zip cands).filterMap (fun xc => xc.2.map (fun c => (xc.1, c)))
-      else []
-    else []
+          some (.scan {
+            keys,
+            doms,
+            active := cs.active,
+            interactions := bis.interactions,
+            work := boxSize * (cs.active.length + bis.count + keys.length) })
+      else none
+    else none
+
+def denseRunForcedScanV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (job : DenseForcedScanV p) : List (VarId × ZMod p) :=
+  let survC := denseCompiledSurvV bs facts job.active job.interactions job.keys
+  match denseScanBoxV survC.run job.doms with
+  | none => job.keys.map (fun x => (x, (0 : ZMod p)))
+  | some cands =>
+    (job.keys.zip cands).filterMap (fun xc => xc.2.map (fun c => (xc.1, c)))
+
+def denseRunForcedPlanV (bs : BusSemantics p) (facts : BusFacts p bs) :
+    DenseForcedPlanV p → List (VarId × ZMod p)
+  | .done forced => forced
+  | .scan job => denseRunForcedScanV bs facts job
+
+/-- All checked forced constants over `xs`, factored through the scheduler's preflight plan. -/
+def denseForcedOverV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomainTable p)
+    (fidx : DenseForcedIdx p) (xs : List VarId) : List (VarId × ZMod p) :=
+  match denseForcedPreflightV T fidx xs with
+  | none => []
+  | some plan => denseRunForcedPlanV bs facts plan
 
 /-! ## `collectForced`, value-only
 
@@ -509,21 +545,55 @@ private def ddRegB : VarRegistry × VarId :=
   ddRegA.1.register { name := "x", powdrId? := some 2 }
 #guard denseDedupTargetsV [[ddRegA.2], [ddRegB.2]] ∅ == [[ddRegA.2], [ddRegB.2]]
 
-/-- Collect every checked forced constant: dedup the targets, then fold each target's forced
-    constants into the solution map in target order. When `parallel`, the independent per-target
-    enumerations are spawned as `Task`s and joined in the same order, so the output is unchanged. -/
+def domainBatchParallelChunks : Nat := 64
+
+def denseTakeForcedChunkV (budget : Nat) :
+    List (DenseForcedPlanV p) → Nat → List (DenseForcedPlanV p) × List (DenseForcedPlanV p)
+  | [], _ => ([], [])
+  | plan :: rest, used =>
+    if used != 0 && budget < used + plan.work then ([], plan :: rest)
+    else
+      let tail := denseTakeForcedChunkV budget rest (used + plan.work)
+      (plan :: tail.1, tail.2)
+
+def denseForcedChunksV (budget : Nat) : Nat → List (DenseForcedPlanV p) →
+    List (List (DenseForcedPlanV p))
+  | _, [] => []
+  | 0, plans => [plans]
+  | splits + 1, plans =>
+    let chunk := denseTakeForcedChunkV budget plans 0
+    chunk.1 :: denseForcedChunksV budget splits chunk.2
+
+def denseRunForcedChunkV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (chunk : List (DenseForcedPlanV p)) : List (List (VarId × ZMod p)) :=
+  chunk.map (denseRunForcedPlanV bs facts)
+
+def denseForcedChunkTaskV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (chunk : List (DenseForcedPlanV p)) : Task (List (List (VarId × ZMod p))) :=
+  if chunk.any DenseForcedPlanV.needsScan then
+    Task.spawn fun _ => denseRunForcedChunkV bs facts chunk
+  else
+    Task.pure (denseRunForcedChunkV bs facts chunk)
+
+def denseInsertForcedV (dσ : DenseSolved p) (forced : List (VarId × ZMod p)) : DenseSolved p :=
+  dσ.insertAll (forced.map (fun f => (f.1, DenseExpr.const f.2)))
+
+/-- Preflight targets, then run real scans in at most `domainBatchParallelChunks` ordered tasks. -/
 def denseCollectForcedV (bs : BusSemantics p) (facts : BusFacts p bs)
     (T : DenseDomainTable p) (fidx : DenseForcedIdx p) (parallel : Bool)
     (targets : List (List VarId)) (seen : Std.HashSet (List VarId)) (dσ0 : DenseSolved p) :
     DenseSolved p :=
   let uniq := denseDedupTargetsV targets seen
+  let plans := uniq.filterMap (denseForcedPreflightV T fidx)
   if parallel then
-    let tasks := uniq.map (fun xs => Task.spawn fun _ => denseForcedOverV bs facts T fidx xs)
-    tasks.foldl (init := dσ0) fun dσ t =>
-      dσ.insertAll ((t.get).map (fun f => (f.1, DenseExpr.const f.2)))
+    let totalWork := plans.foldl (fun total plan => total + plan.work) 0
+    let budget := max 1 ((totalWork + domainBatchParallelChunks - 1) /
+      domainBatchParallelChunks)
+    let chunks := denseForcedChunksV budget (domainBatchParallelChunks - 1) plans
+    let tasks := chunks.map (denseForcedChunkTaskV bs facts)
+    (tasks.flatMap Task.get).foldl denseInsertForcedV dσ0
   else
-    uniq.foldl (init := dσ0) fun dσ xs =>
-      dσ.insertAll ((denseForcedOverV bs facts T fidx xs).map (fun f => (f.1, DenseExpr.const f.2)))
+    plans.foldl (fun dσ plan => denseInsertForcedV dσ (denseRunForcedPlanV bs facts plan)) dσ0
 
 /-! ## The pass transform, value-only -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -1611,7 +1611,7 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
       ((denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false)
         ∧ ∀ i ∈ denseBIVars bi, i ∈ xs) :
     ∀ f ∈ denseForcedOverV bs facts T fidx xs, denv f.1 = f.2 := by
-  unfold denseForcedOverV
+  unfold denseForcedOverV denseForcedPreflightV
   cases hdoms : T.doms xs with
   | none => intro f hf; simp at hf
   | some fdoms =>
@@ -1642,7 +1642,10 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
           rw [hcontra] at hsurv; exact absurd hsurv (by simp)
       | some cands =>
           intro f hf
-          obtain ⟨n, hn1, hn2⟩ := mem_zip_filterMap (fdoms.map Prod.fst) cands f hf
+          have hf' : f ∈ ((fdoms.map Prod.fst).zip cands).filterMap
+              (fun xc => xc.2.map (fun c => (xc.1, c))) := by
+            simpa only [denseRunForcedPlanV, denseRunForcedScanV, hscan] using hf
+          obtain ⟨n, hn1, hn2⟩ := mem_zip_filterMap (fdoms.map Prod.fst) cands f hf'
           have hforce := denseScanBoxV_forces _ _ cands hscan n f.2 hn2 _ hinbox hsurv
           rw [List.getElem?_map, hn1] at hforce
           simp only [Option.map_some, Option.some.injEq] at hforce
@@ -1711,6 +1714,77 @@ theorem EntailedMap_foldl_insert (d : DenseConstraintSystem p) (bs : BusSemantic
     with `fn ()`). -/
 theorem get_spawn {α : Type} (f : Unit → α) : (Task.spawn f).get = f () := rfl
 
+theorem get_pure {α : Type} (x : α) : (Task.pure x).get = x := rfl
+
+theorem denseTakeForcedChunkV_append (budget used : Nat) (plans : List (DenseForcedPlanV p)) :
+    (denseTakeForcedChunkV budget plans used).1 ++
+      (denseTakeForcedChunkV budget plans used).2 = plans := by
+  induction plans generalizing used with
+  | nil => rfl
+  | cons plan rest ih =>
+    rw [denseTakeForcedChunkV]
+    by_cases hsplit : used != 0 && budget < used + plan.work
+    · rw [if_pos hsplit]
+      rfl
+    · rw [if_neg hsplit]
+      simpa only [List.cons_append] using
+        congrArg (plan :: ·) (ih (used + plan.work))
+
+theorem denseForcedChunksV_flatten (budget splits : Nat) (plans : List (DenseForcedPlanV p)) :
+    (denseForcedChunksV budget splits plans).flatten = plans := by
+  induction splits generalizing plans with
+  | zero => cases plans <;> simp [denseForcedChunksV]
+  | succ splits ih =>
+    cases plans with
+    | nil => simp [denseForcedChunksV]
+    | cons plan rest =>
+      simp only [denseForcedChunksV, List.flatten_cons, ih]
+      exact denseTakeForcedChunkV_append budget 0 (plan :: rest)
+
+theorem denseForcedChunkTaskV_get (bs : BusSemantics p) (facts : BusFacts p bs)
+    (chunk : List (DenseForcedPlanV p)) :
+    (denseForcedChunkTaskV bs facts chunk).get = denseRunForcedChunkV bs facts chunk := by
+  unfold denseForcedChunkTaskV
+  split
+  · exact get_spawn _
+  · exact get_pure _
+
+private theorem denseFlatMapMap_eq_mapFlatten {α β : Type} (f : α → β)
+    (chunks : List (List α)) :
+    chunks.flatMap (fun chunk => chunk.map f) = chunks.flatten.map f := by
+  induction chunks with
+  | nil => rfl
+  | cons chunk rest ih => simp only [List.flatMap_cons, List.flatten_cons, List.map_append, ih]
+
+theorem denseForcedChunkTasksV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (budget splits : Nat) (plans : List (DenseForcedPlanV p)) :
+    ((denseForcedChunksV budget splits plans).map (denseForcedChunkTaskV bs facts)).flatMap
+        Task.get = plans.map (denseRunForcedPlanV bs facts) := by
+  rw [List.flatMap_map]
+  simp only [denseForcedChunkTaskV_get, denseRunForcedChunkV]
+  rw [denseFlatMapMap_eq_mapFlatten, denseForcedChunksV_flatten]
+
+private theorem densePreflightFoldV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (T : DenseDomainTable p) (fidx : DenseForcedIdx p) (targets : List (List VarId))
+    (dσ0 : DenseSolved p) :
+    (targets.filterMap (denseForcedPreflightV T fidx)).foldl
+        (fun dσ plan => denseInsertForcedV dσ (denseRunForcedPlanV bs facts plan)) dσ0 =
+      targets.foldl (fun dσ xs => dσ.insertAll
+        ((denseForcedOverV bs facts T fidx xs).map (fun f => (f.1, DenseExpr.const f.2)))) dσ0 := by
+  induction targets generalizing dσ0 with
+  | nil => rfl
+  | cons xs rest ih =>
+    cases hp : denseForcedPreflightV T fidx xs with
+    | none =>
+      simp only [List.filterMap_cons, hp, List.foldl_cons, denseForcedOverV,
+        List.map_nil, DenseSolved.insertAll]
+      exact ih dσ0
+    | some plan =>
+      simp only [List.filterMap_cons, hp, List.foldl_cons, denseForcedOverV,
+        denseInsertForcedV]
+      exact ih (dσ0.insertAll
+        ((denseRunForcedPlanV bs facts plan).map (fun f => (f.1, DenseExpr.const f.2))))
+
 /-- The parallel and serial branches of `denseCollectForcedV` compute the same solution map, so the
     entailment invariant can be proved over the single serial fold over `denseDedupTargetsV`. -/
 theorem denseCollectForcedV_eq_serial (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -1722,8 +1796,9 @@ theorem denseCollectForcedV_eq_serial (bs : BusSemantics p) (facts : BusFacts p 
             ((denseForcedOverV bs facts T fidx xs).map (fun f => (f.1, DenseExpr.const f.2)))) dσ0 := by
   simp only [denseCollectForcedV]
   split_ifs with hp
-  · simp only [List.foldl_map, get_spawn]
-  · rfl
+  · rw [denseForcedChunkTasksV_eq, List.foldl_map]
+    exact densePreflightFoldV bs facts T fidx (denseDedupTargetsV targets seen) dσ0
+  · exact densePreflightFoldV bs facts T fidx (denseDedupTargetsV targets seen) dσ0
 
 /-- The `collectForced` fold preserves the entailment invariant (via
     `denseCollectForcedV_eq_serial`; `hforced` is stated for every variable set). -/

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -275,9 +275,9 @@ worklists where a substitution dirties only the items mentioning substituted var
 the levers there are effectiveness-side (replace enumeration classes with algebra, cf. the
 quadratic-roots effectiveness idea 1) or intra-enumeration.
 
-**R7. Intra-pass parallelism**  ·  partially **done (entry 114)**: domainBatch's per-target
-enumerations are `Task`-parallel with ordered joins (byte-identical σ; keccak domainBatch
-55 → 18 s on 4 cores — CI's 32 cores have more headroom). Still open: domainFold's and
+**R7. Intra-pass parallelism**  ·  partially **done (entries 114, 132)**: domainBatch's independent
+enumerations use ordered parallel joins, with entry 132 preflighting every target and replacing
+per-target tasks with at most 64 contiguous work-balanced chunks. Still open: domainFold's and
 reencode's per-target *gating* work is also independent between accepts, but their loops rewrite
 `cs` on accept, so parallelizing needs a speculative gather-then-replay structure — only worth it
 if their serial remainder grows relative to the rest. busPairCancel/busUnify are inherently

--- a/docs/log.md
+++ b/docs/log.md
@@ -4578,3 +4578,31 @@ Full same-runner runtime and effectiveness evaluation is delegated to the draft 
 and proof-integrity/unused-theorem checks pass.
 
 **Worked locally: yes (representative domainBatch runtime win; full-set result pending CI).**
+
+### 132. Runtime: preflighted bounded domainBatch tasks
+
+`domainBatch` now separates per-target planning from enumeration. The sequential preflight applies
+all domain, box-size, informativeness, and work gates, resolves the no-effective-filter shortcut,
+and drops rejected targets before any task is created. Remaining plans are partitioned into at most
+64 contiguous chunks by estimated scan work; only chunks containing a real scan use `Task.spawn`,
+while immediate singleton results use `Task.pure`. Results are joined and inserted in original
+target order.
+
+The generated C completes the `filterMap` preflight before constructing chunks or tasks, has its
+only spawn in the chunk runner, and captures the compiled plan chunk rather than the domain table
+and target index. A `gdb` counter on OpenVM keccak observed 193 task spawns over all ten pass
+invocations, versus the old first invocation alone spawning 24,582 per-target tasks. The new proof
+shows that chunk flattening restores the exact plan sequence and that both spawned and pure tasks
+return the serial result, preserving `denseCollectForcedV_eq_serial` and the existing correctness
+argument.
+
+Local profiles used entry 131's merged measurements as the baseline; no `origin/main` binary was
+rebuilt. `domainBatch` changed from 1449 → 1525 ms on OpenVM keccak, 206 → 209 ms on
+`openvm-eth/apc_044`, 36 → 33 ms on `openvm-eth/apc_094`, 1616 → 1590 ms on
+`wasm-eth/apc_063`, and 29 → 29 ms on `wasm-eth/apc_065`. The five-case sum was 3336 → 3386 ms
+(+1.5%, within local timing noise), with unchanged cleanup iteration counts. The main result is the
+bounded task count and removal of rejected-target task allocation; full same-runner runtime and
+effectiveness evaluation is delegated to the draft PR's CI workflows.
+
+**Worked locally: yes (fan-out reduced by orders of magnitude; representative runtime neutral;
+full-set result pending CI).**


### PR DESCRIPTION
## Summary

- preflight every deduplicated domainBatch target before scheduling, dropping rejected targets and resolving immediate singleton results without task allocation
- partition real scan plans into at most 64 contiguous, estimated-work-balanced chunks and join them in target order
- prove chunked and serial collection are identical, including both spawned and pure task paths
- record the mechanism, generated-C inspection, and representative profiles in the runtime log

## Why

The former parallel path spawned one task per raw target. On OpenVM keccak, its first invocation created 24,582 tasks for only 4,103 eligible enumerations. The bounded implementation created 193 tasks across the entire ten-invocation profile.

## Validation

- `lake build` (2,538 jobs, warning-free)
- `Scripts/check-proof-integrity.sh`
- generated C inspection: preflight completes before task creation; the only spawn is the chunk runner and its closure captures the compiled chunk rather than the domain table/index
- representative local profiles against merged #185 values: domainBatch five-case sum 3336 → 3386 ms (+1.5%, within local timing noise), with unchanged cleanup iteration counts

Full same-runner runtime and effectiveness evaluation is delegated to triggered PR CI.