### PR TITLE
Runtime: streamline domainBatch generated field setup

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -265,8 +265,8 @@ def denseBoxFoldV {β : Type} (ops : DenseZModOps p) (f : β → List (ZMod p) �
         (fun acc'' v => f acc'' (v :: a)) stop acc') stop rest acc
 
 /-- `(assignments doms).all pred`, value-only (used by `denseConstraintRedundantV`). -/
-def denseAllBoxV (pred : List (ZMod p) → Bool) (doms : List (FiniteDomain p)) : Bool :=
-  let ops : DenseZModOps p := denseZModOps
+def denseAllBoxV (ops : DenseZModOps p) (pred : List (ZMod p) → Bool)
+    (doms : List (FiniteDomain p)) : Bool :=
   denseBoxFoldV ops (fun acc pt => acc && pred pt) (fun acc => !acc) doms true
 
 /-! ### The value-only box scan
@@ -297,9 +297,9 @@ def denseScanStopV : Option (DenseCandsV p) → Bool
 
 /-- The value-only box scan, streamed lazily over the symbolic domains; the caller
     (`denseForcedOverV`) zips the final mask with `keys` once, after the scan finishes. -/
-def denseScanBoxV (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p)) :
+def denseScanBoxV (ops : DenseZModOps p) (surv : List (ZMod p) → Bool)
+    (doms : List (FiniteDomain p)) :
     Option (DenseCandsV p) :=
-  let ops : DenseZModOps p := denseZModOps
   denseBoxFoldV ops (denseScanStepV surv) denseScanStopV doms none
 
 /-! ## Redundancy check, value-only -/
@@ -315,11 +315,13 @@ def denseConstraintRedundantV (T : DenseDomainTable p) (c : DenseExpr p) : Bool 
       | some ic =>
         let ops : DenseZModOps p := denseZModOps
         let dec : DecidableEq (ZMod p) := inferInstance
-        denseAllBoxV
+        denseAllBoxV ops
           (fun a => @decide (denseIExprEvalWithV ops a ic = ops.zero) (dec _ ops.zero))
           (d.map Prod.snd)
       | none =>
-        denseAllBoxV (fun a => decide (c.eval (denseEnvOfKeysV (d.map Prod.fst) a) = 0))
+        let ops : DenseZModOps p := denseZModOps
+        denseAllBoxV ops
+          (fun a => decide (c.eval (denseEnvOfKeysV (d.map Prod.fst) a) = ops.zero))
           (d.map Prod.snd)
 
 def denseDomainBelowV (d : FiniteDomain p) (bound : Nat) : Bool :=
@@ -503,11 +505,15 @@ def denseForcedPreflightV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
       else none
     else none
 
+def densePairValueV (value : ZMod p) (keys : List VarId) : List (VarId × ZMod p) :=
+  keys.map (fun x => (x, value))
+
 def denseRunForcedScanV (bs : BusSemantics p) (facts : BusFacts p bs)
     (job : DenseForcedScanV p) : List (VarId × ZMod p) :=
   let survC := denseCompiledSurvV bs facts job.active job.interactions job.keys
-  match denseScanBoxV survC.run job.doms with
-  | none => job.keys.map (fun x => (x, (0 : ZMod p)))
+  let ops : DenseZModOps p := denseZModOps
+  match denseScanBoxV ops survC.run job.doms with
+  | none => densePairValueV ops.zero job.keys
   | some cands =>
     (job.keys.zip cands).filterMap (fun xc => xc.2.map (fun c => (xc.1, c)))
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -616,15 +616,17 @@ theorem foldlStop_denseScanStep_none (surv : List (ZMod p) → Bool) :
       · exact ih h pt' hpt'
 
 /-- **Value-only scan `none` case.** No point of the box survives the scanned predicate. -/
