### PR TITLE
Index reencode degree rejection

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1247,27 +1247,30 @@ theorem denseBuildReencode_bits_valid_of_eq {reg reg1 : VarRegistry} {useIdx : B
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId) (xs : List VarId)
-    (freshBase : String) (bs : BusSemantics p)
+    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+    (usePlan : DenseReencodeUsePlan p) (xs : List VarId) (freshBase : String)
+    (bs : BusSemantics p)
     (hcov : d.CoveredBy reg) (hvs : ∀ x, varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
-    ∧ (∀ i, (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1.isInput i
+    reg.Extends (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).1
+    ∧ (∀ i, (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).1.isInput i
         = reg.isInput i)
-    ∧ (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
+    ∧ (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.1.CoveredBy
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).1
     ∧ DenseDerivations.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.1
-    ∧ (∀ x, (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.2.2.2.contains x
-          = true →
-        x ∈ (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1.occ)
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).1
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.2.1
+    ∧ (∀ x,
+        Std.HashSet.contains
+            (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.2.2.2.2.1
+            x = true →
+        x ∈ (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.1.occ)
     ∧ DensePassCorrect
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1.isInput d
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).1.isInput d
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.1
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs freshBase
   case case4 =>
-    rename_i hgate hcoll reg1 bits hm hbeq hdpr hA hB hC hD ro hwd
+    rename_i hgate hcoll reg1 bits hm hbeq pre hdpr hA hB hC hD ro hwd roCsVs
     have hbext : reg.Extends reg1 := denseBuildReencode_ext_of_eq hbeq
     have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
       denseBuildReencode_isInput_of_eq hbeq i
@@ -1294,45 +1297,147 @@ theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Boo
         (fun i => denseBuildReencode_isInput_of_eq (by assumption) i) hcov hvs
 
 set_option maxHeartbeats 1000000 in
+theorem denseReencodeStepDirect_correct [Fact p.Prime] (b : DegreeBound)
+    (reg : VarRegistry) (d : DenseConstraintSystem p) (arrCs : Array (DenseExpr p))
+    (varSet : Std.HashSet VarId) (xs : List VarId) (freshBase : String)
+    (bs : BusSemantics p) (hcov : d.CoveredBy reg)
+    (hvs : ∀ x, varSet.contains x = true → x ∈ d.occ) :
+    reg.Extends (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).1
+    ∧ (∀ i, (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).1.isInput i
+        = reg.isInput i)
+    ∧ (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.1.CoveredBy
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).1
+    ∧ DenseDerivations.CoveredBy
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).1
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.2.1
+    ∧ (∀ x, (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.2.2.2.contains x
+          = true →
+        x ∈ (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.1.occ)
+    ∧ DensePassCorrect
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).1.isInput d
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.1
+        (denseReencodeStepDirect b reg d arrCs varSet xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStepDirect b reg d arrCs varSet xs freshBase
+  case case4 =>
+    rename_i hgate hcoll reg1 bits hm hbeq hdpr hA hB hC hD ro hwd
+    have hbext : reg.Extends reg1 := denseBuildReencode_ext_of_eq hbeq
+    have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
+      denseBuildReencode_isInput_of_eq hbeq i
+    have hbval : ∀ bb ∈ bits, reg1.Valid bb := denseBuildReencode_bits_valid_of_eq hbeq
+    have hpolyVars := denseCheckReencode_polyVars d xs bits hm hD
+    have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
+      rw [hbii x]; exact List.all_eq_true.mp hgate x hx
+    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := fun x hx => hvs x (List.all_eq_true.mp hA x hx)
+    have hxsB : ∀ x ∈ xs, x ∉ bits := fun x hx =>
+      of_decide_eq_true (List.all_eq_true.mp hB x hx)
+    have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
+      have hpd : (reg1.resolve bb).powdrId? = none :=
+        of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
+      show (reg1.resolve bb).powdrId?.isSome = false
+      rw [hpd]; rfl
+    have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
+      hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
+    refine ⟨hbext, hbii, ?_, ?_, ?_, ?_⟩
+    · exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov) hbval hpolyVars
+    · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
+    · intro x hx; rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx
+    · exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB hbnInput hD
+  all_goals first
+    | exact stepIdentityPost reg reg d varSet bs (VarRegistry.Extends.refl reg)
+        (fun _ => rfl) hcov hvs
+    | exact stepIdentityPost reg _ d varSet bs (denseBuildReencode_ext_of_eq (by assumption))
+        (fun i => denseBuildReencode_isInput_of_eq (by assumption) i) hcov hvs
+
+set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (bs : BusSemantics p) :
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
-      (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId),
+      (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+      (usePlan : DenseReencodeUsePlan p),
       d.CoveredBy reg → (∀ x, varSet.contains x = true → x ∈ d.occ) →
-      reg.Extends (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
-      ∧ (∀ i, (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1.isInput i
+      reg.Extends (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).1
+      ∧ (∀ i,
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).1.isInput i
           = reg.isInput i)
-      ∧ (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.1.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
+      ∧ (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).2.1.CoveredBy
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).1
       ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.2
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).1
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).2.2
       ∧ DensePassCorrect
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1.isInput d
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.2 bs := by
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).1.isInput d
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).2.1
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet usePlan).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
-      intro idx reg d csIdx arrCs varSet hcov hvs
+      intro idx reg d csIdx arrCs varSet usePlan hcov hvs
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
         ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov, (by intro x hx; simp at hx),
         DensePassCorrect.refl reg.isInput d bs⟩
   | cons xs rest ih =>
-      intro idx reg d csIdx arrCs varSet hcov hvs
+      intro idx reg d csIdx arrCs varSet usePlan hcov hvs
       simp only [denseReencodeLoop]
-      rcases hstep : denseReencodeStep b useIdx reg d csIdx arrCs varSet xs
+      rcases hstep : denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs
           (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
-          with ⟨reg1, d1, derivs1, csIdx1, arrCs1, varSet1⟩
-      have hsp := denseReencodeStep_correct b useIdx reg d csIdx arrCs varSet xs
+          with ⟨reg1, d1, derivs1, csIdx1, arrCs1, varSet1, usePlan1⟩
+      have hsp := denseReencodeStep_correct b useIdx reg d csIdx arrCs varSet usePlan xs
           (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}") bs hcov hvs
       simp only [hstep] at hsp
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
-      rcases hrec : denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
+      rcases hrec :
+          denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 usePlan1
           with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 hs_cov hs_vs
+      have hih := ih (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 usePlan1 hs_cov hs_vs
+      simp only [hrec] at hih
+      obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
+      refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
+      · exact DenseDerivations.coveredBy_append
+          (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
+      · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
+        have hstepcert : DensePassCorrect reg2.isInput d d1 derivs1 bs := by
+          rw [hfe]; exact hs_correct
+        exact hstepcert.andThen hr_correct
+
+set_option maxHeartbeats 1000000 in
+theorem denseReencodeLoopDirect_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantics p) :
+    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
+      (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId),
+      d.CoveredBy reg → (∀ x, varSet.contains x = true → x ∈ d.occ) →
+      reg.Extends (denseReencodeLoopDirect b targets idx reg d arrCs varSet).1
+      ∧ (∀ i, (denseReencodeLoopDirect b targets idx reg d arrCs varSet).1.isInput i
+          = reg.isInput i)
+      ∧ (denseReencodeLoopDirect b targets idx reg d arrCs varSet).2.1.CoveredBy
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).1
+      ∧ DenseDerivations.CoveredBy
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).1
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).2.2
+      ∧ DensePassCorrect
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).1.isInput d
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).2.1
+          (denseReencodeLoopDirect b targets idx reg d arrCs varSet).2.2 bs := by
+  intro targets
+  induction targets with
+  | nil =>
+      intro idx reg d arrCs varSet hcov hvs
+      exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
+        (by intro x hx; exact (List.not_mem_nil hx).elim),
+        DensePassCorrect.refl reg.isInput d bs⟩
+  | cons xs rest ih =>
+      intro idx reg d arrCs varSet hcov hvs
+      simp only [denseReencodeLoopDirect]
+      rcases hstep : denseReencodeStepDirect b reg d arrCs varSet xs
+          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+          with ⟨reg1, d1, derivs1, arrCs1, varSet1⟩
+      have hsp := denseReencodeStepDirect_correct b reg d arrCs varSet xs
+        (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}") bs hcov hvs
+      simp only [hstep] at hsp
+      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
+      rcases hrec : denseReencodeLoopDirect b rest (idx + 1) reg1 d1 arrCs1 varSet1
+          with ⟨reg2, d2, derivs2⟩
+      have hih := ih (idx + 1) reg1 d1 arrCs1 varSet1 hs_cov hs_vs
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1358,11 +1463,19 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
   · rw [if_pos hpr]
     haveI : Fact p.Prime := ⟨pw.correct hpr⟩
     extract_lets csVs svSet targets useIdx
-    obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d
-      (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-      d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ) hcov
-      (fun x hx => by rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx)
-    exact ⟨he, hc, hd, hcorr⟩
+    by_cases hui : useIdx
+    · rw [if_pos hui]
+      obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b true bs targets 0 reg d
+        (denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints)
+        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ)
+        denseReencodeEmptyUsePlan hcov
+        (fun x hx => by rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx)
+      exact ⟨he, hc, hd, hcorr⟩
+    · rw [if_neg hui]
+      obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoopDirect_correct b bs targets 0 reg d
+        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ) hcov
+        (fun x hx => by rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx)
+      exact ⟨he, hc, hd, hcorr⟩
   · rw [if_neg hpr]
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -91,6 +91,110 @@ def denseGroupRewrite (xs bits : List VarId) (σfn : VarId → Option (DenseExpr
       if (DenseExpr.mul a b).varsInF xs then denseGroupRewriteCand bits σfn patts (.mul a b)
       else .mul (denseGroupRewrite xs bits σfn patts a) (denseGroupRewrite xs bits σfn patts b)
 
+/-! ## Bounded rewrite degree -/
+
+/-- The exact degree when it is at most `limit`, with early exit above the bound. -/
+def DenseExpr.degreeWithin (limit : Nat) : DenseExpr p → Option Nat
+  | .const _ => some 0
+  | .var _ => if 1 ≤ limit then some 1 else none
+  | .add a b =>
+      match a.degreeWithin limit with
+      | none => none
+      | some da =>
+          match b.degreeWithin limit with
+          | none => none
+          | some db => some (max da db)
+  | .mul a b =>
+      match a.degreeWithin limit with
+      | none => none
+      | some da =>
+          match b.degreeWithin limit with
+          | none => none
+          | some db => if da + db ≤ limit then some (da + db) else none
+
+theorem DenseExpr.degreeWithin_eq (limit : Nat) (e : DenseExpr p) :
+    e.degreeWithin limit = if e.degree ≤ limit then some e.degree else none := by
+  induction e with
+  | const => simp [DenseExpr.degreeWithin, DenseExpr.degree]
+  | var => simp [DenseExpr.degreeWithin, DenseExpr.degree]
+  | add a b iha ihb =>
+      simp only [DenseExpr.degreeWithin, DenseExpr.degree, iha, ihb]
+      by_cases ha : a.degree ≤ limit <;> by_cases hb : b.degree ≤ limit <;>
+        simp [ha, hb]
+  | mul a b iha ihb =>
+      simp only [DenseExpr.degreeWithin, DenseExpr.degree, iha, ihb]
+      by_cases ha : a.degree ≤ limit <;> by_cases hb : b.degree ≤ limit <;>
+        simp [ha, hb] <;> omega
+
+/-- Degree-only twin of `denseGroupRewrite`, without constructing mixed enclosing nodes. -/
+def denseGroupRewriteDegreeWithin (limit : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) :
+    DenseExpr p → Option Nat
+  | .const n => (DenseExpr.const n : DenseExpr p).degreeWithin limit
+  | .var y =>
+      if denseContainsFast xs y then
+        (denseGroupRewriteCand bits σfn patts (.var y)).degreeWithin limit
+      else (DenseExpr.var y : DenseExpr p).degreeWithin limit
+  | .add a b =>
+      if (DenseExpr.add a b).varsInF xs then
+        (denseGroupRewriteCand bits σfn patts (.add a b)).degreeWithin limit
+      else
+        match denseGroupRewriteDegreeWithin limit xs bits σfn patts a with
+        | none => none
+        | some da =>
+            match denseGroupRewriteDegreeWithin limit xs bits σfn patts b with
+            | none => none
+            | some db => some (max da db)
+  | .mul a b =>
+      if (DenseExpr.mul a b).varsInF xs then
+        (denseGroupRewriteCand bits σfn patts (.mul a b)).degreeWithin limit
+      else
+        match denseGroupRewriteDegreeWithin limit xs bits σfn patts a with
+        | none => none
+        | some da =>
+            match denseGroupRewriteDegreeWithin limit xs bits σfn patts b with
+            | none => none
+            | some db => if da + db ≤ limit then some (da + db) else none
+
+theorem denseGroupRewriteDegreeWithin_eq (limit : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
+    (e : DenseExpr p) :
+    denseGroupRewriteDegreeWithin limit xs bits σfn patts e =
+      (denseGroupRewrite xs bits σfn patts e).degreeWithin limit := by
+  induction e with
+  | const => rfl
+  | var y =>
+      simp only [denseGroupRewriteDegreeWithin, denseGroupRewrite]
+      split <;> rfl
+  | add a b iha ihb =>
+      simp only [denseGroupRewriteDegreeWithin, denseGroupRewrite]
+      split
+      · rfl
+      · simp only [DenseExpr.degreeWithin, iha, ihb]
+  | mul a b iha ihb =>
+      simp only [denseGroupRewriteDegreeWithin, denseGroupRewrite]
+      split
+      · rfl
+      · simp only [DenseExpr.degreeWithin, iha, ihb]
+
+/-- Whether rewriting `e` exceeds `limit`; the final system degree guard remains authoritative. -/
+def denseGroupRewriteDegreeOver (limit : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
+    (e : DenseExpr p) : Bool :=
+  decide (limit < (denseGroupRewrite xs bits σfn patts e).degree)
+
+def denseGroupRewriteDegreeOverFast (limit : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
+    (e : DenseExpr p) : Bool :=
+  (denseGroupRewriteDegreeWithin limit xs bits σfn patts e).isNone
+
+@[csimp] theorem denseGroupRewriteDegreeOver_eq_fast :
+    @denseGroupRewriteDegreeOver = @denseGroupRewriteDegreeOverFast := by
+  funext p limit xs bits σfn patts e
+  simp only [denseGroupRewriteDegreeOver, denseGroupRewriteDegreeOverFast,
+    denseGroupRewriteDegreeWithin_eq, DenseExpr.degreeWithin_eq]
+  split <;> simp_all
+
 /-! ## The re-encoded system -/
 
 /-- The re-encoded system: substitute the group everywhere, drop the now-covered constraints, and
@@ -202,6 +306,111 @@ def DenseExpr.sharesVarIn (xs : List VarId) : DenseExpr p → Bool
 
 /-! ## The build/step/loop/pass layer -/
 
+/-- One expression root relevant to the re-encoding degree pre-gate. -/
+structure DenseReencodeUse (p : ℕ) where
+  expr : DenseExpr p
+  vars : List VarId
+  identity : Bool
+
+structure DenseReencodeUseBuild (p : ℕ) where
+  roots : Array (DenseReencodeUse p)
+  buckets : Std.HashMap VarId (List Nat)
+
+/-- Per-invocation root postings and reusable candidate-union scratch. -/
+structure DenseReencodeUsePlan (p : ℕ) where
+  roots : Array (DenseReencodeUse p)
+  buckets : Std.HashMap VarId (Array Nat)
+  marks : Array Nat
+  generation : Nat
+  enabled : Bool
+  directRejects : Nat
+
+def denseReencodeEmptyUsePlan : DenseReencodeUsePlan p :=
+  ⟨#[], ∅, #[], 0, false, 0⟩
+
+def denseReencodeAddUse (st : DenseReencodeUseBuild p) (e : DenseExpr p)
+    (vs : List VarId) (identity : Bool) : DenseReencodeUseBuild p :=
+  let i := st.roots.size
+  { roots := st.roots.push ⟨e, vs, identity⟩
+    buckets := vs.foldl (fun m v => m.insert v (i :: m.getD v [])) st.buckets }
+
+def denseReencodeFreezeUseBuckets (buckets : Std.HashMap VarId (List Nat)) :
+    Std.HashMap VarId (Array Nat) :=
+  buckets.fold (fun out v positions => out.insert v positions.toArray) ∅
+
+/-- Build all algebraic and bus-expression root postings. Constraint variables reuse `csVs`. -/
+def denseBuildReencodeUsePlan (d : DenseConstraintSystem p) (csVs : List (List VarId)) :
+    DenseReencodeUsePlan p :=
+  let stCs := (d.algebraicConstraints.zip csVs).foldl (init := ⟨#[], ∅⟩)
+    fun st cv => denseReencodeAddUse st cv.1 cv.2 true
+  let st := d.busInteractions.foldl (init := stCs) fun st bi =>
+    let mvs := HashedDedup.hashedDedup (hash ·) bi.multiplicity.vars
+    let st := denseReencodeAddUse st bi.multiplicity mvs false
+    bi.payload.foldl (init := st) fun st e =>
+      denseReencodeAddUse st e (HashedDedup.hashedDedup (hash ·) e.vars) false
+  { roots := st.roots
+    buckets := denseReencodeFreezeUseBuckets st.buckets
+    marks := Array.replicate st.roots.size 0
+    generation := 0
+    enabled := true
+    directRejects := 0 }
+
+/-- Check one use-plan posting after deduplicating it with the generation-stamped scratch array. -/
+def denseDegPreRejectUse (b : DegreeBound) (roots : Array (DenseReencodeUse p))
+    (xs bits : List VarId) (σ : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (generation pos : Nat)
+    (marks : Array Nat) : Bool × Array Nat :=
+  if marks[pos]? == some generation then (false, marks)
+  else
+    let marks := marks.setIfInBounds pos generation
+    match roots[pos]? with
+    | none => (false, marks)
+    | some use =>
+        if use.vars.any (denseContainsFast xs) &&
+            !(use.identity && denseVarsInListF xs use.vars) then
+          let limit := if use.identity then b.identities else b.busInteractions
+          (denseGroupRewriteDegreeOver limit xs bits σ patts use.expr, marks)
+        else (false, marks)
+
+def denseDegPreRejectPostingGo (b : DegreeBound) (roots : Array (DenseReencodeUse p))
+    (xs bits : List VarId) (σ : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (generation : Nat)
+    (positions : Array Nat) (marks : Array Nat) (i : Nat) :
+    Nat → Bool × Array Nat
+  | 0 => (false, marks)
+  | fuel + 1 =>
+      match positions[i]? with
+      | none => (false, marks)
+      | some pos =>
+          let checked := denseDegPreRejectUse b roots xs bits σ patts generation pos marks
+          if checked.1 then checked
+          else denseDegPreRejectPostingGo b roots xs bits σ patts generation positions checked.2
+            (i + 1) fuel
+
+def denseDegPreRejectBuckets (b : DegreeBound) (roots : Array (DenseReencodeUse p))
+    (buckets : Std.HashMap VarId (Array Nat))
+    (xs bits : List VarId) (σ : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (generation : Nat) :
+    List VarId → Array Nat → Bool × Array Nat
+  | [], marks => (false, marks)
+  | x :: rest, marks =>
+      let positions := buckets.getD x #[]
+      let checked := denseDegPreRejectPostingGo b roots xs bits σ patts generation positions marks
+        0 positions.size
+      if checked.1 then checked
+      else denseDegPreRejectBuckets b roots buckets xs bits σ patts generation rest checked.2
+
+/-- Indexed degree pre-gate. Each root is rechecked from its stored exact variable list. -/
+def denseDegPreRejectIndexed (b : DegreeBound) (plan : DenseReencodeUsePlan p)
+    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) :
+    Bool × DenseReencodeUsePlan p :=
+  match plan with
+  | ⟨roots, buckets, marks, generation₀, enabled, directRejects⟩ =>
+      let generation := generation₀ + 1
+      let checked := denseDegPreRejectBuckets b roots buckets xs bits (denseGroupSubst xs hm)
+        (denseAssignments (denseBitBox bits)) generation xs marks
+      (checked.1, ⟨roots, buckets, checked.2, generation, enabled, directRejects⟩)
+
 /-- Build the inverted index (`VarId`-keyed twin of `CoveredIndex.buildPruned`), skipping items
     with more than `maxVars` distinct variables. -/
 def denseBuildPruned {α : Type} (varsOf : α → List VarId) (maxVars : Nat) (items : List α) :
@@ -272,22 +481,35 @@ def denseDegPreReject (b : DegreeBound) (d : DenseConstraintSystem p)
     gates in order, minting fresh bits and rewriting `d` only on full acceptance. -/
 def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId) (xs : List VarId)
-    (freshBase : String) :
+    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+    (usePlan : DenseReencodeUsePlan p) (xs : List VarId) (freshBase : String) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseCovIndex ×
-      Array (DenseExpr p) × Std.HashSet VarId :=
+      Array (DenseExpr p) × Std.HashSet VarId × DenseReencodeUsePlan p :=
   if xs.all (fun x => reg.isInput x) then
   if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
       | some i => varSet.contains i
       | none => false) then
     -- fresh-name collision: `denseCheckReencode` would reject after the full freshness scan anyway
-    (reg, d, [], csIdx, arrCs, varSet)
+    (reg, d, [], csIdx, arrCs, varSet, usePlan)
   else
   match denseBuildReencode reg useIdx csIdx arrCs xs freshBase with
-  | (reg1, none) => (reg1, d, [], csIdx, arrCs, varSet)
+  | (reg1, none) => (reg1, d, [], csIdx, arrCs, varSet, usePlan)
   | (reg1, some (bits, hm)) =>
+    let pre := if usePlan.enabled then denseDegPreRejectIndexed b usePlan xs bits hm
+      else (denseDegPreReject b d xs bits hm, usePlan)
     -- Degree pre-gate: reject early what the final `withinDegreeB` gate would reject anyway.
-    if denseDegPreReject b d xs bits hm then (reg1, d, [], csIdx, arrCs, varSet)
+    if pre.1 then
+      let nextPlan :=
+        if useIdx && !pre.2.enabled then
+          let rejects := pre.2.directRejects + 1
+          -- Accepted OpenVM rewrites are cheaper direct; amortize setup over repeated rejections.
+          if 64 ≤ rejects then
+            denseBuildReencodeUsePlan d
+              (d.algebraicConstraints.map
+                (fun c => HashedDedup.hashedDedup (hash ·) c.vars))
+          else { pre.2 with directRejects := rejects }
+        else pre.2
+      (reg1, d, [], csIdx, arrCs, varSet, nextPlan)
     else
     if xs.all (fun x => varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
@@ -296,30 +518,81 @@ def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
       let ro := denseReencodeOut d xs bits hm
       if ro.withinDegreeB b then
         -- `d` changed: rebuild the index and variable set for `ro`.
+        let roCsVs :=
+          ro.algebraicConstraints.map (fun c => HashedDedup.hashedDedup (hash ·) c.vars)
         (reg1, ro,
          bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
          (if useIdx then denseBuildPruned DenseExpr.vars 8 ro.algebraicConstraints else ⟨∅, []⟩),
          ro.algebraicConstraints.toArray,
-         Std.HashSet.ofList ro.occ)
-      else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-  else (reg, d, [], csIdx, arrCs, varSet)
+         Std.HashSet.ofList ro.occ,
+         (if pre.2.enabled then denseBuildReencodeUsePlan ro roCsVs
+          else denseReencodeEmptyUsePlan))
+      else (reg1, d, [], csIdx, arrCs, varSet, pre.2)
+    else (reg1, d, [], csIdx, arrCs, varSet, pre.2)
+    else (reg1, d, [], csIdx, arrCs, varSet, pre.2)
+    else (reg1, d, [], csIdx, arrCs, varSet, pre.2)
+    else (reg1, d, [], csIdx, arrCs, varSet, pre.2)
+  else (reg, d, [], csIdx, arrCs, varSet, usePlan)
 
 /-- Process the candidate groups sequentially, threading the registry, index, and variable set. -/
 def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p → DenseCovIndex →
-      Array (DenseExpr p) → Std.HashSet VarId →
+      Array (DenseExpr p) → Std.HashSet VarId → DenseReencodeUsePlan p →
       VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _, _, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, csIdx, arrCs, varSet =>
-    let (reg1, d1, derivs1, csIdx1, arrCs1, varSet1) :=
-      denseReencodeStep b useIdx reg d csIdx arrCs varSet xs
+  | [], _, reg, d, _, _, _, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, csIdx, arrCs, varSet, usePlan =>
+    let (reg1, d1, derivs1, csIdx1, arrCs1, varSet1, usePlan1) :=
+      denseReencodeStep b useIdx reg d csIdx arrCs varSet usePlan xs
         (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
     let (reg2, d2, derivs2) :=
-      denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
+      denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 usePlan1
+    (reg2, d2, derivs1 ++ derivs2)
+
+/-- The allocation-minimal direct step used below the covered-index threshold. -/
+def denseReencodeStepDirect (b : DegreeBound)
+    (reg : VarRegistry) (d : DenseConstraintSystem p) (arrCs : Array (DenseExpr p))
+    (varSet : Std.HashSet VarId) (xs : List VarId) (freshBase : String) :
+    VarRegistry × DenseConstraintSystem p × DenseDerivations p ×
+      Array (DenseExpr p) × Std.HashSet VarId :=
+  if xs.all (fun x => reg.isInput x) then
+  if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
+      | some i => varSet.contains i
+      | none => false) then
+    (reg, d, [], arrCs, varSet)
+  else
+  match denseBuildReencode reg false ⟨∅, []⟩ arrCs xs freshBase with
+  | (reg1, none) => (reg1, d, [], arrCs, varSet)
+  | (reg1, some (bits, hm)) =>
+    if denseDegPreReject b d xs bits hm then (reg1, d, [], arrCs, varSet)
+    else
+    if xs.all (fun x => varSet.contains x) then
+    if xs.all (fun x => decide (x ∉ bits)) then
+    if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
+    if denseCheckReencode d xs bits hm then
+      let ro := denseReencodeOut d xs bits hm
+      if ro.withinDegreeB b then
+        (reg1, ro,
+         bits.map (fun bb => (bb, denseBitCM (denseAssignments (denseBitBox bits)) xs hm bb)),
+         ro.algebraicConstraints.toArray,
+         Std.HashSet.ofList ro.occ)
+      else (reg1, d, [], arrCs, varSet)
+    else (reg1, d, [], arrCs, varSet)
+    else (reg1, d, [], arrCs, varSet)
+    else (reg1, d, [], arrCs, varSet)
+    else (reg1, d, [], arrCs, varSet)
+  else (reg, d, [], arrCs, varSet)
+
+def denseReencodeLoopDirect (b : DegreeBound) :
+    List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
+      Array (DenseExpr p) → Std.HashSet VarId →
+      VarRegistry × DenseConstraintSystem p × DenseDerivations p
+  | [], _, reg, d, _, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, arrCs, varSet =>
+    let (reg1, d1, derivs1, arrCs1, varSet1) :=
+      denseReencodeStepDirect b reg d arrCs varSet xs
+        (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+    let (reg2, d2, derivs2) :=
+      denseReencodeLoopDirect b rest (idx + 1) reg1 d1 arrCs1 varSet1
     (reg2, d2, derivs1 ++ derivs2)
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
@@ -345,10 +618,15 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         some (vs.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
       else none))
     let useIdx := 8192 ≤ d.algebraicConstraints.length
-    denseReencodeLoop b useIdx targets 0 reg d
-      (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-      d.algebraicConstraints.toArray
-      (Std.HashSet.ofList d.occ)
+    if useIdx then
+      denseReencodeLoop b true targets 0 reg d
+        (denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints)
+        d.algebraicConstraints.toArray
+        (Std.HashSet.ofList d.occ)
+        denseReencodeEmptyUsePlan
+    else
+      denseReencodeLoopDirect b targets 0 reg d d.algebraicConstraints.toArray
+        (Std.HashSet.ofList d.occ)
   else (reg, d, [])
 
 end ApcOptimizer.Dense

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -199,7 +199,12 @@ and candidate-mask scanner, and hot-variable bucket capping (not byte-identical 
 `esFull`).
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
-index gate**  ·  mostly **done (entries 105/107/109)**:
+index gate**  ·  mostly **done (entries 105/107/109/136)**:
+   - ~~reencode degree-rejection whole-system scans~~ **done (entry 136)**: after 64 direct
+     degree rejects on an indexed invocation, a compact expression-root posting plan replaces
+     `sharesVarIn` scans with generation-stamped posting unions. A proved bounded-degree runtime
+     twin avoids constructing mixed enclosing rewrite trees. The direct path remains separate so
+     accepted OpenVM rewrites do not pay the planning-state overhead.
    - reencode: the pruned index (`CoveredIndex.buildPruned`, entry 105 — items with more than 8
      distinct variables can never be covered by a ≤8-variable target, so pruning keeps covered
      sets identical) stays, but **behind the 8192 gate again** (entry 107): CI measured

--- a/docs/log.md
+++ b/docs/log.md
@@ -4698,3 +4698,33 @@ unused-theorem checks pass.
 
 **Worked locally: yes (representative Gauss runtime win with unchanged final sizes; full-set
 result pending CI).**
+
+### 136. Runtime: indexed, degree-only reencode rejection
+
+Large rejection-heavy reencode invocations now build a compact root-use plan after 64 direct degree
+rejects demonstrate that its setup can be amortized. Algebraic roots reuse the pass's existing
+deduplicated variable lists; bus multiplicities and payload expressions are indexed once. Each
+target unions its variable postings through a generation-stamped array, rechecks the stored exact
+root variables, and visits only relevant roots. A retained rewrite rebuilds the plan.
+
+The degree pre-gate uses a proved `@[csimp]` bounded traversal equal to the original
+`degree (denseGroupRewrite ...)` test. It constructs the same checked interpolation only at maximal
+wholly-in-group nodes, combines degrees without building mixed enclosing expression trees, and
+stops when a subtree already exceeds the bound. The final `withinDegreeB` check remains
+authoritative. Small systems use a separate direct step and loop with the original runtime shape;
+an initial shared-state version regressed accepted `openvm-eth/apc_044`, which motivated the split.
+
+Pinned serial profiles changed reencode from 3285 → 2967 ms on OpenVM keccak (−9.7%) and
+1233 → 1205 ms on `openvm-eth/apc_044` (−2.3%). Whole-profile time changed
+41,680 → 40,405 ms (−3.1%) and 5839 → 5769 ms (−1.2%), respectively, with unchanged cleanup
+iterations. Serialized outputs are byte-identical on the five `reencodeProposals.md`
+representatives, so variable, bus-interaction, and algebraic-constraint effectiveness are
+unchanged.
+
+`lake build` is warning-free, generated C has no `sharesVarIn` or full `denseGroupRewrite` call in
+the indexed pre-gate and mutates the generation array without `lean_copy_expand_array`, and the
+proof-integrity and unused-theorem checks pass. Full same-runner runtime evaluation is delegated to
+the draft PR's CI workflow.
+
+**Worked locally: yes (keccak reencode and whole-profile runtime win; direct accepted rewrites
+preserved; full-set result pending CI).**


### PR DESCRIPTION
## What changed

- add an adaptive per-invocation root-use plan for rejection-heavy `reencode` runs
- union variable postings with generation-stamped scratch instead of scanning every expression with `sharesVarIn`
- add a proved bounded-degree runtime twin that avoids constructing mixed enclosing rewrite trees
- retain a separate direct step/loop below the existing covered-index threshold so accepted OpenVM rewrites keep their original runtime shape

## Why

Large Keccak systems repeatedly reject re-encoding candidates on degree after discovering relevant expressions through whole-system scans and constructing temporary rewritten trees. The posting plan and degree-only traversal remove that repeated discovery and allocation work while leaving the final `withinDegreeB` check authoritative.

## Impact

Pinned serial profiles:

- OpenVM Keccak `reencode`: 3285 ms → 2967 ms (−9.7%)
- OpenVM Keccak total: 41,680 ms → 40,405 ms (−3.1%)
- `openvm-eth/apc_044` `reencode`: 1233 ms → 1205 ms (−2.3%)
- `openvm-eth/apc_044` total: 5839 ms → 5769 ms (−1.2%)

Cleanup iterations were unchanged. Serialized outputs are byte-identical on all five representatives from `reencodeProposals.md`, so variable, bus-interaction, and constraint effectiveness are unchanged.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- byte-for-byte `opt-export` comparison on wasm-eth/apc_036, OpenVM apc_067/apc_044/apc_049, and OpenVM Keccak apc_001
- generated-C inspection: indexed pre-gate has no `sharesVarIn`, full `denseGroupRewrite`, or `lean_copy_expand_array` call