### PR TITLE
Keep Gauss rows in canonical sparse affine form

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -1,7 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Affine
 import ApcOptimizer.Implementation.OptimizerPasses.SubstMap
 import ApcOptimizer.Implementation.OptimizerPasses.Normalize
-import ApcOptimizer.Implementation.OptimizerPasses.ListSplit
 import Batteries.Data.BinaryHeap
 
 set_option autoImplicit false
@@ -12,13 +11,6 @@ Correctness and the wired `denseGaussElimPass` live in `Proofs/Gauss.lean`. -/
 namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
-
-/-- Number of variable occurrences (with multiplicity). -/
-def DenseExpr.varCount : DenseExpr p → Nat
-  | .const _ => 0
-  | .var _ => 1
-  | .add a b => a.varCount + b.varCount
-  | .mul a b => a.varCount + b.varCount
 
 /-- Fold variable leaves in left-to-right order without materializing `vars`. -/
 def DenseExpr.foldVars {α : Type} (e : DenseExpr p) (f : α → VarId → α) (init : α) : α :=
@@ -32,91 +24,11 @@ def DenseExpr.isVar : DenseExpr p → Bool
   | .var _ => true
   | _ => false
 
-/-- The duplication cost of a dense pivot `x := t`, with the protection penalty. -/
-def densePivotScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (xt : VarId × DenseExpr p) : Nat :=
-  let base := (occ.getD xt.1 1 - 1) * (1 + xt.2.varCount)
-  if prot.contains xt.1 && !xt.2.isVar then base + 1000000 else base
-
-/-! ## `toExpr` size facts -/
-
-theorem denseToExpr_foldl_varCount (terms : List (VarId × ZMod p)) :
-    ∀ init : DenseExpr p,
-      (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).varCount
-        = init.varCount + terms.length := by
-  induction terms with
-  | nil => intro init; simp
-  | cons t rest ih =>
-      intro init
-      rw [List.foldl_cons, ih]
-      simp only [DenseExpr.varCount, List.length_cons]
-      omega
-
-theorem DenseLinExpr.toExpr_varCount (l : DenseLinExpr p) : l.toExpr.varCount = l.terms.length := by
-  rw [DenseLinExpr.toExpr, denseToExpr_foldl_varCount]
-  simp [DenseExpr.varCount]
-
-theorem DenseLinExpr.scale_terms_length (k : ZMod p) (l : DenseLinExpr p) :
-    (l.scale k).terms.length = l.terms.length := by
-  simp [DenseLinExpr.scale]
-
-theorem denseToExpr_foldl_isVar (terms : List (VarId × ZMod p)) :
-    ∀ init : DenseExpr p, init.isVar = false →
-      (terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) init).isVar = false := by
-  induction terms with
-  | nil => intro init h; simpa using h
-  | cons t rest ih => intro init _; exact ih _ rfl
-
-theorem DenseLinExpr.toExpr_isVar (l : DenseLinExpr p) : l.toExpr.isVar = false :=
-  denseToExpr_foldl_isVar l.terms _ rfl
-
-/-- Score of a dense pivot on `v` whose solution has `oc` variable occurrences; the
-    `densePivotScore` protection penalty reduces to `prot.contains v`, since a `toExpr` solution is
-    never a bare variable. -/
+/-- The occurrence-weighted duplication cost of pivoting on `v`, with a protection penalty. -/
 def denseGaussScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId)
     (oc : Nat) : Nat :=
   let base := (occ.getD v 1 - 1) * (1 + oc)
   if prot.contains v then base + 1000000 else base
-
-theorem denseGaussScore_eq_densePivotScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (v : VarId) (t : DenseExpr p) (oc : Nat) (hiv : t.isVar = false) (hvc : t.varCount = oc) :
-    denseGaussScore occ prot v oc = densePivotScore occ prot (v, t) := by
-  subst hvc
-  simp only [denseGaussScore, densePivotScore, hiv, Bool.not_false, Bool.and_true]
-
-/-! ## Closed forms for `trySolve` / `trySolveUnit` -/
-
-theorem DenseLinExpr.trySolve_eq_of_one (l : DenseLinExpr p) (v : VarId) (h : l.coeff v = 1) :
-    l.trySolve v = some (v, ((l.others v).scale (-1)).toExpr) := by
-  unfold DenseLinExpr.trySolve; rw [if_pos h]
-
-theorem DenseLinExpr.trySolve_eq_of_negOne (l : DenseLinExpr p) (v : VarId) (h1 : l.coeff v ≠ 1)
-    (h2 : l.coeff v = -1) : l.trySolve v = some (v, (l.others v).toExpr) := by
-  unfold DenseLinExpr.trySolve; rw [if_neg h1, if_pos h2]
-
-theorem DenseLinExpr.trySolve_eq_none (l : DenseLinExpr p) (v : VarId)
-    (h : ¬(l.coeff v = 1 ∨ l.coeff v = -1)) : l.trySolve v = none := by
-  unfold DenseLinExpr.trySolve
-  rw [if_neg (fun hh => h (Or.inl hh)), if_neg (fun hh => h (Or.inr hh))]
-
-theorem DenseLinExpr.trySolveUnit_eq_of (l : DenseLinExpr p) (v : VarId)
-    (h : l.coeff v * (l.coeff v)⁻¹ = 1) :
-    l.trySolveUnit v = some (v, ((l.others v).scale (-(l.coeff v)⁻¹)).toExpr) := by
-  unfold DenseLinExpr.trySolveUnit; rw [if_pos h]
-
-theorem DenseLinExpr.trySolveUnit_eq_none (l : DenseLinExpr p) (v : VarId)
-    (h : ¬l.coeff v * (l.coeff v)⁻¹ = 1) : l.trySolveUnit v = none := by
-  unfold DenseLinExpr.trySolveUnit; rw [if_neg h]
-
-/-! ## Coefficient / occurrence index -/
-
-/-- Coefficient sum of the terms whose variable is `v`. -/
-def denseCsum (terms : List (VarId × ZMod p)) (v : VarId) : ZMod p :=
-  ((terms.filter (fun t => t.1 = v)).map Prod.snd).sum
-
-/-- Occurrence count of `v` among the terms. -/
-def denseCcnt (terms : List (VarId × ZMod p)) (v : VarId) : Nat :=
-  (terms.filter (fun t => t.1 = v)).length
 
 /-- One index step: add `t`'s coefficient and one occurrence to `t.1`'s entry (0 if absent). -/
 def denseIdxStep (m : Std.HashMap VarId (ZMod p × Nat)) (t : VarId × ZMod p) :
@@ -126,55 +38,6 @@ def denseIdxStep (m : Std.HashMap VarId (ZMod p × Nat)) (t : VarId × ZMod p) :
 /-- The coefficient/occurrence index of a term list. -/
 def denseCoeffIdx (terms : List (VarId × ZMod p)) : Std.HashMap VarId (ZMod p × Nat) :=
   terms.foldl denseIdxStep ∅
-
-theorem denseIdxStep_fold (terms : List (VarId × ZMod p)) :
-    ∀ (m : Std.HashMap VarId (ZMod p × Nat)) (v : VarId),
-      ((terms.foldl denseIdxStep m)[v]?).getD (0, 0)
-        = (((m[v]?).getD (0, 0)).1 + denseCsum terms v,
-           ((m[v]?).getD (0, 0)).2 + denseCcnt terms v) := by
-  induction terms with
-  | nil => intro m v; simp [denseCsum, denseCcnt]
-  | cons t rest ih =>
-      intro m v
-      rw [List.foldl_cons, ih (denseIdxStep m t) v]
-      have hstep : ((denseIdxStep m t)[v]?).getD (0, 0)
-          = (((m[v]?).getD (0, 0)).1 + (if t.1 = v then t.2 else 0),
-             ((m[v]?).getD (0, 0)).2 + (if t.1 = v then 1 else 0)) := by
-        unfold denseIdxStep
-        rw [Std.HashMap.getElem?_insert]
-        by_cases htv : t.1 = v
-        · subst htv; simp
-        · rw [if_neg (by simpa using htv), if_neg htv, if_neg htv]
-          simp
-      rw [hstep]
-      have hcsum : denseCsum (t :: rest) v = (if t.1 = v then t.2 else 0) + denseCsum rest v := by
-        unfold denseCsum; by_cases htv : t.1 = v <;> simp [htv]
-      have hccnt : denseCcnt (t :: rest) v = denseCcnt rest v + (if t.1 = v then 1 else 0) := by
-        unfold denseCcnt; by_cases htv : t.1 = v <;> simp [htv]
-      rw [hcsum, hccnt]
-      refine Prod.ext ?_ ?_ <;> ring
-
-theorem denseCoeffIdx_get (terms : List (VarId × ZMod p)) (v : VarId) :
-    ((denseCoeffIdx terms)[v]?).getD (0, 0) = (denseCsum terms v, denseCcnt terms v) := by
-  simp [denseCoeffIdx, denseIdxStep_fold terms ∅ v]
-
-theorem denseCoeffIdx_coeff (l : DenseLinExpr p) (v : VarId) :
-    (((denseCoeffIdx l.terms)[v]?).getD (0, 0)).1 = l.coeff v := by
-  rw [denseCoeffIdx_get]; rfl
-
-theorem dense_filter_eq_ne_length (terms : List (VarId × ZMod p)) (v : VarId) :
-    (terms.filter (fun t => t.1 ≠ v)).length + (terms.filter (fun t => t.1 = v)).length
-      = terms.length := by
-  induction terms with
-  | nil => rfl
-  | cons t rest ih => by_cases htv : t.1 = v <;> simp_all <;> omega
-
-theorem denseCoeffIdx_others (l : DenseLinExpr p) (v : VarId) :
-    l.terms.length - (((denseCoeffIdx l.terms)[v]?).getD (0, 0)).2 = (l.others v).terms.length := by
-  rw [denseCoeffIdx_get]
-  simp only [DenseLinExpr.others, denseCcnt]
-  have h := dense_filter_eq_ne_length l.terms v
-  omega
 
 /-! ## Descriptors -/
 
@@ -186,24 +49,6 @@ def densePm1Desc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
     some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
   else none
 
