### PR TITLE
Byte-justify values through a surviving bitwise-lookup (XOR) relation

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
@@ -186,12 +186,62 @@ def denseBasisJustified (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSema
   | some L => denseBasisReduceGo bound bnd facts fwits basisFuel 0 L.norm
   | none => false
 
+/-! ## Bitwise-lookup AND/OR-output justification -/
+
+/-- The form `2·x + r − o1 − o2`, whose vanishing witnesses `2·x = o1 + o2 − r` (`x = o1 & o2`). -/
+def denseXorAndForm (x : VarId) (o1 o2 r : DenseExpr p) : DenseExpr p :=
+  .add (.mul (.const 2) (.var x))
+    (.add r (.add (.mul (.const (-1)) o1) (.mul (.const (-1)) o2)))
+
+/-- The form `2·x − r − o1 − o2`, whose vanishing witnesses `2·x = o1 + o2 + r` (`x = o1 | o2`). -/
+def denseXorOrForm (x : VarId) (o1 o2 r : DenseExpr p) : DenseExpr p :=
+  .add (.mul (.const 2) (.var x))
+    (.add (.mul (.const (-1)) r) (.add (.mul (.const (-1)) o1) (.mul (.const (-1)) o2)))
+
+/-- Does a dense expression linearize to the zero form (`= 0` under every assignment)? -/
+def denseLinIsZero (e : DenseExpr p) : Bool :=
+  match denseLinearize e with
+  | some L => decide ((DenseLinExpr.norm L).const = 0) && (DenseLinExpr.norm L).terms.isEmpty
+  | none => false
+
+/-- Does one surviving interaction pin `x` as the AND (or, when `allowOr`, OR) output of a
+    byte-forced XOR pair? On a `byteXorSpec` bus (byte bound `≤ 256`), an active (nonzero constant
+    multiplicity) message decoding to `(op, o1, o2, r)` with `op = xorOp` forces `o1, o2 ∈ [0,256)`
+    and `r = o1 ⊕ o2`; if the result slot additionally obeys `r = o1 + o2 − 2·x` (then `x = o1 & o2`)
+    or, when `allowOr`, `r = 2·x − o1 − o2` (then `x = o1 | o2`), then `x ∈ [0,256)` under every
+    assignment satisfying the interaction. E.g. the surviving XOR `[b, c, -2·x + b + c, 1]` pins the
+    AND output `x < 256`. The OR arm is gated by `allowOr` because it is only enabled where it is
+    variable-safe (see the dispatcher). Soundness in `Proofs/BusPairCancelJustify.lean`. -/
+def denseXorAndByteWit (allowOr : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  match facts.byteXorSpec bi.busId with
+  | none => false
+  | some spec =>
+    decide (spec.bound ≤ 256) &&
+    (match bi.multiplicity.constValue? with
+     | some mv => decide (mv ≠ 0)
+     | none => false) &&
+    (match spec.decode bi.payload with
+     | some (op, o1, o2, r) =>
+       decide (op = (.const spec.xorOp : DenseExpr p)) &&
+       (denseLinIsZero (denseXorAndForm x o1 o2 r) ||
+         (allowOr && denseLinIsZero (denseXorOrForm x o1 o2 r)))
+     | none => false)
+
+/-- Is `x` byte-justified by some surviving XOR interaction in `wl` (`denseXorAndByteWit`)? -/
+def denseXorAndByteJustified (allowOr : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) (wl : List (BusInteraction (DenseExpr p))) : Bool :=
+  wl.any (denseXorAndByteWit allowOr bs facts x)
+
 /-- Is `e` provably a byte under every assignment satisfying the remaining system? Tries, in order:
     a constant `< bound`; a variable with a bus-fact bound `≤ bound`; (when `deep`) a
-    selector-flag-domain deep justification or a single-variable finite-domain justification; an
-    affine recomposition of bounded limbs; or a basis reduction against range-checked slot forms
-    (`fwits`). Remaining interactions are consulted through `wits`; `domCs`/`candsOf` are precomputed
-    by the caller. -/
+    selector-flag-domain deep justification, or a bitwise-lookup AND/OR-output justification
+    (`denseXorAndByteWit`), or a single-variable finite-domain justification; an affine recomposition
+    of bounded limbs; or a basis reduction against range-checked slot forms (`fwits`). Remaining
+    interactions are consulted through `wits`; `domCs`/`candsOf` are precomputed by the caller. The
+    AND/OR arm allows the OR form only via `wits` (never `fwits`): the memory-limb XOR that would
+    unlock it in the pair-cancel caller is a `fwits` form-witness, and enabling OR there perturbs the
+    memory-ordering gadgets into a variable regression, so it is kept to the variable-safe AND form. -/
 def denseByteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
@@ -205,7 +255,10 @@ def denseByteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
         | some b => decide (b ≤ bound)
         | none => false) ||
        (deep && decide (256 ≤ bound) &&
-         denseDeepByteJustified domCs (candsOf x) bs facts wits x)
+         denseDeepByteJustified domCs (candsOf x) bs facts wits x) ||
+       (deep && decide (256 ≤ bound) &&
+         (denseXorAndByteJustified true bs facts x (wits x) ||
+           denseXorAndByteJustified false bs facts x (fwits x)))
      | _ => false) ||
     (deep && decide (256 ≤ bound) && denseDomainByteJustified domCs e) ||
     denseAffineJustified bound (fun x => denseFindVarBound bs facts (wits x) x) e ||

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
@@ -457,6 +457,209 @@ theorem denseBasisJustified_sound (bound : Nat) (bnd : VarId → Option Nat) {bs
       Nat.mod_eq_of_lt (by omega)]
     omega
 
