### PR TITLE
perf(redundantByteDrop): indexed byte-justification (~37x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
@@ -211,14 +211,6 @@ def denseByteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
     denseAffineJustified bound (fun x => denseFindVarBound bs facts (wits x) x) e ||
     denseBasisJustified bound (fun x => denseFindVarBound bs facts (wits x) x) facts fwits e
 
-/-- The plain full-scan form (used by the coda's `RedundantByteDrop`): naive per-query filters, with
-    the basis arm disabled (`fwits = []`). -/
-def denseByteJustified (bound : Nat) (deep : Bool) (all : List (DenseExpr p))
-    (bs : BusSemantics p) (facts : BusFacts p bs)
-    (rest : List (BusInteraction (DenseExpr p))) (e : DenseExpr p) : Bool :=
-  denseByteJustifiedW bound deep (all.filter DenseExpr.isSingleVar)
-    (fun x => all.filter (DenseExpr.mentions x)) bs facts (fun _ => rest) (fun _ => []) e
-
 /-- Are all of `R`'s payload entries at the declared byte slots justified (through the witness
     lookup `wits` and precomputed `domCs`/`candsOf`, see `denseByteJustifiedW`)? -/
 def denseRecvSlotsJustified (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
@@ -533,22 +533,6 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List 
         fwits e denv (fun v b hb => denseFindVarBound_sound bs facts (wits v) v b hb denv (hbusW v))
         (fun v bi hbi => hbus bi (hfwits v bi hbi)) h
 
-/-- The plain full-scan form: `denseByteJustifiedW_sound` at the naive per-query filters. -/
-theorem denseByteJustified_sound (bound : Nat) (deep : Bool) (all : List (DenseExpr p))
-    (bs : BusSemantics p)
-    (facts : BusFacts p bs) (rest : List (BusInteraction (DenseExpr p))) (e : DenseExpr p)
-    (hdeep : deep = true → p.Prime)
-    (h : denseByteJustified bound deep all bs facts rest e = true) (denv : VarId → ZMod p)
-    (hall : ∀ c' ∈ all, c'.eval denv = 0)
-    (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
-    (e.eval denv).val < bound :=
-  denseByteJustifiedW_sound bound deep all (all.filter DenseExpr.isSingleVar)
-    (fun x => all.filter (DenseExpr.mentions x)) bs facts rest (fun _ => rest)
-    (fun _ => []) e hdeep
-    (fun _ hc => List.mem_of_mem_filter hc) (fun _ _ hc => List.mem_of_mem_filter hc)
-    (fun _ _ hbi => hbi) (fun _ _ hbi => absurd hbi (by simp)) h denv hall hbus
-
 /-- If every declared byte slot of `R` is justified, then at every such slot the evaluated payload
     entry of `R` (under any `denv` zeroing `all` and never violating the remaining witnessed
     interactions) is a byte/limb (`< bound`) — `denseDropPair_correct`'s `hbyte` obligation. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
@@ -11,11 +11,52 @@ set_option autoImplicit false
 (`RedundantByteDrop.lean`). Every dropped interaction is a recognised byte check whose operands are
 all byte-justified from the non-circular base (`denseByteDropBase`), hence accepted under every
 assignment satisfying the filtered system. Built via `denseFilterBusEntailed`
-(`Proofs/FlagFoldDrops.lean`) and `denseByteJustified_sound` (`Proofs/BusPairCancelJustify.lean`). -/
+(`Proofs/FlagFoldDrops.lean`) and `denseByteJustifiedW_sound` (`Proofs/BusPairCancelJustify.lean`),
+fed the per-variable bucket indexes built once per invocation. -/
 
 namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
+
+/-! ## Soundness of the per-variable bucket index: every looked-up item was indexed -/
+
+/-- Inserting `a` (already in `S`) under any variable list preserves "every bucket value is in
+    `S`". -/
+theorem denseVarBucketAdd_mem {α : Type} {S : List α} (a : α) (ha : a ∈ S) :
+    ∀ (vs : List VarId) (m : Std.HashMap VarId (List α)),
+      (∀ x, ∀ b ∈ m.getD x [], b ∈ S) →
+      ∀ x, ∀ b ∈ (denseVarBucketAdd m vs a).getD x [], b ∈ S := by
+  intro vs
+  induction vs with
+  | nil => intro m hm; simpa [denseVarBucketAdd] using hm
+  | cons y rest ih =>
+    intro m hm
+    have hstep : ∀ x, ∀ b ∈ (m.insert y (a :: m.getD y [])).getD x [], b ∈ S := by
+      intro x b hb
+      by_cases hxy : y = x
+      · subst hxy
+        rw [Std.HashMap.getD_insert_self] at hb
+        rcases List.mem_cons.1 hb with h | h
+        · exact h ▸ ha
+        · exact hm y b h
+      · rw [Std.HashMap.getD_insert, if_neg (by simpa using hxy)] at hb
+        exact hm x b hb
+    have := ih (m.insert y (a :: m.getD y [])) hstep
+    simpa [denseVarBucketAdd, List.foldl_cons] using this
+
+/-- Every item returned by a bucket lookup was one of the indexed items. -/
+theorem denseVarBucket_mem {α : Type} (varsOf : α → List VarId) (items : List α) :
+    ∀ x, ∀ a ∈ denseVarBucketLookup (denseVarBucket varsOf items) x, a ∈ items := by
+  unfold denseVarBucketLookup denseVarBucket
+  induction items with
+  | nil =>
+    intro x a ha; simp only [List.foldr_nil, Std.HashMap.getD_empty, List.not_mem_nil] at ha
+  | cons c rest ih =>
+    intro x a ha
+    rw [List.foldr_cons] at ha
+    exact denseVarBucketAdd_mem c (List.mem_cons_self ..) ((varsOf c).eraseDups)
+      (List.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅ rest)
+      (fun x' b hb => List.mem_cons_of_mem _ (ih x' b hb)) x a ha
 
 /-- A recognized byte check lives on a stateless bus. -/
 theorem denseByteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -51,35 +92,58 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
     DensePassCorrect isInput d (denseRedundantByteDropF pw bs facts d) [] bs := by
   unfold denseRedundantByteDropF
   refine DensePassCorrect.denseFilterBusEntailed d bs isInput
-    (denseByteDropKeep pw bs facts d.algebraicConstraints (denseByteDropBase bs facts d)) ?_ ?_
+    (denseByteDropKeepW pw bs facts (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+      (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
+      (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))) ?_ ?_
   · intro bi _ hkf
-    unfold denseByteDropKeep at hkf
+    unfold denseByteDropKeepW at hkf
     cases hro : denseByteCheckOperands? bs facts bi with
     | none => rw [hro] at hkf; exact absurd hkf (by simp)
     | some ops => exact denseByteCheckOperands?_stateless bs facts bi ops hro
   · intro bi _ hkf denv hsat _
-    unfold denseByteDropKeep at hkf
+    unfold denseByteDropKeepW at hkf
     cases hro : denseByteCheckOperands? bs facts bi with
     | none => rw [hro] at hkf; exact absurd hkf (by simp)
     | some ops =>
       rw [hro] at hkf
-      have hjust : ops.all (fun e => denseByteJustified 256 pw.isPrime
-          d.algebraicConstraints bs facts (denseByteDropBase bs facts d) e) = true := by
+      have hjust : ops.all (fun e => denseByteJustifiedW 256 pw.isPrime
+          (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+          (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
+          bs facts
+          (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
+          (fun _ => []) e) = true := by
         simpa using hkf
-      refine denseByteCheckOperands?_accepted bs facts bi ops hro denv (fun e he => ?_)
-      refine denseByteJustified_sound 256 pw.isPrime d.algebraicConstraints bs facts
-        (denseByteDropBase bs facts d) e (fun h => pw.correct h)
-        (List.all_eq_true.mp hjust e he) denv
-        (fun c hc => hsat.1 c hc) (fun bi' hbi' hmult => ?_)
       -- every justification-base interaction survives the filter, so `hsat` accepts it
-      have hnone : denseByteCheckOperands? bs facts bi' = none := by
-        have := (List.mem_filter.1 hbi').2
-        simpa using this
-      have hkeep : denseByteDropKeep pw bs facts d.algebraicConstraints
-          (denseByteDropBase bs facts d) bi' = true := by
-        unfold denseByteDropKeep
-        rw [hnone]
-      exact hsat.2 bi' (List.mem_filter.2 ⟨(List.mem_filter.1 hbi').1, hkeep⟩) hmult
+      have hbusbase : ∀ bi' ∈ denseByteDropBase bs facts d,
+          (denseBIEval bi' denv).multiplicity ≠ 0 →
+          bs.violatesConstraint (denseBIEval bi' denv) = false := by
+        intro bi' hbi' hmult
+        have hnone : denseByteCheckOperands? bs facts bi' = none := by
+          have h := (List.mem_filter.1 hbi').2
+          rw [Option.isNone_iff_eq_none] at h
+          simpa using h
+        have hkeep : denseByteDropKeepW pw bs facts
+            (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+            (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
+            (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
+            bi' = true := by
+          unfold denseByteDropKeepW; rw [hnone]
+        exact hsat.2 bi' (List.mem_filter.2 ⟨(List.mem_filter.1 hbi').1, hkeep⟩) hmult
+      refine denseByteCheckOperands?_accepted bs facts bi ops hro denv (fun e he => ?_)
+      exact denseByteJustifiedW_sound 256 pw.isPrime d.algebraicConstraints
+        (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+        (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
+        bs facts (denseByteDropBase bs facts d)
+        (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
+        (fun _ => []) e
+        (fun h => pw.correct h)
+        (fun c hc => List.mem_of_mem_filter hc)
+        (fun x c hc => denseVarBucket_mem DenseExpr.vars d.algebraicConstraints x c hc)
+        (fun v bi'' hbi'' =>
+          denseVarBucket_mem denseBIVars (denseByteDropBase bs facts d) v bi'' hbi'')
+        (fun _ bi'' hbi'' => absurd hbi'' (by simp))
+        (List.all_eq_true.mp hjust e he) denv
+        (fun c hc => hsat.1 c hc) hbusbase
 
 /-- The dense redundant byte-check drop pass; transform `denseRedundantByteDropF`
     (`RedundantByteDrop.lean`). -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -14,6 +14,29 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+/-! ## A generic uncapped per-variable bucket index
+
+`denseByteJustifiedW` needs, per operand variable, the constraints mentioning it (`candsOf`) and the
+base interactions bounding it (`wits`). Computing those by filtering the whole system on every
+operand query is O(system) per query. We instead build, once per pass, a per-variable index mapping
+each variable to the items mentioning it, and feed those lookups to `denseByteJustifiedW`. Uncapped
+and order-preserving so a lookup returns exactly the same list a `filter (mentions x)` would. -/
+
+/-- Record `a` under each variable in `vs` (prepending, so a right-to-left build keeps source
+    order). -/
+def denseVarBucketAdd {α : Type} (m : Std.HashMap VarId (List α)) (vs : List VarId) (a : α) :
+    Std.HashMap VarId (List α) :=
+  vs.foldl (fun m x => m.insert x (a :: m.getD x [])) m
+
+/-- Index each item under every variable it mentions (via `varsOf`), keeping source order. -/
+def denseVarBucket {α : Type} (varsOf : α → List VarId) (items : List α) :
+    Std.HashMap VarId (List α) :=
+  items.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅
+
+/-- Look up the items indexed under `x`. -/
+def denseVarBucketLookup {α : Type} (I : Std.HashMap VarId (List α)) (x : VarId) : List α :=
+  I.getD x []
+
 /-- The operands whose byte-ness *implies* this interaction's acceptance (at any multiplicity):
     the checked operands of any fold-recognized shape, packed pair included (`denseByteShape?`);
     `none` otherwise. -/
@@ -27,20 +50,31 @@ def denseByteDropBase (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseCo
     List (BusInteraction (DenseExpr p)) :=
   d.busInteractions.filter (fun bi => (denseByteCheckOperands? bs facts bi).isNone)
 
-/-- Keep `bi` unless it is a recognized byte check whose operands are all byte-justified from the
-    constraints and the justification base. -/
-def denseByteDropKeep (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (all : List (DenseExpr p)) (rest : List (BusInteraction (DenseExpr p)))
+/-- Keep `bi` unless it is a recognized byte check whose operands are all byte-justified through the
+    prebuilt per-variable indexes `domCs`/`candsOf` (constraints) and `wits` (base interactions).
+    Consumes `denseByteJustifiedW`, so the O(system) per-operand scans in `denseByteJustified` become
+    per-variable bucket lookups. -/
+def denseByteDropKeepW (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (DenseExpr p)) (candsOf : VarId → List (DenseExpr p))
+    (wits : VarId → List (BusInteraction (DenseExpr p)))
     (bi : BusInteraction (DenseExpr p)) : Bool :=
   match denseByteCheckOperands? bs facts bi with
-  | some ops => !(ops.all (fun e => denseByteJustified 256 pw.isPrime all bs facts rest e))
+  | some ops =>
+    !(ops.all (fun e =>
+      denseByteJustifiedW 256 pw.isPrime domCs candsOf bs facts wits (fun _ => []) e))
   | none => true
 
 /-- Drops a byte-check interaction when all its operands are already proven to be bytes elsewhere —
     from the constraints and the un-droppable base interactions — so the check is redundant
-    (`denseRedundantByteDropPass`). -/
+    (`denseRedundantByteDropPass`). The domain/candidate/witness structures are built once per
+    invocation (per-variable bucket indexes) and shared across every operand query. -/
 def denseRedundantByteDropF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
-  d.filterBus (denseByteDropKeep pw bs facts d.algebraicConstraints (denseByteDropBase bs facts d))
+  let base := denseByteDropBase bs facts d
+  let domCs := d.algebraicConstraints.filter DenseExpr.isSingleVar
+  let candsIdx := denseVarBucket DenseExpr.vars d.algebraicConstraints
+  let witsIdx := denseVarBucket denseBIVars base
+  d.filterBus (denseByteDropKeepW pw bs facts domCs
+    (denseVarBucketLookup candsIdx) (denseVarBucketLookup witsIdx))
 
 end ApcOptimizer.Dense


### PR DESCRIPTION
## What

Removes the O(system)-per-operand full scan in the coda's `redundantByteDrop`, the #2 remaining hot pass on large APCs.

## Root cause

`denseRedundantByteDropF` filters bus interactions, dropping a recognized byte check when every operand is byte-justified. It justified each operand with the **full-scan** `denseByteJustified`, which on *every* operand query:
- recomputed `all.filter (·.mentions x)` (the candidate constraints), and `all.filter isSingleVar`, and
- scanned the **entire** base-interaction list for a range bound (`denseFindVarBound`).

So the pass was O(#byte-checks × (constraints + base)). On the coda's large systems — e.g. the 170k-variable SHA-256 APC with ~12k bus interactions — this was ~71s.

## Change

There is already an **indexed** justification, `denseByteJustifiedW`, taking prebuilt per-variable structures (busPairCancel uses it). `redundantByteDrop` just used the naive form. Now it builds them once per invocation:
- `domCs` (single-var constraints) once, not per query;
- `candsOf` / `wits` served from a small generic **uncapped, order-preserving** per-variable bucket index (`denseVarBucket`), so a lookup returns exactly the list `filter (mentions x)` would.

`denseByteJustifiedW_sound` only needs the indexes to be **subsets** of the scanned lists for soundness; the new `denseVarBucket_mem` lemma discharges that. The now-dead full-scan `denseByteJustified` / `denseByteJustified_sound` are deleted.

## Results

- `ecrecover_53k`: `redundantByteDrop` **20.7s → 0.55s (~37×)**; total 204s → 173s.
- On the 170k SHA-256 APC the pass was ~71s (6.6% of total).
- **Effectiveness unchanged** — byte-identical `run` output across the first 20 `Benchmarks/OpenVM/openvm-eth` fixtures.
- `Scripts/check-proof-integrity.sh` passes (correctness theorems still rest only on the three standard axioms; no `sorry`/`axiom`; no unused theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)