-theorem denseScanBoxV_none_unsat (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p))
-    (h : denseScanBoxV surv doms = none) : ∀ pt ∈ assignmentsV doms, surv pt = false := by
+theorem denseScanBoxV_none_unsat (ops : DenseZModOps p) (surv : List (ZMod p) → Bool)
+    (doms : List (FiniteDomain p)) (h : denseScanBoxV ops surv doms = none) :
+    ∀ pt ∈ assignmentsV doms, surv pt = false := by
   rw [denseScanBoxV, denseBoxFoldV_eq] at h
   exact foldlStop_denseScanStep_none surv (assignmentsV doms) h
 
 /-- **Value-only scan `some` case.** A `some c` in the returned mask is agreed on by every surviving
     enumerated point. -/
-theorem denseScanBoxV_forces (surv : List (ZMod p) → Bool) (doms : List (FiniteDomain p))
-    (mask : DenseCandsV p) (h : denseScanBoxV surv doms = some mask) (n : Nat) (c : ZMod p)
+theorem denseScanBoxV_forces (ops : DenseZModOps p) (surv : List (ZMod p) → Bool)
+    (doms : List (FiniteDomain p)) (mask : DenseCandsV p)
+    (h : denseScanBoxV ops surv doms = some mask) (n : Nat) (c : ZMod p)
     (hmask : mask[n]? = some (some c)) :
     ∀ pt ∈ assignmentsV doms, surv pt = true → pt[n]? = some c := by
   rw [denseScanBoxV, denseBoxFoldV_eq] at h
@@ -1632,13 +1634,13 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
         · exact fun bi hbi => (hbis bi hbi).1
         · intro e he i hi; rw [hkeys]; exact (hes e he).2 i hi
         · intro bi hbi i hi; rw [hkeys]; exact (hbis bi hbi).2 i hi
