### PR TITLE
Use exact array-backed state in Gauss

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -24,11 +24,14 @@ def DenseExpr.isVar : DenseExpr p → Bool
   | .var _ => true
   | _ => false
 
+abbrev DenseGaussOcc := Array Nat
+abbrev DenseGaussProt := ByteArray
+
 /-- The occurrence-weighted duplication cost of pivoting on `v`, with a protection penalty. -/
-def denseGaussScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId)
+def denseGaussScore (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId)
     (oc : Nat) : Nat :=
-  let base := (occ.getD v 1 - 1) * (1 + oc)
-  if prot.contains v then base + 1000000 else base
+  let base := ((occ[v.index]?).getD 1 - 1) * (1 + oc)
+  if (prot[v.index]?).getD 0 != 0 then base + 1000000 else base
 
 /-- One index step: add `t`'s coefficient and one occurrence to `t.1`'s entry (0 if absent). -/
 def denseIdxStep (m : Std.HashMap VarId (ZMod p × Nat)) (t : VarId × ZMod p) :
@@ -43,7 +46,7 @@ def denseCoeffIdx (terms : List (VarId × ZMod p)) : Std.HashMap VarId (ZMod p �
 
 /-- `±1`-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` succeeds. -/
 def densePm1Desc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     Option (VarId × Nat) :=
   if ((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1 then
     some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
@@ -52,7 +55,7 @@ def densePm1Desc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
 /-- Unit-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` fails but
     `l.trySolveUnit v` succeeds. -/
 def denseUnitDesc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     Option (VarId × Nat) :=
   if ¬(((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1)
       ∧ ((idx[v]?).getD (0, 0)).1 * (((idx[v]?).getD (0, 0)).1)⁻¹ = 1 then
@@ -61,7 +64,7 @@ def denseUnitDesc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
 
 /-- All pivot descriptors, `±1` first (matching the order of `densePm1PivotsOf ++
     denseUnitPivotsOf`). -/
-def densePivotDescs (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+def densePivotDescs (l : DenseLinExpr p) (occ : DenseGaussOcc) (prot : DenseGaussProt) :
     List (VarId × Nat) :=
   let idx := denseCoeffIdx l.terms
   let total := l.terms.length
@@ -102,7 +105,7 @@ theorem denseCoeffIdxWith_eq (ops : DenseZModOps p) (terms : List (VarId × ZMod
   simp only [denseCoeffIdx, denseCoeffIdxFast, denseCoeffIdxWith_eq]
 
 def densePm1DescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     Option (VarId × Nat) :=
   let cv := (idx[v]?).getD (ops.zero, 0)
   if cv.1 = ops.one ∨ cv.1 = ops.negOne then
@@ -110,7 +113,7 @@ def densePm1DescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × 
   else none
 
 def denseUnitDescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     Option (VarId × Nat) :=
   let cv := (idx[v]?).getD (ops.zero, 0)
   if ¬(cv.1 = ops.one ∨ cv.1 = ops.negOne) ∧
@@ -119,29 +122,29 @@ def denseUnitDescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p ×
   else none
 
 def densePivotDescsWith (ops : DenseZModOps p) (l : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : List (VarId × Nat) :=
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) : List (VarId × Nat) :=
   let idx := denseCoeffIdxWith ops l.terms ∅
   let total := l.terms.length
   (l.terms.map Prod.fst).filterMap (densePm1DescWith ops idx total occ prot) ++
     (l.terms.map Prod.fst).filterMap (denseUnitDescWith ops idx total occ prot)
 
-def densePivotDescsFast (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : List (VarId × Nat) :=
+def densePivotDescsFast (l : DenseLinExpr p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) : List (VarId × Nat) :=
   let ops : DenseZModOps p := denseZModOps
   densePivotDescsWith ops l occ prot
 
 theorem densePm1DescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     densePm1DescWith ops idx total occ prot v = densePm1Desc idx total occ prot v := by
   simp only [densePm1DescWith, densePm1Desc, ops.zero_eq, ops.one_eq, ops.negOne_eq]
 
 theorem denseUnitDescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt) (v : VarId) :
     denseUnitDescWith ops idx total occ prot v = denseUnitDesc idx total occ prot v := by
   simp only [denseUnitDescWith, denseUnitDesc, ops.zero_eq, ops.one_eq, ops.negOne_eq, ops.mul_eq]
 
 theorem densePivotDescsWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) :
     densePivotDescsWith ops l occ prot = densePivotDescs l occ prot := by
   unfold densePivotDescsWith densePivotDescs denseCoeffIdx
   rw [denseCoeffIdxWith_eq]
@@ -152,17 +155,21 @@ theorem densePivotDescsWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
   exact (densePivotDescsWith_eq denseZModOps l occ prot).symm
 
 /-- Occurrence counts of every variable across the dense system (one traversal). -/
-def denseOccurrenceMap (d : DenseConstraintSystem p) : Std.HashMap VarId Nat :=
-  let addE := fun (m : Std.HashMap VarId Nat) (e : DenseExpr p) =>
-    e.foldVars (fun m x => m.insert x (m.getD x 0 + 1)) m
-  let m := d.algebraicConstraints.foldl addE ∅
-  d.busInteractions.foldl (fun m bi => bi.payload.foldl addE (addE m bi.multiplicity)) m
+def denseOccurrenceMap (capacity : Nat) (d : DenseConstraintSystem p) : DenseGaussOcc :=
+  let addE := fun (m : DenseGaussOcc) (e : DenseExpr p) =>
+    e.foldVars (fun m x =>
+      m.setIfInBounds x.index ((m[x.index]?).getD 0 + 1)) m
+  let m := d.algebraicConstraints.foldl addE (Array.replicate capacity 0)
+  d.busInteractions.foldl
+    (fun m bi => bi.payload.foldl addE (addE m bi.multiplicity)) m
 
 /-- Variables occurring as a *raw* payload slot of a stateless interaction. -/
-def denseProtectedVars (d : DenseConstraintSystem p) (bs : BusSemantics p) : Std.HashSet VarId :=
-  d.busInteractions.foldl (init := ∅) fun s bi =>
+def denseProtectedVars (capacity : Nat) (d : DenseConstraintSystem p)
+    (bs : BusSemantics p) : DenseGaussProt :=
+  d.busInteractions.foldl (init := ⟨Array.replicate capacity 0⟩) fun s bi =>
     if bs.isStateful bi.busId then s
-    else bi.payload.foldl (fun s e => match e with | .var x => s.insert x | _ => s) s
+    else bi.payload.foldl
+      (fun s e => match e with | .var x => s.set! x.index 1 | _ => s) s
 
 /-- A plain (proof-free) solution map keyed by `VarId`; correctness is established by the
     correctness proof (`Proofs/Gauss.lean`), not carried as a structure invariant. -/
@@ -177,6 +184,13 @@ def empty : DenseSolved p := { map := ∅, revDeps := ∅ }
 /-- The map as a lookup function (what `substF` consumes). -/
 def fn (dσ : DenseSolved p) : VarId → Option (DenseExpr p) := fun i => dσ.map[i]?
 
+def insertRevDeps (owner : VarId) : DenseExpr p →
+    Std.HashMap VarId (Std.HashSet VarId) → Std.HashMap VarId (Std.HashSet VarId)
+  | .const _, rd => rd
+  | .var x, rd => rd.insert x (((rd[x]?).getD ∅).insert owner)
+  | .add a b, rd => insertRevDeps owner b (insertRevDeps owner a rd)
+  | .mul a b, rd => insertRevDeps owner b (insertRevDeps owner a rd)
+
 /-- Insert a list of pairs: for each, insert into the map and fold the value's variables into the
     reverse-dependency index. -/
 def insertAll (dσ : DenseSolved p) : List (VarId × DenseExpr p) → DenseSolved p
@@ -184,7 +198,7 @@ def insertAll (dσ : DenseSolved p) : List (VarId × DenseExpr p) → DenseSolve
   | (x, t) :: rest =>
       DenseSolved.insertAll
         { map := dσ.map.insert x t,
-          revDeps := t.foldVars (fun rd z => rd.insert z (((rd[z]?).getD ∅).insert x)) dσ.revDeps }
+          revDeps := insertRevDeps x t dσ.revDeps }
         rest
 
 theorem insertAll_map :
@@ -223,16 +237,17 @@ def denseLinSubstF (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p))
 
 /-- Substitute one canonical affine row into another. -/
 def denseLinSubst (l : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) : DenseLinExpr p :=
-  denseLinSubstF l (fun y => if y = x then some t else none)
+  let const := l.terms.foldl
+    (fun out yc => if yc.1 = x then out + yc.2 * t.const else out) l.const
+  let terms := l.terms.flatMap (fun yc =>
+    if yc.1 = x then t.terms.map (fun zc => (zc.1, yc.2 * zc.2)) else [yc])
+  (DenseLinExpr.mk const terms).norm
 
 def denseLinAdd (a b : DenseLinExpr p) : DenseLinExpr p :=
   (a.add b).norm
 
 def denseLinScale (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
   (l.scale k).norm
-
-def DenseLinExpr.mentions (l : DenseLinExpr p) (x : VarId) : Bool :=
-  l.terms.any (fun yc => yc.1 = x)
 
 inductive DenseGaussReduced (p : ℕ) where
   | affine (row : DenseLinExpr p)
@@ -295,38 +310,204 @@ def denseSparseSubstF (σ : VarId → Option (DenseLinExpr p)) : DenseExpr p →
           let rb := denseSparseSubstF σ b
           denseReducedMul ra rb
 
+def denseSparseSubstOne (x : VarId) (t : DenseLinExpr p) : DenseExpr p → DenseGaussReduced p
+  | .const n => .affine ⟨n, []⟩
+  | .var y => if y = x then .affine t else .affine ⟨0, [(y, 1)]⟩
+  | e@(.add a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubst row x t)
+      | none =>
+          let ra := denseSparseSubstOne x t a
+          let rb := denseSparseSubstOne x t b
+          denseReducedAdd ra rb
+  | e@(.mul a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubst row x t)
+      | none =>
+          let ra := denseSparseSubstOne x t a
+          let rb := denseSparseSubstOne x t b
+          denseReducedMul ra rb
+
 def denseReducedSubst (r : DenseGaussReduced p) (x : VarId)
     (t : DenseLinExpr p) : DenseGaussReduced p :=
   match r with
   | .affine row => .affine (denseLinSubst row x t)
-  | .nonlinear expr => denseSparseSubstF (fun y => if y = x then some t else none) expr
+  | .nonlinear expr => denseSparseSubstOne x t expr
 
 structure DenseSparseSolved (p : ℕ) where
-  map : Std.HashMap VarId (DenseLinExpr p)
-  revDeps : Std.HashMap VarId (Std.HashSet VarId)
+  rows : Array (Option (DenseLinExpr p))
+  revDeps : Array (Std.HashSet VarId)
+  rewriteSeen : Array (Std.HashSet VarId)
+  supportMarks : ByteArray
+  keys : Array VarId
 
 namespace DenseSparseSolved
 
-def empty : DenseSparseSolved p := { map := ∅, revDeps := ∅ }
+def empty (capacity : Nat) : DenseSparseSolved p :=
+  { rows := Array.replicate capacity none
+    revDeps := Array.replicate capacity ∅
+    rewriteSeen := Array.replicate capacity ∅
+    supportMarks := ⟨Array.replicate capacity 0⟩
+    keys := #[] }
 
-def fn (dσ : DenseSparseSolved p) : VarId → Option (DenseLinExpr p) := fun i => dσ.map[i]?
+def lookup (dσ : DenseSparseSolved p) (x : VarId) : Option (DenseLinExpr p) :=
+  (dσ.rows[x.index]?).join
 
-def insertAll (dσ : DenseSparseSolved p) :
-    List (VarId × DenseLinExpr p) → DenseSparseSolved p
-  | [] => dσ
-  | (x, t) :: rest =>
-      DenseSparseSolved.insertAll
-        { map := dσ.map.insert x t
-          revDeps := t.terms.foldl
-            (fun rd zc => rd.insert zc.1 (((rd[zc.1]?).getD ∅).insert x)) dσ.revDeps }
-        rest
+def fn (dσ : DenseSparseSolved p) : VarId → Option (DenseLinExpr p) := dσ.lookup
 
-def materialize (dσ : DenseSparseSolved p) : DenseSolved p :=
-  let map := dσ.map.toList.foldl
-    (fun out xt => out.insert xt.1 xt.2.toExpr) (∅ : Std.HashMap VarId (DenseExpr p))
-  { map, revDeps := ∅ }
+def fnExpr (dσ : DenseSparseSolved p) : VarId → Option (DenseExpr p) :=
+  fun x => (dσ.lookup x).map DenseLinExpr.toExpr
+
+def deps (dσ : DenseSparseSolved p) (x : VarId) : Std.HashSet VarId :=
+  (dσ.revDeps[x.index]?).getD ∅
+
+def rewriteCount (dσ : DenseSparseSolved p) (x : VarId) : Nat :=
+  ((dσ.rewriteSeen[x.index]?).getD ∅).size
+
+def isEmpty (dσ : DenseSparseSolved p) : Bool := dσ.keys.isEmpty
+
+def markOldDeps : DenseSparseSolved p → List (VarId × ZMod p) → DenseSparseSolved p
+  | dσ, [] => dσ
+  | dσ, yc :: rest =>
+      markOldDeps { dσ with supportMarks := dσ.supportMarks.set! yc.1.index 1 } rest
+
+def addNewDeps (owner : VarId) :
+    DenseSparseSolved p → List (VarId × ZMod p) → DenseSparseSolved p
+  | dσ, [] => dσ
+  | dσ, yc :: rest =>
+      if (dσ.supportMarks[yc.1.index]?).getD 0 == 0 then
+        let bucket := ((dσ.revDeps[yc.1.index]?).getD ∅).insert owner
+        let seen := ((dσ.rewriteSeen[yc.1.index]?).getD ∅).insert owner
+        addNewDeps owner
+          { dσ with
+            revDeps := dσ.revDeps.setIfInBounds yc.1.index bucket
+            rewriteSeen := dσ.rewriteSeen.setIfInBounds yc.1.index seen
+            supportMarks := dσ.supportMarks.set! yc.1.index 2 } rest
+      else
+        addNewDeps owner
+          { dσ with supportMarks := dσ.supportMarks.set! yc.1.index 2 } rest
+
+def removeOldDeps (owner : VarId) :
+    DenseSparseSolved p → List (VarId × ZMod p) → DenseSparseSolved p
+  | dσ, [] => dσ
+  | dσ, yc :: rest =>
+      let mark := (dσ.supportMarks[yc.1.index]?).getD 0
+      let dσ :=
+        if mark == 1 then
+          let bucket := ((dσ.revDeps[yc.1.index]?).getD ∅).erase owner
+          { dσ with revDeps := dσ.revDeps.setIfInBounds yc.1.index bucket }
+        else dσ
+      removeOldDeps owner
+        { dσ with supportMarks := dσ.supportMarks.set! yc.1.index 0 } rest
+
+def clearNewDepMarks :
+    DenseSparseSolved p → List (VarId × ZMod p) → DenseSparseSolved p
+  | dσ, [] => dσ
+  | dσ, yc :: rest =>
+      clearNewDepMarks
+        { dσ with supportMarks := dσ.supportMarks.set! yc.1.index 0 } rest
+
+def diffDeps (dσ : DenseSparseSolved p) (owner : VarId)
+    (oldTerms newTerms : List (VarId × ZMod p)) : DenseSparseSolved p :=
+  let dσ := markOldDeps dσ oldTerms
+  let dσ := addNewDeps owner dσ newTerms
+  let dσ := removeOldDeps owner dσ oldTerms
+  clearNewDepMarks dσ newTerms
+
+def clearDeps (dσ : DenseSparseSolved p) (x : VarId) : DenseSparseSolved p :=
+  { dσ with revDeps := dσ.revDeps.setIfInBounds x.index ∅ }
+
+def replace (dσ : DenseSparseSolved p) (x : VarId)
+    (t : DenseLinExpr p) : DenseSparseSolved p :=
+  let old := dσ.lookup x
+  let oldTerms := old.map (·.terms) |>.getD []
+  let dσ := dσ.diffDeps x oldTerms t.terms
+  { dσ with
+    rows := dσ.rows.setIfInBounds x.index (some t)
+    keys := if old.isSome || dσ.rows[x.index]?.isNone then dσ.keys else dσ.keys.push x }
 
 end DenseSparseSolved
+
+def denseSparseExprSubst (dσ : DenseSparseSolved p) : DenseExpr p → DenseExpr p
+  | .const n => .const n
+  | .var x =>
+      match dσ.lookup x with
+      | some row => row.toExpr
+      | none => .var x
+  | .add a b => .add (denseSparseExprSubst dσ a) (denseSparseExprSubst dσ b)
+  | .mul a b => .mul (denseSparseExprSubst dσ a) (denseSparseExprSubst dσ b)
+
+def denseSparseBISubst (dσ : DenseSparseSolved p)
+    (bi : BusInteraction (DenseExpr p)) : BusInteraction (DenseExpr p) :=
+  { busId := bi.busId
+    multiplicity := denseSparseExprSubst dσ bi.multiplicity
+    payload := bi.payload.map (denseSparseExprSubst dσ) }
+
+def DenseConstraintSystem.substSparse
+    (d : DenseConstraintSystem p) (dσ : DenseSparseSolved p) : DenseConstraintSystem p :=
+  { algebraicConstraints := d.algebraicConstraints.map (denseSparseExprSubst dσ)
+    busInteractions := d.busInteractions.map (denseSparseBISubst dσ) }
+
+structure DenseSparseAdoption (p : ℕ) where
+  solved : DenseSparseSolved p
+  changed : Std.HashSet VarId
+
+def denseSparseAdoptStep (trackChanged : Bool) (x : VarId) (t : DenseLinExpr p)
+    (acc : DenseSparseAdoption p) (y : VarId) : DenseSparseAdoption p :=
+  match acc.solved.lookup y with
+  | none => acc
+  | some row =>
+      let row := denseLinSubst row x t
+      let changed :=
+        if trackChanged then
+          row.terms.foldl (fun changed yc => changed.insert yc.1) acc.changed
+        else acc.changed
+      { solved := acc.solved.replace y row, changed }
+
+def denseSparseAdopt (trackChanged : Bool) (dσ : DenseSparseSolved p) (x : VarId)
+    (t : DenseLinExpr p) : DenseSparseAdoption p :=
+  let touched := dσ.deps x
+  let dσ := dσ.clearDeps x
+  let changed :=
+    if trackChanged then
+      t.terms.foldl (fun changed yc => changed.insert yc.1)
+        (Std.HashSet.emptyWithCapacity t.terms.length)
+    else ∅
+  let out := touched.fold (denseSparseAdoptStep trackChanged x t) { solved := dσ, changed }
+  { out with solved := out.solved.replace x t }
+
+def denseLinSubstSolved (l : DenseLinExpr p) (dσ : DenseSparseSolved p) :
+    DenseLinExpr p :=
+  let const := l.terms.foldl (fun out yc =>
+    match dσ.lookup yc.1 with
+    | some t => out + yc.2 * t.const
+    | none => out) l.const
+  let terms := l.terms.flatMap (fun yc =>
+    match dσ.lookup yc.1 with
+    | some t => t.terms.map (fun zc => (zc.1, yc.2 * zc.2))
+    | none => [yc])
+  (DenseLinExpr.mk const terms).norm
+
+def denseSparseSubstSolved (dσ : DenseSparseSolved p) : DenseExpr p → DenseGaussReduced p
+  | .const n => .affine ⟨n, []⟩
+  | .var x =>
+      match dσ.lookup x with
+      | some row => .affine row
+      | none => .affine ⟨0, [(x, 1)]⟩
+  | e@(.add a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubstSolved row dσ)
+      | none =>
+          let ra := denseSparseSubstSolved dσ a
+          let rb := denseSparseSubstSolved dσ b
+          denseReducedAdd ra rb
+  | e@(.mul a b) =>
+      match denseLinearize e with
+      | some row => .affine (denseLinSubstSolved row dσ)
+      | none =>
+          let ra := denseSparseSubstSolved dσ a
+          let rb := denseSparseSubstSolved dσ b
+          denseReducedMul ra rb
 
 def denseSparseSolveAt (l : DenseLinExpr p) (x : VarId) :
     Option (VarId × DenseLinExpr p) :=
@@ -336,30 +517,59 @@ def denseSparseSolveAt (l : DenseLinExpr p) (x : VarId) :
     some (x, denseLinScale (-(l.coeff x)⁻¹) (l.others x))
   else none
 
-def denseSparseBest (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
-  match (densePivotDescs l occ prot).argmin Prod.snd with
+def densePm1BestStepWith (ops : DenseZModOps p)
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt)
+    (best : Option (VarId × Nat)) (yc : VarId × ZMod p) : Option (VarId × Nat) :=
+  if yc.2 = ops.one ∨ yc.2 = ops.negOne then
+    let score := denseGaussScore occ prot yc.1 (total - 1)
+    match best with
+    | none => some (yc.1, score)
+    | some old => if score < old.2 then some (yc.1, score) else best
+  else best
+
+def denseUnitBestStepWith (ops : DenseZModOps p)
+    (total : Nat) (occ : DenseGaussOcc) (prot : DenseGaussProt)
+    (best : Option (VarId × Nat)) (yc : VarId × ZMod p) : Option (VarId × Nat) :=
+  if ¬(yc.2 = ops.one ∨ yc.2 = ops.negOne) ∧
+      ops.mul yc.2 yc.2⁻¹ = ops.one then
+    let score := denseGaussScore occ prot yc.1 (total - 1)
+    match best with
+    | none => some (yc.1, score)
+    | some old => if score < old.2 then some (yc.1, score) else best
+  else best
+
+def denseBestPivotWith (ops : DenseZModOps p) (l : DenseLinExpr p)
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) : Option (VarId × Nat) :=
+  let total := l.terms.length
+  l.terms.foldl (denseUnitBestStepWith ops total occ prot)
+    (l.terms.foldl (densePm1BestStepWith ops total occ prot) none)
+
+def denseBestPivot (l : DenseLinExpr p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) : Option (VarId × Nat) :=
+  let ops : DenseZModOps p := denseZModOps
+  denseBestPivotWith ops l occ prot
+
+def denseSparseBest (l : DenseLinExpr p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) : Option (VarId × DenseLinExpr p) :=
+  match denseBestPivot l occ prot with
   | none => none
   | some (x, _) => denseSparseSolveAt l x
 
-def denseReducedBest (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
+def denseReducedBest (r : DenseGaussReduced p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) : Option (VarId × DenseLinExpr p) :=
   match r with
   | .affine row => denseSparseBest row occ prot
   | .nonlinear _ => none
 
-def denseSparseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+def denseSparseGaussLoop (occ : DenseGaussOcc) (prot : DenseGaussProt) :
     List (DenseExpr p) → DenseSparseSolved p → DenseSparseSolved p
   | [], dσ => dσ
   | c :: rest, dσ =>
-      let c' := denseSparseSubstF dσ.fn c
+      let c' := denseSparseSubstSolved dσ c
       match denseReducedBest c' occ prot with
       | none => denseSparseGaussLoop occ prot rest dσ
       | some (x, t) =>
-          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-          let pairs := touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
-          denseSparseGaussLoop occ prot rest (dσ.insertAll pairs)
+          denseSparseGaussLoop occ prot rest (denseSparseAdopt false dσ x t).solved
 
 structure DenseMarkowitzPivot where
   var : VarId
@@ -405,82 +615,94 @@ abbrev DenseMarkowitzHeap :=
 
 structure DenseMarkowitzState (p : ℕ) where
   rows : Array (DenseMarkowitzRow p)
-  degrees : Std.HashMap VarId Nat
-  rowDeps : Std.HashMap VarId (Std.HashSet Nat)
-  pivotRows : Std.HashMap VarId (Std.HashSet Nat)
+  degrees : Array Nat
+  rowDeps : Array (Std.HashSet Nat)
+  pivotRows : Array (Std.HashSet Nat)
   heap : DenseMarkowitzHeap
 
-def denseMarkowitzPivots (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
+def denseMarkowitzPm1StepWith (ops : DenseZModOps p)
+    (total : Nat) (rev : List DenseMarkowitzPivot)
+    (yc : VarId × ZMod p) : List DenseMarkowitzPivot :=
+  if yc.2 = ops.one ∨ yc.2 = ops.negOne then
+    { var := yc.1, rhsNnz := total - 1 } :: rev
+  else rev
+
+def denseMarkowitzUnitStepWith (ops : DenseZModOps p)
+    (total : Nat) (rev : List DenseMarkowitzPivot)
+    (yc : VarId × ZMod p) : List DenseMarkowitzPivot :=
+  if ¬(yc.2 = ops.one ∨ yc.2 = ops.negOne) ∧
+      ops.mul yc.2 yc.2⁻¹ = ops.one then
+    { var := yc.1, rhsNnz := total - 1 } :: rev
+  else rev
+
+def denseMarkowitzPivots (r : DenseGaussReduced p) : List DenseMarkowitzPivot :=
   match r with
   | .nonlinear _ => []
   | .affine l =>
-      let idx := denseCoeffIdx l.terms
-      let vars := l.terms.map Prod.fst
-      let descs := vars.filterMap (densePm1Desc idx l.terms.length occ prot) ++
-        vars.filterMap (denseUnitDesc idx l.terms.length occ prot)
-      let out := descs.foldl (fun (out, seen) (x, _) =>
-        if seen.contains x then (out, seen)
-        else
-          let cv := (idx[x]?).getD (0, 0)
-          ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
-        (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
-      out.1.reverse
+      let ops : DenseZModOps p := denseZModOps
+      let total := l.terms.length
+      let pm1 := l.terms.foldl (denseMarkowitzPm1StepWith ops total) []
+      let unit := l.terms.foldl (denseMarkowitzUnitStepWith ops total) pm1
+      unit.reverse
 
-def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (generation : Nat := 0) : DenseMarkowitzRow p :=
+def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p)
+    (generation : Nat := 0) : DenseMarkowitzRow p :=
   let reduced := DenseGaussReduced.fromExpr e
   { rowId
     reduced
     vars := reduced.vars
-    pivots := denseMarkowitzPivots reduced occ prot
+    pivots := denseMarkowitzPivots reduced
     generation
     active := true }
 
 def denseMarkowitzRefreshRow (r : DenseMarkowitzRow p) (x : VarId) (t : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzRow p :=
+    : DenseMarkowitzRow p :=
   let reduced := denseReducedSubst r.reduced x t
   { rowId := r.rowId
     reduced
     vars := reduced.vars
-    pivots := denseMarkowitzPivots reduced occ prot
+    pivots := denseMarkowitzPivots reduced
     generation := r.generation + 1
     active := true }
 
-def denseMarkowitzDegreeAdd (m : Std.HashMap VarId Nat) (xs : List VarId) :
-    Std.HashMap VarId Nat :=
-  xs.foldl (fun m x => m.insert x (m.getD x 0 + 1)) m
+def denseMarkowitzDegreeAdd (degrees : Array Nat) (xs : List VarId) : Array Nat :=
+  xs.foldl (fun degrees x =>
+    degrees.setIfInBounds x.index ((degrees[x.index]?).getD 0 + 1)) degrees
 
-def denseMarkowitzDegreeSub (m : Std.HashMap VarId Nat) (xs : List VarId) :
-    Std.HashMap VarId Nat :=
-  xs.foldl (fun m x => m.insert x (m.getD x 0 - 1)) m
+def denseMarkowitzDegreeSub (degrees : Array Nat) (xs : List VarId) : Array Nat :=
+  xs.foldl (fun degrees x =>
+    degrees.setIfInBounds x.index ((degrees[x.index]?).getD 0 - 1)) degrees
 
-def denseMarkowitzIndexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).insert rowId)) idx
+def denseMarkowitzIndexRow (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
+  xs.foldl (fun idx x =>
+    idx.setIfInBounds x.index (((idx[x.index]?).getD ∅).insert rowId)) idx
 
-def denseMarkowitzUnindexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).erase rowId)) idx
+def denseMarkowitzUnindexRow (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
+  xs.foldl (fun idx x =>
+    idx.setIfInBounds x.index (((idx[x.index]?).getD ∅).erase rowId)) idx
 
-def denseMarkowitzIndexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
+def denseMarkowitzIndexPivots (idx : Array (Std.HashSet Nat))
     (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
-    Std.HashMap VarId (Std.HashSet Nat) :=
+    Array (Std.HashSet Nat) :=
   pivots.foldl
-    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).insert rowId)) idx
+    (fun idx q =>
+      idx.setIfInBounds q.var.index (((idx[q.var.index]?).getD ∅).insert rowId)) idx
 
-def denseMarkowitzUnindexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
+def denseMarkowitzUnindexPivots (idx : Array (Std.HashSet Nat))
     (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
-    Std.HashMap VarId (Std.HashSet Nat) :=
+    Array (Std.HashSet Nat) :=
   pivots.foldl
-    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).erase rowId)) idx
+    (fun idx q =>
+      idx.setIfInBounds q.var.index (((idx[q.var.index]?).getD ∅).erase rowId)) idx
 