+/-! # Soundness of the bitwise-lookup AND/OR-output justification
+
+`_sound` lemmas for `denseXorAndByteWit`/`denseXorAndByteJustified`: a surviving bus-6 XOR
+interaction whose result slot pins `2·x = o1 + o2 − r` (the AND output `x = o1 & o2`) or
+`2·x = o1 + o2 + r` (the OR output `x = o1 | o2`) forces `x` into `[0,256)`, backed by
+`byteXorSpec_sound` (the bus semantics) — not reproven here. -/
+
+/-- Bit-decomposition identity `a + b = (a ⊕ b) + 2·(a & b)`, by strong recursion on the low bit. -/
+theorem nat_add_eq_xor_add_two_mul_and (a : ℕ) :
+    ∀ b, a + b = Nat.xor a b + 2 * Nat.land a b := by
+  induction a using Nat.strong_induction_on with
+  | _ a ih =>
+    intro b
+    rcases Nat.eq_zero_or_pos a with rfl | ha
+    · simp
+    · have hrec := ih (a / 2) (Nat.div_lt_self ha (by norm_num)) (b / 2)
+      have hxd : Nat.xor a b / 2 = Nat.xor (a / 2) (b / 2) := Nat.xor_div_two
+      have had : Nat.land a b / 2 = Nat.land (a / 2) (b / 2) := Nat.and_div_two
+      have hxm := Nat.div_add_mod (Nat.xor a b) 2
+      have ham := Nat.div_add_mod (Nat.land a b) 2
+      have hda := Nat.div_add_mod a 2
+      have hdb := Nat.div_add_mod b 2
+      have hla2 : Nat.land a b % 2 = 1 ↔ (a % 2 = 1 ∧ b % 2 = 1) := Nat.and_mod_two_eq_one
+      have hxa2 : (Nat.xor a b % 2 = 1) ↔ ¬(a % 2 = 1 ↔ b % 2 = 1) := Nat.xor_mod_two_eq_one
+      have hmx := Nat.mod_two_eq_zero_or_one (Nat.xor a b)
+      have hml := Nat.mod_two_eq_zero_or_one (Nat.land a b)
+      rw [hxd] at hxm
+      rw [had] at ham
+      rcases Nat.mod_two_eq_zero_or_one a with hpa | hpa <;>
+        rcases Nat.mod_two_eq_zero_or_one b with hpb | hpb <;> omega
+
+/-- Bit-decomposition identity `a + b + (a ⊕ b) = 2·(a | b)`, by strong recursion on the low bit. -/
+theorem nat_add_add_xor_eq_two_mul_lor (a : ℕ) :
+    ∀ b, a + b + Nat.xor a b = 2 * Nat.lor a b := by
+  induction a using Nat.strong_induction_on with
+  | _ a ih =>
+    intro b
+    rcases Nat.eq_zero_or_pos a with rfl | ha
+    · simp [Nat.two_mul]
+    · have hrec := ih (a / 2) (Nat.div_lt_self ha (by norm_num)) (b / 2)
+      have hxd : Nat.xor a b / 2 = Nat.xor (a / 2) (b / 2) := Nat.xor_div_two
+      have hod : Nat.lor a b / 2 = Nat.lor (a / 2) (b / 2) := Nat.or_div_two
+      have hxm := Nat.div_add_mod (Nat.xor a b) 2
+      have hom := Nat.div_add_mod (Nat.lor a b) 2
+      have hda := Nat.div_add_mod a 2
+      have hdb := Nat.div_add_mod b 2
+      have hlo2 : Nat.lor a b % 2 = 1 ↔ (a % 2 = 1 ∨ b % 2 = 1) := Nat.or_mod_two_eq_one
+      have hxa2 : (Nat.xor a b % 2 = 1) ↔ ¬(a % 2 = 1 ↔ b % 2 = 1) := Nat.xor_mod_two_eq_one
+      have hmx := Nat.mod_two_eq_zero_or_one (Nat.xor a b)
+      have hmo := Nat.mod_two_eq_zero_or_one (Nat.lor a b)
+      rw [hxd] at hxm
+      rw [hod] at hom
+      rcases Nat.mod_two_eq_zero_or_one a with hpa | hpa <;>
+        rcases Nat.mod_two_eq_zero_or_one b with hpb | hpb <;> omega
+
+/-- If `denseLinIsZero e` holds, `e` evaluates to `0` under every assignment. -/
+theorem denseLinIsZero_sound (e : DenseExpr p) (h : denseLinIsZero e = true)
+    (denv : VarId → ZMod p) : e.eval denv = 0 := by
+  unfold denseLinIsZero at h
+  cases hL : denseLinearize e with
+  | none => rw [hL] at h; simp at h
+  | some L =>
+    rw [hL, Bool.and_eq_true] at h
+    obtain ⟨hconst, hterms⟩ := h
+    have hconst' : (DenseLinExpr.norm L).const = 0 := of_decide_eq_true hconst
+    have hterms' : (DenseLinExpr.norm L).terms = [] := List.isEmpty_iff.mp hterms
+    rw [denseLinearize_eval e L hL denv, ← DenseLinExpr.norm_eval]
+    simp only [DenseLinExpr.eval, hconst', hterms', List.map_nil, List.sum_nil, add_zero]
+
+/-- Evaluation of the AND-witness form `2·x + r − o1 − o2`. -/
+theorem denseXorAndForm_eval (x : VarId) (o1 o2 r : DenseExpr p) (denv : VarId → ZMod p) :
+    (denseXorAndForm x o1 o2 r).eval denv
+      = 2 * denv x + r.eval denv - o1.eval denv - o2.eval denv := by
+  simp only [denseXorAndForm, DenseExpr.eval]; ring
+
+/-- Evaluation of the OR-witness form `2·x − r − o1 − o2`. -/
+theorem denseXorOrForm_eval (x : VarId) (o1 o2 r : DenseExpr p) (denv : VarId → ZMod p) :
+    (denseXorOrForm x o1 o2 r).eval denv
+      = 2 * denv x - r.eval denv - o1.eval denv - o2.eval denv := by
+  simp only [denseXorOrForm, DenseExpr.eval]; ring
+
+/-- From `2·z = 2·k` (in `ZMod p`, `p` prime) with `k < 256` a natural, conclude `z.val < 256`:
+    cancel `2` (field, unless `p = 2` where `z.val < p ≤ 2`). -/
+theorem two_mul_eq_two_mul_byte [Fact p.Prime] (z : ZMod p) (k : ℕ) (hk : k < 256)
+    (hfin : (2 : ZMod p) * z = 2 * ((k : ℕ) : ZMod p)) : z.val < 256 := by
+  haveI : NeZero p := ⟨(Fact.out : p.Prime).ne_zero⟩
+  by_cases h2 : (2 : ZMod p) = 0
+  · have hcast2 : ((2 : ℕ) : ZMod p) = 0 := by exact_mod_cast h2
+    have hdvd : p ∣ 2 := (CharP.cast_eq_zero_iff (ZMod p) p 2).mp hcast2
+    have hple : p ≤ 2 := Nat.le_of_dvd (by decide) hdvd
+    have hlt := ZMod.val_lt z
+    omega
+  · have hz : z = ((k : ℕ) : ZMod p) := mul_left_cancel₀ h2 hfin
+    rw [hz, ZMod.val_natCast]
+    have := Nat.mod_le k p
+    omega
+
+/-- A surviving XOR interaction whose result slot pins `2·x = o1 + o2 − r` (AND) or
+    `2·x = o1 + o2 + r` (OR) forces `x < 256`: the accepted (byte-forced) operands and the XOR
+    relation give `x = o1 & o2` resp. `x = o1 | o2 ∈ [0,256)`. -/
+theorem denseXorAndByteWit_sound [Fact p.Prime] (allowOr : Bool)
+    (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) (bi : BusInteraction (DenseExpr p))
+    (h : denseXorAndByteWit allowOr bs facts x bi = true) (denv : VarId → ZMod p)
+    (hviol : (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.violatesConstraint (denseBIEval bi denv) = false) :
+    (denv x).val < 256 := by
+  unfold denseXorAndByteWit at h
+  cases hspec : facts.byteXorSpec bi.busId with
+  | none => rw [hspec] at h; simp at h
+  | some spec =>
+    rw [hspec, Bool.and_eq_true, Bool.and_eq_true] at h
+    obtain ⟨⟨hbnd, hmul⟩, hdec⟩ := h
+    have hbnd' : spec.bound ≤ 256 := of_decide_eq_true hbnd
+    cases hmc : bi.multiplicity.constValue? with
+    | none => rw [hmc] at hmul; simp at hmul
+    | some mv =>
+      rw [hmc] at hmul
+      have hmv : mv ≠ 0 := of_decide_eq_true hmul
+      cases hd : spec.decode bi.payload with
+      | none => rw [hd] at hdec; simp at hdec
+      | some t =>
+        obtain ⟨op, o1, o2, r⟩ := t
+        rw [hd, Bool.and_eq_true] at hdec
+        obtain ⟨hop, hlin⟩ := hdec
+        have hopEv : op.eval denv = spec.xorOp := by rw [of_decide_eq_true hop]; rfl
+        have hmulEv : (denseBIEval bi denv).multiplicity = mv :=
+          bi.multiplicity.constValue?_sound mv hmc denv
+        have hvf : bs.violatesConstraint (denseBIEval bi denv) = false :=
+          hviol (by rw [hmulEv]; exact hmv)
+        obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound bi.busId spec hspec
+        have hdecEv : spec.decode (denseBIEval bi denv).payload
+            = some (op.eval denv, o1.eval denv, o2.eval denv, r.eval denv) := by
+          show spec.decode (bi.payload.map (fun e => e.eval denv)) = _
+          rw [spec.decode_map, hd]; rfl
+        obtain ⟨ha, hb, hxr⟩ :=
+          ((hsound (denseBIEval bi denv).payload (op.eval denv) (o1.eval denv) (o2.eval denv)
+              (r.eval denv) (denseBIEval bi denv).multiplicity hdecEv).1 hopEv).mp hvf
+        have haa : (((o1.eval denv).val : ℕ) : ZMod p) = o1.eval denv :=
+          ZMod.natCast_rightInverse (o1.eval denv)
+        have hbb : (((o2.eval denv).val : ℕ) : ZMod p) = o2.eval denv :=
+          ZMod.natCast_rightInverse (o2.eval denv)
+        have hrr : (((r.eval denv).val : ℕ) : ZMod p) = r.eval denv :=
+          ZMod.natCast_rightInverse (r.eval denv)
+        rcases Bool.or_eq_true _ _ |>.mp hlin with hand | hor
+        · -- AND: `2·x = o1 + o2 − r`, so `x = o1 & o2`
+          have hzero := denseLinIsZero_sound (denseXorAndForm x o1 o2 r) hand denv
+          rw [denseXorAndForm_eval] at hzero
+          have heq : (2 : ZMod p) * denv x
+              = o1.eval denv + o2.eval denv - r.eval denv := by linear_combination hzero
+          have hident : (o1.eval denv).val + (o2.eval denv).val
+              = (r.eval denv).val + 2 * Nat.land (o1.eval denv).val (o2.eval denv).val := by
+            have hid := nat_add_eq_xor_add_two_mul_and (o1.eval denv).val (o2.eval denv).val
+            rw [← hxr] at hid; exact hid
+          have hZ : o1.eval denv + o2.eval denv
+              = r.eval denv
+                + 2 * ((Nat.land (o1.eval denv).val (o2.eval denv).val : ℕ) : ZMod p) := by
+            have hc := congrArg (fun n : ℕ => (n : ZMod p)) hident
+            push_cast at hc
+            rw [haa, hbb, hrr] at hc
+            linear_combination hc
+          refine two_mul_eq_two_mul_byte (denv x) (Nat.land (o1.eval denv).val (o2.eval denv).val)
+            ?_ (by linear_combination heq + hZ)
+          have hkle : Nat.land (o1.eval denv).val (o2.eval denv).val ≤ (o1.eval denv).val :=
+            Nat.and_le_left
+          omega
+        · -- OR: `2·x = o1 + o2 + r`, so `x = o1 | o2`
+          have hor' : denseLinIsZero (denseXorOrForm x o1 o2 r) = true := by
+            rw [Bool.and_eq_true] at hor; exact hor.2
+          have hzero := denseLinIsZero_sound (denseXorOrForm x o1 o2 r) hor' denv
+          rw [denseXorOrForm_eval] at hzero
+          have heq : (2 : ZMod p) * denv x
+              = o1.eval denv + o2.eval denv + r.eval denv := by linear_combination hzero
+          have hident : (o1.eval denv).val + (o2.eval denv).val + (r.eval denv).val
+              = 2 * Nat.lor (o1.eval denv).val (o2.eval denv).val := by
+            have hid := nat_add_add_xor_eq_two_mul_lor (o1.eval denv).val (o2.eval denv).val
+            rw [← hxr] at hid; exact hid
+          have hZ : o1.eval denv + o2.eval denv + r.eval denv
+              = 2 * ((Nat.lor (o1.eval denv).val (o2.eval denv).val : ℕ) : ZMod p) := by
+            have hc := congrArg (fun n : ℕ => (n : ZMod p)) hident
+            push_cast at hc
+            rw [haa, hbb, hrr] at hc
+            linear_combination hc
+          refine two_mul_eq_two_mul_byte (denv x) (Nat.lor (o1.eval denv).val (o2.eval denv).val)
+            ?_ (by linear_combination heq + hZ)
+          have h256 : (2 : ℕ) ^ 8 = 256 := by norm_num
+          have hlt : Nat.lor (o1.eval denv).val (o2.eval denv).val < 2 ^ 8 :=
+            Nat.or_lt_two_pow (by rw [h256]; omega) (by rw [h256]; omega)
+          rw [h256] at hlt; exact hlt
+
+/-- If some interaction of `wl` (each never violating when active) AND/OR-output-justifies `x`,
+    then `x` is a byte. -/
+theorem denseXorAndByteJustified_sound [Fact p.Prime] (allowOr : Bool)
+    (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) (wl : List (BusInteraction (DenseExpr p)))
+    (h : denseXorAndByteJustified allowOr bs facts x wl = true) (denv : VarId → ZMod p)
+    (hbus : ∀ bi ∈ wl, (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.violatesConstraint (denseBIEval bi denv) = false) :
+    (denv x).val < 256 := by
+  unfold denseXorAndByteJustified at h
+  obtain ⟨bi, hbi, hb⟩ := List.any_eq_true.1 h
+  exact denseXorAndByteWit_sound allowOr bs facts x bi hb denv (hbus bi hbi)
+
 /-! # Soundness of the byte-justification dispatcher
 
 `_sound` lemmas for `denseByteJustifiedW`/`denseByteJustified`/`denseRecvSlotsJustified`.
@@ -500,22 +703,31 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List 
       | var x =>
         dsimp only at h
         show (denv x).val < bound
-        rcases Bool.or_eq_true _ _ |>.mp h with h' | h'
-        · cases hb : denseFindVarBound bs facts (wits x) x with
-          | some b =>
-            rw [hb] at h'
-            dsimp only at h'
+        rcases Bool.or_eq_true _ _ |>.mp h with hAB | hC
+        · rcases Bool.or_eq_true _ _ |>.mp hAB with h' | h'
+          · cases hb : denseFindVarBound bs facts (wits x) x with
+            | some b =>
+              rw [hb] at h'
+              dsimp only at h'
+              exact lt_of_lt_of_le
+                (denseFindVarBound_sound bs facts (wits x) x b hb denv (hbusW x))
+                (of_decide_eq_true h')
+            | none => rw [hb] at h'; simp at h'
+          · rw [Bool.and_eq_true, Bool.and_eq_true] at h'
+            haveI : Fact p.Prime := ⟨hdeep h'.1.1⟩
+            haveI : NeZero p := ⟨(hdeep h'.1.1).ne_zero⟩
             exact lt_of_lt_of_le
-              (denseFindVarBound_sound bs facts (wits x) x b hb denv (hbusW x))
-              (of_decide_eq_true h')
-          | none => rw [hb] at h'; simp at h'
-        · rw [Bool.and_eq_true, Bool.and_eq_true] at h'
-          haveI : Fact p.Prime := ⟨hdeep h'.1.1⟩
-          haveI : NeZero p := ⟨(hdeep h'.1.1).ne_zero⟩
-          exact lt_of_lt_of_le
-            (denseDeepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
-              h'.2 denv hall hbusW)
-            (of_decide_eq_true h'.1.2)
+              (denseDeepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
+                h'.2 denv hall hbusW)
+              (of_decide_eq_true h'.1.2)
+        · rw [Bool.and_eq_true, Bool.and_eq_true] at hC
+          haveI : Fact p.Prime := ⟨hdeep hC.1.1⟩
+          refine lt_of_lt_of_le ?_ (of_decide_eq_true hC.1.2)
+          rcases Bool.or_eq_true _ _ |>.mp hC.2 with hw | hf
+          · exact denseXorAndByteJustified_sound true bs facts x (wits x) hw denv
+              (fun bi hbi => hbusW x bi hbi)
+          · exact denseXorAndByteJustified_sound false bs facts x (fwits x) hf denv
+              (fun bi hbi => hbus bi (hfwits x bi hbi))
       | const n => simp at h
       | add a b => simp at h
       | mul a b => simp at h

--- a/docs/log.md
+++ b/docs/log.md
@@ -4606,3 +4606,40 @@ effectiveness evaluation is delegated to the draft PR's CI workflows.
 
 **Worked locally: yes (fan-out reduced by orders of magnitude; representative runtime neutral;
 full-set result pending CI).**
+### 133. Byte-justify a value through a surviving bitwise-lookup (XOR) relation
+
+The dense byte-justifier (`denseByteJustifiedW`, `BusPairCancelJustify.lean`) could prove
+`e ∈ [0,256)` only from a direct range check, a bus-fact slot bound, a selector-domain
+enumeration, or an affine/basis recomposition — never through a surviving bus-6 (OpenVM
+BitwiseLookup) XOR relation. That blind spot left byte checks and duplicate memory reads
+un-droppable when a read-back value's byteness came only from such a relation.
+
+New arm `denseXorAndByteWit`: on a `byteXorSpec` bus (byte bound `≤ 256`), an active XOR message
+decoding to `(op, o1, o2, r)` with `op = xorOp` forces `o1, o2 ∈ [0,256)` and `r = o1 ⊕ o2`
+(`byteXorSpec_sound`, reused — the bus semantics is not reproven). If the result slot additionally
+pins `2·x = o1 + o2 − r` then `x = o1 & o2`, or `2·x = o1 + o2 + r` then `x = o1 | o2`, so `x` is a
+byte. Soundness rests on the two bit-decomposition identities `a + b = (a⊕b) + 2·(a&b)` and
+`a + b + (a⊕b) = 2·(a|b)` (proved by strong recursion on the low bit) plus a `2·z = 2·k`
+cancellation in the prime field; the recognizer is a purely syntactic linear-identity check on the
+slot, so a false recognition would fail the linear check rather than mis-justify.
+
+Wired into `denseByteJustifiedW`'s `.var x` branch, so both consumers pick it up:
+`redundantByteDrop` drops self-XOR byte checks `[x, x, 0, 1]` whose `x` is already an XOR AND/OR
+output, and `busPairCancel` telescopes exact-duplicate memory send/receive pairs whose read-back
+limbs are so pinned (e.g. apc_042 register reads). The AND form fires from `wits ∪ fwits`; the OR
+form is restricted to `wits` — in the pair-cancel caller the enabling XOR is an `fwits`
+form-witness, and letting OR fire there perturbs a memory address-ordering (`diff_marker`) gadget on
+apc_037 into a +4 variable regression, so OR is kept to the variable-safe path.
+
+Bus interactions before → after on the openvm-eth set (variables unchanged on every case,
+constraints unchanged): apc_042 260 → 244 (−16, the headline duplicate-memory telescoping),
+apc_100 −4, apc_037 −5, apc_073 −2, apc_090 −2, and −1 on each of apc_008/014/018/038/039/051/053/
+056/060/064/069/075/079/092/093/096/097. Set totals 16355 → 16309 bus interactions (−46) with
+27757 → 27757 variables (zero per-case variable regressions). Full same-runner evaluation is
+delegated to the draft PR's CI.
+
+`lake build` is warning-free; proof integrity green (correctness axioms
+{propext, Classical.choice, Quot.sound}, no `sorry`/`admit`/`axiom`/`native_decide`, no unused
+theorems).
+
+**Worked locally: yes (bus-interaction win, zero variable regressions).**


### PR DESCRIPTION
## What

The dense byte-justifier (`denseByteJustifiedW`, `BusPairCancelJustify.lean`) could prove `e ∈ [0,256)` only from a direct range check, a bus-fact slot bound, a selector-domain enumeration, or an affine/basis recomposition — **never through a surviving bus-6 (BitwiseLookup) XOR relation**. That one blind spot left both duplicate memory reads un-telescoped and self-XOR byte checks un-droppable when a value's byteness came only from such a relation.

## Mechanism

New arm `denseXorAndByteWit`: on a `byteXorSpec` bus (byte bound ≤ 256), an active XOR message decoding to `(op, o1, o2, r)` with `op = xorOp` forces `o1, o2 ∈ [0,256)` and `r = o1 ⊕ o2` (reuses `byteXorSpec_sound` — bus semantics not reproven). If the result slot additionally pins `2·x = o1 + o2 − r` then `x = o1 & o2`, or `2·x = o1 + o2 + r` then `x = o1 | o2`, so `x` is a byte. Soundness rests on the bit-decomposition identities `a + b = (a⊕b) + 2·(a&b)` and `a + b + (a⊕b) = 2·(a|b)` plus a `2·z = 2·k` cancellation in the prime field. The recognizer is a purely syntactic linear-identity check on the slot, so a false recognition fails the check rather than mis-justifying.

Wired into `denseByteJustifiedW`'s `.var x` branch, so **both** consumers pick it up:
- `redundantByteDrop` drops self-XOR byte checks `[x, x, 0, 1]` whose `x` is already an XOR AND/OR output;
- `busPairCancel` telescopes exact-duplicate memory send/receive pairs whose read-back limbs are so pinned (e.g. apc_042 register reads).

The AND form fires from `wits ∪ fwits`; the OR form is restricted to `wits` — in the pair-cancel caller the enabling XOR is an `fwits` form-witness, and letting OR fire there perturbs a memory address-ordering (`diff_marker`) gadget on apc_037 into a +4 variable regression, so OR is kept to the variable-safe path.

## Effectiveness (openvm-eth, 100 cases)

Bus interactions **3.558× → 3.568×** (aggregate 16355 → 16309, −46), variables unchanged (4.553×, **zero per-case variable regressions**), constraints unchanged. Headline: apc_042 260 → 244 (−16, duplicate-memory telescoping); plus apc_037 −5, apc_100 −4, apc_073/090 −2, and −1 on each of apc_008/014/018/038/039/051/053/056/060/064/069/075/079/092/093/096/097 (self-XOR drops).

## Checks

- `lake build` warning-free.
- `Scripts/check-proof-integrity.sh` green: correctness axioms `{propext, Classical.choice, Quot.sound}`; no `sorry`/`admit`/`axiom`/`native_decide`; no unused theorems.

Only `Implementation/` (un-audited) touched; no audited surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtHf5UpZK5Xid2bqWPzcv3)_