### PR TITLE
perf(oneHotAnnihilate): index product constraints (O(constraints²) → O(constraints))

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/OneHotAnnihilate.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/OneHotAnnihilate.lean
@@ -28,20 +28,29 @@ def denseReadCloser (c : DenseExpr p) : Option (VarId × DenseLinExpr p) :=
   | .mul a (.var i) => (denseAffineCloser a).map (fun la => (i, la))
   | _ => none
 
-/-- Does the system contain a product constraint `v * x` (in either operand order)? -/
-def denseHasProd (d : DenseConstraintSystem p) (v x : VarId) : Bool :=
-  d.algebraicConstraints.any
-    (fun c => c == .mul (.var v) (.var x) || c == .mul (.var x) (.var v))
+/-- The set of variable pairs `(a, b)` such that `a * b` is a present constraint. Built once so the
+    product test is a hash lookup, not a per-query scan of every constraint. -/
+def denseProdSet (cs : List (DenseExpr p)) : Std.HashSet (VarId × VarId) :=
+  cs.foldl (fun s c =>
+    match c with
+    | .mul (.var a) (.var b) => s.insert (a, b)
+    | _ => s) ∅
+
+/-- Does the system contain a product constraint `v * x` (in either operand order)? Reads the
+    precomputed `denseProdSet`. -/
+def denseHasProdS (s : Std.HashSet (VarId × VarId)) (v x : VarId) : Bool :=
+  s.contains (v, x) || s.contains (x, v)
 
 /-- If `c` is a closer applied to `x` and every one-hot term of the closer has a recorded product
-    with `x`, `x` is dead (one-hot-annihilated). -/
-def denseDeadFromCloser (d : DenseConstraintSystem p) (c : DenseExpr p) : Option VarId :=
+    with `x` (via the precomputed product set `s`), `x` is dead (one-hot-annihilated). -/
+def denseDeadFromCloser (s : Std.HashSet (VarId × VarId)) (c : DenseExpr p) : Option VarId :=
   match denseReadCloser c with
-  | some (x, la) => if la.terms.all (fun t => denseHasProd d t.1 x) then some x else none
+  | some (x, la) => if la.terms.all (fun t => denseHasProdS s t.1 x) then some x else none
   | none => none
 
 /-- All one-hot dead variables in the system. -/
 def denseDeadVars (d : DenseConstraintSystem p) : List VarId :=