-theorem densePm1Desc_eq (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (v : VarId) :
-    densePm1Desc (denseCoeffIdx l.terms) l.terms.length occ prot v
-      = (l.trySolve v).map (fun xt => (xt.1, densePivotScore occ prot xt)) := by
-  unfold densePm1Desc
-  rw [denseCoeffIdx_coeff l v, denseCoeffIdx_others l v]
-  by_cases h1 : l.coeff v = 1
-  · rw [if_pos (Or.inl h1), DenseLinExpr.trySolve_eq_of_one l v h1, Option.map_some,
-      denseGaussScore_eq_densePivotScore occ prot v (((l.others v).scale (-1)).toExpr)
-        (l.others v).terms.length (DenseLinExpr.toExpr_isVar _)
-        (by rw [DenseLinExpr.toExpr_varCount, DenseLinExpr.scale_terms_length])]
-  · by_cases h2 : l.coeff v = -1
-    · rw [if_pos (Or.inr h2), DenseLinExpr.trySolve_eq_of_negOne l v h1 h2, Option.map_some,
-        denseGaussScore_eq_densePivotScore occ prot v ((l.others v).toExpr)
-          (l.others v).terms.length (DenseLinExpr.toExpr_isVar _) (DenseLinExpr.toExpr_varCount _)]
-    · rw [if_neg (by rintro (h | h); exacts [h1 h, h2 h]),
-        DenseLinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h]), Option.map_none]
-
 /-- Unit-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` fails but
     `l.trySolveUnit v` succeeds. -/
 def denseUnitDesc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
@@ -214,27 +59,6 @@ def denseUnitDesc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
     some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
   else none
 
-theorem denseUnitDesc_eq (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (v : VarId) :
-    denseUnitDesc (denseCoeffIdx l.terms) l.terms.length occ prot v
-      = (match l.trySolve v with | some _ => none | none => l.trySolveUnit v).map
-          (fun xt : VarId × DenseExpr p => (xt.1, densePivotScore occ prot xt)) := by
-  unfold denseUnitDesc
-  rw [denseCoeffIdx_coeff l v, denseCoeffIdx_others l v]
-  by_cases h1 : l.coeff v = 1
-  · rw [if_neg (fun hc => hc.1 (Or.inl h1)), DenseLinExpr.trySolve_eq_of_one l v h1]; rfl
-  · by_cases h2 : l.coeff v = -1
-    · rw [if_neg (fun hc => hc.1 (Or.inr h2)), DenseLinExpr.trySolve_eq_of_negOne l v h1 h2]; rfl
-    · rw [DenseLinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h])]
-      by_cases h3 : l.coeff v * (l.coeff v)⁻¹ = 1
-      · rw [if_pos ⟨by rintro (h | h); exacts [h1 h, h2 h], h3⟩,
-          DenseLinExpr.trySolveUnit_eq_of l v h3,
-          denseGaussScore_eq_densePivotScore occ prot v (((l.others v).scale (-(l.coeff v)⁻¹)).toExpr)
-            (l.others v).terms.length (DenseLinExpr.toExpr_isVar _)
-            (by rw [DenseLinExpr.toExpr_varCount, DenseLinExpr.scale_terms_length])]
-        rfl
-      · rw [if_neg (fun hc => h3 hc.2), DenseLinExpr.trySolveUnit_eq_none l v h3]; rfl
-
 /-- All pivot descriptors, `±1` first (matching the order of `densePm1PivotsOf ++
     denseUnitPivotsOf`). -/
 def densePivotDescs (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
@@ -243,19 +67,6 @@ def densePivotDescs (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : S
   let total := l.terms.length
   (l.terms.map Prod.fst).filterMap (densePm1Desc idx total occ prot)
     ++ (l.terms.map Prod.fst).filterMap (denseUnitDesc idx total occ prot)
-
-theorem densePivotDescs_eq (c : DenseExpr p) (l : DenseLinExpr p) (hlin : denseLinearize c = some l)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    densePivotDescs l occ prot
-      = (densePm1PivotsOf c ++ denseUnitPivotsOf c).map (fun xt => (xt.1, densePivotScore occ prot xt)) := by
-  show (l.terms.map Prod.fst).filterMap (densePm1Desc (denseCoeffIdx l.terms) l.terms.length occ prot)
-      ++ (l.terms.map Prod.fst).filterMap (denseUnitDesc (denseCoeffIdx l.terms) l.terms.length occ prot)
-      = (densePm1PivotsOf c ++ denseUnitPivotsOf c).map (fun xt => (xt.1, densePivotScore occ prot xt))
-  unfold densePm1PivotsOf denseUnitPivotsOf
-  rw [hlin, List.map_append, map_filterMap, map_filterMap]
-  congr 1
-  · exact List.filterMap_congr (fun v _ => densePm1Desc_eq l occ prot v)
-  · exact List.filterMap_congr (fun v _ => denseUnitDesc_eq l occ prot v)
 
 /-! ## Boxed runtime twins -/
 
@@ -340,76 +151,6 @@ theorem densePivotDescsWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
   funext p l occ prot
   exact (densePivotDescsWith_eq denseZModOps l occ prot).symm
 
-/-! ## Fast pivot selection -/
-
-/-- The cheapest solvable dense pivot of a constraint, building the solution only for the winner. -/
-def denseFastBest (c : DenseExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    Option (VarId × DenseExpr p) :=
-  match denseLinearize c with
-  | none => none
-  | some l =>
-      match (densePivotDescs l occ prot).argmin Prod.snd with
-      | none => none
-      | some (x, _) =>
-          match l.trySolve x with
-          | some xt => some xt
-          | none => l.trySolveUnit x
-
-theorem DenseLinExpr.trySolve_fst (l : DenseLinExpr p) (v : VarId) (w : VarId × DenseExpr p)
-    (h : l.trySolve v = some w) : w.1 = v := by
-  unfold DenseLinExpr.trySolve at h
-  split_ifs at h
-  all_goals simp_all [Prod.ext_iff]
-
-theorem DenseLinExpr.trySolveUnit_fst (l : DenseLinExpr p) (v : VarId) (w : VarId × DenseExpr p)
-    (h : l.trySolveUnit v = some w) : w.1 = v := by
-  unfold DenseLinExpr.trySolveUnit at h
-  split_ifs at h
-  all_goals simp_all [Prod.ext_iff]
-
-theorem denseMem_pm1_trySolve (c : DenseExpr p) (l : DenseLinExpr p)
-    (hlin : denseLinearize c = some l) (w : VarId × DenseExpr p) (h : w ∈ densePm1PivotsOf c) :
-    l.trySolve w.1 = some w := by
-  unfold densePm1PivotsOf at h
-  rw [hlin] at h
-  obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-  rw [DenseLinExpr.trySolve_fst l v w hv]; exact hv
-
-theorem denseMem_unit_trySolveUnit (c : DenseExpr p) (l : DenseLinExpr p)
-    (hlin : denseLinearize c = some l) (w : VarId × DenseExpr p) (h : w ∈ denseUnitPivotsOf c) :
-    l.trySolve w.1 = none ∧ l.trySolveUnit w.1 = some w := by
-  unfold denseUnitPivotsOf at h
-  rw [hlin] at h
-  obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-  cases hts : l.trySolve v with
-  | some r => rw [hts] at hv; simp at hv
-  | none =>
-      rw [hts] at hv
-      rw [DenseLinExpr.trySolveUnit_fst l v w hv]
-      exact ⟨hts, hv⟩
-
-theorem denseFastBest_eq (c : DenseExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) :
-    denseFastBest c occ prot
-      = (densePm1PivotsOf c ++ denseUnitPivotsOf c).argmin (densePivotScore occ prot) := by
-  unfold denseFastBest
-  split
-  · next hlin => simp [densePm1PivotsOf, denseUnitPivotsOf, hlin]
-  · next l hlin =>
-      rw [densePivotDescs_eq c l hlin occ prot,
-        argmin_map_key (fun xt => (xt.1, densePivotScore occ prot xt)) (densePivotScore occ prot)
-          Prod.snd (fun _ => rfl)]
-      cases hA : (densePm1PivotsOf c ++ denseUnitPivotsOf c).argmin (densePivotScore occ prot) with
-      | none => simp
-      | some w =>
-          simp only [Option.map_some]
-          have hmem : w ∈ densePm1PivotsOf c ++ denseUnitPivotsOf c :=
-            List.argmin_mem (by rw [hA]; exact Option.mem_some_self w)
-          rcases List.mem_append.1 hmem with hp | hu
-          · rw [denseMem_pm1_trySolve c l hlin w hp]
-          · obtain ⟨hn, hs⟩ := denseMem_unit_trySolveUnit c l hlin w hu
-            rw [hn, hs]
-
 /-- Occurrence counts of every variable across the dense system (one traversal). -/
 def denseOccurrenceMap (d : DenseConstraintSystem p) : Std.HashMap VarId Nat :=
   let addE := fun (m : Std.HashMap VarId Nat) (e : DenseExpr p) =>
@@ -459,19 +200,6 @@ theorem insertAll_map :
 
 end DenseSolved
 
-def denseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    List (DenseExpr p) → DenseSolved p → DenseSolved p
-  | [], dσ => dσ
-  | c :: rest, dσ =>
-      let c' := (c.substF dσ.fn).normalize
-      match denseFastBest c' occ prot with
-      | none => denseGaussLoop occ prot rest dσ
-      | some (x, t) =>
-          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-          let pairs := touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
-          denseGaussLoop occ prot rest (dσ.insertAll pairs)
-
 /-! ## Dynamic sparse scheduling -/
 
 def DenseExpr.uniqueVars (e : DenseExpr p) : List VarId :=
@@ -480,13 +208,166 @@ def DenseExpr.uniqueVars (e : DenseExpr p) : List VarId :=
     (([], ∅) : List VarId × Std.HashSet VarId)
   st.1.reverse
 
+/-- Substitute sparse affine rows into an affine row, preserving first-occurrence term order. -/
+def denseLinSubstF (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p)) :
+    DenseLinExpr p :=
+  let const := l.terms.foldl (fun out yc =>
+    match σ yc.1 with
+    | some t => out + yc.2 * t.const
+    | none => out) l.const
+  let terms := l.terms.flatMap (fun yc =>
+    match σ yc.1 with
+    | some t => t.terms.map (fun zc => (zc.1, yc.2 * zc.2))
+    | none => [yc])
+  (DenseLinExpr.mk const terms).norm
+
+/-- Substitute one canonical affine row into another. -/
+def denseLinSubst (l : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) : DenseLinExpr p :=
+  denseLinSubstF l (fun y => if y = x then some t else none)
+
+def denseLinAdd (a b : DenseLinExpr p) : DenseLinExpr p :=
+  (a.add b).norm
+
+def denseLinScale (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
+  (l.scale k).norm
+
+def DenseLinExpr.mentions (l : DenseLinExpr p) (x : VarId) : Bool :=
+  l.terms.any (fun yc => yc.1 = x)
+
+inductive DenseGaussReduced (p : ℕ) where
+  | affine (row : DenseLinExpr p)
+  | nonlinear (expr : DenseExpr p)
+
+namespace DenseGaussReduced
+
+def toExpr : DenseGaussReduced p → DenseExpr p
+  | .affine row => row.toExpr
+  | .nonlinear expr => expr
+
+def vars : DenseGaussReduced p → List VarId
+  | .affine row => row.terms.map Prod.fst
+  | .nonlinear expr => expr.uniqueVars
+
+def fromExpr (e : DenseExpr p) : DenseGaussReduced p :=
+  match denseLinearize e with
+  | some row => .affine row.norm
+  | none =>
+      let normalized := e.normalize
+      match denseLinearize normalized with
+      | some row => .affine row.norm
+      | none => .nonlinear normalized
+
+end DenseGaussReduced
+
+def denseReducedAdd (ra rb : DenseGaussReduced p) : DenseGaussReduced p :=
+  match ra, rb with
+  | .affine la, .affine lb => .affine (denseLinAdd la lb)
+  | _, _ => .nonlinear (.add ra.toExpr rb.toExpr)
+
+def denseReducedMul (ra rb : DenseGaussReduced p) : DenseGaussReduced p :=
+  match ra, rb with
+  | .affine la, .affine lb =>
+      if la.terms.isEmpty then .affine (denseLinScale la.const lb)
+      else if lb.terms.isEmpty then .affine (denseLinScale lb.const la)
+      else .nonlinear (.mul la.toExpr lb.toExpr)
+  | _, _ => .nonlinear (.mul ra.toExpr rb.toExpr)
+
+/-- Simultaneous sparse substitution and affine normalization, retaining expressions only for
+    genuinely nonlinear subtrees. -/
+def denseSparseSubstF (σ : VarId → Option (DenseLinExpr p)) : DenseExpr p → DenseGaussReduced p
+  | .const n => .affine ⟨n, []⟩
+  | .var x =>
+      match σ x with
+      | some row => .affine row
+      | none => .affine ⟨0, [(x, 1)]⟩
+  | e@(.add a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubstF row σ)
+      | none =>
+          let ra := denseSparseSubstF σ a
+          let rb := denseSparseSubstF σ b
+          denseReducedAdd ra rb
+  | e@(.mul a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubstF row σ)
+      | none =>
+          let ra := denseSparseSubstF σ a
+          let rb := denseSparseSubstF σ b
+          denseReducedMul ra rb
+
+def denseReducedSubst (r : DenseGaussReduced p) (x : VarId)
+    (t : DenseLinExpr p) : DenseGaussReduced p :=
+  match r with
+  | .affine row => .affine (denseLinSubst row x t)
+  | .nonlinear expr => denseSparseSubstF (fun y => if y = x then some t else none) expr
+
+structure DenseSparseSolved (p : ℕ) where
+  map : Std.HashMap VarId (DenseLinExpr p)
+  revDeps : Std.HashMap VarId (Std.HashSet VarId)
+
+namespace DenseSparseSolved
+
+def empty : DenseSparseSolved p := { map := ∅, revDeps := ∅ }
+
+def fn (dσ : DenseSparseSolved p) : VarId → Option (DenseLinExpr p) := fun i => dσ.map[i]?
+
+def insertAll (dσ : DenseSparseSolved p) :
+    List (VarId × DenseLinExpr p) → DenseSparseSolved p
+  | [] => dσ
+  | (x, t) :: rest =>
+      DenseSparseSolved.insertAll
+        { map := dσ.map.insert x t
+          revDeps := t.terms.foldl
+            (fun rd zc => rd.insert zc.1 (((rd[zc.1]?).getD ∅).insert x)) dσ.revDeps }
+        rest
+
+def materialize (dσ : DenseSparseSolved p) : DenseSolved p :=
+  let map := dσ.map.toList.foldl
+    (fun out xt => out.insert xt.1 xt.2.toExpr) (∅ : Std.HashMap VarId (DenseExpr p))
+  { map, revDeps := ∅ }
+
+end DenseSparseSolved
+
+def denseSparseSolveAt (l : DenseLinExpr p) (x : VarId) :
+    Option (VarId × DenseLinExpr p) :=
+  if l.coeff x = 1 then some (x, denseLinScale (-1) (l.others x))
+  else if l.coeff x = -1 then some (x, l.others x)
+  else if l.coeff x * (l.coeff x)⁻¹ = 1 then
+    some (x, denseLinScale (-(l.coeff x)⁻¹) (l.others x))
+  else none
+
+def denseSparseBest (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
+  match (densePivotDescs l occ prot).argmin Prod.snd with
+  | none => none
+  | some (x, _) => denseSparseSolveAt l x
+
+def denseReducedBest (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
+  match r with
+  | .affine row => denseSparseBest row occ prot
+  | .nonlinear _ => none
+
+def denseSparseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    List (DenseExpr p) → DenseSparseSolved p → DenseSparseSolved p
+  | [], dσ => dσ
+  | c :: rest, dσ =>
+      let c' := denseSparseSubstF dσ.fn c
+      match denseReducedBest c' occ prot with
+      | none => denseSparseGaussLoop occ prot rest dσ
+      | some (x, t) =>
+          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
+          let pairs := touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
+          denseSparseGaussLoop occ prot rest (dσ.insertAll pairs)
+
 structure DenseMarkowitzPivot where
   var : VarId
   rhsNnz : Nat
 
 structure DenseMarkowitzRow (p : ℕ) where
   rowId : Nat
-  reduced : DenseExpr p
+  reduced : DenseGaussReduced p
   vars : List VarId
   pivots : List DenseMarkowitzPivot
   generation : Nat
@@ -529,11 +410,11 @@ structure DenseMarkowitzState (p : ℕ) where
   pivotRows : Std.HashMap VarId (Std.HashSet Nat)
   heap : DenseMarkowitzHeap
 
-def denseMarkowitzPivots (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
+def denseMarkowitzPivots (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
     (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
-  match denseLinearize e with
-  | none => []
-  | some l =>
+  match r with
+  | .nonlinear _ => []
+  | .affine l =>
       let idx := denseCoeffIdx l.terms
       let vars := l.terms.map Prod.fst
       let descs := vars.filterMap (densePm1Desc idx l.terms.length occ prot) ++
@@ -548,12 +429,22 @@ def denseMarkowitzPivots (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
 
 def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
     (prot : Std.HashSet VarId) (generation : Nat := 0) : DenseMarkowitzRow p :=
-  let reduced := e.normalize
+  let reduced := DenseGaussReduced.fromExpr e
   { rowId
     reduced
-    vars := reduced.uniqueVars
+    vars := reduced.vars
     pivots := denseMarkowitzPivots reduced occ prot
     generation
+    active := true }
+
+def denseMarkowitzRefreshRow (r : DenseMarkowitzRow p) (x : VarId) (t : DenseLinExpr p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzRow p :=
+  let reduced := denseReducedSubst r.reduced x t
+  { rowId := r.rowId
+    reduced
+    vars := reduced.vars
+    pivots := denseMarkowitzPivots reduced occ prot
+    generation := r.generation + 1
     active := true }
 
 def denseMarkowitzDegreeAdd (m : Std.HashMap VarId Nat) (xs : List VarId) :
@@ -585,7 +476,7 @@ def denseMarkowitzUnindexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
     (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).erase rowId)) idx
 
 def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
+    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
     (r : DenseMarkowitzRow p) (q : DenseMarkowitzPivot) : DenseMarkowitzEntry :=
   let solvedDegree := ((dσ.revDeps[q.var]?).getD ∅).size
   let activeDegree := st.degrees.getD q.var 1
@@ -598,7 +489,7 @@ def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarI
     generation := r.generation }
 
 def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
+    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
     (r : DenseMarkowitzRow p) : Option DenseMarkowitzEntry :=
   r.pivots.foldl (fun best q =>
     let entry := denseMarkowitzEntryOf occ prot dσ st rowId r q
@@ -607,7 +498,7 @@ def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet V
     | some old => if denseMarkowitzEntryBetter entry old then some entry else best) none
 
 def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSolved p) (st : DenseMarkowitzState p) (rowId : Nat) :
+    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat) :
     DenseMarkowitzState p :=
   match st.rows[rowId]? with
   | none => st
@@ -637,7 +528,7 @@ def denseMarkowitzBuild (constraints : List (DenseExpr p))
       rowDeps := denseMarkowitzIndexRow st.rowDeps rowId r.vars
       pivotRows := denseMarkowitzIndexPivots st.pivotRows rowId r.pivots }) base
   indexed.rows.foldl (fun st r =>
-    match denseMarkowitzBestEntry? occ prot DenseSolved.empty st r.rowId r with
+    match denseMarkowitzBestEntry? occ prot DenseSparseSolved.empty st r.rowId r with
     | none => st
     | some entry => { st with heap := st.heap.insert entry }) indexed
 
@@ -666,13 +557,13 @@ def denseMarkowitzCollectIds (idx : Std.HashMap VarId (Std.HashSet Nat))
     ((idx[x]?).getD ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
 
 def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
+    (dσ : DenseSparseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
     DenseMarkowitzState p :=
   (denseMarkowitzCollectIds st.pivotRows changed).toList.foldl
     (denseMarkowitzPushRow occ prot dσ) st
 
 def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (x : VarId) (t : DenseExpr p) (st : DenseMarkowitzState p) :
+    (x : VarId) (t : DenseLinExpr p) (st : DenseMarkowitzState p) :
     DenseMarkowitzState p × Std.HashSet VarId :=
   let rowIds := ((st.rowDeps[x]?).getD ∅).toList
   rowIds.foldl (fun (st, changed) rowId =>
@@ -681,7 +572,7 @@ def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet 
     | some r =>
         if !r.active || !r.vars.contains x then (st, changed)
         else
-          let r' := denseMarkowitzRow r.rowId (r.reduced.subst x t) occ prot (r.generation + 1)
+          let r' := denseMarkowitzRefreshRow r x t occ prot
           let changed := (r.vars ++ r'.vars).foldl (fun s y => s.insert y) changed
           ({ st with
               rows := st.rows.setIfInBounds rowId r'
@@ -707,38 +598,34 @@ def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
           pivotRows := denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots },
         changed)
 
-def denseMarkowitzAdoptPairs (dσ : DenseSolved p) (x : VarId) (t : DenseExpr p) :
-    List (VarId × DenseExpr p) :=
+def denseMarkowitzAdoptPairs (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p) :
+    List (VarId × DenseLinExpr p) :=
   let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
     (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-  touched.map (fun ys => (ys.1, (ys.2.subst x t).normalize)) ++ [(x, t)]
+  touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
 
 def denseMarkowitzAdopt (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (entry : DenseMarkowitzEntry) (x : VarId) (t : DenseExpr p)
-    (pairs : List (VarId × DenseExpr p)) (st : DenseMarkowitzState p)
-    (dσ : DenseSolved p) : DenseMarkowitzState p :=
+    (entry : DenseMarkowitzEntry) (x : VarId) (t : DenseLinExpr p)
+    (pairs : List (VarId × DenseLinExpr p)) (st : DenseMarkowitzState p)
+    (dσ : DenseSparseSolved p) : DenseMarkowitzState p :=
   let (st, selectedVars) := denseMarkowitzDeactivate entry.rowId st
   let (st, rowVars) := denseMarkowitzRefreshRows occ prot x t st
   let changed := pairs.foldl (fun changed yt =>
-    yt.2.foldVars (fun changed y => changed.insert y) changed) (selectedVars ∪ rowVars)
+    yt.2.terms.foldl (fun changed yc => changed.insert yc.1) changed) (selectedVars ∪ rowVars)
   denseMarkowitzRekey occ prot dσ changed st
 
-def denseSolveAt (c : DenseExpr p) (x : VarId) : Option (VarId × DenseExpr p) :=
-  match denseLinearize c with
-  | none => none
-  | some l =>
-      match l.trySolve x with
-      | some xt => some xt
-      | none => l.trySolveUnit x
-
-def denseMarkowitzPick (c : DenseExpr p) (x : VarId) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseExpr p) :=
-  match denseSolveAt c x with
+def denseMarkowitzPick (r : DenseGaussReduced p) (x : VarId) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
+  let hinted := match r with
+    | .affine l => denseSparseSolveAt l x
+    | .nonlinear _ => none
+  match hinted with
   | some xt => some xt
-  | none => denseFastBest c occ prot
+  | none => denseReducedBest r occ prot
 
 def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (sources : Array (DenseExpr p)) : Nat → DenseMarkowitzState p → DenseSolved p → DenseSolved p
+    (sources : Array (DenseExpr p)) : Nat → DenseMarkowitzState p →
+      DenseSparseSolved p → DenseSparseSolved p
   | 0, _, dσ => dσ
   | fuel + 1, st, dσ =>
       match denseMarkowitzPopValid (st.heap.size + 1) st with
@@ -748,7 +635,7 @@ def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
           | none => denseMarkowitzLoop occ prot sources fuel
               (denseMarkowitzDeactivate entry.rowId st).1 dσ
           | some c =>
-              let c' := (c.substF dσ.fn).normalize
+              let c' := denseSparseSubstF dσ.fn c
               match denseMarkowitzPick c' entry.pivot occ prot with
               | none => denseMarkowitzLoop occ prot sources fuel
                   (denseMarkowitzDeactivate entry.rowId st).1 dσ
@@ -760,57 +647,29 @@ def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
                     st dσ
 
 def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : DenseSolved p :=
+    (prot : Std.HashSet VarId) : DenseSparseSolved p :=
   let sources := constraints.toArray
   let st := denseMarkowitzBuild constraints occ prot
-  denseMarkowitzLoop occ prot sources sources.size st DenseSolved.empty
+  denseMarkowitzLoop occ prot sources sources.size st DenseSparseSolved.empty
 
 def denseSourceOrderSchedule (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
-  let first := denseGaussLoop occ prot constraints DenseSolved.empty
-  if first.map.isEmpty then first else denseGaussLoop occ prot constraints first
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSparseSolved p :=
+  let first := denseSparseGaussLoop occ prot constraints DenseSparseSolved.empty
+  if first.map.isEmpty then first else denseSparseGaussLoop occ prot constraints first
 
 def denseMarkowitzMinRows : Nat := 8192
 
 def denseGaussSchedule (constraints : List (DenseExpr p))
     (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
-  if constraints.length < denseMarkowitzMinRows
-  then denseSourceOrderSchedule constraints occ prot
-  else denseMarkowitzSchedule constraints occ prot
+  (if constraints.length < denseMarkowitzMinRows
+    then denseSourceOrderSchedule constraints occ prot
+    else denseMarkowitzSchedule constraints occ prot).materialize
 
 theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : VarId)
     (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
   simp only [DenseLinExpr.others, List.mem_map] at h ⊢
   obtain ⟨tt, htt, rfl⟩ := h
   exact ⟨tt, List.mem_of_mem_filter htt, rfl⟩
-
-theorem denseTrySolve_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarId × DenseExpr p)
-    (h : l.trySolve v = some w) : ∀ x ∈ w.2.vars, x ∈ l.terms.map Prod.fst := by
-  by_cases h1 : l.coeff v = 1
-  · rw [DenseLinExpr.trySolve_eq_of_one l v h1] at h
-    injection h with h'; subst h'
-    intro x hx
-    exact l.others_terms_fst_mem v x
-      (by rw [← DenseLinExpr.scale_terms_fst (-1) (l.others v)]; exact DenseLinExpr.toExpr_vars _ x hx)
-  · by_cases h2 : l.coeff v = -1
-    · rw [DenseLinExpr.trySolve_eq_of_negOne l v h1 h2] at h
-      injection h with h'; subst h'
-      intro x hx
-      exact l.others_terms_fst_mem v x (DenseLinExpr.toExpr_vars _ x hx)
-    · rw [DenseLinExpr.trySolve_eq_none l v (by rintro (h | h); exacts [h1 h, h2 h])] at h
-      exact absurd h (by simp)
-
-theorem denseTrySolveUnit_vars_subset (l : DenseLinExpr p) (v : VarId) (w : VarId × DenseExpr p)
-    (h : l.trySolveUnit v = some w) : ∀ x ∈ w.2.vars, x ∈ l.terms.map Prod.fst := by
-  by_cases h1 : l.coeff v * (l.coeff v)⁻¹ = 1
-  · rw [DenseLinExpr.trySolveUnit_eq_of l v h1] at h
-    injection h with h'; subst h'
-    intro x hx
-    exact l.others_terms_fst_mem v x
-      (by rw [← DenseLinExpr.scale_terms_fst (-(l.coeff v)⁻¹) (l.others v)]
-          exact DenseLinExpr.toExpr_vars _ x hx)
-  · rw [DenseLinExpr.trySolveUnit_eq_none l v h1] at h
-    exact absurd h (by simp)
 
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
     assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost on large

--- a/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
@@ -2,33 +2,6 @@ import ApcOptimizer.Implementation.OptimizerPasses.Basic
 
 set_option autoImplicit false
 
-/-! ### Generic `argmin` / `filterMap` list lemmas -/
-
-/-- `argmin` commutes with a key-preserving map (`kγ (g a) = kα a`): the winner of the mapped list
-    is the mapped winner — lets us score cheap descriptors instead of built candidates. -/
-theorem argmin_map_key {α γ : Type*} (g : α → γ) (kα : α → Nat) (kγ : γ → Nat)
-    (h : ∀ a, kγ (g a) = kα a) : ∀ l : List α, (l.map g).argmin kγ = (l.argmin kα).map g := by
-  intro l
-  induction l with
-  | nil => simp
-  | cons a t ih =>
-      rw [List.map_cons, List.argmin_cons, List.argmin_cons, ih]
-      cases t.argmin kα with
-      | none => simp
-      | some c =>
-          simp only [Option.map_some, h]
-          by_cases hlt : kα c < kα a <;> simp [hlt]
-
-theorem map_filterMap {α β γ : Type*} (f : α → Option β) (g : β → γ) (l : List α) :
-    (l.filterMap f).map g = l.filterMap (fun a => (f a).map g) := by
-  induction l with
-  | nil => simp
-  | cons a t ih =>
-      simp only [List.filterMap_cons]
-      cases f a with
-      | none => simpa using ih
-      | some b => simp [ih]
-
 /-- `filterMap` respects pointwise equality of its function on the list. -/
 theorem filterMap_congr' {β γ : Type _} {f g : β → Option γ} (l : List β)
     (h : ∀ x ∈ l, f x = g x) : l.filterMap f = l.filterMap g := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -7,112 +7,572 @@ set_option autoImplicit false
 /-! # Correctness for the dense Gauss-elimination pass.
 Substitution-shaped: correctness rides on `DenseConstraintSystem.substF_denseCorrect`
 (`Proofs/DomainBatch.lean`), fed the final solution map's entailment and occurrence closure, both
-established by `denseMarkowitzLoop_sound`. -/
+established by `denseSparseMarkowitzLoop_sound`. -/
 
 namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
-/-- Substituting `i := t` and evaluating equals evaluating with `i` rebound to `t.eval denv`. -/
-theorem DenseExpr.eval_subst (e : DenseExpr p) (i : VarId) (t : DenseExpr p)
+def denseLinEnv (σ : VarId → Option (DenseLinExpr p)) (denv : VarId → ZMod p) :
+    VarId → ZMod p :=
+  fun i => match σ i with | some row => row.eval denv | none => denv i
+
+theorem denseLinSubstData_eval (terms : List (VarId × ZMod p))
+    (σ : VarId → Option (DenseLinExpr p)) (denv : VarId → ZMod p) (k : ZMod p) :
+    terms.foldl (fun out yc =>
+        match σ yc.1 with
+        | some t => out + yc.2 * t.const
+        | none => out) k
+      + ((terms.flatMap (fun yc =>
+          match σ yc.1 with
+          | some t => t.terms.map (fun zc => (zc.1, yc.2 * zc.2))
+          | none => [yc])).map (fun zc => zc.2 * denv zc.1)).sum
+    = k + (terms.map (fun yc => yc.2 * denseLinEnv σ denv yc.1)).sum := by
+  induction terms generalizing k with
+  | nil => simp
+  | cons yc rest ih =>
+      simp only [List.foldl_cons, List.flatMap_cons, List.map_append, List.sum_append,
+        List.map_cons, List.sum_cons]
+      cases hσ : σ yc.1 with
+      | none =>
+          simp only [List.map_singleton, List.sum_singleton]
+          rw [show denseLinEnv σ denv yc.1 = denv yc.1 by simp [denseLinEnv, hσ]]
+          have hrest := ih k
+          linear_combination hrest
+      | some row =>
+          simp only [List.map_map]
+          rw [show denseLinEnv σ denv yc.1 = row.eval denv by simp [denseLinEnv, hσ],
+            DenseLinExpr.eval]
+          have hrest := ih (k + yc.2 * row.const)
+          have hscale :
+              ((row.terms.map fun zc => (zc.1, yc.2 * zc.2)).map
+                  fun zc => zc.2 * denv zc.1).sum
+                = yc.2 * ((row.terms.map fun zc => zc.2 * denv zc.1).sum) := by
+            induction row.terms with
+            | nil => simp
+            | cons zc zs ihz =>
+                simp only [List.map_cons, List.sum_cons, ihz]
+                ring
+          rw [show
+            (row.terms.map ((fun zc => zc.2 * denv zc.1) ∘
+              fun zc => (zc.1, yc.2 * zc.2))).sum
+              = yc.2 * ((row.terms.map fun zc => zc.2 * denv zc.1).sum) by
+                simpa [Function.comp_def] using hscale]
+          linear_combination hrest
+
+theorem denseLinSubstF_eval (l : DenseLinExpr p)
+    (σ : VarId → Option (DenseLinExpr p)) (denv : VarId → ZMod p) :
+    (denseLinSubstF l σ).eval denv = l.eval (denseLinEnv σ denv) := by
+  rw [denseLinSubstF, DenseLinExpr.norm_eval]
+  simp only [DenseLinExpr.eval]
+  exact denseLinSubstData_eval l.terms σ denv l.const
+
+theorem denseLinSubstF_terms_closed (l : DenseLinExpr p)
+    (σ : VarId → Option (DenseLinExpr p)) (S : VarId → Prop)
+    (hl : ∀ z ∈ l.terms.map Prod.fst, S z)
+    (hσ : ∀ i row, σ i = some row → ∀ z ∈ row.terms.map Prod.fst, S z) :
+    ∀ z ∈ (denseLinSubstF l σ).terms.map Prod.fst, S z := by
+  intro z hz
+  let rawTerms := l.terms.flatMap (fun yc =>
+    match σ yc.1 with
+    | some t => t.terms.map (fun zc => (zc.1, yc.2 * zc.2))
+    | none => [yc])
+  have hzraw : z ∈ rawTerms.map Prod.fst := by
+    exact DenseLinExpr.norm_terms_fst
+      ⟨l.terms.foldl (fun out yc =>
+        match σ yc.1 with
+        | some t => out + yc.2 * t.const
+        | none => out) l.const, rawTerms⟩ z hz
+  simp only [rawTerms, List.mem_map, List.mem_flatMap] at hzraw
+  obtain ⟨zc, ⟨yc, hyc, hyout⟩, hzc⟩ := hzraw
+  cases hrow : σ yc.1 with
+  | none =>
+      simp only [hrow, List.mem_singleton] at hyout
+      subst zc
+      exact hzc ▸ hl yc.1 (List.mem_map.2 ⟨yc, hyc, rfl⟩)
+  | some row =>
+      simp only [hrow, List.mem_map] at hyout
+      obtain ⟨rc, hrc, hrczc⟩ := hyout
+      subst zc
+      exact hzc ▸ hσ yc.1 row hrow rc.1 (List.mem_map.2 ⟨rc, hrc, rfl⟩)
+
+theorem denseLinAdd_eval (a b : DenseLinExpr p) (denv : VarId → ZMod p) :
+    (denseLinAdd a b).eval denv = a.eval denv + b.eval denv := by
+  rw [denseLinAdd, DenseLinExpr.norm_eval, DenseLinExpr.add_eval]
+
+theorem denseLinScale_eval (k : ZMod p) (l : DenseLinExpr p) (denv : VarId → ZMod p) :
+    (denseLinScale k l).eval denv = k * l.eval denv := by
+  rw [denseLinScale, DenseLinExpr.norm_eval, DenseLinExpr.scale_eval]
+
+theorem denseLinAdd_toExpr_eval (a b : DenseLinExpr p) (denv : VarId → ZMod p) :
+    (denseLinAdd a b).toExpr.eval denv = a.toExpr.eval denv + b.toExpr.eval denv := by
+  simp only [DenseLinExpr.toExpr_eval, denseLinAdd_eval]
+
+theorem denseLinScale_toExpr_eval (k : ZMod p) (l : DenseLinExpr p)
     (denv : VarId → ZMod p) :
-    (e.subst i t).eval denv = e.eval (Function.update denv i (t.eval denv)) := by
+    (denseLinScale k l).toExpr.eval denv = k * l.toExpr.eval denv := by
+  simp only [DenseLinExpr.toExpr_eval, denseLinScale_eval]
+
+theorem denseLinAdd_terms_closed (a b : DenseLinExpr p) (S : VarId → Prop)
+    (ha : ∀ z ∈ a.terms.map Prod.fst, S z)
+    (hb : ∀ z ∈ b.terms.map Prod.fst, S z) :
+    ∀ z ∈ (denseLinAdd a b).terms.map Prod.fst, S z := by
+  intro z hz
+  have hz' := DenseLinExpr.norm_terms_fst (a.add b) z hz
+  simp only [DenseLinExpr.add, List.map_append, List.mem_append] at hz'
+  exact hz'.elim (ha z) (hb z)
+
+theorem denseLinScale_terms_closed (k : ZMod p) (l : DenseLinExpr p) (S : VarId → Prop)
+    (hl : ∀ z ∈ l.terms.map Prod.fst, S z) :
+    ∀ z ∈ (denseLinScale k l).terms.map Prod.fst, S z := by
+  intro z hz
+  have hz' := DenseLinExpr.norm_terms_fst (l.scale k) z hz
+  rw [DenseLinExpr.scale_terms_fst] at hz'
+  exact hl z hz'
+
+theorem denseSparseMulReduced_eval (ra rb : DenseGaussReduced p) (denv : VarId → ZMod p) :
+    (denseReducedMul ra rb).toExpr.eval denv
+      = ra.toExpr.eval denv * rb.toExpr.eval denv := by
+  cases ra with
+  | nonlinear ea =>
+      cases rb <;> simp [denseReducedMul, DenseGaussReduced.toExpr, DenseExpr.eval]
+  | affine la =>
+      cases rb with
+      | nonlinear eb => simp [denseReducedMul, DenseGaussReduced.toExpr, DenseExpr.eval]
+      | affine lb =>
+          simp only [denseReducedMul, DenseGaussReduced.toExpr]
+          by_cases ha : la.terms.isEmpty
+          · rw [if_pos ha]
+            simp only [denseLinScale_toExpr_eval]
+            rw [DenseLinExpr.toExpr_eval la]
+            simp [DenseLinExpr.eval, List.isEmpty_iff.1 ha]
+          · rw [if_neg ha]
+            by_cases hb : lb.terms.isEmpty
+            · rw [if_pos hb]
+              simp only [denseLinScale_toExpr_eval]
+              rw [DenseLinExpr.toExpr_eval lb]
+              simp [DenseLinExpr.eval, List.isEmpty_iff.1 hb, mul_comm]
+            · rw [if_neg hb]
+              rfl
+
+theorem denseSparseSubstF_eval (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p)
+    (denv : VarId → ZMod p) (hσ : ∀ i row, σ i = some row → denv i = row.eval denv) :
+    (denseSparseSubstF σ e).toExpr.eval denv = e.eval denv := by
+  have henv : denseLinEnv σ denv = denv := by
+    funext i
+    cases hi : σ i with
+    | none => simp [denseLinEnv, hi]
+    | some row => simp [denseLinEnv, hi, hσ i row hi]
   induction e with
-  | const n => simp [DenseExpr.subst, DenseExpr.eval]
-  | var j =>
-      simp only [DenseExpr.subst]
-      by_cases h : j = i
-      · subst h; simp [DenseExpr.eval, Function.update_self]
-      · rw [if_neg h]; simp [DenseExpr.eval, Function.update_of_ne h]
-  | add a b iha ihb => simp only [DenseExpr.subst, DenseExpr.eval, iha, ihb]
-  | mul a b iha ihb => simp only [DenseExpr.subst, DenseExpr.eval, iha, ihb]
+  | const n => rfl
+  | var i =>
+      simp only [denseSparseSubstF]
+      cases hi : σ i with
+      | none =>
+          simp only [DenseGaussReduced.toExpr, DenseExpr.eval]
+          rw [DenseLinExpr.toExpr_eval]
+          simp [DenseLinExpr.eval]
+      | some row =>
+          simp only [DenseGaussReduced.toExpr, DenseExpr.eval]
+          rw [DenseLinExpr.toExpr_eval, ← hσ i row hi]
+  | add a b iha ihb =>
+      simp only [denseSparseSubstF]
+      cases hlin : denseLinearize (.add a b) with
+      | some row =>
+          simp only [DenseGaussReduced.toExpr]
+          rw [DenseLinExpr.toExpr_eval, denseLinSubstF_eval, henv,
+            ← denseLinearize_eval (.add a b) row hlin]
+      | none =>
+          cases ha : denseSparseSubstF σ a <;>
+            cases hb : denseSparseSubstF σ b <;>
+            simp_all [denseReducedAdd, DenseGaussReduced.toExpr, DenseExpr.eval,
+              denseLinAdd_toExpr_eval]
+  | mul a b iha ihb =>
+      simp only [denseSparseSubstF]
+      cases hlin : denseLinearize (.mul a b) with
+      | some row =>
+          simp only [DenseGaussReduced.toExpr]
+          rw [DenseLinExpr.toExpr_eval, denseLinSubstF_eval, henv,
+            ← denseLinearize_eval (.mul a b) row hlin]
+      | none =>
+          have hm := denseSparseMulReduced_eval
+            (denseSparseSubstF σ a) (denseSparseSubstF σ b) denv
+          rw [iha, ihb] at hm
+          simpa only [DenseExpr.eval] using hm
 
-/-! ## Affine soundness -/
+def DenseGaussReduced.support : DenseGaussReduced p → List VarId
+  | .affine row => row.terms.map Prod.fst
+  | .nonlinear expr => expr.vars
 
-/-- If `l.trySolve v` returns `(x, t)` and `l` evaluates to zero, then `x = t` under `denv`. -/
-theorem DenseLinExpr.trySolve_sound (l : DenseLinExpr p) (v x : VarId) (t : DenseExpr p)
-    (h : l.trySolve v = some (x, t)) (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
-    denv x = t.eval denv := by
-  unfold DenseLinExpr.trySolve at h
-  split_ifs at h with h1 h2
+def DenseGaussReduced.Closed (r : DenseGaussReduced p) (S : VarId → Prop) : Prop :=
+  ∀ z ∈ r.support, S z
+
+theorem denseSparseAddReduced_closed (ra rb : DenseGaussReduced p) (S : VarId → Prop)
+    (ha : ra.Closed S) (hb : rb.Closed S) :
+    (denseReducedAdd ra rb).Closed S := by
+  revert ha hb
+  cases ra with
+  | affine la =>
+      cases rb with
+      | affine lb =>
+          intro ha hb
+          simp only [denseReducedAdd, DenseGaussReduced.Closed,
+            DenseGaussReduced.support] at ha hb ⊢
+          exact denseLinAdd_terms_closed la lb S ha hb
+      | nonlinear eb =>
+          intro ha hb
+          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact DenseLinExpr.toExpr_vars la z hz |> ha z
+          · exact hb z hz
+  | nonlinear ea =>
+      cases rb with
+      | affine lb =>
+          intro ha hb
+          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact ha z hz
+          · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
+      | nonlinear eb =>
+          intro ha hb
+          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact ha z hz
+          · exact hb z hz
+
+theorem denseSparseMulReduced_closed (ra rb : DenseGaussReduced p) (S : VarId → Prop)
+    (ha : ra.Closed S) (hb : rb.Closed S) :
+    (denseReducedMul ra rb).Closed S := by
+  revert ha hb
+  cases ra with
+  | affine la =>
+      cases rb with
+      | affine lb =>
+          intro ha hb
+          simp only [denseReducedMul, DenseGaussReduced.Closed,
+            DenseGaussReduced.support] at ha hb ⊢
+          by_cases hla : la.terms.isEmpty
+          · rw [if_pos hla]
+            exact denseLinScale_terms_closed la.const lb S hb
+          · rw [if_neg hla]
+            by_cases hlb : lb.terms.isEmpty
+            · rw [if_pos hlb]
+              exact denseLinScale_terms_closed lb.const la S ha
+            · rw [if_neg hlb]
+              intro z hz
+              simp only [DenseExpr.vars, List.mem_append] at hz
+              rcases hz with hz | hz
+              · exact DenseLinExpr.toExpr_vars la z hz |> ha z
+              · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
+      | nonlinear eb =>
+          intro ha hb
+          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact DenseLinExpr.toExpr_vars la z hz |> ha z
+          · exact hb z hz
+  | nonlinear ea =>
+      cases rb with
+      | affine lb =>
+          intro ha hb
+          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact ha z hz
+          · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
+      | nonlinear eb =>
+          intro ha hb
+          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
+            DenseGaussReduced.toExpr] at ha hb ⊢
+          intro z hz
+          simp only [DenseExpr.vars, List.mem_append] at hz
+          rcases hz with hz | hz
+          · exact ha z hz
+          · exact hb z hz
+
+theorem denseSparseSubstF_closed (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p)
+    (S : VarId → Prop) (he : ∀ z ∈ e.vars, S z)
+    (hσ : ∀ i row, σ i = some row → ∀ z ∈ row.terms.map Prod.fst, S z) :
+    (denseSparseSubstF σ e).Closed S := by
+  induction e with
+  | const n =>
+      simp [denseSparseSubstF, DenseGaussReduced.Closed, DenseGaussReduced.support]
+  | var i =>
+      simp only [denseSparseSubstF]
+      cases hi : σ i with
+      | none =>
+          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support,
+            List.map_singleton, List.mem_singleton]
+          intro z hz
+          subst z
+          exact he i (by simp [DenseExpr.vars])
+      | some row =>
+          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
+          exact hσ i row hi
+  | add a b iha ihb =>
+      simp only [denseSparseSubstF]
+      cases hlin : denseLinearize (.add a b) with
+      | some row =>
+          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
+          apply denseLinSubstF_terms_closed row σ S
+          · intro z hz
+            exact he z (denseLinearize_mem_vars (.add a b) row hlin z hz)
+          · exact hσ
+      | none =>
+          have hea : ∀ z ∈ a.vars, S z :=
+            fun z hz => he z (by simp [DenseExpr.vars, hz])
+          have heb : ∀ z ∈ b.vars, S z :=
+            fun z hz => he z (by simp [DenseExpr.vars, hz])
+          have ha := iha hea
+          have hb := ihb heb
+          exact denseSparseAddReduced_closed
+            (denseSparseSubstF σ a) (denseSparseSubstF σ b) S ha hb
+  | mul a b iha ihb =>
+      simp only [denseSparseSubstF]
+      cases hlin : denseLinearize (.mul a b) with
+      | some row =>
+          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
+          apply denseLinSubstF_terms_closed row σ S
+          · intro z hz
+            exact he z (denseLinearize_mem_vars (.mul a b) row hlin z hz)
+          · exact hσ
+      | none =>
+          have hea : ∀ z ∈ a.vars, S z :=
+            fun z hz => he z (by simp [DenseExpr.vars, hz])
+          have heb : ∀ z ∈ b.vars, S z :=
+            fun z hz => he z (by simp [DenseExpr.vars, hz])
+          have ha := iha hea
+          have hb := ihb heb
+          exact denseSparseMulReduced_closed
+            (denseSparseSubstF σ a) (denseSparseSubstF σ b) S ha hb
+
+theorem denseLinSubst_eval (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p)
+    (denv : VarId → ZMod p) (hx : denv x = t.eval denv) :
+    (denseLinSubst s x t).eval denv = s.eval denv := by
+  rw [denseLinSubst, denseLinSubstF_eval]
+  congr 1
+  funext y
+  by_cases hy : y = x
+  · subst y
+    simp [denseLinEnv, hx]
+  · simp [denseLinEnv, hy]
+
+theorem denseLinSubst_terms_closed (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p)
+    (S : VarId → Prop) (hs : ∀ z ∈ s.terms.map Prod.fst, S z)
+    (ht : ∀ z ∈ t.terms.map Prod.fst, S z) :
+    ∀ z ∈ (denseLinSubst s x t).terms.map Prod.fst, S z := by
+  apply denseLinSubstF_terms_closed s _ S hs
+  intro i row hi
+  by_cases hix : i = x
+  · subst i
+    have hrow : t = row := by simpa using hi
+    subst row
+    exact ht
+  · simp [hix] at hi
+
+theorem denseSparseSolveAt_sound (l : DenseLinExpr p) (x y : VarId)
+    (t : DenseLinExpr p) (h : denseSparseSolveAt l x = some (y, t))
+    (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
+    denv y = t.eval denv := by
+  unfold denseSparseSolveAt at h
+  split_ifs at h with h1 h2 h3
   · simp only [Option.some.injEq, Prod.mk.injEq] at h
     obtain ⟨rfl, rfl⟩ := h
-    rw [DenseLinExpr.toExpr_eval, DenseLinExpr.scale_eval]
-    have hs := l.eval_split v denv
-    rw [h1, one_mul] at hs; rw [hs] at hl
+    rw [denseLinScale_eval]
+    have hs := l.eval_split x denv
+    rw [h1, one_mul] at hs
+    rw [hs] at hl
     linear_combination hl
   · simp only [Option.some.injEq, Prod.mk.injEq] at h
     obtain ⟨rfl, rfl⟩ := h
-    rw [DenseLinExpr.toExpr_eval]
-    have hs := l.eval_split v denv
-    rw [h2] at hs; rw [hs] at hl
+    have hs := l.eval_split x denv
+    rw [h2] at hs
+    rw [hs] at hl
     linear_combination -hl
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    rw [denseLinScale_eval]
+    have hs := l.eval_split x denv
+    have h0 : l.coeff x * denv x + (l.others x).eval denv = 0 := by
+      rw [← hs]
+      exact hl
+    linear_combination (l.coeff x)⁻¹ * h0 - denv x * h3
 
-/-- If `l.trySolveUnit v` returns `(x, t)` and `l` evaluates to zero, then `x = t` under `denv`. -/
-theorem DenseLinExpr.trySolveUnit_sound (l : DenseLinExpr p) (v x : VarId) (t : DenseExpr p)
-    (h : l.trySolveUnit v = some (x, t)) (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
-    denv x = t.eval denv := by
-  unfold DenseLinExpr.trySolveUnit at h
-  split_ifs at h with h1
-  simp only [Option.some.injEq, Prod.mk.injEq] at h
-  obtain ⟨rfl, rfl⟩ := h
-  rw [DenseLinExpr.toExpr_eval, DenseLinExpr.scale_eval]
-  have hs := l.eval_split v denv
-  have h0 : l.coeff v * denv v + (l.others v).eval denv = 0 := by rw [← hs]; exact hl
-  linear_combination (l.coeff v)⁻¹ * h0 - denv v * h1
+theorem denseSparseSolveAt_terms (l : DenseLinExpr p) (x y : VarId)
+    (t : DenseLinExpr p) (h : denseSparseSolveAt l x = some (y, t)) :
+    ∀ z ∈ t.terms.map Prod.fst, z ∈ l.terms.map Prod.fst := by
+  unfold denseSparseSolveAt at h
+  split_ifs at h with h1 h2 h3
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    intro z hz
+    have hz' := DenseLinExpr.norm_terms_fst ((l.others x).scale (-1)) z hz
+    rw [DenseLinExpr.scale_terms_fst] at hz'
+    exact l.others_terms_fst_mem x z hz'
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    exact fun z hz => l.others_terms_fst_mem x z hz
+  · simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    intro z hz
+    have hz' := DenseLinExpr.norm_terms_fst
+      ((l.others x).scale (-(l.coeff x)⁻¹)) z hz
+    rw [DenseLinExpr.scale_terms_fst] at hz'
+    exact l.others_terms_fst_mem x z hz'
 
-/-- Every `±1`-pivot of a dense constraint entails its equality. -/
-theorem densePm1PivotsOf_sound (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
-    (h : (x, t) ∈ densePm1PivotsOf c) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
-    denv x = t.eval denv := by
-  grind [densePm1PivotsOf, denseLinearize_eval, DenseLinExpr.trySolve_sound]
+theorem denseSparseBest_sound (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+    (h : denseSparseBest l occ prot = some (y, t))
+    (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
+    denv y = t.eval denv := by
+  unfold denseSparseBest at h
+  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
+  | none => simp [hm] at h
+  | some q =>
+      simp only [hm] at h
+      exact denseSparseSolveAt_sound l q.1 y t h denv hl
 
-/-- Every unit-pivot of a dense constraint entails its equality. -/
-theorem denseUnitPivotsOf_sound (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
-    (h : (x, t) ∈ denseUnitPivotsOf c) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
-    denv x = t.eval denv := by
-  grind [denseUnitPivotsOf, denseLinearize_eval, DenseLinExpr.trySolveUnit_sound]
+theorem denseSparseBest_terms (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+    (h : denseSparseBest l occ prot = some (y, t)) :
+    ∀ z ∈ t.terms.map Prod.fst, z ∈ l.terms.map Prod.fst := by
+  unfold denseSparseBest at h
+  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
+  | none => simp [hm] at h
+  | some q =>
+      simp only [hm] at h
+      exact denseSparseSolveAt_terms l q.1 y t h
 
-/-! ## Pivot-vars bounds -/
+theorem denseReducedBest_sound (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+    (h : denseReducedBest r occ prot = some (y, t))
+    (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
+    denv y = t.eval denv := by
+  cases r with
+  | nonlinear e => simp [denseReducedBest] at h
+  | affine l =>
+      exact denseSparseBest_sound l occ prot y t h denv
+        (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
 
-/-- A `±1`-pivot solution mentions only the constraint's variables. -/
-theorem densePm1PivotsOf_vars (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
-    (h : (x, t) ∈ densePm1PivotsOf c) : ∀ y ∈ t.vars, y ∈ c.vars := by
-  intro y hy
-  unfold densePm1PivotsOf at h
-  cases hL : denseLinearize c with
-  | none => rw [hL] at h; simp at h
-  | some l =>
-      rw [hL] at h
-      obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-      exact denseLinearize_mem_vars c l hL y (denseTrySolve_vars_subset l v (x, t) hv y hy)
+theorem denseReducedBest_terms (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+    (h : denseReducedBest r occ prot = some (y, t)) :
+    ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
+  cases r with
+  | nonlinear e => simp [denseReducedBest] at h
+  | affine l => exact denseSparseBest_terms l occ prot y t h
 
-/-- A unit-pivot solution mentions only the constraint's variables. -/
-theorem denseUnitPivotsOf_vars (c : DenseExpr p) (x : VarId) (t : DenseExpr p)
-    (h : (x, t) ∈ denseUnitPivotsOf c) : ∀ y ∈ t.vars, y ∈ c.vars := by
-  intro y hy
-  unfold denseUnitPivotsOf at h
-  cases hL : denseLinearize c with
-  | none => rw [hL] at h; simp at h
-  | some l =>
-      rw [hL] at h
-      obtain ⟨v, _, hv⟩ := List.mem_filterMap.1 h
-      cases htr : l.trySolve v with
-      | some r => rw [htr] at hv; simp at hv
+theorem denseMarkowitzPick_sound (r : DenseGaussReduced p) (hint y : VarId)
+    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (h : denseMarkowitzPick r hint occ prot = some (y, t))
+    (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
+    denv y = t.eval denv := by
+  unfold denseMarkowitzPick at h
+  cases r with
+  | nonlinear e =>
+      simp only at h
+      exact denseReducedBest_sound (.nonlinear e) occ prot y t h denv hr
+  | affine l =>
+      cases hs : denseSparseSolveAt l hint with
       | none =>
-          rw [htr] at hv
-          exact denseLinearize_mem_vars c l hL y (denseTrySolveUnit_vars_subset l v (x, t) hv y hy)
+          simp only [hs] at h
+          exact denseReducedBest_sound (.affine l) occ prot y t h denv hr
+      | some q =>
+          have hq : q = (y, t) := Option.some.inj (by simpa [hs] using h)
+          rw [hq] at hs
+          exact denseSparseSolveAt_sound l hint y t hs denv
+            (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
 
-theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+theorem denseMarkowitzPick_terms (r : DenseGaussReduced p) (hint y : VarId)
+    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (h : denseMarkowitzPick r hint occ prot = some (y, t)) :
+    ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
+  unfold denseMarkowitzPick at h
+  cases r with
+  | nonlinear e =>
+      simp only at h
+      exact denseReducedBest_terms (.nonlinear e) occ prot y t h
+  | affine l =>
+      cases hs : denseSparseSolveAt l hint with
+      | none =>
+          simp only [hs] at h
+          exact denseReducedBest_terms (.affine l) occ prot y t h
+      | some q =>
+          have hq : q = (y, t) := Option.some.inj (by simpa [hs] using h)
+          rw [hq] at hs
+          exact denseSparseSolveAt_terms l hint y t hs
+
+theorem DenseSparseSolved.insertAll_map :
+    ∀ (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p),
+      (dσ.insertAll pairs).map =
+        pairs.foldl (fun m pr => m.insert pr.1 pr.2) dσ.map := by
+  intro pairs
+  induction pairs with
+  | nil => intro dσ; rfl
+  | cons hd tl ih =>
+      intro dσ
+      obtain ⟨x, t⟩ := hd
+      simp only [DenseSparseSolved.insertAll, List.foldl_cons]
+      rw [ih]
+
+theorem sparseFoldlInsert_preserves {Q : VarId → DenseLinExpr p → Prop} :
+    ∀ (pairs : List (VarId × DenseLinExpr p))
+      (m : Std.HashMap VarId (DenseLinExpr p)),
+      (∀ i t, m[i]? = some t → Q i t) → (∀ pr ∈ pairs, Q pr.1 pr.2) →
+      ∀ i t, (pairs.foldl (fun out pr => out.insert pr.1 pr.2) m)[i]? = some t →
+        Q i t := by
+  intro pairs
+  induction pairs with
+  | nil => intro m hm _ i t ht; exact hm i t ht
+  | cons hd rest ih =>
+      intro m hm hpairs i t ht
+      obtain ⟨x, t0⟩ := hd
+      simp only [List.foldl_cons] at ht
+      refine ih (m.insert x t0) ?_
+        (fun pr hpr => hpairs pr (List.mem_cons_of_mem _ hpr)) i t ht
+      intro j s hjs
+      rw [Std.HashMap.getElem?_insert] at hjs
+      split_ifs at hjs with hjx
+      · simp only [Option.some.injEq] at hjs
+        have hj : x = j := by simpa using hjx
+        rw [← hjs, ← hj]
+        exact hpairs (x, t0) (List.mem_cons_self ..)
+      · exact hm j s hjs
+
+theorem DenseSparseSolved.insertAll_preserves {Q : VarId → DenseLinExpr p → Prop}
+    (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p)
+    (hσ : ∀ i t, dσ.fn i = some t → Q i t)
+    (hpairs : ∀ pr ∈ pairs, Q pr.1 pr.2) :
+    ∀ i t, (dσ.insertAll pairs).fn i = some t → Q i t := by
+  intro i t ht
+  simp only [DenseSparseSolved.fn, DenseSparseSolved.insertAll_map] at ht
+  exact sparseFoldlInsert_preserves pairs dσ.map hσ hpairs i t ht
+
+theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
     (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    ∀ (pending : List (DenseExpr p)) (dσ : DenseSolved p),
+    ∀ (pending : List (DenseExpr p)) (dσ : DenseSparseSolved p),
       (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
-      (∀ denv, d.satisfies bs denv → ∀ i t, dσ.fn i = some t → denv i = t.eval denv) →
-      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseGaussLoop occ prot pending dσ).fn i = some t → denv i = t.eval denv) ∧
-      (∀ i t, (denseGaussLoop occ prot pending dσ).fn i = some t →
-          ∀ z ∈ t.vars, z ∈ d.occ) := by
+        dσ.fn i = some t → denv i = t.eval denv) →
+      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) →
+      (∀ denv, d.satisfies bs denv → ∀ i t,
+          (denseSparseGaussLoop occ prot pending dσ).fn i = some t →
+          denv i = t.eval denv) ∧
+      (∀ i t, (denseSparseGaussLoop occ prot pending dσ).fn i = some t →
+          ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
   intro pending
   induction pending with
   | nil => intro dσ _ hσs hσv; exact ⟨hσs, hσv⟩
@@ -121,42 +581,30 @@ theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
       have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
       have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
         fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
-      cases hfb : denseFastBest ((c.substF dσ.fn).normalize) occ prot with
+      let c' := denseSparseSubstF dσ.fn c
+      cases hpick : denseReducedBest (denseSparseSubstF dσ.fn c) occ prot with
       | none =>
-          simp only [denseGaussLoop, hfb]
+          simp only [denseSparseGaussLoop, hpick]
           exact ih dσ hrest hσs hσv
       | some xt =>
           obtain ⟨x, t⟩ := xt
-          have hmem : (x, t) ∈ densePm1PivotsOf ((c.substF dσ.fn).normalize)
-              ++ denseUnitPivotsOf ((c.substF dσ.fn).normalize) := by
-            have hfb2 := hfb
-            rw [denseFastBest_eq] at hfb2
-            exact List.argmin_mem (by rw [hfb2]; exact Option.mem_some_self _)
-          have hc'occ : ∀ z ∈ ((c.substF dσ.fn).normalize).vars, z ∈ d.occ := by
-            intro z hz
-            have hz2 : z ∈ (c.substF dσ.fn).vars := DenseExpr.normalize_vars _ z hz
-            rcases DenseExpr.substF_vars dσ.fn c z hz2 with h | ⟨i, _, tt, hft, hzt⟩
-            · exact DenseConstraintSystem.mem_occ_of_constraint hcmem h
-            · exact hσv i tt hft z hzt
+          have hcclosed : c'.Closed (· ∈ d.occ) := by
+            apply denseSparseSubstF_closed dσ.fn c
+            · intro z hz
+              exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
+            · exact hσv
           have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
             intro denv hsat
-            have hc0 : c.eval denv = 0 := hsat.1 c hcmem
-            have hc'z : ((c.substF dσ.fn).normalize).eval denv = 0 := by
-              rw [DenseExpr.normalize_eval, DenseExpr.eval_substF,
-                  denseEnvF_eq_self dσ.fn denv (hσs denv hsat)]
-              exact hc0
-            rcases List.mem_append.1 hmem with hp | hu
-            · exact densePm1PivotsOf_sound ((c.substF dσ.fn).normalize) x t hp denv hc'z
-            · exact denseUnitPivotsOf_sound ((c.substF dσ.fn).normalize) x t hu denv hc'z
-          have htocc : ∀ z ∈ t.vars, z ∈ d.occ := by
+            apply denseReducedBest_sound c' occ prot x t hpick denv
+            rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
+            exact hsat.1 c hcmem
+          have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
             intro z hz
-            rcases List.mem_append.1 hmem with hp | hu
-            · exact hc'occ z
-                (densePm1PivotsOf_vars ((c.substF dσ.fn).normalize) x t hp z hz)
-            · exact hc'occ z
-                (denseUnitPivotsOf_vars ((c.substF dσ.fn).normalize) x t hu z hz)
-          have htouched : ∀ y s, (y, s) ∈ ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-                (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none)) →
+            exact hcclosed z (denseReducedBest_terms c' occ prot x t hpick z hz)
+          have htouched : ∀ y s, (y, s) ∈
+                ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+                  (dσ.map[y]?).bind
+                    (fun s => if s.mentions x then some (y, s) else none)) →
               dσ.fn y = some s := by
             intro y s hys
             obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
@@ -168,128 +616,44 @@ theorem denseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
               exact hs'
             · rw [if_neg hm] at hif
               exact absurd hif (by simp)
-          simp only [denseGaussLoop, hfb]
+          simp only [denseSparseGaussLoop, hpick]
           refine ih _ hrest ?_ ?_
           · intro denv hsat
-            refine DenseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
+            refine DenseSparseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
             intro pr hpr
             rcases List.mem_append.1 hpr with hin | hin
             · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
               have hmemys : dσ.fn y = some s := htouched y s hys
               have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-              have hxe : denv x = t.eval denv := hx denv hsat
-              show denv y = ((s.subst x t).normalize).eval denv
-              rw [DenseExpr.normalize_eval, DenseExpr.eval_subst, ← hxe,
-                Function.update_eq_self, hy]
+              exact hy.trans (denseLinSubst_eval s x t denv (hx denv hsat)).symm
             · rw [List.mem_singleton] at hin
               subst hin
               exact hx denv hsat
-          · refine DenseSolved.insertAll_preserves _ dσ hσv ?_
+          · refine DenseSparseSolved.insertAll_preserves _ dσ hσv ?_
             intro pr hpr
             rcases List.mem_append.1 hpr with hin | hin
             · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
               have hmemys : dσ.fn y = some s := htouched y s hys
-              intro z hz
-              have hz2 : z ∈ (s.subst x t).vars := DenseExpr.normalize_vars _ z hz
-              rcases DenseExpr.subst_vars s x t z hz2 with h | h
-              · exact hσv y s hmemys z h
-              · exact htocc z h
+              exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
+                (hσv y s hmemys) htocc
             · rw [List.mem_singleton] at hin
               subst hin
               exact htocc
 
-theorem denseSolveAt_sound (c : DenseExpr p) (x y : VarId) (t : DenseExpr p)
-    (h : denseSolveAt c x = some (y, t)) (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
-    denv y = t.eval denv := by
-  unfold denseSolveAt at h
-  cases hlin : denseLinearize c with
-  | none => simp [hlin] at h
-  | some l =>
-      rw [hlin] at h
-      have hl : l.eval denv = 0 := by rw [← denseLinearize_eval c l hlin]; exact hc
-      cases hs : l.trySolve x with
-      | none =>
-          have hunit : l.trySolveUnit x = some (y, t) := by simpa [hlin, hs] using h
-          exact DenseLinExpr.trySolveUnit_sound l x y t hunit denv hl
-      | some xt =>
-          have hxt : xt = (y, t) := Option.some.inj (by simpa [hlin, hs] using h)
-          rw [hxt] at hs
-          exact DenseLinExpr.trySolve_sound l x y t hs denv hl
-
-theorem denseSolveAt_vars (c : DenseExpr p) (x y : VarId) (t : DenseExpr p)
-    (h : denseSolveAt c x = some (y, t)) : ∀ z ∈ t.vars, z ∈ c.vars := by
-  intro z hz
-  unfold denseSolveAt at h
-  cases hlin : denseLinearize c with
-  | none => simp [hlin] at h
-  | some l =>
-      rw [hlin] at h
-      cases hs : l.trySolve x with
-      | none =>
-          have hunit : l.trySolveUnit x = some (y, t) := by simpa [hlin, hs] using h
-          exact denseLinearize_mem_vars c l hlin z
-            (denseTrySolveUnit_vars_subset l x (y, t) hunit z hz)
-      | some xt =>
-          have hxt : xt = (y, t) := Option.some.inj (by simpa [hlin, hs] using h)
-          rw [hxt] at hs
-          exact denseLinearize_mem_vars c l hlin z
-            (denseTrySolve_vars_subset l x (y, t) hs z hz)
-
-theorem denseMarkowitzPick_sound (c : DenseExpr p) (hint y : VarId) (t : DenseExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (h : denseMarkowitzPick c hint occ prot = some (y, t))
-    (denv : VarId → ZMod p) (hc : c.eval denv = 0) :
-    denv y = t.eval denv := by
-  unfold denseMarkowitzPick at h
-  cases hs : denseSolveAt c hint with
-  | some xt =>
-      have hxt : xt = (y, t) := Option.some.inj (by simpa [hs] using h)
-      rw [hxt] at hs
-      exact denseSolveAt_sound c hint y t hs denv hc
-  | none =>
-      simp only [hs] at h
-      have hfb := h
-      rw [denseFastBest_eq] at hfb
-      have hmem : (y, t) ∈ densePm1PivotsOf c ++ denseUnitPivotsOf c :=
-        List.argmin_mem (by rw [hfb]; exact Option.mem_some_self _)
-      rcases List.mem_append.1 hmem with hp | hu
-      · exact densePm1PivotsOf_sound c y t hp denv hc
-      · exact denseUnitPivotsOf_sound c y t hu denv hc
-
-theorem denseMarkowitzPick_vars (c : DenseExpr p) (hint y : VarId) (t : DenseExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (h : denseMarkowitzPick c hint occ prot = some (y, t)) :
-    ∀ z ∈ t.vars, z ∈ c.vars := by
-  intro z hz
-  unfold denseMarkowitzPick at h
-  cases hs : denseSolveAt c hint with
-  | some xt =>
-      have hxt : xt = (y, t) := Option.some.inj (by simpa [hs] using h)
-      rw [hxt] at hs
-      exact denseSolveAt_vars c hint y t hs z hz
-  | none =>
-      simp only [hs] at h
-      have hfb := h
-      rw [denseFastBest_eq] at hfb
-      have hmem : (y, t) ∈ densePm1PivotsOf c ++ denseUnitPivotsOf c :=
-        List.argmin_mem (by rw [hfb]; exact Option.mem_some_self _)
-      rcases List.mem_append.1 hmem with hp | hu
-      · exact densePm1PivotsOf_vars c y t hp z hz
-      · exact denseUnitPivotsOf_vars c y t hu z hz
-
-theorem denseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
     (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
     (sources : Array (DenseExpr p))
     (hsrc : ∀ (i : Nat) (c : DenseExpr p),
       sources[i]? = some c → c ∈ d.algebraicConstraints) :
-    ∀ (fuel : Nat) (st : DenseMarkowitzState p) (dσ : DenseSolved p),
-      (∀ denv, d.satisfies bs denv → ∀ i t, dσ.fn i = some t → denv i = t.eval denv) →
-      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
+    ∀ (fuel : Nat) (st : DenseMarkowitzState p) (dσ : DenseSparseSolved p),
+      (∀ denv, d.satisfies bs denv → ∀ i t,
+        dσ.fn i = some t → denv i = t.eval denv) →
+      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
           (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
           denv i = t.eval denv) ∧
       (∀ i t, (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
-          ∀ z ∈ t.vars, z ∈ d.occ) := by
+          ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
   intro fuel
   induction fuel with
   | zero => intro st dσ hσs hσv; exact ⟨hσs, hσv⟩
@@ -307,33 +671,28 @@ theorem denseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSyste
               exact ih _ _ hσs hσv
           | some c =>
               have hcmem : c ∈ d.algebraicConstraints := hsrc entry.rowId c hsource
-              let c' := (c.substF dσ.fn).normalize
-              cases hpick : denseMarkowitzPick c' entry.pivot occ prot with
+              let c' := denseSparseSubstF dσ.fn c
+              cases hpick :
+                  denseMarkowitzPick (denseSparseSubstF dσ.fn c) entry.pivot occ prot with
               | none =>
-                  dsimp [c'] at hpick
                   simp only [denseMarkowitzLoop, hpop, hsource, hpick]
                   exact ih _ _ hσs hσv
               | some xt =>
                   obtain ⟨x, t⟩ := xt
-                  dsimp [c'] at hpick
-                  have hc'occ : ∀ z ∈ c'.vars, z ∈ d.occ := by
-                    intro z hz
-                    have hz2 : z ∈ (c.substF dσ.fn).vars :=
-                      DenseExpr.normalize_vars _ z hz
-                    rcases DenseExpr.substF_vars dσ.fn c z hz2 with h | ⟨i, _, tt, hft, hzt⟩
-                    · exact DenseConstraintSystem.mem_occ_of_constraint hcmem h
-                    · exact hσv i tt hft z hzt
+                  have hcclosed : c'.Closed (· ∈ d.occ) := by
+                    apply denseSparseSubstF_closed dσ.fn c
+                    · intro z hz
+                      exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
+                    · exact hσv
                   have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
                     intro denv hsat
-                    have hc0 : c.eval denv = 0 := hsat.1 c hcmem
-                    have hc'z : c'.eval denv = 0 := by
-                      rw [DenseExpr.normalize_eval, DenseExpr.eval_substF,
-                          denseEnvF_eq_self dσ.fn denv (hσs denv hsat)]
-                      exact hc0
-                    exact denseMarkowitzPick_sound c' entry.pivot x t occ prot hpick denv hc'z
-                  have htocc : ∀ z ∈ t.vars, z ∈ d.occ := by
+                    apply denseMarkowitzPick_sound c' entry.pivot x t occ prot hpick denv
+                    rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
+                    exact hsat.1 c hcmem
+                  have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
                     intro z hz
-                    exact hc'occ z (denseMarkowitzPick_vars c' entry.pivot x t occ prot hpick z hz)
+                    exact hcclosed z
+                      (denseMarkowitzPick_terms c' entry.pivot x t occ prot hpick z hz)
                   have htouched : ∀ y s, (y, s) ∈
                         ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
                           (dσ.map[y]?).bind
@@ -354,72 +713,116 @@ theorem denseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSyste
                   have hnexts : ∀ denv, d.satisfies bs denv → ∀ i u,
                       dσ'.fn i = some u → denv i = u.eval denv := by
                     intro denv hsat
-                    refine DenseSolved.insertAll_preserves pairs dσ (hσs denv hsat) ?_
+                    refine DenseSparseSolved.insertAll_preserves pairs dσ
+                      (hσs denv hsat) ?_
                     intro pr hpr
                     unfold denseMarkowitzAdoptPairs at hpr
                     rcases List.mem_append.1 hpr with hin | hin
                     · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
                       have hmemys : dσ.fn y = some s := htouched y s hys
                       have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-                      have hxe : denv x = t.eval denv := hx denv hsat
-                      show denv y = ((s.subst x t).normalize).eval denv
-                      rw [DenseExpr.normalize_eval, DenseExpr.eval_subst, ← hxe,
-                        Function.update_eq_self, hy]
+                      exact hy.trans
+                        (denseLinSubst_eval s x t denv (hx denv hsat)).symm
                     · rw [List.mem_singleton] at hin
                       subst hin
                       exact hx denv hsat
-                  have hnextv : ∀ i u, dσ'.fn i = some u → ∀ z ∈ u.vars, z ∈ d.occ := by
-                    refine DenseSolved.insertAll_preserves pairs dσ hσv ?_
+                  have hnextv : ∀ i u, dσ'.fn i = some u →
+                      ∀ z ∈ u.terms.map Prod.fst, z ∈ d.occ := by
+                    refine DenseSparseSolved.insertAll_preserves pairs dσ hσv ?_
                     intro pr hpr
                     unfold denseMarkowitzAdoptPairs at hpr
                     rcases List.mem_append.1 hpr with hin | hin
                     · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
                       have hmemys : dσ.fn y = some s := htouched y s hys
-                      intro z hz
-                      have hz2 : z ∈ (s.subst x t).vars := DenseExpr.normalize_vars _ z hz
-                      rcases DenseExpr.subst_vars s x t z hz2 with h | h
-                      · exact hσv y s hmemys z h
-                      · exact htocc z h
+                      exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
+                        (hσv y s hmemys) htocc
                     · rw [List.mem_singleton] at hin
                       subst hin
                       exact htocc
                   simp only [denseMarkowitzLoop, hpop, hsource, hpick]
                   exact ih _ dσ' hnexts hnextv
 
-theorem denseMarkowitzSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+theorem denseSparseMarkowitzSchedule_sound (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
         (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
         denv i = t.eval denv) ∧
     (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  apply denseMarkowitzLoop_sound bs d occ prot d.algebraicConstraints.toArray
+        ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
+  apply denseSparseMarkowitzLoop_sound bs d occ prot d.algebraicConstraints.toArray
   · intro i c hc
     rw [List.getElem?_toArray] at hc
     exact List.mem_of_getElem? hc
   · intro _ _ _ _ h
-    exact absurd h (by simp [DenseSolved.fn, DenseSolved.empty])
+    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
   · intro _ _ h
-    exact absurd h (by simp [DenseSolved.fn, DenseSolved.empty])
+    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
 
-theorem denseSourceOrderSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+theorem denseSparseSourceOrderSchedule_sound (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
         (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
         denv i = t.eval denv) ∧
     (∀ i t, (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  have hfirst := denseGaussLoop_sound bs d occ prot d.algebraicConstraints DenseSolved.empty
+        ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
+  have hfirst := denseSparseGaussLoop_sound bs d occ prot
+    d.algebraicConstraints DenseSparseSolved.empty
     (fun _c hc => hc)
-    (fun _ _ _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
-    (fun _ _ hti => absurd hti (by simp [DenseSolved.fn, DenseSolved.empty]))
+    (fun _ _ _ _ hti =>
+      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
+    (fun _ _ hti =>
+      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
   by_cases hempty :
-      (denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty).map.isEmpty
+      (denseSparseGaussLoop occ prot d.algebraicConstraints
+        DenseSparseSolved.empty).map.isEmpty
   · simpa [denseSourceOrderSchedule, hempty] using hfirst
-  · have hsecond := denseGaussLoop_sound bs d occ prot d.algebraicConstraints
-      (denseGaussLoop occ prot d.algebraicConstraints DenseSolved.empty)
+  · have hsecond := denseSparseGaussLoop_sound bs d occ prot
+      d.algebraicConstraints
+      (denseSparseGaussLoop occ prot d.algebraicConstraints DenseSparseSolved.empty)
       (fun _c hc => hc) hfirst.1 hfirst.2
     simpa [denseSourceOrderSchedule, hempty] using hsecond
+
+theorem DenseSparseSolved.materialize_lookup (dσ : DenseSparseSolved p)
+    (i : VarId) (e : DenseExpr p) (h : dσ.materialize.fn i = some e) :
+    ∃ row, dσ.fn i = some row ∧ e = row.toExpr := by
+  simp only [DenseSparseSolved.materialize, DenseSolved.fn] at h
+  let pairs := dσ.map.toList.map (fun xt => (xt.1, xt.2.toExpr))
+  have hpairs :
+      pairs.foldl (fun out xt => out.insert xt.1 xt.2)
+          (∅ : Std.HashMap VarId (DenseExpr p)) =
+        dσ.map.toList.foldl (fun out xt => out.insert xt.1 xt.2.toExpr) ∅ := by
+    exact List.foldl_map
+  rw [← hpairs] at h
+  apply foldl_insert_getElem pairs
+    (∅ : Std.HashMap VarId (DenseExpr p))
+    (Q := fun j out => ∃ row, dσ.fn j = some row ∧ out = row.toExpr)
+  · intro j out hj
+    exact absurd hj (by simp)
+  · intro pr hpr
+    obtain ⟨xt, hxt, rfl⟩ := List.mem_map.1 hpr
+    refine ⟨xt.2, ?_, rfl⟩
+    exact Std.HashMap.mem_toList_iff_getElem?_eq_some.1 hxt
+  · exact h
+
+theorem DenseSparseSolved.materialize_sound (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) (dσ : DenseSparseSolved p)
+    (hs : ∀ denv, d.satisfies bs denv → ∀ i t,
+      dσ.fn i = some t → denv i = t.eval denv)
+    (hv : ∀ i t, dσ.fn i = some t →
+      ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) :
+    (∀ denv, d.satisfies bs denv → ∀ i e,
+        dσ.materialize.fn i = some e → denv i = e.eval denv) ∧
+    (∀ i e, dσ.materialize.fn i = some e → ∀ z ∈ e.vars, z ∈ d.occ) := by
+  constructor
+  · intro denv hsat i e he
+    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
+    rw [DenseLinExpr.toExpr_eval]
+    exact hs denv hsat i row hrow
+  · intro i e he z hz
+    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
+    exact hv i row hrow z (DenseLinExpr.toExpr_vars row z hz)
 
 theorem denseGaussSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
     (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
@@ -430,8 +833,13 @@ theorem denseGaussSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSyste
         ∀ z ∈ t.vars, z ∈ d.occ) := by
   unfold denseGaussSchedule
   split
-  · exact denseSourceOrderSchedule_sound bs d occ prot
-  · exact denseMarkowitzSchedule_sound bs d occ prot
+  · exact DenseSparseSolved.materialize_sound bs d _
+      (denseSparseSourceOrderSchedule_sound bs d occ prot).1
+      (denseSparseSourceOrderSchedule_sound bs d occ prot).2
+  · exact DenseSparseSolved.materialize_sound bs d _
+      (denseSparseMarkowitzSchedule_sound bs d occ prot).1
+      (denseSparseMarkowitzSchedule_sound bs d occ prot).2
+
 
 /-! ## The pass's correctness -/
 

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -234,10 +234,11 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      values in the fully-applied pass body and pass them as parameters** (the `FlagFold`
      comment's pattern); when a pass's profile makes no sense relative to its work, suspect this
      first and bisect with a skip-the-body experiment.
-   - ~~`normalize` linearize fusion~~ **done (entry 115)** for `normalizePass`
-     (`normalizeFused`, proven equal). Gauss's per-constraint `substF |> normalize` still walks
-     the old way. PR #156's wider gauss sweep rewrite was closed after too little whole-run
-     benefit, so this remains available only if a fresh profile justifies it.
+   - ~~`normalize` linearize fusion~~ **done (entries 115, 135)**: `normalizePass` uses
+     `normalizeFused`, while Gauss keeps every affine source row, stored solution, touched-row
+     rewrite, and Markowitz cache in canonical `DenseLinExpr` form. Expression trees survive only
+     for genuinely nonlinear subtrees and at the final `substF` boundary, so pivot sweeps no
+     longer rebuild affine trees merely to linearize them again.
    - ~~`iterateToFixpoint` sizeKey recomputation~~ **done (entry 115)**: the input's key is
      threaded (`iterateToFixpointFrom`), halving the per-cycle occurrence-list walks (~6 % of
      whole-run samples).

--- a/docs/log.md
+++ b/docs/log.md
@@ -4667,3 +4667,34 @@ updated PR's CI.
 
 **Worked locally: yes (RSP baseline behavior restored while the large-case runtime win remains;
 full-set result pending CI).**
+
+### 135. Runtime: canonical sparse affine Gauss rows
+
+Gauss now keeps affine source reductions, stored solutions, touched-row rewrites, and Markowitz
+row caches as normalized `DenseLinExpr` values. Sparse substitutions accumulate constants and
+terms directly, merge like terms once, and retain `DenseExpr` only around genuinely nonlinear
+subtrees. The final solution map is converted to expressions once, immediately before the
+existing system-wide substitution boundary. The old expression-based source loop and selector
+proof chain were removed.
+
+The correctness proof works directly over sparse-row evaluation and support. It proves the
+source-order and Markowitz loop invariants independently of scheduler metadata, then proves that
+one-time `HashMap` materialization preserves every lookup's evaluation and occurrence closure.
+The generated C contains only the sparse source loop and materializes `DenseLinExpr.toExpr` at the
+schedule boundary; the old `denseGaussLoop` and `denseFastBest` functions are absent.
+
+One serial local profile was run on each representative from `ranked_passes.md`, using the stacked
+PR #190 revision `32e63a7` as baseline. Gauss changed from 4818 → 4064 ms on
+`wasm-eth/apc_063` (−15.6%), 3893 → 3304 ms on `wasm-eth/apc_037` (−15.1%),
+1182 → 669 ms on `openvm-eth/apc_037` (−43.4%), 3010 → 2718 ms on OpenVM keccak
+(−9.7%), and 444 → 421 ms on `openvm-eth/apc_005` (−5.2%). The five-case Gauss sum
+fell 13,347 → 11,176 ms (−16.3%); whole-profile time fell 141,453 → 138,181 ms
+(−2.3%). Cleanup iteration counts and final variable, bus-interaction, and constraint counts
+matched the baseline on all five cases. Full same-runner runtime and corpus effectiveness
+evaluation is delegated to the stacked draft PR's CI workflows.
+
+`lake build` is warning-free, generated C was inspected, and the proof-integrity and
+unused-theorem checks pass.
+
+**Worked locally: yes (representative Gauss runtime win with unchanged final sizes; full-set
+result pending CI).**


### PR DESCRIPTION
## Summary

- keep affine source reductions, stored solutions, touched-row rewrites, and Markowitz caches as canonical `DenseLinExpr` rows
- substitute and normalize rows directly, retaining `DenseExpr` only for genuinely nonlinear subtrees
- materialize the final sparse solution map to expressions once at the existing system-wide substitution boundary
- replace the old expression-based proof chain with direct sparse evaluation/support invariants for both source-order and Markowitz schedules
- remove the obsolete expression selector and its orphaned helper lemmas

## Why

Gauss repeatedly rebuilt affine expression trees, traversed them for substitution and normalization, and then linearized them back into rows. Keeping the affine form throughout the elimination loop removes that representation churn while preserving the scheduler and pivot order from #190.

## Local representative profiles

Each representative from `ranked_passes.md` was profiled exactly once on this branch. The baseline is revision `32e63a7` from #190.

| APC | Gauss baseline | Gauss sparse | Change |
|---|---:|---:|---:|
| wasm-eth `apc_063` | 4818 ms | 4064 ms | -15.6% |
| wasm-eth `apc_037` | 3893 ms | 3304 ms | -15.1% |
| openvm-eth `apc_037` | 1182 ms | 669 ms | -43.4% |
| OpenVM keccak `apc_001` | 3010 ms | 2718 ms | -9.7% |
| openvm-eth `apc_005` | 444 ms | 421 ms | -5.2% |

Five-case Gauss time: **13,347 → 11,176 ms (-16.3%)**. Whole-profile time: **141,453 → 138,181 ms (-2.3%)**. Cleanup iteration counts and final variable, bus-interaction, and constraint counts matched the baseline on all five cases.

## Triggered CI

All build, proof-integrity, effectiveness, and runtime jobs passed before the rebase. The [generated benchmark report](https://github.com/powdr-labs/apc-optimizer/pull/191#issuecomment-5054895483) is refreshed automatically by CI for the rebased commit.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection: sparse source/Markowitz loops remain in row form and call `DenseLinExpr.toExpr` only during final materialization

PR #190 is merged; this branch is rebased directly onto `main` commit `8f2fe58`.