-      cases hscan : denseScanBoxV (denseCompiledSurvV bs facts
+      cases hscan : denseScanBoxV (denseZModOps : DenseZModOps p) (denseCompiledSurvV bs facts
           (denseGatherConstraintsV fidx xs).active
           (denseGatherBusesV fidx xs).interactions
           (fdoms.map Prod.fst)).run (fdoms.map Prod.snd) with
       | none =>
           intro f hf
-          have hcontra := denseScanBoxV_none_unsat _ _ hscan _ hinbox
+          have hcontra := denseScanBoxV_none_unsat _ _ _ hscan _ hinbox
           rw [hcontra] at hsurv; exact absurd hsurv (by simp)
       | some cands =>
           intro f hf
@@ -1646,7 +1648,7 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
               (fun xc => xc.2.map (fun c => (xc.1, c))) := by
             simpa only [denseRunForcedPlanV, denseRunForcedScanV, hscan] using hf
           obtain ⟨n, hn1, hn2⟩ := mem_zip_filterMap (fdoms.map Prod.fst) cands f hf'
-          have hforce := denseScanBoxV_forces _ _ cands hscan n f.2 hn2 _ hinbox hsurv
+          have hforce := denseScanBoxV_forces _ _ _ cands hscan n f.2 hn2 _ hinbox hsurv
           rw [List.getElem?_map, hn1] at hforce
           simp only [Option.map_some, Option.some.injEq] at hforce
           exact hforce

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -187,13 +187,15 @@ these need no new proof.
      still recompute per-constraint `eraseDups`, but only on gate-passing constraints (proofs
      unfold them — rework only if they show up in profiles).
 
-**R2. domainBatch setup and enumeration**  ·  **mostly done (entries 104, 128–131)**. Entry 129
+**R2. domainBatch setup and enumeration**  ·  **mostly done (entries 104, 128–133)**. Entry 129
 skips the Cartesian scan when every active filter is already discharged by
 constant evaluation or exact `BusFacts` and extracts constant domains directly. Entry 130 stores
 anchor buckets as arrays and summarizes inactive variable-free constraints once, so targets no
 longer materialize candidate lists or walk the same inactive tail. Entry 131 advances range domains
 in `ZMod` instead of recasting each element and compiles exact range/byte bus facts into scalar,
-allocation-free checks, with the opaque evaluator retained as fallback. Remaining:
+allocation-free checks, with the opaque evaluator retained as fallback. Entry 133 keeps field
+operation records behind the redundancy gates and threads the scan's record through its vacuous
+result construction. Remaining:
 `constraintRedundant` full-box scans (they pay once to save per-target work), the list-shaped point
 and candidate-mask scanner, and hot-variable bucket capping (not byte-identical — the gates read
 `esFull`).

--- a/docs/log.md
+++ b/docs/log.md
@@ -4606,3 +4606,29 @@ effectiveness evaluation is delegated to the draft PR's CI workflows.
 
 **Worked locally: yes (fan-out reduced by orders of magnitude; representative runtime neutral;
 full-set result pending CI).**
+
+### 133. Runtime: hoist domainBatch field support out of generated loops
+
+The redundancy checker now receives one `DenseZModOps` record in its box fold and constructs that
+record only after the domain and box-size gates. Its fallback compares against the record's zero,
+so generated `denseConstraintRedundantV` no longer constructs and projects a `ZMod` ring dictionary
+at function entry for every constraint, including early rejects. The box scanner likewise receives
+its operations record from `denseRunForcedScanV`; the vacuous-result path passes `ops.zero` to a
+first-order key/value mapper instead of reconstructing generic zero on every recursive map step.
+
+Generated C confirms that the redundancy function begins directly with variable/domain lookup and
+does not build field support before either early exit. The new mapping loop takes zero as a value
+argument and contains no `ZMod_commRing` call or superclass projection. Constant range bounds were
+already stored in compiled bus plans by entry 131, and entry 130's gather loops already use borrowed
+array reads, tail jumps, and exclusive accumulators with no `lean_dec_ref_cold`, so those two proposed
+cleanups required no further source change.
+
+Three local runs of each `domainBatchProposals.md` representative used entry 132's merged
+measurements as the baseline; no baseline binary was rebuilt. Median `domainBatch` time changed
+from 1525 → 1504 ms on OpenVM keccak, 209 → 203 ms on `openvm-eth/apc_044`, 33 → 33 ms on
+`openvm-eth/apc_094`, 1590 → 1569 ms on `wasm-eth/apc_063`, and 29 → 28 ms on
+`wasm-eth/apc_065`. The five-case sum was 3386 → 3337 ms (−1.4%). Cleanup iteration counts and
+final sizes were unchanged. Full same-runner runtime and effectiveness evaluation is delegated to
+the draft PR's CI workflows.
+
+**Worked locally: yes (small consistent representative runtime win; full-set result pending CI).**


### PR DESCRIPTION
## Summary

- pass a single `DenseZModOps` record into domainBatch redundancy and scan box folds instead of reconstructing field support inside them
- keep redundancy-check field setup behind the domain and box-size gates
- make the vacuous scan result mapper accept `ops.zero` as an explicit value, eliminating generic-zero reconstruction per key
- update the scan proofs for the explicit operations parameter and record the generated-code/runtime evidence

The other two proposed cleanups were already present after #185/#186: constant range bounds live in compiled bus predicates, and gather loops emit borrowed array reads with tail jumps and exclusive accumulators.

## Root cause

Lean's generated code hoisted the fallback's generic `ZMod` zero support to the entry of `denseConstraintRedundantV`. That built and projected the ring dictionary for every constraint, including early rejects. The vacuous `keys.map (fun x => (x, 0))` specialization repeated the same dictionary traversal on every recursive map step.

The new generated C starts redundancy checking with variable/domain lookup and constructs field operations only after the cheap gates. Its key/value mapper receives zero directly and has no `ZMod_commRing` or superclass-projection calls.

## Local evaluation

Three runs per representative, using merged #186's recorded values as baseline:

| case | #186 | this branch (median) |
|---|---:|---:|
| OpenVM keccak | 1525 ms | 1504 ms |
| openvm-eth apc_044 | 209 ms | 203 ms |
| openvm-eth apc_094 | 33 ms | 33 ms |
| wasm-eth apc_063 | 1590 ms | 1569 ms |
| wasm-eth apc_065 | 29 ms | 28 ms |
| **sum** | **3386 ms** | **3337 ms (-1.4%)** |

Cleanup iteration counts and final sizes were unchanged. Full same-runner runtime and effectiveness evaluation is delegated to PR CI.

## Validation

- `lake build` (2,538 jobs, warning-free)
- `Scripts/check-proof-integrity.sh`
- generated `DomainBatchRuntime.c` inspection
- three local profiles of each representative APC