### PR TITLE
Schedule Gauss pivots by dynamic Markowitz cost

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -2,6 +2,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.Affine
 import ApcOptimizer.Implementation.OptimizerPasses.SubstMap
 import ApcOptimizer.Implementation.OptimizerPasses.Normalize
 import ApcOptimizer.Implementation.OptimizerPasses.ListSplit
+import Batteries.Data.BinaryHeap
 
 set_option autoImplicit false
 
@@ -458,20 +459,298 @@ theorem insertAll_map :
 
 end DenseSolved
 
-/-- Reduce each pending constraint by the current solutions, adopt the cheapest solvable pivot,
-    and resolve it into the affected stored solutions. -/
-def denseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    List (DenseExpr p) → DenseSolved p → DenseSolved p
-  | [], dσ => dσ
-  | c :: rest, dσ =>
-      let c' := (c.substF dσ.fn).normalize
-      match denseFastBest c' occ prot with
-      | none => denseGaussLoop occ prot rest dσ
-      | some (x, t) =>
-          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-          let pairs := touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
-          denseGaussLoop occ prot rest (dσ.insertAll pairs)
+/-! ## Dynamic sparse scheduling -/
+
+def DenseExpr.uniqueVars (e : DenseExpr p) : List VarId :=
+  let st := e.foldVars (fun (out, seen) x =>
+    if seen.contains x then (out, seen) else (x :: out, seen.insert x))
+    (([], ∅) : List VarId × Std.HashSet VarId)
+  st.1.reverse
+
+structure DenseMarkowitzPivot where
+  var : VarId
+  rhsNnz : Nat
+
+structure DenseMarkowitzRow (p : ℕ) where
+  rowId : Nat
+  reduced : DenseExpr p
+  vars : List VarId
+  pivots : List DenseMarkowitzPivot
+  generation : Nat
+  active : Bool
+
+structure DenseMarkowitzEntry where
+  isProtected : Nat
+  fill : Nat
+  rewrite : Nat
+  localScore : Nat
+  rowId : Nat
+  pivot : VarId
+  generation : Nat
+
+def denseMarkowitzEntryBetter (a b : DenseMarkowitzEntry) : Bool :=
+  if a.isProtected < b.isProtected then true
+  else if b.isProtected < a.isProtected then false
+  else if a.fill < b.fill then true
+  else if b.fill < a.fill then false
+  else if a.rewrite < b.rewrite then true
+  else if b.rewrite < a.rewrite then false
+  else if a.localScore < b.localScore then true
+  else if b.localScore < a.localScore then false
+  else if a.rowId < b.rowId then true
+  else if b.rowId < a.rowId then false
+  else if a.pivot.index < b.pivot.index then true
+  else if b.pivot.index < a.pivot.index then false
+  else a.generation < b.generation
+
+def denseMarkowitzHeapLt (a b : DenseMarkowitzEntry) : Bool :=
+  denseMarkowitzEntryBetter b a
+
+abbrev DenseMarkowitzHeap :=
+  Batteries.BinaryHeap DenseMarkowitzEntry denseMarkowitzHeapLt
+
+structure DenseMarkowitzState (p : ℕ) where
+  rows : Array (DenseMarkowitzRow p)
+  degrees : Std.HashMap VarId Nat
+  rowDeps : Std.HashMap VarId (Std.HashSet Nat)
+  pivotRows : Std.HashMap VarId (Std.HashSet Nat)
+  heap : DenseMarkowitzHeap
+
+def denseMarkowitzPivots (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
+  match denseLinearize e with
+  | none => []
+  | some l =>
+      let idx := denseCoeffIdx l.terms
+      let vars := l.terms.map Prod.fst
+      let descs := vars.filterMap (densePm1Desc idx l.terms.length occ prot) ++
+        vars.filterMap (denseUnitDesc idx l.terms.length occ prot)
+      let out := descs.foldl (fun (out, seen) (x, _) =>
+        if seen.contains x then (out, seen)
+        else
+          let cv := (idx[x]?).getD (0, 0)
+          ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
+        (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
+      out.1.reverse
+
+def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) (generation : Nat := 0) : DenseMarkowitzRow p :=
+  let reduced := e.normalize
+  { rowId
+    reduced
+    vars := reduced.uniqueVars
+    pivots := denseMarkowitzPivots reduced occ prot
+    generation
+    active := true }
+
+def denseMarkowitzDegreeAdd (m : Std.HashMap VarId Nat) (xs : List VarId) :
+    Std.HashMap VarId Nat :=
+  xs.foldl (fun m x => m.insert x (m.getD x 0 + 1)) m
+
+def denseMarkowitzDegreeSub (m : Std.HashMap VarId Nat) (xs : List VarId) :
+    Std.HashMap VarId Nat :=
+  xs.foldl (fun m x => m.insert x (m.getD x 0 - 1)) m
+
+def denseMarkowitzIndexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
+  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).insert rowId)) idx
+
+def denseMarkowitzUnindexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
+  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).erase rowId)) idx
+
+def denseMarkowitzIndexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
+    (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
+    Std.HashMap VarId (Std.HashSet Nat) :=
+  pivots.foldl
+    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).insert rowId)) idx
+
+def denseMarkowitzUnindexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
+    (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
+    Std.HashMap VarId (Std.HashSet Nat) :=
+  pivots.foldl
+    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).erase rowId)) idx
+
+def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
+    (r : DenseMarkowitzRow p) (q : DenseMarkowitzPivot) : DenseMarkowitzEntry :=
+  let solvedDegree := ((dσ.revDeps[q.var]?).getD ∅).size
+  let activeDegree := st.degrees.getD q.var 1
+  { isProtected := if prot.contains q.var then 1 else 0
+    fill := q.rhsNnz * (activeDegree - 1)
+    rewrite := q.rhsNnz * solvedDegree
+    localScore := denseGaussScore occ prot q.var q.rhsNnz
+    rowId
+    pivot := q.var
+    generation := r.generation }
+
+def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
+    (r : DenseMarkowitzRow p) : Option DenseMarkowitzEntry :=
+  r.pivots.foldl (fun best q =>
+    let entry := denseMarkowitzEntryOf occ prot dσ st rowId r q
+    match best with
+    | none => some entry
+    | some old => if denseMarkowitzEntryBetter entry old then some entry else best) none
+
+def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat) :
+    DenseMarkowitzState p :=
+  match st.rows[rowId]? with
+  | none => st
+  | some r =>
+      if !r.active then st
+      else
+        let r' := { r with generation := r.generation + 1 }
+        let st' := { st with rows := st.rows.setIfInBounds rowId r' }
+        match denseMarkowitzBestEntry? occ prot dσ st' rowId r' with
+        | none => st'
+        | some entry => { st' with heap := st'.heap.insert entry }
+
+def denseMarkowitzBuild (constraints : List (DenseExpr p))
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzState p :=
+  let base : DenseMarkowitzState p :=
+    { rows := #[]
+      degrees := ∅
+      rowDeps := ∅
+      pivotRows := ∅
+      heap := ∅ }
+  let indexed := constraints.foldl (fun st c =>
+    let rowId := st.rows.size
+    let r := denseMarkowitzRow rowId c occ prot
+    { st with
+      rows := st.rows.push r
+      degrees := denseMarkowitzDegreeAdd st.degrees r.vars
+      rowDeps := denseMarkowitzIndexRow st.rowDeps rowId r.vars
+      pivotRows := denseMarkowitzIndexPivots st.pivotRows rowId r.pivots }) base
+  indexed.rows.foldl (fun st r =>
+    match denseMarkowitzBestEntry? occ prot DenseSolved.empty st r.rowId r with
+    | none => st
+    | some entry => { st with heap := st.heap.insert entry }) indexed
+
+def denseMarkowitzEntryValid (st : DenseMarkowitzState p)
+    (entry : DenseMarkowitzEntry) : Bool :=
+  match st.rows[entry.rowId]? with
+  | none => false
+  | some r =>
+      r.active && r.generation == entry.generation
+
+def denseMarkowitzPopValid : Nat → DenseMarkowitzState p →
+    Option (DenseMarkowitzEntry × DenseMarkowitzState p)
+  | 0, _ => none
+  | fuel + 1, st =>
+      let (entry?, heap) := st.heap.extractMax
+      let st := { st with heap }
+      match entry? with
+      | none => none
+      | some entry =>
+          if denseMarkowitzEntryValid st entry then some (entry, st)
+          else denseMarkowitzPopValid fuel st
+
+def denseMarkowitzCollectIds (idx : Std.HashMap VarId (Std.HashSet Nat))
+    (xs : Std.HashSet VarId) : Std.HashSet Nat :=
+  xs.toList.foldl (fun out x =>
+    ((idx[x]?).getD ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
+
+def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (dσ : DenseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
+    DenseMarkowitzState p :=
+  (denseMarkowitzCollectIds st.pivotRows changed).toList.foldl
+    (denseMarkowitzPushRow occ prot dσ) st
+
+def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (x : VarId) (t : DenseExpr p) (st : DenseMarkowitzState p) :
+    DenseMarkowitzState p × Std.HashSet VarId :=
+  let rowIds := ((st.rowDeps[x]?).getD ∅).toList
+  rowIds.foldl (fun (st, changed) rowId =>
+    match st.rows[rowId]? with
+    | none => (st, changed)
+    | some r =>
+        if !r.active || !r.vars.contains x then (st, changed)
+        else
+          let r' := denseMarkowitzRow r.rowId (r.reduced.subst x t) occ prot (r.generation + 1)
+          let changed := (r.vars ++ r'.vars).foldl (fun s y => s.insert y) changed
+          ({ st with
+              rows := st.rows.setIfInBounds rowId r'
+              degrees := denseMarkowitzDegreeAdd
+                (denseMarkowitzDegreeSub st.degrees r.vars) r'.vars
+              rowDeps := denseMarkowitzIndexRow
+                (denseMarkowitzUnindexRow st.rowDeps rowId r.vars) rowId r'.vars
+              pivotRows := denseMarkowitzIndexPivots
+                (denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots) rowId r'.pivots },
+            changed)) (st, ∅)
+
+def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
+    DenseMarkowitzState p × Std.HashSet VarId :=
+  match st.rows[rowId]? with
+  | none => (st, ∅)
+  | some r =>
+      let changed := r.vars.foldl (fun s x => s.insert x) ∅
+      ({ st with
+          rows := st.rows.setIfInBounds rowId
+            { r with active := false, generation := r.generation + 1 }
+          degrees := denseMarkowitzDegreeSub st.degrees r.vars
+          rowDeps := denseMarkowitzUnindexRow st.rowDeps rowId r.vars
+          pivotRows := denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots },
+        changed)
+
+def denseMarkowitzAdoptPairs (dσ : DenseSolved p) (x : VarId) (t : DenseExpr p) :
+    List (VarId × DenseExpr p) :=
+  let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+    (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
+  touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
+
+def denseMarkowitzAdopt (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (entry : DenseMarkowitzEntry) (x : VarId) (t : DenseExpr p)
+    (pairs : List (VarId × DenseExpr p)) (st : DenseMarkowitzState p)
+    (dσ : DenseSolved p) : DenseMarkowitzState p :=
+  let (st, selectedVars) := denseMarkowitzDeactivate entry.rowId st
+  let (st, rowVars) := denseMarkowitzRefreshRows occ prot x t st
+  let changed := pairs.foldl (fun changed yt =>
+    yt.2.foldVars (fun changed y => changed.insert y) changed) (selectedVars ∪ rowVars)
+  denseMarkowitzRekey occ prot dσ changed st
+
+def denseSolveAt (c : DenseExpr p) (x : VarId) : Option (VarId × DenseExpr p) :=
+  match denseLinearize c with
+  | none => none
+  | some l =>
+      match l.trySolve x with
+      | some xt => some xt
+      | none => l.trySolveUnit x
+
+def denseMarkowitzPick (c : DenseExpr p) (x : VarId) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : Option (VarId × DenseExpr p) :=
+  match denseSolveAt c x with
+  | some xt => some xt
+  | none => denseFastBest c occ prot
+
+def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (sources : Array (DenseExpr p)) : Nat → DenseMarkowitzState p → DenseSolved p → DenseSolved p
+  | 0, _, dσ => dσ
+  | fuel + 1, st, dσ =>
+      match denseMarkowitzPopValid (st.heap.size + 1) st with
+      | none => dσ
+      | some (entry, st) =>
+          match sources[entry.rowId]? with
+          | none => denseMarkowitzLoop occ prot sources fuel
+              (denseMarkowitzDeactivate entry.rowId st).1 dσ
+          | some c =>
+              let c' := (c.substF dσ.fn).normalize
+              match denseMarkowitzPick c' entry.pivot occ prot with
+              | none => denseMarkowitzLoop occ prot sources fuel
+                  (denseMarkowitzDeactivate entry.rowId st).1 dσ
+              | some (x, t) =>
+                  let pairs := denseMarkowitzAdoptPairs dσ x t
+                  let dσ := dσ.insertAll pairs
+                  let st := denseMarkowitzAdopt occ prot entry x t pairs st dσ
+                  denseMarkowitzLoop occ prot sources fuel
+                    st dσ
+
+def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : DenseSolved p :=
+  let sources := constraints.toArray
+  let st := denseMarkowitzBuild constraints occ prot
+  denseMarkowitzLoop occ prot sources sources.size st DenseSolved.empty
 
 theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : VarId)
     (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
@@ -508,26 +787,21 @@ theorem denseTrySolveUnit_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarI
     exact absurd h (by simp)
 
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
-    assignment `x := 2*y + 3` and substitutes it everywhere, dropping `x`. The cheapest solvable
-    pivot is chosen per constraint over two sweeps, then the whole solution map is substituted
-    through the system in one pass. -/
+    assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost. -/
 def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   let occ := denseOccurrenceMap d
   let prot := denseProtectedVars d bs
-  let first := denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty
-  if first.map.isEmpty then d
-  else d.substF (denseGaussLoop occ prot d.algebraicConstraints first).fn
+  let solved := denseMarkowitzSchedule d.algebraicConstraints occ prot
+  if solved.map.isEmpty then d else d.substF solved.fn
 
 /-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
 theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     denseGaussElim bs d =
-      if (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints DenseSolved.empty).map.isEmpty
+      if (denseMarkowitzSchedule d.algebraicConstraints
+          (denseOccurrenceMap d) (denseProtectedVars d bs)).map.isEmpty
       then d
-      else d.substF (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints
-          (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-            d.algebraicConstraints DenseSolved.empty)).fn := rfl
+      else d.substF (denseMarkowitzSchedule d.algebraicConstraints
+          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn := rfl
 
 /-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -459,6 +459,19 @@ theorem insertAll_map :
 
 end DenseSolved
 
+def denseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    List (DenseExpr p) → DenseSolved p → DenseSolved p
+  | [], dσ => dσ
+  | c :: rest, dσ =>
+      let c' := (c.substF dσ.fn).normalize
+      match denseFastBest c' occ prot with
+      | none => denseGaussLoop occ prot rest dσ
+      | some (x, t) =>
+          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
+          let pairs := touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
+          denseGaussLoop occ prot rest (dσ.insertAll pairs)
+
 /-! ## Dynamic sparse scheduling -/
 
 def DenseExpr.uniqueVars (e : DenseExpr p) : List VarId :=
@@ -752,6 +765,19 @@ def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : Std.HashMap
   let st := denseMarkowitzBuild constraints occ prot
   denseMarkowitzLoop occ prot sources sources.size st DenseSolved.empty
 
+def denseSourceOrderSchedule (constraints : List (DenseExpr p))
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
+  let first := denseGaussLoop occ prot constraints DenseSolved.empty
+  if first.map.isEmpty then first else denseGaussLoop occ prot constraints first
+
+def denseMarkowitzMinRows : Nat := 8192
+
+def denseGaussSchedule (constraints : List (DenseExpr p))
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
+  if constraints.length < denseMarkowitzMinRows
+  then denseSourceOrderSchedule constraints occ prot
+  else denseMarkowitzSchedule constraints occ prot
+
 theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : VarId)
     (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
   simp only [DenseLinExpr.others, List.mem_map] at h ⊢
@@ -787,20 +813,21 @@ theorem denseTrySolveUnit_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarI
     exact absurd h (by simp)
 
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
-    assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost. -/
+    assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost on large
+    systems and preserving source order on smaller systems. -/
 def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   let occ := denseOccurrenceMap d
   let prot := denseProtectedVars d bs
-  let solved := denseMarkowitzSchedule d.algebraicConstraints occ prot
+  let solved := denseGaussSchedule d.algebraicConstraints occ prot
   if solved.map.isEmpty then d else d.substF solved.fn
 
 /-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
 theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     denseGaussElim bs d =
-      if (denseMarkowitzSchedule d.algebraicConstraints
+      if (denseGaussSchedule d.algebraicConstraints
           (denseOccurrenceMap d) (denseProtectedVars d bs)).map.isEmpty
       then d
-      else d.substF (denseMarkowitzSchedule d.algebraicConstraints
+      else d.substF (denseGaussSchedule d.algebraicConstraints
           (denseOccurrenceMap d) (denseProtectedVars d bs)).fn := rfl
 
 /-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -7,7 +7,7 @@ set_option autoImplicit false
 /-! # Correctness for the dense Gauss-elimination pass.
 Substitution-shaped: correctness rides on `DenseConstraintSystem.substF_denseCorrect`
 (`Proofs/DomainBatch.lean`), fed the final solution map's entailment and occurrence closure, both
-established by `denseGaussLoop_sound`. -/
+established by `denseMarkowitzLoop_sound`. -/
 
 namespace ApcOptimizer.Dense
 
@@ -103,122 +103,222 @@ theorem denseUnitPivotsOf_vars (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
           rw [htr] at hv
           exact denseLinearize_mem_vars c l hL y (denseTrySolveUnit_vars_subset l v (x, t) hv y hy)
 
-/-! ## The Gauss-loop invariant: the `DenseSolved` accumulator stays entailed and
-occurrence-closed, by structural induction over the pending constraints. -/
+theorem denseSolveAt_sound (c : DenseExpr p) (x y : VarId) (t : DenseExpr p)
+    (h : denseSolveAt c x = some (y, t)) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
+    denv y = t.eval denv := by
+  unfold denseSolveAt at h
+  cases hlin : denseLinearize c with
+  | none => simp [hlin] at h
+  | some l =>
+      rw [hlin] at h
+      have hl : l.eval denv = 0 := by rw [← denseLinearize_eval c l hlin]; exact hc
+      cases hs : l.trySolve x with
+      | none =>
+          have hunit : l.trySolveUnit x = some (y, t) := by simpa [hlin, hs] using h
+          exact DenseLinExpr.trySolveUnit_sound l x y t hunit denv hl
+      | some xt =>
+          have hxt : xt = (y, t) := Option.some.inj (by simpa [hlin, hs] using h)
+          rw [hxt] at hs
+          exact DenseLinExpr.trySolve_sound l x y t hs denv hl
 
-theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    ∀ (pending : List (DenseExpr p)) (dσ : DenseSolved p),
-      (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
+theorem denseSolveAt_vars (c : DenseExpr p) (x y : VarId) (t : DenseExpr p)
+    (h : denseSolveAt c x = some (y, t)) : ∀ z ∈ t.vars, z ∈ c.vars := by
+  intro z hz
+  unfold denseSolveAt at h
+  cases hlin : denseLinearize c with
+  | none => simp [hlin] at h
+  | some l =>
+      rw [hlin] at h
+      cases hs : l.trySolve x with
+      | none =>
+          have hunit : l.trySolveUnit x = some (y, t) := by simpa [hlin, hs] using h
+          exact denseLinearize_mem_vars c l hlin z
+            (denseTrySolveUnit_vars_subset l x (y, t) hunit z hz)
+      | some xt =>
+          have hxt : xt = (y, t) := Option.some.inj (by simpa [hlin, hs] using h)
+          rw [hxt] at hs
+          exact denseLinearize_mem_vars c l hlin z
+            (denseTrySolve_vars_subset l x (y, t) hs z hz)
+
+theorem denseMarkowitzPick_sound (c : DenseExpr p) (hint y : VarId) (t : DenseExpr p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (h : denseMarkowitzPick c hint occ prot = some (y, t))
+    (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
+    denv y = t.eval denv := by
+  unfold denseMarkowitzPick at h
+  cases hs : denseSolveAt c hint with
+  | some xt =>
+      have hxt : xt = (y, t) := Option.some.inj (by simpa [hs] using h)
+      rw [hxt] at hs
+      exact denseSolveAt_sound c hint y t hs denv hc
+  | none =>
+      simp only [hs] at h
+      have hfb := h
+      rw [denseFastBest_eq] at hfb
+      have hmem : (y, t) ∈ densePm1PivotsOf c ++ denseUnitPivotsOf c :=
+        List.argmin_mem (by rw [hfb]; exact Option.mem_some_self _)
+      rcases List.mem_append.1 hmem with hp | hu
+      · exact densePm1PivotsOf_sound c y t hp denv hc
+      · exact denseUnitPivotsOf_sound c y t hu denv hc
+
+theorem denseMarkowitzPick_vars (c : DenseExpr p) (hint y : VarId) (t : DenseExpr p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (h : denseMarkowitzPick c hint occ prot = some (y, t)) :
+    ∀ z ∈ t.vars, z ∈ c.vars := by
+  intro z hz
+  unfold denseMarkowitzPick at h
+  cases hs : denseSolveAt c hint with
+  | some xt =>
+      have hxt : xt = (y, t) := Option.some.inj (by simpa [hs] using h)
+      rw [hxt] at hs
+      exact denseSolveAt_vars c hint y t hs z hz
+  | none =>
+      simp only [hs] at h
+      have hfb := h
+      rw [denseFastBest_eq] at hfb
+      have hmem : (y, t) ∈ densePm1PivotsOf c ++ denseUnitPivotsOf c :=
+        List.argmin_mem (by rw [hfb]; exact Option.mem_some_self _)
+      rcases List.mem_append.1 hmem with hp | hu
+      · exact densePm1PivotsOf_vars c y t hp z hz
+      · exact denseUnitPivotsOf_vars c y t hu z hz
+
+theorem denseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (sources : Array (DenseExpr p))
+    (hsrc : ∀ (i : Nat) (c : DenseExpr p),
+      sources[i]? = some c → c ∈ d.algebraicConstraints) :
+    ∀ (fuel : Nat) (st : DenseMarkowitzState p) (dσ : DenseSolved p),
       (∀ denv, d.satisfies bs denv → ∀ i t, dσ.fn i = some t → denv i = t.eval denv) →
       (∀ i t, dσ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseGaussLoop occ prot pending dσ).fn i = some t → denv i = t.eval denv) ∧
-      (∀ i t, (denseGaussLoop occ prot pending dσ).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
-  intro pending
-  induction pending with
-  | nil => intro dσ _ hσs hσv; exact ⟨hσs, hσv⟩
-  | cons c rest ih =>
-      intro dσ hpend hσs hσv
-      have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
-      have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
-        fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
-      cases hfb : denseFastBest ((c.substF dσ.fn).normalize) occ prot with
+          (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
+          denv i = t.eval denv) ∧
+      (∀ i t, (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
+          ∀ z ∈ t.vars, z ∈ d.occ) := by
+  intro fuel
+  induction fuel with
+  | zero => intro st dσ hσs hσv; exact ⟨hσs, hσv⟩
+  | succ fuel ih =>
+      intro st dσ hσs hσv
+      cases hpop : denseMarkowitzPopValid (st.heap.size + 1) st with
       | none =>
-          simp only [denseGaussLoop, hfb]
-          exact ih dσ hrest hσs hσv
-      | some xt =>
-          obtain ⟨x, t⟩ := xt
-          have hmem : (x, t) ∈ densePm1PivotsOf ((c.substF dσ.fn).normalize)
-              ++ denseUnitPivotsOf ((c.substF dσ.fn).normalize) := by
-            have hfb2 := hfb
-            rw [denseFastBest_eq] at hfb2
-            exact List.argmin_mem (by rw [hfb2]; exact Option.mem_some_self _)
-          have hc'occ : ∀ z ∈ ((c.substF dσ.fn).normalize).vars, z ∈ d.occ := by
-            intro z hz
-            have hz2 : z ∈ (c.substF dσ.fn).vars := DenseExpr.normalize_vars _ z hz
-            rcases DenseExpr.substF_vars dσ.fn c z hz2 with h | ⟨i, _, tt, hft, hzt⟩
-            · exact DenseConstraintSystem.mem_occ_of_constraint hcmem h
-            · exact hσv i tt hft z hzt
-          have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
-            intro denv hsat
-            have hc0 : c.eval denv = 0 := hsat.1 c hcmem
-            have hc'z : ((c.substF dσ.fn).normalize).eval denv = 0 := by
-              rw [DenseExpr.normalize_eval, DenseExpr.eval_substF,
-                  denseEnvF_eq_self dσ.fn denv (hσs denv hsat)]
-              exact hc0
-            rcases List.mem_append.1 hmem with hp | hu
-            · exact densePm1PivotsOf_sound ((c.substF dσ.fn).normalize) x t hp denv hc'z
-            · exact denseUnitPivotsOf_sound ((c.substF dσ.fn).normalize) x t hu denv hc'z
-          have htocc : ∀ z ∈ t.vars, z ∈ d.occ := by
-            intro z hz
-            rcases List.mem_append.1 hmem with hp | hu
-            · exact hc'occ z (densePm1PivotsOf_vars ((c.substF dσ.fn).normalize) x t hp z hz)
-            · exact hc'occ z (denseUnitPivotsOf_vars ((c.substF dσ.fn).normalize) x t hu z hz)
-          have htouched : ∀ y s, (y, s) ∈ ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-                (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none)) →
-              dσ.fn y = some s := by
-            intro y s hys
-            obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
-            obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
-            by_cases hm : s'.mentions x
-            · rw [if_pos hm] at hif
-              simp only [Option.some.injEq, Prod.mk.injEq] at hif
-              obtain ⟨rfl, rfl⟩ := hif
-              exact hs'
-            · rw [if_neg hm] at hif; exact absurd hif (by simp)
-          simp only [denseGaussLoop, hfb]
-          refine ih _ hrest ?_ ?_
-          · intro denv hsat
-            refine DenseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-              have hxe : denv x = t.eval denv := hx denv hsat
-              show denv y = ((s.subst x t).normalize).eval denv
-              rw [DenseExpr.normalize_eval, DenseExpr.eval_subst, ← hxe, Function.update_eq_self, hy]
-            · rw [List.mem_singleton] at hin; subst hin
-              exact hx denv hsat
-          · refine DenseSolved.insertAll_preserves _ dσ hσv ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              intro z hz
-              have hz2 : z ∈ (s.subst x t).vars := DenseExpr.normalize_vars _ z hz
-              rcases DenseExpr.subst_vars s x t z hz2 with h | h
-              · exact hσv y s hmemys z h
-              · exact htocc z h
-            · rw [List.mem_singleton] at hin; subst hin
-              exact htocc
+          simp only [denseMarkowitzLoop, hpop]
+          exact ⟨hσs, hσv⟩
+      | some out =>
+          obtain ⟨entry, st'⟩ := out
+          cases hsource : sources[entry.rowId]? with
+          | none =>
+              simp only [denseMarkowitzLoop, hpop, hsource]
+              exact ih _ _ hσs hσv
+          | some c =>
+              have hcmem : c ∈ d.algebraicConstraints := hsrc entry.rowId c hsource
+              let c' := (c.substF dσ.fn).normalize
+              cases hpick : denseMarkowitzPick c' entry.pivot occ prot with
+              | none =>
+                  dsimp [c'] at hpick
+                  simp only [denseMarkowitzLoop, hpop, hsource, hpick]
+                  exact ih _ _ hσs hσv
+              | some xt =>
+                  obtain ⟨x, t⟩ := xt
+                  dsimp [c'] at hpick
+                  have hc'occ : ∀ z ∈ c'.vars, z ∈ d.occ := by
+                    intro z hz
+                    have hz2 : z ∈ (c.substF dσ.fn).vars :=
+                      DenseExpr.normalize_vars _ z hz
+                    rcases DenseExpr.substF_vars dσ.fn c z hz2 with h | ⟨i, _, tt, hft, hzt⟩
+                    · exact DenseConstraintSystem.mem_occ_of_constraint hcmem h
+                    · exact hσv i tt hft z hzt
+                  have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
+                    intro denv hsat
+                    have hc0 : c.eval denv = 0 := hsat.1 c hcmem
+                    have hc'z : c'.eval denv = 0 := by
+                      rw [DenseExpr.normalize_eval, DenseExpr.eval_substF,
+                          denseEnvF_eq_self dσ.fn denv (hσs denv hsat)]
+                      exact hc0
+                    exact denseMarkowitzPick_sound c' entry.pivot x t occ prot hpick denv hc'z
+                  have htocc : ∀ z ∈ t.vars, z ∈ d.occ := by
+                    intro z hz
+                    exact hc'occ z (denseMarkowitzPick_vars c' entry.pivot x t occ prot hpick z hz)
+                  have htouched : ∀ y s, (y, s) ∈
+                        ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+                          (dσ.map[y]?).bind
+                            (fun s => if s.mentions x then some (y, s) else none)) →
+                      dσ.fn y = some s := by
+                    intro y s hys
+                    obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
+                    obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
+                    by_cases hm : s'.mentions x
+                    · rw [if_pos hm] at hif
+                      simp only [Option.some.injEq, Prod.mk.injEq] at hif
+                      obtain ⟨rfl, rfl⟩ := hif
+                      exact hs'
+                    · rw [if_neg hm] at hif
+                      exact absurd hif (by simp)
+                  let pairs := denseMarkowitzAdoptPairs dσ x t
+                  let dσ' := dσ.insertAll pairs
+                  have hnexts : ∀ denv, d.satisfies bs denv → ∀ i u,
+                      dσ'.fn i = some u → denv i = u.eval denv := by
+                    intro denv hsat
+                    refine DenseSolved.insertAll_preserves pairs dσ (hσs denv hsat) ?_
+                    intro pr hpr
+                    unfold denseMarkowitzAdoptPairs at hpr
+                    rcases List.mem_append.1 hpr with hin | hin
+                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
+                      have hmemys : dσ.fn y = some s := htouched y s hys
+                      have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
+                      have hxe : denv x = t.eval denv := hx denv hsat
+                      show denv y = ((s.subst x t).normalize).eval denv
+                      rw [DenseExpr.normalize_eval, DenseExpr.eval_subst, ← hxe,
+                        Function.update_eq_self, hy]
+                    · rw [List.mem_singleton] at hin
+                      subst hin
+                      exact hx denv hsat
+                  have hnextv : ∀ i u, dσ'.fn i = some u → ∀ z ∈ u.vars, z ∈ d.occ := by
+                    refine DenseSolved.insertAll_preserves pairs dσ hσv ?_
+                    intro pr hpr
+                    unfold denseMarkowitzAdoptPairs at hpr
+                    rcases List.mem_append.1 hpr with hin | hin
+                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
+                      have hmemys : dσ.fn y = some s := htouched y s hys
+                      intro z hz
+                      have hz2 : z ∈ (s.subst x t).vars := DenseExpr.normalize_vars _ z hz
+                      rcases DenseExpr.subst_vars s x t z hz2 with h | h
+                      · exact hσv y s hmemys z h
+                      · exact htocc z h
+                    · rw [List.mem_singleton] at hin
+                      subst hin
+                      exact htocc
+                  simp only [denseMarkowitzLoop, hpop, hsource, hpick]
+                  exact ih _ dσ' hnexts hnextv
+
+theorem denseMarkowitzSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    (∀ denv, d.satisfies bs denv → ∀ i t,
+        (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
+        denv i = t.eval denv) ∧
+    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
+        ∀ z ∈ t.vars, z ∈ d.occ) := by
+  apply denseMarkowitzLoop_sound bs d occ prot d.algebraicConstraints.toArray
+  · intro i c hc
+    rw [List.getElem?_toArray] at hc
+    exact List.mem_of_getElem? hc
+  · intro _ _ _ _ h
+    exact absurd h (by simp [DenseSolved.fn, DenseSolved.empty])
+  · intro _ _ h
+    exact absurd h (by simp [DenseSolved.fn, DenseSolved.empty])
 
 /-! ## The pass's correctness -/
 
-/-- The final Gauss-loop solution map (from the pass's initial accumulators) is entailed and
-    occurrence-closed. -/
+/-- The scheduled solution map is entailed and occurrence-closed. -/
 theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints
-          (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-            d.algebraicConstraints DenseSolved.empty)).fn i = some t →
+        (denseMarkowitzSchedule d.algebraicConstraints
+          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
           denv i = t.eval denv) ∧
-    (∀ i t, (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-        d.algebraicConstraints
-        (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-          d.algebraicConstraints DenseSolved.empty)).fn i = some t →
+    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints
+        (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
         ∀ z ∈ t.vars, z ∈ d.occ) := by
-  have hfirst := denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
-    d.algebraicConstraints DenseSolved.empty (fun _c hc => hc)
-    (fun _ _ _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
-    (fun _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
-  exact denseGaussLoop_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
-    d.algebraicConstraints
-    (denseGaussLoop (denseOccurrenceMap d) (denseProtectedVars d bs)
-      d.algebraicConstraints DenseSolved.empty)
-    (fun _c hc => hc) hfirst.1 hfirst.2
+  exact denseMarkowitzSchedule_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
 
 /-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
     occurrence-closed solution map, whose solutions are covered because their variables occur in a

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -103,6 +103,101 @@ theorem denseUnitPivotsOf_vars (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
           rw [htr] at hv
           exact denseLinearize_mem_vars c l hL y (denseTrySolveUnit_vars_subset l v (x, t) hv y hy)
 
+theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    ∀ (pending : List (DenseExpr p)) (dσ : DenseSolved p),
+      (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
+      (∀ denv, d.satisfies bs denv → ∀ i t, dσ.fn i = some t → denv i = t.eval denv) →
+      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
+      (∀ denv, d.satisfies bs denv → ∀ i t,
+          (denseGaussLoop occ prot pending dσ).fn i = some t → denv i = t.eval denv) ∧
+      (∀ i t, (denseGaussLoop occ prot pending dσ).fn i = some t →
+          ∀ z ∈ t.vars, z ∈ d.occ) := by
+  intro pending
+  induction pending with
+  | nil => intro dσ _ hσs hσv; exact ⟨hσs, hσv⟩
+  | cons c rest ih =>
+      intro dσ hpend hσs hσv
+      have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
+      have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
+        fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
+      cases hfb : denseFastBest ((c.substF dσ.fn).normalize) occ prot with
+      | none =>
+          simp only [denseGaussLoop, hfb]
+          exact ih dσ hrest hσs hσv
+      | some xt =>
+          obtain ⟨x, t⟩ := xt
+          have hmem : (x, t) ∈ densePm1PivotsOf ((c.substF dσ.fn).normalize)
+              ++ denseUnitPivotsOf ((c.substF dσ.fn).normalize) := by
+            have hfb2 := hfb
+            rw [denseFastBest_eq] at hfb2
+            exact List.argmin_mem (by rw [hfb2]; exact Option.mem_some_self _)
+          have hc'occ : ∀ z ∈ ((c.substF dσ.fn).normalize).vars, z ∈ d.occ := by
+            intro z hz
+            have hz2 : z ∈ (c.substF dσ.fn).vars := DenseExpr.normalize_vars _ z hz
+            rcases DenseExpr.substF_vars dσ.fn c z hz2 with h | ⟨i, _, tt, hft, hzt⟩
+            · exact DenseConstraintSystem.mem_occ_of_constraint hcmem h
+            · exact hσv i tt hft z hzt
+          have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
+            intro denv hsat
+            have hc0 : c.eval denv = 0 := hsat.1 c hcmem
+            have hc'z : ((c.substF dσ.fn).normalize).eval denv = 0 := by
+              rw [DenseExpr.normalize_eval, DenseExpr.eval_substF,
+                  denseEnvF_eq_self dσ.fn denv (hσs denv hsat)]
+              exact hc0
+            rcases List.mem_append.1 hmem with hp | hu
+            · exact densePm1PivotsOf_sound ((c.substF dσ.fn).normalize) x t hp denv hc'z
+            · exact denseUnitPivotsOf_sound ((c.substF dσ.fn).normalize) x t hu denv hc'z
+          have htocc : ∀ z ∈ t.vars, z ∈ d.occ := by
+            intro z hz
+            rcases List.mem_append.1 hmem with hp | hu
+            · exact hc'occ z
+                (densePm1PivotsOf_vars ((c.substF dσ.fn).normalize) x t hp z hz)
+            · exact hc'occ z
+                (denseUnitPivotsOf_vars ((c.substF dσ.fn).normalize) x t hu z hz)
+          have htouched : ∀ y s, (y, s) ∈ ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+                (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none)) →
+              dσ.fn y = some s := by
+            intro y s hys
+            obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
+            obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
+            by_cases hm : s'.mentions x
+            · rw [if_pos hm] at hif
+              simp only [Option.some.injEq, Prod.mk.injEq] at hif
+              obtain ⟨rfl, rfl⟩ := hif
+              exact hs'
+            · rw [if_neg hm] at hif
+              exact absurd hif (by simp)
+          simp only [denseGaussLoop, hfb]
+          refine ih _ hrest ?_ ?_
+          · intro denv hsat
+            refine DenseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
+            intro pr hpr
+            rcases List.mem_append.1 hpr with hin | hin
+            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
+              have hmemys : dσ.fn y = some s := htouched y s hys
+              have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
+              have hxe : denv x = t.eval denv := hx denv hsat
+              show denv y = ((s.subst x t).normalize).eval denv
+              rw [DenseExpr.normalize_eval, DenseExpr.eval_subst, ← hxe,
+                Function.update_eq_self, hy]
+            · rw [List.mem_singleton] at hin
+              subst hin
+              exact hx denv hsat
+          · refine DenseSolved.insertAll_preserves _ dσ hσv ?_
+            intro pr hpr
+            rcases List.mem_append.1 hpr with hin | hin
+            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
+              have hmemys : dσ.fn y = some s := htouched y s hys
+              intro z hz
+              have hz2 : z ∈ (s.subst x t).vars := DenseExpr.normalize_vars _ z hz
+              rcases DenseExpr.subst_vars s x t z hz2 with h | h
+              · exact hσv y s hmemys z h
+              · exact htocc z h
+            · rw [List.mem_singleton] at hin
+              subst hin
+              exact htocc
+
 theorem denseSolveAt_sound (c : DenseExpr p) (x y : VarId) (t : DenseExpr p)
     (h : denseSolveAt c x = some (y, t)) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
     denv y = t.eval denv := by
@@ -307,18 +402,49 @@ theorem denseMarkowitzSchedule_sound (bs : BusSemantics p) (d : DenseConstraintS
   · intro _ _ h
     exact absurd h (by simp [DenseSolved.fn, DenseSolved.empty])
 
+theorem denseSourceOrderSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    (∀ denv, d.satisfies bs denv → ∀ i t,
+        (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
+        denv i = t.eval denv) ∧
+    (∀ i t, (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
+        ∀ z ∈ t.vars, z ∈ d.occ) := by
+  have hfirst := denseGaussLoop_sound bs d occ prot d.algebraicConstraints DenseSolved.empty
+    (fun _c hc => hc)
+    (fun _ _ _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
+    (fun _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
+  by_cases hempty :
+      (denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty).map.isEmpty
+  · simpa [denseSourceOrderSchedule, hempty] using hfirst
+  · have hsecond := denseGaussLoop_sound bs d occ prot d.algebraicConstraints
+      (denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty)
+      (fun _c hc => hc) hfirst.1 hfirst.2
+    simpa [denseSourceOrderSchedule, hempty] using hsecond
+
+theorem denseGaussSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    (∀ denv, d.satisfies bs denv → ∀ i t,
+        (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
+        denv i = t.eval denv) ∧
+    (∀ i t, (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
+        ∀ z ∈ t.vars, z ∈ d.occ) := by
+  unfold denseGaussSchedule
+  split
+  · exact denseSourceOrderSchedule_sound bs d occ prot
+  · exact denseMarkowitzSchedule_sound bs d occ prot
+
 /-! ## The pass's correctness -/
 
 /-- The scheduled solution map is entailed and occurrence-closed. -/
 theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseMarkowitzSchedule d.algebraicConstraints
+        (denseGaussSchedule d.algebraicConstraints
           (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
           denv i = t.eval denv) ∧
-    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints
+    (∀ i t, (denseGaussSchedule d.algebraicConstraints
         (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
         ∀ z ∈ t.vars, z ∈ d.occ) := by
-  exact denseMarkowitzSchedule_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
+  exact denseGaussSchedule_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
 
 /-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
     occurrence-closed solution map, whose solutions are covered because their variables occur in a

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -254,7 +254,14 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      checked heap. It updates only rows incident to each chosen pivot and ranks protected status,
      classical fill, stored-solution rewrite cost, and the prior local score lexicographically.
      Heap metadata remains untrusted: every selection is re-solved from the original constraint
-     under the current substitution before adoption.
+     under the current substitution before adoption. Entry 134 keeps the exact source-order path
+     below 8192 rows: the scheduler's fixed cost is not justified there, and changing the affine
+     basis in nonlinear-connected components can worsen later syntactic cleanup.
+   - **Still open — component-aware Gauss scheduling**: source-order and Markowitz eliminate the
+     same number of pivots on the affected SP1 shapes, but choose different bases where affine rows
+     share variables with nonlinear constraints. Preserve source order only in those connected
+     components and use Markowitz in purely affine components; this could safely extend dynamic
+     scheduling below the coarse 8192-row gate.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -249,6 +249,12 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      empty first solution map returns immediately, while productive runs retain both sweeps;
      occurrence and reverse-dependency construction fold expression leaves directly without
      building `DenseExpr.vars` and its append chains.
+   - ~~gauss source-order sweeps~~ **done (entry 133)**: a dynamic global Markowitz scheduler
+     keeps normalized rows, exact active incidence, all solvable pivots, and a lazy generation-
+     checked heap. It updates only rows incident to each chosen pivot and ranks protected status,
+     classical fill, stored-solution rewrite cost, and the prior local score lexicographically.
+     Heap metadata remains untrusted: every selection is re-solved from the original constraint
+     under the current substitution before adoption.
 
 **R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
 *medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs

--- a/docs/log.md
+++ b/docs/log.md
@@ -4606,3 +4606,35 @@ effectiveness evaluation is delegated to the draft PR's CI workflows.
 
 **Worked locally: yes (fan-out reduced by orders of magnitude; representative runtime neutral;
 full-set result pending CI).**
+
+### 133. Runtime: dynamic global Markowitz scheduling for Gauss
+
+Gauss now replaces its two source-order sweeps with a dynamic global scheduler. Each active row
+caches its normalized expression, unique variables, and all solvable pivots; exact row/column and
+pivot/row incidence maps maintain classical Markowitz fill costs as pivots eliminate variables.
+A generation-checked binary heap selects the global minimum, with protected-variable status,
+stored-solution rewrite work, the prior local score, row position, and variable index as stable
+tie-breakers. Only incident rows are substituted and relinearized. Removed rows are also removed
+from the incidence maps, while stale heap entries are discarded lazily.
+
+The scheduler is proof-irrelevant planning data. Before adopting a heap choice, Gauss reloads the
+original constraint, applies the complete current solution, normalizes it, and solves the hinted
+pivot again (falling back to the verified local selector if needed). The new fuel-inductive proof
+therefore establishes entailment and occurrence closure without trusting heap order, generations,
+cached rows, incidence maps, or scores.
+
+One serial local profile was run on each representative from `ranked_passes.md`, using the
+same-session `origin/main` profiles as baseline. Gauss changed from 42,368 → 4,508 ms on
+`wasm-eth/apc_063` (−89.4%), 11,209 → 3,636 ms on `wasm-eth/apc_037` (−67.6%),
+1,190 → 742 ms on `openvm-eth/apc_037` (−37.6%), 2,536 → 2,927 ms on OpenVM keccak
+(+15.4%), and 444 → 504 ms on `openvm-eth/apc_005` (+13.5%). The five-case Gauss sum fell
+57,747 → 12,317 ms (−78.7%); whole-profile time fell 185,174 → 141,421 ms (−23.6%).
+Cleanup iteration counts were unchanged except `openvm-eth/apc_037`, which took one additional
+productive cycle and ended one variable and one constraint smaller.
+
+`lake build` is warning-free, generated C uses specialized heap and row-fold functions, and the
+proof-integrity and unused-theorem checks pass. Full same-runner runtime and effectiveness
+evaluation is delegated to the draft PR's CI workflows.
+
+**Worked locally: yes (large representative Gauss and whole-profile runtime win; full-set result
+pending CI).**

--- a/docs/log.md
+++ b/docs/log.md
@@ -4638,3 +4638,32 @@ evaluation is delegated to the draft PR's CI workflows.
 
 **Worked locally: yes (large representative Gauss and whole-profile runtime win; full-set result
 pending CI).**
+
+### 134. Runtime: gate Markowitz scheduling below 8192 rows
+
+PR #190's effectiveness CI showed that unconditional Markowitz scheduling changed the final SP1
+RSP variable count from 10,627 to 10,702. Seven cases regressed by 91 variables while two improved
+by 16. Targeted tracing on the repeated apc_016 shape found equal source-order and Markowitz pivot
+counts in each cleanup cycle, but different pivot keys and right-hand sides in affine rows connected
+to nonlinear constraints. The regression is therefore a downstream basis-sensitivity effect, not
+a missed-elimination or stale-heap bug.
+
+Putting the static occurrence score ahead of fill was rejected: apc_016 recovered only 2 of its 18
+variables, apc_024 and apc_060 did not recover any, and apc_073 lost its 13-variable improvement.
+A 16,384-row source-order gate restored RSP and SP1 keccak exactly but also restored the wasm-eth
+apc_037 Gauss cost (11,145 ms versus the 11,209 ms baseline), because earlier passes reduce that
+case below the gate before Gauss runs.
+
+Gauss now retains the exact two-sweep source-order algorithm below 8192 algebraic constraints and
+uses the dynamic scheduler only at or above that size. All SP1 RSP inputs have at most 3433
+constraints, so the corpus retains its previous pivot behavior without a VM-specific condition. A
+targeted apc_016 export returned to 268 variables, 262 bus interactions, and 21 constraints. The
+single wasm-eth apc_037 profile retained a 3,850 ms Gauss time and 40,341 ms total, respectively
+65.7% and 15.7% below the source-order baseline, and its final profiled state returned from 1898 to
+1896 variables.
+
+The Gauss and executable builds are warning-free; full corpus confirmation is delegated to the
+updated PR's CI.
+
+**Worked locally: yes (RSP baseline behavior restored while the large-case runtime win remains;
+full-set result pending CI).**


### PR DESCRIPTION
## What changed

- replace Gauss's source-order sweeps with a dynamic global Markowitz/min-fill scheduler on systems with at least 8,192 algebraic constraints
- preserve the exact prior two-sweep source-order algorithm below that amortization threshold
- cache normalized active rows, exact row/column incidence, and all solvable pivots
- maintain a generation-checked binary heap and refresh only rows incident to each selected pivot
- revalidate every heap choice against the original constraint under the current substitution, so correctness does not trust scheduler metadata
- prove both scheduling paths and their size-gated composition

## Why

Source order makes substitution cost highly order-dependent. On the large wasm representatives this accounted for tens of seconds. Global min-fill ordering chooses pivots expected to create less downstream expression growth and updates only affected rows.

The first CI run also showed why this must be gated: on small SP1/RSP systems, Markowitz eliminated the same number of variables but chose a different affine basis in components connected to nonlinear constraints. Later syntactic cleanup then left 75 extra variables across the corpus. Retaining exact source order below 8,192 rows avoids that basis change and also avoids scheduler overhead where it cannot amortize.

## Local validation

The original scheduler was profiled exactly once on each representative from `ranked_passes.md`: five-case Gauss time fell **57,747 → 12,317 ms (-78.7%)**, and combined whole-profile time fell **185,174 → 141,421 ms (-23.6%)**.

For the gated follow-up:

- repeated RSP regression `apc_016`: restored from 286/264/21 to main's **268 variables / 262 buses / 21 constraints**
- wasm-eth `apc_037`: Gauss **11,209 → 3,850 ms (-65.7%)**, whole profile **47,851 → 40,341 ms (-15.7%)**
- wasm-eth `apc_037` final profiled state: restored from 1,898 to main's **1,896 variables**
- a 16,384 cutoff was tested and rejected because it restored the old wasm runtime
- putting static occurrence score ahead of fill was tested and rejected because it did not recover the regressions and lost an existing 13-variable improvement

Checks:

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection for specialized heap/comparator/fold paths

Updated CI should provide the authoritative corpus effectiveness and runtime result for target `32e63a7`.