-  d.algebraicConstraints.filterMap (denseDeadFromCloser d)
+  let s := denseProdSet d.algebraicConstraints
+  d.algebraicConstraints.filterMap (denseDeadFromCloser s)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/OneHotAnnihilate.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/OneHotAnnihilate.lean
@@ -12,6 +12,50 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+/-! ## Soundness of the product-pair set: an indexed pair was a present product constraint -/
+
+private theorem denseProdSet_foldl_mem (cs : List (DenseExpr p)) :
+    ∀ (s0 : Std.HashSet (VarId × VarId)) (a b : VarId),
+      (a, b) ∈ cs.foldl (fun s c =>
+        match c with | .mul (.var a') (.var b') => s.insert (a', b') | _ => s) s0 →
+      (a, b) ∈ s0 ∨ (DenseExpr.mul (.var a) (.var b) : DenseExpr p) ∈ cs := by
+  induction cs with
+  | nil => intro s0 a b h; exact Or.inl (by simpa using h)
+  | cons c rest ih =>
+    intro s0 a b h
+    rw [List.foldl_cons] at h
+    have hstep : (a, b) ∈ (match c with
+        | .mul (.var a') (.var b') => s0.insert (a', b') | _ => s0) ∨
+        (DenseExpr.mul (.var a) (.var b) : DenseExpr p) ∈ c :: rest := by
+      rcases ih _ a b h with h' | h'
+      · exact Or.inl h'
+      · exact Or.inr (List.mem_cons_of_mem _ h')
+    rcases hstep with h' | h'
+    · match c with
+      | .const _ => exact Or.inl (by simpa using h')
+      | .var _ => exact Or.inl (by simpa using h')
+      | .add _ _ => exact Or.inl (by simpa using h')
+      | .mul (.const _) _ => exact Or.inl (by simpa using h')
+      | .mul (.add _ _) _ => exact Or.inl (by simpa using h')
+      | .mul (.mul _ _) _ => exact Or.inl (by simpa using h')
+      | .mul (.var a') (.const _) => exact Or.inl (by simpa using h')
+      | .mul (.var a') (.add _ _) => exact Or.inl (by simpa using h')
+      | .mul (.var a') (.mul _ _) => exact Or.inl (by simpa using h')
+      | .mul (.var a') (.var b') =>
+        simp only [Std.HashSet.mem_insert, beq_iff_eq, Prod.mk.injEq] at h'
+        rcases h' with ⟨rfl, rfl⟩ | hin
+        · exact Or.inr (List.mem_cons_self ..)
+        · exact Or.inl hin
+    · exact Or.inr h'
+
+/-- Every pair the product set records is a present `a * b` constraint. -/
+theorem denseProdSet_mem {cs : List (DenseExpr p)} {a b : VarId}
+    (h : (a, b) ∈ denseProdSet cs) :
+    (DenseExpr.mul (.var a) (.var b) : DenseExpr p) ∈ cs := by
+  rcases denseProdSet_foldl_mem cs ∅ a b h with h' | h'
+  · simp at h'
+  · exact h'
+
 /-- The affine-closer recogniser's guarantee: the cofactor is `Σ mᵢ − 1` (`k = 1`) or `1 − Σ mᵢ`
     (`k = −1`); in both, `const = −k` and every coefficient is `k`. -/
 theorem denseAffineCloser_spec (a : DenseExpr p) (la : DenseLinExpr p)
@@ -111,18 +155,20 @@ theorem denseDeadVars_entailed (d : DenseConstraintSystem p) (bs : BusSemantics 
         linear_combination hcq0
     have hveval : ∀ t ∈ la.terms, denv t.1 * denv x' = 0 := by
       intro t ht
-      have hp : denseHasProd d t.1 x' = true := (List.all_eq_true.1 hgate) t ht
-      unfold denseHasProd at hp
-      obtain ⟨cv, hcv_mem, hcv⟩ := List.any_eq_true.1 hp
-      have hcv0 : cv.eval denv = 0 := hconstr cv hcv_mem
-      simp only [Bool.or_eq_true] at hcv
-      rcases hcv with he | he
-      · obtain rfl := eq_of_beq he
-        simpa only [DenseExpr.eval] using hcv0
-      · obtain rfl := eq_of_beq he
-        simp only [DenseExpr.eval] at hcv0
-        rw [mul_comm] at hcv0
-        exact hcv0
+      have hp : denseHasProdS (denseProdSet d.algebraicConstraints) t.1 x' = true :=
+        (List.all_eq_true.1 hgate) t ht
+      unfold denseHasProdS at hp
+      rw [Bool.or_eq_true] at hp
+      have hcv0 : (DenseExpr.mul (.var t.1) (.var x') : DenseExpr p).eval denv = 0 ∨
+          (DenseExpr.mul (.var x') (.var t.1) : DenseExpr p).eval denv = 0 := by
+        rcases hp with h1 | h1
+        · exact Or.inl (hconstr _ (denseProdSet_mem (Std.HashSet.mem_iff_contains.mpr h1)))
+        · exact Or.inr (hconstr _ (denseProdSet_mem (Std.HashSet.mem_iff_contains.mpr h1)))
+      rcases hcv0 with he | he
+      · simpa only [DenseExpr.eval] using he
+      · simp only [DenseExpr.eval] at he
+        rw [mul_comm] at he
+        exact he
     exact denseAnnihilate hveval hqeval
 
 /-- Every variable of an added `x = 0` occurs in `d`: the closer `.mul A (.var x)` is a present


### PR DESCRIPTION
## What

Removes the O(constraints²) product scan in `oneHotAnnihilate`.

## Root cause

`denseDeadVars` recognizes one-hot closers `(x₁ + … + xₙ − 1)·x = 0` and marks `x` dead when every marker product `xᵢ·x = 0` is present. Presence was tested by `denseHasProd`, which scanned the **entire constraint list** for each `(marker, x)` pair — O(#closers × #markers × #constraints) ≈ O(constraints²) on systems dense in one-hot closers (keccak/SHA). It was ~50s on the 170k-variable SHA-256 APC.

## Change

Build the set of present variable products once — `denseProdSet : HashSet (VarId × VarId)` — and make the product test a hash lookup (`denseHasProdS`).

`denseHasProd` only ever matched a constraint **structurally equal** to `mul (var v) (var x)`, which is exactly what `denseProdSet` records, so the result is unchanged. The new `denseProdSet_mem` lemma recovers the witnessing product constraint the soundness proof (`denseDeadVars_entailed`) needs.

## Results

- `ecrecover_53k`: `oneHotAnnihilate` **2.24s → 0.19s (~11×)**.
- ~50s on the 170k SHA-256 APC (4.6% of total).
- **Effectiveness identical** — byte-identical `run` output across the first 20 `Benchmarks/OpenVM/openvm-eth` fixtures.
- `Scripts/check-proof-integrity.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)