-def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzEntryOf (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
     (r : DenseMarkowitzRow p) (q : DenseMarkowitzPivot) : DenseMarkowitzEntry :=
-  let solvedDegree := ((dσ.revDeps[q.var]?).getD ∅).size
-  let activeDegree := st.degrees.getD q.var 1
-  { isProtected := if prot.contains q.var then 1 else 0
+  let solvedDegree := dσ.rewriteCount q.var
+  let activeDegree := (st.degrees[q.var.index]?).getD 1
+  { isProtected := if (prot[q.var.index]?).getD 0 != 0 then 1 else 0
     fill := q.rhsNnz * (activeDegree - 1)
     rewrite := q.rhsNnz * solvedDegree
     localScore := denseGaussScore occ prot q.var q.rhsNnz
@@ -488,7 +710,7 @@ def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarI
     pivot := q.var
     generation := r.generation }
 
-def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzBestEntry? (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
     (r : DenseMarkowitzRow p) : Option DenseMarkowitzEntry :=
   r.pivots.foldl (fun best q =>
@@ -497,7 +719,7 @@ def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet V
     | none => some entry
     | some old => if denseMarkowitzEntryBetter entry old then some entry else best) none
 
-def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzPushRow (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat) :
     DenseMarkowitzState p :=
   match st.rows[rowId]? with
@@ -512,23 +734,25 @@ def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarI
         | some entry => { st' with heap := st'.heap.insert entry }
 
 def denseMarkowitzBuild (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzState p :=
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (capacity : Nat) :
+    DenseMarkowitzState p :=
   let base : DenseMarkowitzState p :=
     { rows := #[]
-      degrees := ∅
-      rowDeps := ∅
-      pivotRows := ∅
+      degrees := Array.replicate capacity 0
+      rowDeps := Array.replicate capacity ∅
+      pivotRows := Array.replicate capacity ∅
       heap := ∅ }
   let indexed := constraints.foldl (fun st c =>
     let rowId := st.rows.size
-    let r := denseMarkowitzRow rowId c occ prot
+    let r := denseMarkowitzRow rowId c
     { st with
       rows := st.rows.push r
       degrees := denseMarkowitzDegreeAdd st.degrees r.vars
       rowDeps := denseMarkowitzIndexRow st.rowDeps rowId r.vars
       pivotRows := denseMarkowitzIndexPivots st.pivotRows rowId r.pivots }) base
+  let emptySolved : DenseSparseSolved p := DenseSparseSolved.empty capacity
   indexed.rows.foldl (fun st r =>
-    match denseMarkowitzBestEntry? occ prot DenseSparseSolved.empty st r.rowId r with
+    match denseMarkowitzBestEntry? occ prot emptySolved st r.rowId r with
     | none => st
     | some entry => { st with heap := st.heap.insert entry }) indexed
 
@@ -551,28 +775,29 @@ def denseMarkowitzPopValid : Nat → DenseMarkowitzState p →
           if denseMarkowitzEntryValid st entry then some (entry, st)
           else denseMarkowitzPopValid fuel st
 
-def denseMarkowitzCollectIds (idx : Std.HashMap VarId (Std.HashSet Nat))
+def denseMarkowitzCollectIds (idx : Array (Std.HashSet Nat))
     (xs : Std.HashSet VarId) : Std.HashSet Nat :=
   xs.toList.foldl (fun out x =>
-    ((idx[x]?).getD ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
+    ((idx[x.index]?).getD ∅).toList.foldl (fun out rowId => out.insert rowId) out)
+    (Std.HashSet.emptyWithCapacity xs.size)
 
-def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzRekey (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (dσ : DenseSparseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
     DenseMarkowitzState p :=
   (denseMarkowitzCollectIds st.pivotRows changed).toList.foldl
     (denseMarkowitzPushRow occ prot dσ) st
 
-def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (x : VarId) (t : DenseLinExpr p) (st : DenseMarkowitzState p) :
+def denseMarkowitzRefreshRows (x : VarId) (t : DenseLinExpr p)
+    (st : DenseMarkowitzState p) :
     DenseMarkowitzState p × Std.HashSet VarId :=
-  let rowIds := ((st.rowDeps[x]?).getD ∅).toList
+  let rowIds := ((st.rowDeps[x.index]?).getD ∅).toList
   rowIds.foldl (fun (st, changed) rowId =>
     match st.rows[rowId]? with
     | none => (st, changed)
     | some r =>
         if !r.active || !r.vars.contains x then (st, changed)
         else
-          let r' := denseMarkowitzRefreshRow r x t occ prot
+          let r' := denseMarkowitzRefreshRow r x t
           let changed := (r.vars ++ r'.vars).foldl (fun s y => s.insert y) changed
           ({ st with
               rows := st.rows.setIfInBounds rowId r'
@@ -582,14 +807,15 @@ def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet 
                 (denseMarkowitzUnindexRow st.rowDeps rowId r.vars) rowId r'.vars
               pivotRows := denseMarkowitzIndexPivots
                 (denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots) rowId r'.pivots },
-            changed)) (st, ∅)
+            changed)) (st, Std.HashSet.emptyWithCapacity rowIds.length)
 
 def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
     DenseMarkowitzState p × Std.HashSet VarId :=
   match st.rows[rowId]? with
   | none => (st, ∅)
   | some r =>
-      let changed := r.vars.foldl (fun s x => s.insert x) ∅
+      let changed := r.vars.foldl (fun s x => s.insert x)
+        (Std.HashSet.emptyWithCapacity r.vars.length)
       ({ st with
           rows := st.rows.setIfInBounds rowId
             { r with active := false, generation := r.generation + 1 }
@@ -598,24 +824,17 @@ def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
           pivotRows := denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots },
         changed)
 
-def denseMarkowitzAdoptPairs (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p) :
-    List (VarId × DenseLinExpr p) :=
-  let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-    (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-  touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
-
-def denseMarkowitzAdopt (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzAdopt (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (entry : DenseMarkowitzEntry) (x : VarId) (t : DenseLinExpr p)
-    (pairs : List (VarId × DenseLinExpr p)) (st : DenseMarkowitzState p)
+    (solvedVars : Std.HashSet VarId) (st : DenseMarkowitzState p)
     (dσ : DenseSparseSolved p) : DenseMarkowitzState p :=
   let (st, selectedVars) := denseMarkowitzDeactivate entry.rowId st
-  let (st, rowVars) := denseMarkowitzRefreshRows occ prot x t st
-  let changed := pairs.foldl (fun changed yt =>
-    yt.2.terms.foldl (fun changed yc => changed.insert yc.1) changed) (selectedVars ∪ rowVars)
+  let (st, rowVars) := denseMarkowitzRefreshRows x t st
+  let changed := solvedVars ∪ (selectedVars ∪ rowVars)
   denseMarkowitzRekey occ prot dσ changed st
 
-def denseMarkowitzPick (r : DenseGaussReduced p) (x : VarId) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
+def denseMarkowitzPick (r : DenseGaussReduced p) (x : VarId) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) : Option (VarId × DenseLinExpr p) :=
   let hinted := match r with
     | .affine l => denseSparseSolveAt l x
     | .nonlinear _ => none
@@ -623,7 +842,7 @@ def denseMarkowitzPick (r : DenseGaussReduced p) (x : VarId) (occ : Std.HashMap 
   | some xt => some xt
   | none => denseReducedBest r occ prot
 
-def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+def denseMarkowitzLoop (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (sources : Array (DenseExpr p)) : Nat → DenseMarkowitzState p →
       DenseSparseSolved p → DenseSparseSolved p
   | 0, _, dσ => dσ
@@ -635,35 +854,37 @@ def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
           | none => denseMarkowitzLoop occ prot sources fuel
               (denseMarkowitzDeactivate entry.rowId st).1 dσ
           | some c =>
-              let c' := denseSparseSubstF dσ.fn c
+              let c' := denseSparseSubstSolved dσ c
               match denseMarkowitzPick c' entry.pivot occ prot with
               | none => denseMarkowitzLoop occ prot sources fuel
                   (denseMarkowitzDeactivate entry.rowId st).1 dσ
               | some (x, t) =>
-                  let pairs := denseMarkowitzAdoptPairs dσ x t
-                  let dσ := dσ.insertAll pairs
-                  let st := denseMarkowitzAdopt occ prot entry x t pairs st dσ
+                  let adopted := denseSparseAdopt true dσ x t
+                  let dσ := adopted.solved
+                  let st := denseMarkowitzAdopt occ prot entry x t adopted.changed st dσ
                   denseMarkowitzLoop occ prot sources fuel
                     st dσ
 
-def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : DenseSparseSolved p :=
+def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (capacity : Nat) : DenseSparseSolved p :=
   let sources := constraints.toArray
-  let st := denseMarkowitzBuild constraints occ prot
-  denseMarkowitzLoop occ prot sources sources.size st DenseSparseSolved.empty
+  let st := denseMarkowitzBuild constraints occ prot capacity
+  denseMarkowitzLoop occ prot sources sources.size st (DenseSparseSolved.empty capacity)
 
 def denseSourceOrderSchedule (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSparseSolved p :=
-  let first := denseSparseGaussLoop occ prot constraints DenseSparseSolved.empty
-  if first.map.isEmpty then first else denseSparseGaussLoop occ prot constraints first
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (capacity : Nat) :
+    DenseSparseSolved p :=
+  let first := denseSparseGaussLoop occ prot constraints (DenseSparseSolved.empty capacity)
+  if first.isEmpty then first else denseSparseGaussLoop occ prot constraints first
 
 def denseMarkowitzMinRows : Nat := 8192
 
-def denseGaussSchedule (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
-  (if constraints.length < denseMarkowitzMinRows
-    then denseSourceOrderSchedule constraints occ prot
-    else denseMarkowitzSchedule constraints occ prot).materialize
+def denseGaussSparseSchedule (constraints : List (DenseExpr p))
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (capacity : Nat) :
+    DenseSparseSolved p :=
+  if constraints.length < denseMarkowitzMinRows
+    then denseSourceOrderSchedule constraints occ prot capacity
+    else denseMarkowitzSchedule constraints occ prot capacity
 
 theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : VarId)
     (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
@@ -674,20 +895,12 @@ theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : 
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
     assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost on large
     systems and preserving source order on smaller systems. -/
-def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
-  let occ := denseOccurrenceMap d
-  let prot := denseProtectedVars d bs
-  let solved := denseGaussSchedule d.algebraicConstraints occ prot
-  if solved.map.isEmpty then d else d.substF solved.fn
-
-/-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
-theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
-    denseGaussElim bs d =
-      if (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).map.isEmpty
-      then d
-      else d.substF (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn := rfl
+def denseGaussElimSized (capacity : Nat) (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  let occ := denseOccurrenceMap capacity d
+  let prot := denseProtectedVars capacity d bs
+  let solved := denseGaussSparseSchedule d.algebraicConstraints occ prot capacity
+  if solved.isEmpty then d else d.substSparse solved
 
 /-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Gauss
+import ApcOptimizer.Implementation.OptimizerPasses.BridgeSteps
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DomainBatch
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.FlagUnify
 
@@ -200,6 +201,26 @@ theorem denseSparseSubstF_eval (σ : VarId → Option (DenseLinExpr p)) (e : Den
           rw [iha, ihb] at hm
           simpa only [DenseExpr.eval] using hm
 
+theorem denseLinSubstSolved_eq (l : DenseLinExpr p) (dσ : DenseSparseSolved p) :
+    denseLinSubstSolved l dσ = denseLinSubstF l dσ.fn := by
+  rfl
+
+theorem denseSparseSubstSolved_eq (dσ : DenseSparseSolved p) (e : DenseExpr p) :
+    denseSparseSubstSolved dσ e = denseSparseSubstF dσ.fn e := by
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      simp only [denseSparseSubstSolved, denseSparseSubstF]
+      split
+      · rw [denseLinSubstSolved_eq]
+      · rw [iha, ihb]
+  | mul a b iha ihb =>
+      simp only [denseSparseSubstSolved, denseSparseSubstF]
+      split
+      · rw [denseLinSubstSolved_eq]
+      · rw [iha, ihb]
+
 def DenseGaussReduced.support : DenseGaussReduced p → List VarId
   | .affine row => row.terms.map Prod.fst
   | .nonlinear expr => expr.vars
@@ -359,10 +380,37 @@ theorem denseSparseSubstF_closed (σ : VarId → Option (DenseLinExpr p)) (e : D
           exact denseSparseMulReduced_closed
             (denseSparseSubstF σ a) (denseSparseSubstF σ b) S ha hb
 
+theorem denseLinSubst_eq (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) :
+    denseLinSubst s x t = denseLinSubstF s (fun y => if y = x then some t else none) := by
+  have hconst :
+      (fun (out : ZMod p) (yc : VarId × ZMod p) =>
+        if yc.1 = x then out + yc.2 * t.const else out) =
+      (fun out yc =>
+        match if yc.1 = x then some t else none with
+        | some row => out + yc.2 * row.const
+        | none => out) := by
+    funext out yc
+    split <;> rfl
+  have hterms :
+      (fun (yc : VarId × ZMod p) =>
+        if yc.1 = x then t.terms.map (fun zc => (zc.1, yc.2 * zc.2)) else [yc]) =
+      (fun yc =>
+        match if yc.1 = x then some t else none with
+        | some row => row.terms.map (fun zc => (zc.1, yc.2 * zc.2))
+        | none => [yc]) := by
+    funext yc
+    split <;> rfl
+  unfold denseLinSubst denseLinSubstF
+  apply congrArg DenseLinExpr.norm
+  exact congrArg₂ DenseLinExpr.mk
+    (congrArg (fun f => s.terms.foldl f s.const) hconst)
+    (congrArg (fun f => s.terms.flatMap f) hterms)
+
 theorem denseLinSubst_eval (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p)
     (denv : VarId → ZMod p) (hx : denv x = t.eval denv) :
     (denseLinSubst s x t).eval denv = s.eval denv := by
-  rw [denseLinSubst, denseLinSubstF_eval]
+  rw [denseLinSubst_eq]
+  rw [denseLinSubstF_eval]
   congr 1
   funext y
   by_cases hy : y = x
@@ -374,6 +422,7 @@ theorem denseLinSubst_terms_closed (s : DenseLinExpr p) (x : VarId) (t : DenseLi
     (S : VarId → Prop) (hs : ∀ z ∈ s.terms.map Prod.fst, S z)
     (ht : ∀ z ∈ t.terms.map Prod.fst, S z) :
     ∀ z ∈ (denseLinSubst s x t).terms.map Prod.fst, S z := by
+  rw [denseLinSubst_eq]
   apply denseLinSubstF_terms_closed s _ S hs
   intro i row hi
   by_cases hix : i = x
@@ -433,31 +482,31 @@ theorem denseSparseSolveAt_terms (l : DenseLinExpr p) (x y : VarId)
     rw [DenseLinExpr.scale_terms_fst] at hz'
     exact l.others_terms_fst_mem x z hz'
 
-theorem denseSparseBest_sound (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+theorem denseSparseBest_sound (l : DenseLinExpr p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (y : VarId) (t : DenseLinExpr p)
     (h : denseSparseBest l occ prot = some (y, t))
     (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
     denv y = t.eval denv := by
   unfold denseSparseBest at h
-  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
+  cases hm : denseBestPivot l occ prot with
   | none => simp [hm] at h
   | some q =>
       simp only [hm] at h
       exact denseSparseSolveAt_sound l q.1 y t h denv hl
 
-theorem denseSparseBest_terms (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+theorem denseSparseBest_terms (l : DenseLinExpr p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (y : VarId) (t : DenseLinExpr p)
     (h : denseSparseBest l occ prot = some (y, t)) :
     ∀ z ∈ t.terms.map Prod.fst, z ∈ l.terms.map Prod.fst := by
   unfold denseSparseBest at h
-  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
+  cases hm : denseBestPivot l occ prot with
   | none => simp [hm] at h
   | some q =>
       simp only [hm] at h
       exact denseSparseSolveAt_terms l q.1 y t h
 
-theorem denseReducedBest_sound (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+theorem denseReducedBest_sound (r : DenseGaussReduced p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (y : VarId) (t : DenseLinExpr p)
     (h : denseReducedBest r occ prot = some (y, t))
     (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
     denv y = t.eval denv := by
@@ -467,8 +516,8 @@ theorem denseReducedBest_sound (r : DenseGaussReduced p) (occ : Std.HashMap VarI
       exact denseSparseBest_sound l occ prot y t h denv
         (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
 
-theorem denseReducedBest_terms (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
+theorem denseReducedBest_terms (r : DenseGaussReduced p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (y : VarId) (t : DenseLinExpr p)
     (h : denseReducedBest r occ prot = some (y, t)) :
     ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
   cases r with
@@ -476,7 +525,7 @@ theorem denseReducedBest_terms (r : DenseGaussReduced p) (occ : Std.HashMap VarI
   | affine l => exact denseSparseBest_terms l occ prot y t h
 
 theorem denseMarkowitzPick_sound (r : DenseGaussReduced p) (hint y : VarId)
-    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (t : DenseLinExpr p) (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (h : denseMarkowitzPick r hint occ prot = some (y, t))
     (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
     denv y = t.eval denv := by
@@ -497,7 +546,7 @@ theorem denseMarkowitzPick_sound (r : DenseGaussReduced p) (hint y : VarId)
             (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
 
 theorem denseMarkowitzPick_terms (r : DenseGaussReduced p) (hint y : VarId)
-    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (t : DenseLinExpr p) (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (h : denseMarkowitzPick r hint occ prot = some (y, t)) :
     ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
   unfold denseMarkowitzPick at h
@@ -515,54 +564,142 @@ theorem denseMarkowitzPick_terms (r : DenseGaussReduced p) (hint y : VarId)
           rw [hq] at hs
           exact denseSparseSolveAt_terms l hint y t hs
 
-theorem DenseSparseSolved.insertAll_map :
-    ∀ (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p),
-      (dσ.insertAll pairs).map =
-        pairs.foldl (fun m pr => m.insert pr.1 pr.2) dσ.map := by
-  intro pairs
-  induction pairs with
-  | nil => intro dσ; rfl
-  | cons hd tl ih =>
-      intro dσ
-      obtain ⟨x, t⟩ := hd
-      simp only [DenseSparseSolved.insertAll, List.foldl_cons]
+theorem DenseSparseSolved.clearDeps_lookup (dσ : DenseSparseSolved p) (x y : VarId) :
+    (dσ.clearDeps x).lookup y = dσ.lookup y := by
+  rfl
+
+@[simp] theorem DenseSparseSolved.empty_lookup (capacity : Nat) (x : VarId) :
+    (DenseSparseSolved.empty capacity : DenseSparseSolved p).lookup x = none := by
+  simp only [DenseSparseSolved.lookup, DenseSparseSolved.empty]
+  by_cases h : x.index < capacity
+  · rw [Array.getElem?_eq_getElem (by simpa using h)]
+    simp
+  · rw [Array.getElem?_eq_none (by simpa using h)]
+    rfl
+
+theorem DenseSparseSolved.markOldDeps_rows (dσ : DenseSparseSolved p)
+    (terms : List (VarId × ZMod p)) :
+    (markOldDeps dσ terms).rows = dσ.rows := by
+  induction terms generalizing dσ with
+  | nil => rfl
+  | cons yc rest ih =>
+      simp only [markOldDeps]
       rw [ih]
 
-theorem sparseFoldlInsert_preserves {Q : VarId → DenseLinExpr p → Prop} :
-    ∀ (pairs : List (VarId × DenseLinExpr p))
-      (m : Std.HashMap VarId (DenseLinExpr p)),
-      (∀ i t, m[i]? = some t → Q i t) → (∀ pr ∈ pairs, Q pr.1 pr.2) →
-      ∀ i t, (pairs.foldl (fun out pr => out.insert pr.1 pr.2) m)[i]? = some t →
-        Q i t := by
-  intro pairs
-  induction pairs with
-  | nil => intro m hm _ i t ht; exact hm i t ht
-  | cons hd rest ih =>
-      intro m hm hpairs i t ht
-      obtain ⟨x, t0⟩ := hd
-      simp only [List.foldl_cons] at ht
-      refine ih (m.insert x t0) ?_
-        (fun pr hpr => hpairs pr (List.mem_cons_of_mem _ hpr)) i t ht
-      intro j s hjs
-      rw [Std.HashMap.getElem?_insert] at hjs
-      split_ifs at hjs with hjx
-      · simp only [Option.some.injEq] at hjs
-        have hj : x = j := by simpa using hjx
-        rw [← hjs, ← hj]
-        exact hpairs (x, t0) (List.mem_cons_self ..)
-      · exact hm j s hjs
+theorem DenseSparseSolved.addNewDeps_rows (dσ : DenseSparseSolved p) (owner : VarId)
+    (terms : List (VarId × ZMod p)) :
+    (addNewDeps owner dσ terms).rows = dσ.rows := by
+  induction terms generalizing dσ with
+  | nil => rfl
+  | cons yc rest ih =>
+      simp only [addNewDeps]
+      split
+      · rw [ih]
+      · rw [ih]
 
-theorem DenseSparseSolved.insertAll_preserves {Q : VarId → DenseLinExpr p → Prop}
-    (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p)
-    (hσ : ∀ i t, dσ.fn i = some t → Q i t)
-    (hpairs : ∀ pr ∈ pairs, Q pr.1 pr.2) :
-    ∀ i t, (dσ.insertAll pairs).fn i = some t → Q i t := by
-  intro i t ht
-  simp only [DenseSparseSolved.fn, DenseSparseSolved.insertAll_map] at ht
-  exact sparseFoldlInsert_preserves pairs dσ.map hσ hpairs i t ht
+theorem DenseSparseSolved.removeOldDeps_rows (dσ : DenseSparseSolved p) (owner : VarId)
+    (terms : List (VarId × ZMod p)) :
+    (removeOldDeps owner dσ terms).rows = dσ.rows := by
+  induction terms generalizing dσ with
+  | nil => rfl
+  | cons yc rest ih =>
+      simp only [removeOldDeps]
+      split
+      · rw [ih]
+      · rw [ih]
+
+theorem DenseSparseSolved.clearNewDepMarks_rows (dσ : DenseSparseSolved p)
+    (terms : List (VarId × ZMod p)) :
+    (clearNewDepMarks dσ terms).rows = dσ.rows := by
+  induction terms generalizing dσ with
+  | nil => rfl
+  | cons yc rest ih =>
+      simp only [clearNewDepMarks]
+      rw [ih]
+
+theorem DenseSparseSolved.diffDeps_rows (dσ : DenseSparseSolved p) (owner : VarId)
+    (oldTerms newTerms : List (VarId × ZMod p)) :
+    (dσ.diffDeps owner oldTerms newTerms).rows = dσ.rows := by
+  simp only [diffDeps, clearNewDepMarks_rows, removeOldDeps_rows, addNewDeps_rows,
+    markOldDeps_rows]
+
+theorem DenseSparseSolved.replace_rows (dσ : DenseSparseSolved p) (x : VarId)
+    (t : DenseLinExpr p) :
+    (dσ.replace x t).rows = dσ.rows.setIfInBounds x.index (some t) := by
+  simp only [DenseSparseSolved.replace, DenseSparseSolved.diffDeps_rows]
+
+theorem DenseSparseSolved.replace_preserves {Q : VarId → DenseLinExpr p → Prop}
+    (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p)
+    (hσ : ∀ i row, dσ.lookup i = some row → Q i row) (ht : Q x t) :
+    ∀ i row, (dσ.replace x t).lookup i = some row → Q i row := by
+  intro i row hi
+  simp only [DenseSparseSolved.lookup, dσ.replace_rows x t,
+    Array.getElem?_setIfInBounds] at hi
+  split at hi
+  · next hxi =>
+    split at hi
+    · simp only [Option.join_some, Option.some.injEq] at hi
+      have hix : x = i := by
+        cases x
+        cases i
+        simp_all
+      subst i
+      simpa only [hi] using ht
+    · simp at hi
+  · exact hσ i row hi
+
+theorem denseSparseAdoptStep_preserves {Q : VarId → DenseLinExpr p → Prop}
+    (trackChanged : Bool) (x : VarId) (t : DenseLinExpr p)
+    (acc : DenseSparseAdoption p) (y : VarId)
+    (hacc : ∀ i row, acc.solved.lookup i = some row → Q i row)
+    (hsubst : ∀ i row, Q i row → Q i (denseLinSubst row x t)) :
+    ∀ i row, (denseSparseAdoptStep trackChanged x t acc y).solved.lookup i = some row →
+      Q i row := by
+  intro i row hi
+  cases hy : acc.solved.lookup y with
+  | none =>
+      simp only [denseSparseAdoptStep, hy] at hi
+      exact hacc i row hi
+  | some old =>
+      simp only [denseSparseAdoptStep, hy] at hi
+      exact DenseSparseSolved.replace_preserves acc.solved y (denseLinSubst old x t)
+        hacc (hsubst y old (hacc y old hy)) i row hi
+
+theorem denseSparseAdopt_preserves {Q : VarId → DenseLinExpr p → Prop}
+    (trackChanged : Bool) (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p)
+    (hσ : ∀ i row, dσ.lookup i = some row → Q i row) (ht : Q x t)
+    (hsubst : ∀ i row, Q i row → Q i (denseLinSubst row x t)) :
+    ∀ i row, (denseSparseAdopt trackChanged dσ x t).solved.lookup i = some row → Q i row := by
+  let initial : DenseSparseAdoption p :=
+    { solved := dσ.clearDeps x
+      changed :=
+        if trackChanged then
+          t.terms.foldl (fun changed yc => changed.insert yc.1)
+            (Std.HashSet.emptyWithCapacity t.terms.length)
+        else ∅ }
+  have hinitial : ∀ i row, initial.solved.lookup i = some row → Q i row := by
+    intro i row hi
+    exact hσ i row (by simpa [initial, DenseSparseSolved.clearDeps_lookup] using hi)
+  have hfold :
+      ∀ (ys : List VarId) (acc : DenseSparseAdoption p),
+        (∀ i row, acc.solved.lookup i = some row → Q i row) →
+        ∀ i row, (ys.foldl (denseSparseAdoptStep trackChanged x t) acc).solved.lookup i =
+          some row →
+          Q i row := by
+    intro ys
+    induction ys with
+    | nil => intro acc hacc; exact hacc
+    | cons y rest ih =>
+        intro acc hacc
+        simp only [List.foldl_cons]
+        exact ih _ (denseSparseAdoptStep_preserves trackChanged x t acc y hacc hsubst)
+  intro i row hi
+  have hout := hfold (dσ.deps x).toList initial hinitial
+  exact DenseSparseSolved.replace_preserves _ x t (hout) ht i row
+    (by simpa [denseSparseAdopt, initial, Std.HashSet.fold_eq_foldl_toList] using hi)
 
 theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) :
     ∀ (pending : List (DenseExpr p)) (dσ : DenseSparseSolved p),
       (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
@@ -581,14 +718,16 @@ theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSys
       have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
       have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
         fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
-      let c' := denseSparseSubstF dσ.fn c
-      cases hpick : denseReducedBest (denseSparseSubstF dσ.fn c) occ prot with
+      let c' := denseSparseSubstSolved dσ c
+      cases hpick : denseReducedBest (denseSparseSubstSolved dσ c) occ prot with
       | none =>
           simp only [denseSparseGaussLoop, hpick]
           exact ih dσ hrest hσs hσv
       | some xt =>
           obtain ⟨x, t⟩ := xt
           have hcclosed : c'.Closed (· ∈ d.occ) := by
+            change (denseSparseSubstSolved dσ c).Closed (· ∈ d.occ)
+            rw [denseSparseSubstSolved_eq]
             apply denseSparseSubstF_closed dσ.fn c
             · intro z hz
               exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
@@ -596,52 +735,25 @@ theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSys
           have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
             intro denv hsat
             apply denseReducedBest_sound c' occ prot x t hpick denv
-            rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
+            change (denseSparseSubstSolved dσ c).toExpr.eval denv = 0
+            rw [denseSparseSubstSolved_eq,
+              denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
             exact hsat.1 c hcmem
           have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
             intro z hz
             exact hcclosed z (denseReducedBest_terms c' occ prot x t hpick z hz)
-          have htouched : ∀ y s, (y, s) ∈
-                ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-                  (dσ.map[y]?).bind
-                    (fun s => if s.mentions x then some (y, s) else none)) →
-              dσ.fn y = some s := by
-            intro y s hys
-            obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
-            obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
-            by_cases hm : s'.mentions x
-            · rw [if_pos hm] at hif
-              simp only [Option.some.injEq, Prod.mk.injEq] at hif
-              obtain ⟨rfl, rfl⟩ := hif
-              exact hs'
-            · rw [if_neg hm] at hif
-              exact absurd hif (by simp)
           simp only [denseSparseGaussLoop, hpick]
           refine ih _ hrest ?_ ?_
           · intro denv hsat
-            refine DenseSparseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-              exact hy.trans (denseLinSubst_eval s x t denv (hx denv hsat)).symm
-            · rw [List.mem_singleton] at hin
-              subst hin
-              exact hx denv hsat
-          · refine DenseSparseSolved.insertAll_preserves _ dσ hσv ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
-                (hσv y s hmemys) htocc
-            · rw [List.mem_singleton] at hin
-              subst hin
-              exact htocc
+            exact denseSparseAdopt_preserves false dσ x t (hσs denv hsat)
+              (hx denv hsat)
+              (fun y s hy => hy.trans
+                (denseLinSubst_eval s x t denv (hx denv hsat)).symm)
+          · exact denseSparseAdopt_preserves false dσ x t hσv htocc
+              (fun y s hs => denseLinSubst_terms_closed s x t (· ∈ d.occ) hs htocc)
 
 theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
+    (occ : DenseGaussOcc) (prot : DenseGaussProt)
     (sources : Array (DenseExpr p))
     (hsrc : ∀ (i : Nat) (c : DenseExpr p),
       sources[i]? = some c → c ∈ d.algebraicConstraints) :
@@ -671,15 +783,17 @@ theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstrain
               exact ih _ _ hσs hσv
           | some c =>
               have hcmem : c ∈ d.algebraicConstraints := hsrc entry.rowId c hsource
-              let c' := denseSparseSubstF dσ.fn c
+              let c' := denseSparseSubstSolved dσ c
               cases hpick :
-                  denseMarkowitzPick (denseSparseSubstF dσ.fn c) entry.pivot occ prot with
+                  denseMarkowitzPick (denseSparseSubstSolved dσ c) entry.pivot occ prot with
               | none =>
                   simp only [denseMarkowitzLoop, hpop, hsource, hpick]
                   exact ih _ _ hσs hσv
               | some xt =>
                   obtain ⟨x, t⟩ := xt
                   have hcclosed : c'.Closed (· ∈ d.occ) := by
+                    change (denseSparseSubstSolved dσ c).Closed (· ∈ d.occ)
+                    rw [denseSparseSubstSolved_eq]
                     apply denseSparseSubstF_closed dσ.fn c
                     · intro z hz
                       exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
@@ -687,208 +801,182 @@ theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstrain
                   have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
                     intro denv hsat
                     apply denseMarkowitzPick_sound c' entry.pivot x t occ prot hpick denv
-                    rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
+                    change (denseSparseSubstSolved dσ c).toExpr.eval denv = 0
+                    rw [denseSparseSubstSolved_eq,
+                      denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
                     exact hsat.1 c hcmem
                   have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
                     intro z hz
                     exact hcclosed z
                       (denseMarkowitzPick_terms c' entry.pivot x t occ prot hpick z hz)
-                  have htouched : ∀ y s, (y, s) ∈
-                        ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
-                          (dσ.map[y]?).bind
-                            (fun s => if s.mentions x then some (y, s) else none)) →
-                      dσ.fn y = some s := by
-                    intro y s hys
-                    obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
-                    obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
-                    by_cases hm : s'.mentions x
-                    · rw [if_pos hm] at hif
-                      simp only [Option.some.injEq, Prod.mk.injEq] at hif
-                      obtain ⟨rfl, rfl⟩ := hif
-                      exact hs'
-                    · rw [if_neg hm] at hif
-                      exact absurd hif (by simp)
-                  let pairs := denseMarkowitzAdoptPairs dσ x t
-                  let dσ' := dσ.insertAll pairs
+                  let adopted := denseSparseAdopt true dσ x t
+                  let dσ' := adopted.solved
                   have hnexts : ∀ denv, d.satisfies bs denv → ∀ i u,
                       dσ'.fn i = some u → denv i = u.eval denv := by
                     intro denv hsat
-                    refine DenseSparseSolved.insertAll_preserves pairs dσ
-                      (hσs denv hsat) ?_
-                    intro pr hpr
-                    unfold denseMarkowitzAdoptPairs at hpr
-                    rcases List.mem_append.1 hpr with hin | hin
-                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-                      have hmemys : dσ.fn y = some s := htouched y s hys
-                      have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-                      exact hy.trans
-                        (denseLinSubst_eval s x t denv (hx denv hsat)).symm
-                    · rw [List.mem_singleton] at hin
-                      subst hin
-                      exact hx denv hsat
+                    exact denseSparseAdopt_preserves true dσ x t (hσs denv hsat)
+                      (hx denv hsat)
+                      (fun y s hy => hy.trans
+                        (denseLinSubst_eval s x t denv (hx denv hsat)).symm)
                   have hnextv : ∀ i u, dσ'.fn i = some u →
                       ∀ z ∈ u.terms.map Prod.fst, z ∈ d.occ := by
-                    refine DenseSparseSolved.insertAll_preserves pairs dσ hσv ?_
-                    intro pr hpr
-                    unfold denseMarkowitzAdoptPairs at hpr
-                    rcases List.mem_append.1 hpr with hin | hin
-                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-                      have hmemys : dσ.fn y = some s := htouched y s hys
-                      exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
-                        (hσv y s hmemys) htocc
-                    · rw [List.mem_singleton] at hin
-                      subst hin
-                      exact htocc
+                    exact denseSparseAdopt_preserves true dσ x t hσv htocc
+                      (fun y s hs =>
+                        denseLinSubst_terms_closed s x t (· ∈ d.occ) hs htocc)
                   simp only [denseMarkowitzLoop, hpop, hsource, hpick]
                   exact ih _ dσ' hnexts hnextv
 
 theorem denseSparseMarkowitzSchedule_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) :
+    (d : DenseConstraintSystem p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (capacity : Nat) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
+        (denseMarkowitzSchedule d.algebraicConstraints occ prot capacity).fn i = some t →
         denv i = t.eval denv) ∧
-    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
+    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints occ prot capacity).fn i = some t →
         ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
   apply denseSparseMarkowitzLoop_sound bs d occ prot d.algebraicConstraints.toArray
   · intro i c hc
     rw [List.getElem?_toArray] at hc
     exact List.mem_of_getElem? hc
   · intro _ _ _ _ h
-    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
+    simp [DenseSparseSolved.fn] at h
   · intro _ _ h
-    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
+    simp [DenseSparseSolved.fn] at h
 
 theorem denseSparseSourceOrderSchedule_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) :
+    (d : DenseConstraintSystem p) (occ : DenseGaussOcc)
+    (prot : DenseGaussProt) (capacity : Nat) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
+        (denseSourceOrderSchedule d.algebraicConstraints occ prot capacity).fn i = some t →
         denv i = t.eval denv) ∧
-    (∀ i t, (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
+    (∀ i t, (denseSourceOrderSchedule d.algebraicConstraints occ prot capacity).fn i = some t →
         ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
   have hfirst := denseSparseGaussLoop_sound bs d occ prot
-    d.algebraicConstraints DenseSparseSolved.empty
+    d.algebraicConstraints (DenseSparseSolved.empty capacity)
     (fun _c hc => hc)
-    (fun _ _ _ _ hti =>
-      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
-    (fun _ _ hti =>
-      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
+    (fun _ _ _ _ hti => by simp [DenseSparseSolved.fn] at hti)
+    (fun _ _ hti => by simp [DenseSparseSolved.fn] at hti)
   by_cases hempty :
       (denseSparseGaussLoop occ prot d.algebraicConstraints
-        DenseSparseSolved.empty).map.isEmpty
+        (DenseSparseSolved.empty capacity)).isEmpty
   · simpa [denseSourceOrderSchedule, hempty] using hfirst
   · have hsecond := denseSparseGaussLoop_sound bs d occ prot
       d.algebraicConstraints
-      (denseSparseGaussLoop occ prot d.algebraicConstraints DenseSparseSolved.empty)
+      (denseSparseGaussLoop occ prot d.algebraicConstraints
+        (DenseSparseSolved.empty capacity))
       (fun _c hc => hc) hfirst.1 hfirst.2
     simpa [denseSourceOrderSchedule, hempty] using hsecond
 
-theorem DenseSparseSolved.materialize_lookup (dσ : DenseSparseSolved p)
-    (i : VarId) (e : DenseExpr p) (h : dσ.materialize.fn i = some e) :
-    ∃ row, dσ.fn i = some row ∧ e = row.toExpr := by
-  simp only [DenseSparseSolved.materialize, DenseSolved.fn] at h
-  let pairs := dσ.map.toList.map (fun xt => (xt.1, xt.2.toExpr))
-  have hpairs :
-      pairs.foldl (fun out xt => out.insert xt.1 xt.2)
-          (∅ : Std.HashMap VarId (DenseExpr p)) =
-        dσ.map.toList.foldl (fun out xt => out.insert xt.1 xt.2.toExpr) ∅ := by
-    exact List.foldl_map
-  rw [← hpairs] at h
-  apply foldl_insert_getElem pairs
-    (∅ : Std.HashMap VarId (DenseExpr p))
-    (Q := fun j out => ∃ row, dσ.fn j = some row ∧ out = row.toExpr)
-  · intro j out hj
-    exact absurd hj (by simp)
-  · intro pr hpr
-    obtain ⟨xt, hxt, rfl⟩ := List.mem_map.1 hpr
-    refine ⟨xt.2, ?_, rfl⟩
-    exact Std.HashMap.mem_toList_iff_getElem?_eq_some.1 hxt
-  · exact h
-
-theorem DenseSparseSolved.materialize_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (dσ : DenseSparseSolved p)
-    (hs : ∀ denv, d.satisfies bs denv → ∀ i t,
-      dσ.fn i = some t → denv i = t.eval denv)
-    (hv : ∀ i t, dσ.fn i = some t →
-      ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) :
-    (∀ denv, d.satisfies bs denv → ∀ i e,
-        dσ.materialize.fn i = some e → denv i = e.eval denv) ∧
-    (∀ i e, dσ.materialize.fn i = some e → ∀ z ∈ e.vars, z ∈ d.occ) := by
-  constructor
-  · intro denv hsat i e he
-    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
-    rw [DenseLinExpr.toExpr_eval]
-    exact hs denv hsat i row hrow
-  · intro i e he z hz
-    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
-    exact hv i row hrow z (DenseLinExpr.toExpr_vars row z hz)
-
-theorem denseGaussSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
-        denv i = t.eval denv) ∧
-    (∀ i t, (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  unfold denseGaussSchedule
+theorem denseGaussSparseSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : DenseGaussOcc) (prot : DenseGaussProt) (capacity : Nat) :
+    (∀ denv, d.satisfies bs denv → ∀ i row,
+        (denseGaussSparseSchedule d.algebraicConstraints occ prot capacity).lookup i =
+          some row →
+        denv i = row.eval denv) ∧
+    (∀ i row,
+        (denseGaussSparseSchedule d.algebraicConstraints occ prot capacity).lookup i =
+          some row →
+        ∀ z ∈ row.terms.map Prod.fst, z ∈ d.occ) := by
+  unfold denseGaussSparseSchedule
   split
-  · exact DenseSparseSolved.materialize_sound bs d _
-      (denseSparseSourceOrderSchedule_sound bs d occ prot).1
-      (denseSparseSourceOrderSchedule_sound bs d occ prot).2
-  · exact DenseSparseSolved.materialize_sound bs d _
-      (denseSparseMarkowitzSchedule_sound bs d occ prot).1
-      (denseSparseMarkowitzSchedule_sound bs d occ prot).2
+  · exact denseSparseSourceOrderSchedule_sound bs d occ prot capacity
+  · exact denseSparseMarkowitzSchedule_sound bs d occ prot capacity
 
+theorem DenseSparseSolved.fnExpr_lookup (dσ : DenseSparseSolved p)
+    (i : VarId) (e : DenseExpr p) (h : dσ.fnExpr i = some e) :
+    ∃ row, dσ.lookup i = some row ∧ e = row.toExpr := by
+  unfold DenseSparseSolved.fnExpr at h
+  cases hrow : dσ.lookup i with
+  | none => simp [hrow] at h
+  | some row =>
+      simp only [hrow, Option.map_some, Option.some.injEq] at h
+      exact ⟨row, rfl, h.symm⟩
+
+theorem denseSparseExprSubst_eq (dσ : DenseSparseSolved p) (e : DenseExpr p) :
+    denseSparseExprSubst dσ e = e.substF dσ.fnExpr := by
+  induction e with
+  | const n => rfl
+  | var x =>
+      simp only [denseSparseExprSubst, DenseExpr.substF, DenseSparseSolved.fnExpr]
+      cases hrow : dσ.lookup x <;> rfl
+  | add a b iha ihb => simp only [denseSparseExprSubst, DenseExpr.substF, iha, ihb]
+  | mul a b iha ihb => simp only [denseSparseExprSubst, DenseExpr.substF, iha, ihb]
+
+theorem denseSparseBISubst_eq (dσ : DenseSparseSolved p)
+    (bi : BusInteraction (DenseExpr p)) :
+    denseSparseBISubst dσ bi = denseBIsubstF bi dσ.fnExpr := by
+  have hfn : denseSparseExprSubst dσ = fun e => e.substF dσ.fnExpr :=
+    funext (denseSparseExprSubst_eq dσ)
+  cases bi
+  simp only [denseSparseBISubst, denseBIsubstF, hfn]
+
+theorem DenseConstraintSystem.substSparse_eq
+    (d : DenseConstraintSystem p) (dσ : DenseSparseSolved p) :
+    d.substSparse dσ = d.substF dσ.fnExpr := by
+  have hfn : denseSparseExprSubst dσ = fun e => e.substF dσ.fnExpr :=
+    funext (denseSparseExprSubst_eq dσ)
+  have hbi : denseSparseBISubst dσ = fun bi => denseBIsubstF bi dσ.fnExpr :=
+    funext (denseSparseBISubst_eq dσ)
+  cases d
+  simp only [DenseConstraintSystem.substSparse, DenseConstraintSystem.substF,
+    hfn, hbi]
 
 /-! ## The pass's correctness -/
 
-/-- The scheduled solution map is entailed and occurrence-closed. -/
-theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
-          denv i = t.eval denv) ∧
-    (∀ i t, (denseGaussSchedule d.algebraicConstraints
-        (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  exact denseGaussSchedule_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
+/-- The scheduled sparse rows are entailed and occurrence-closed. -/
+theorem denseGaussElimSized_loop_invariant (capacity : Nat)
+    (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+    (∀ denv, d.satisfies bs denv → ∀ i e,
+        (denseGaussSparseSchedule d.algebraicConstraints
+          (denseOccurrenceMap capacity d) (denseProtectedVars capacity d bs) capacity).fnExpr i =
+            some e →
+          denv i = e.eval denv) ∧
+    (∀ i e, (denseGaussSparseSchedule d.algebraicConstraints
+        (denseOccurrenceMap capacity d) (denseProtectedVars capacity d bs) capacity).fnExpr i =
+          some e →
+        ∀ z ∈ e.vars, z ∈ d.occ) := by
+  have hs := denseGaussSparseSchedule_sound bs d (denseOccurrenceMap capacity d)
+    (denseProtectedVars capacity d bs) capacity
+  constructor
+  · intro denv hsat i e he
+    obtain ⟨row, hrow, rfl⟩ :=
+      DenseSparseSolved.fnExpr_lookup _ i e he
+    rw [DenseLinExpr.toExpr_eval]
+    exact hs.1 denv hsat i row hrow
+  · intro i e he z hz
+    obtain ⟨row, hrow, rfl⟩ :=
+      DenseSparseSolved.fnExpr_lookup _ i e he
+    exact hs.2 i row hrow z (DenseLinExpr.toExpr_vars row z hz)
 
-/-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
-    occurrence-closed solution map, whose solutions are covered because their variables occur in a
-    covered system. -/
-theorem denseGaussElim_covered (reg : VarRegistry) (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
-    (denseGaussElim bs d).CoveredBy reg := by
-  rw [denseGaussElim_eq]
-  split_ifs with hempty
+theorem denseGaussElimSized_covered (capacity : Nat) (reg : VarRegistry)
+    (bs : BusSemantics p) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
+    (denseGaussElimSized capacity bs d).CoveredBy reg := by
+  simp only [denseGaussElimSized]
+  split
   · exact hcov
-  · refine DenseConstraintSystem.substF_covered hcov ?_
-    intro i _ t hti z hz
+  · rw [DenseConstraintSystem.substSparse_eq]
+    refine DenseConstraintSystem.substF_covered hcov ?_
+    intro i _ e he z hz
     exact DenseConstraintSystem.occ_valid hcov z
-      ((denseGaussElim_loop_invariant bs d).2 i t hti z hz)
+      ((denseGaussElimSized_loop_invariant capacity bs d).2 i e he z hz)
 
-/-- **Correctness of `denseGaussElim`.** The empty-map branch is the identity (`refl`); the
-    substitution branch is `substF_denseCorrect`, fed the entailment and occurrence-closure of the
-    final solution map. -/
-theorem denseGaussElim_correct (reg : VarRegistry) (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) :
-    DensePassCorrect reg.isInput d (denseGaussElim bs d) [] bs := by
-  have hinv := denseGaussElim_loop_invariant bs d
-  rw [denseGaussElim_eq]
-  split_ifs with hempty
+theorem denseGaussElimSized_correct (capacity : Nat) (reg : VarRegistry)
+    (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+    DensePassCorrect reg.isInput d (denseGaussElimSized capacity bs d) [] bs := by
+  have hinv := denseGaussElimSized_loop_invariant capacity bs d
+  simp only [denseGaussElimSized]
+  split
   · exact DensePassCorrect.refl reg.isInput d bs
-  · exact DenseConstraintSystem.substF_denseCorrect d _ bs reg.isInput
-      (fun denv hsat i t hti => hinv.1 denv hsat i t hti)
-      (fun i t hti z hz => hinv.2 i t hti z hz)
+  · rw [DenseConstraintSystem.substSparse_eq]
+    exact DenseConstraintSystem.substF_denseCorrect d _ bs reg.isInput
+      (fun denv hsat i e he => hinv.1 denv hsat i e he)
+      (fun i e he z hz => hinv.2 i e he z hz)
 
-/-- The wired dense Gauss-elimination pass (transform `denseGaussElim`, `Gauss.lean`). -/
+/-- The wired dense Gauss-elimination pass. -/
 def denseGaussElimPass : DenseVerifiedPassW p :=
-  DenseVerifiedPassW.of
-    (fun bs _ d => denseGaussElim bs d)
-    (fun _ _ _ => [])
-    (fun reg bs _ d hcov => denseGaussElim_covered reg bs d hcov)
-    (fun _ _ _ _ _ => by intro x hx; simp at hx)
-    (fun reg bs _ d _ => denseGaussElim_correct reg bs d)
+  DenseVerifiedPassW.ofDenseStep (fun reg bs _ d hcov =>
+    DenseNativeStep.ofSame bs
+      (denseGaussElimSized_covered reg.byId.size reg bs d hcov)
+      (denseGaussElimSized_correct reg.byId.size reg bs d))
 
 end ApcOptimizer.Dense

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -246,6 +246,14 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      118–119)**: proven `@[csimp]` fast twins box the canonical operations once and each pivot
      descriptor now reads its coefficient/count entry once. The broader dirty-sweep and
      allocation-free-pivot experiment in PR #156 was closed after too little whole-run benefit.
+   - ~~gauss array-backed state, exact reverse dependencies, and generated allocation traps~~
+     **done (entry 136)**: registry-indexed arrays now hold occurrence counts, protection bits,
+     solved rows, live reverse-dependency buckets, Markowitz degrees, and row indexes. A reusable
+     support-mark array maintains exact dependency edges as solved rows change, while a separate
+     append-only history preserves the scheduler's prior rewrite score. Canonical rows feed
+     first-order streaming pivot folds directly; solution lookup, touched-row adoption, and final
+     substitution no longer allocate descriptor lists, lookup closures, or a materialized solution
+     map.
    - ~~gauss empty second sweep and variable-list materialization~~ **done (entry 119)**: an
      empty first solution map returns immediately, while productive runs retain both sweeps;
      occurrence and reverse-dependency construction fold expression leaves directly without

--- a/docs/log.md
+++ b/docs/log.md
@@ -4698,3 +4698,34 @@ unused-theorem checks pass.
 
 **Worked locally: yes (representative Gauss runtime win with unchanged final sizes; full-set
 result pending CI).**
+
+### 136. Runtime: exact array-backed Gauss state and first-order generated code
+
+Gauss now sizes occurrence counts, protected-variable bits, sparse solution rows, exact
+reverse-dependency buckets, support marks, Markowitz degrees, and row indexes directly from the
+variable registry. Replacing a solved row uses reusable support marks to diff its old and new
+supports in linear time, updates the exact dependency edges in the same touched-row fold, and
+clears a pivot bucket before propagation. An append-only rewrite-history index retains the
+historical dependent count used by the merged scheduler, so exact live edges do not silently alter
+its scoring heuristic.
+
+The runtime path consumes canonical affine rows directly. Pivot selection is a first-order
+two-pass fold with explicit ±1 precedence and strict first-wins ties; Markowitz pivot construction
+uses the same canonical coefficients without rebuilding coefficient or deduplication tables.
+Sparse solution lookup is specialized in source and Markowitz substitution, source-order adoption
+skips change-set construction, remaining temporary hash tables are pre-sized when their cardinality
+is known, and final substitution reads the solution array without constructing a `DenseSolved`
+map. Initial Markowitz scoring also shares one empty solution state instead of allocating
+registry-sized arrays per row.
+
+The correctness proof now works directly over the registry-sized sparse schedule and final array
+lookup. `lake build` is warning-free, proof integrity and unused-theorem reachability pass, and the
+generated Gauss C has no `lean_alloc_closure`, `argmin`, or `argAux` sites. One-pass local checks on
+the five representatives preserved cleanup iteration counts and final variable, bus-interaction,
+and constraint counts exactly. Local timing did not establish a win: the final
+`wasm-eth/apc_037` check measured 3954 ms versus the merged 3287 ms Gauss baseline, so the
+same-runner corpus decision is delegated to the draft PR's triggered CI rather than inferred from
+the local machine.
+
+**Worked locally: no (structural and effectiveness checks pass, but local runtime is regressive;
+authoritative corpus result pending CI).**


### PR DESCRIPTION
## What changed

- store Gauss occurrence counts, protection bits, sparse solutions, reverse dependencies, support marks, Markowitz degrees, and row indexes in registry-indexed arrays
- maintain exact live reverse dependencies with a reusable support-mark diff while preserving the scheduler's historical rewrite score separately
- fold touched solution rows directly and skip change-set construction on the source-order path
- consume canonical affine rows with streaming, first-wins pivot selection and direct Markowitz pivot construction
- specialize sparse-solution lookup and final substitution, avoiding solution-map materialization
- hoist the empty Markowitz solution state, pre-size known temporary tables, and remove generated descriptor/closure/argmin allocation paths

## Why

This implements Gauss runtime proposals 4 and 6 together. The prior path retained stale reverse-dependency edges and generated avoidable list, closure, coefficient-index, and solution-materialization work around an already-canonical sparse core.

## Correctness and effectiveness

The correctness proof now targets the registry-sized sparse schedule and direct final lookup. The five representative one-pass checks preserved cleanup iteration counts and final variable, bus-interaction, and constraint counts exactly.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- `git diff --check`
- generated `Gauss.c`: zero `lean_alloc_closure`, `argmin`, or `argAux` occurrences
- one local profile pass on each representative APC

Local timing did not establish a win: the final `wasm-eth/apc_037` check measured 3954 ms versus the merged 3287 ms Gauss baseline. This is intentionally a draft so triggered CI can provide the authoritative same-runner corpus benchmark; the branch should be adjusted if CI confirms the local regression.