### PR TITLE
perf(reencode): cache finite-domain factor plans

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1159,6 +1159,29 @@ theorem denseBuildReencode_props (reg : VarRegistry) (useIdx : Bool) (csIdx : De
          obtain ⟨rfl, -⟩ := heq
          exact denseRegisterBits_valid_of_eq (by assumption) b hb)
 
+theorem denseBuildReencodeCached_props (reg : VarRegistry) (useIdx : Bool)
+    (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p))
+    (cache : DenseReencodeRootCache p) (xs : List VarId) (freshBase : String) :
+    reg.Extends (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1
+    ∧ (∀ i, (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1.isInput i
+        = reg.isInput i)
+    ∧ (∀ bits hm,
+        (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).2.1
+          = some (bits, hm) →
+        ∀ b ∈ bits,
+          (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1.Valid b) := by
+  fun_cases denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase <;>
+    first
+      | exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl,
+          by intro bits hm h; simp at h⟩
+      | (refine ⟨denseRegisterBits_extends_of_eq (by assumption),
+                fun i => denseRegisterBits_isInput_of_eq (by assumption) i, ?_⟩
+         intro bits hm heq b hb
+         dsimp only at heq
+         rw [Option.some.injEq, Prod.mk.injEq] at heq
+         obtain ⟨rfl, -⟩ := heq
+         exact denseRegisterBits_valid_of_eq (by assumption) b hb)
+
 
 theorem coveredBy_of_occ {r : VarRegistry} {d : DenseConstraintSystem p}
     (h : ∀ i ∈ d.occ, r.Valid i) : d.CoveredBy r := by
@@ -1244,6 +1267,40 @@ theorem denseBuildReencode_bits_valid_of_eq {reg reg1 : VarRegistry} {useIdx : B
   have := (denseBuildReencode_props reg useIdx csIdx arrCs xs freshBase).2.2 bits hm (by rw [h])
   rw [h] at this; exact this
 
+theorem denseBuildReencodeCached_ext_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
+    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
+    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
+    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+      (reg1, o, cache1)) : reg.Extends reg1 := by
+  have := (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).1
+  rw [h] at this
+  exact this
+
+theorem denseBuildReencodeCached_isInput_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
+    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
+    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
+    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+      (reg1, o, cache1)) (i : VarId) :
+    reg1.isInput i = reg.isInput i := by
+  have :=
+    (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).2.1 i
+  rw [h] at this
+  exact this
+
+theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
+    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
+    {bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
+    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+      (reg1, some (bits, hm), cache1)) :
+    ∀ bb ∈ bits, reg1.Valid bb := by
+  have := (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).2.2
+    bits hm (by rw [h])
+  rw [h] at this
+  exact this
+
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
@@ -1292,6 +1349,67 @@ theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Boo
     | exact stepIdentityPost reg reg d varSet bs (VarRegistry.Extends.refl reg) (fun _ => rfl) hcov hvs
     | exact stepIdentityPost reg _ d varSet bs (denseBuildReencode_ext_of_eq (by assumption))
         (fun i => denseBuildReencode_isInput_of_eq (by assumption) i) hcov hvs
+
+set_option maxHeartbeats 1000000 in
+theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
+    (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
+    (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
+    (hcov : d.CoveredBy reg) (hvs : ∀ x, state.varSet.contains x = true → x ∈ d.occ) :
+    reg.Extends (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput i
+        = reg.isInput i)
+    ∧ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.CoveredBy
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+    ∧ DenseDerivations.CoveredBy
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1
+    ∧ (∀ x,
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.2.varSet.contains x
+          = true →
+        x ∈ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.occ)
+    ∧ DensePassCorrect
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput d
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStepCached b useIdx reg d state xs freshBase
+  case case4 =>
+    rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
+    have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
+    have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
+      denseBuildReencodeCached_isInput_of_eq hbeq i
+    have hbval : ∀ bb ∈ bits, reg1.Valid bb :=
+      denseBuildReencodeCached_bits_valid_of_eq hbeq
+    have hpolyVars := denseCheckReencode_polyVars d xs bits hm hD
+    have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
+      rw [hbii x]
+      exact List.all_eq_true.mp hgate x hx
+    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := fun x hx =>
+      hvs x (List.all_eq_true.mp hA x hx)
+    have hxsB : ∀ x ∈ xs, x ∉ bits := fun x hx =>
+      of_decide_eq_true (List.all_eq_true.mp hB x hx)
+    have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
+      have hpd : (reg1.resolve bb).powdrId? = none :=
+        of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
+      show (reg1.resolve bb).powdrId?.isSome = false
+      rw [hpd]
+      rfl
+    have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
+      hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
+    refine ⟨hbext, hbii, ?_, ?_, ?_, ?_⟩
+    · exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov)
+        hbval hpolyVars
+    · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
+    · intro x hx
+      rw [Std.HashSet.contains_ofList] at hx
+      exact List.contains_iff_mem.mp hx
+    · exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB
+        hbnInput hD
+  all_goals first
+    | exact stepIdentityPost reg reg d state.varSet bs (VarRegistry.Extends.refl reg)
+        (fun _ => rfl) hcov hvs
+    | exact stepIdentityPost reg _ d state.varSet bs
+        (denseBuildReencodeCached_ext_of_eq (by assumption))
+        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov hvs
 
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
@@ -1344,6 +1462,57 @@ theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Boo
         exact hstepcert.andThen hr_correct
 
 set_option maxHeartbeats 1000000 in
+theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
+    (bs : BusSemantics p) :
+    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
+      (state : DenseReencodeCacheState p),
+      d.CoveredBy reg → (∀ x, state.varSet.contains x = true → x ∈ d.occ) →
+      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state).1
+      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state).1.isInput i
+          = reg.isInput i)
+      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state).2.1.CoveredBy
+          (denseReencodeLoopCached b useIdx targets idx reg d state).1
+      ∧ DenseDerivations.CoveredBy
+          (denseReencodeLoopCached b useIdx targets idx reg d state).1
+          (denseReencodeLoopCached b useIdx targets idx reg d state).2.2
+      ∧ DensePassCorrect
+          (denseReencodeLoopCached b useIdx targets idx reg d state).1.isInput d
+          (denseReencodeLoopCached b useIdx targets idx reg d state).2.1
+          (denseReencodeLoopCached b useIdx targets idx reg d state).2.2 bs := by
+  intro targets
+  induction targets with
+  | nil =>
+      intro idx reg d state hcov hvs
+      show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
+        ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
+        ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
+      exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
+        (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput d bs⟩
+  | cons xs rest ih =>
+      intro idx reg d state hcov hvs
+      simp only [denseReencodeLoopCached]
+      rcases hstep : denseReencodeStepCached b useIdx reg d state xs
+          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+          with ⟨reg1, d1, derivs1, state1⟩
+      have hsp := denseReencodeStepCached_correct b useIdx reg d state xs
+          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}") bs hcov hvs
+      simp only [hstep] at hsp
+      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
+      rcases hrec : denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
+          with ⟨reg2, d2, derivs2⟩
+      have hih := ih (idx + 1) reg1 d1 state1 hs_cov hs_vs
+      simp only [hrec] at hih
+      obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
+      refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
+      · exact DenseDerivations.coveredBy_append
+          (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
+      · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
+        have hstepcert : DensePassCorrect reg2.isInput d d1 derivs1 bs := by
+          rw [hfe]
+          exact hs_correct
+        exact hstepcert.andThen hr_correct
+
+set_option maxHeartbeats 1000000 in
 theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
     (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
     (hcov : d.CoveredBy reg) :
@@ -1357,12 +1526,25 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
   by_cases hpr : pw.isPrime = true
   · rw [if_pos hpr]
     haveI : Fact p.Prime := ⟨pw.correct hpr⟩
-    extract_lets csVs svSet targets useIdx
-    obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d
-      (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-      d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ) hcov
-      (fun x hx => by rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx)
-    exact ⟨he, hc, hd, hcorr⟩
+    extract_lets csVs svSet targets targetSlots targetVars useRootCache useIdx
+    by_cases hcache : useIdx ∧ useRootCache
+    · rw [if_pos hcache]
+      obtain ⟨he, _, hc, hd, hcorr⟩ :=
+        denseReencodeLoopCached_correct b useIdx bs targets 0 reg d
+          ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
+           d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩ hcov
+          (fun x hx => by
+            rw [Std.HashSet.contains_ofList] at hx
+            exact List.contains_iff_mem.mp hx)
+      exact ⟨he, hc, hd, hcorr⟩
+    · rw [if_neg hcache]
+      obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d
+        (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
+        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ) hcov
+        (fun x hx => by
+          rw [Std.HashSet.contains_ofList] at hx
+          exact List.contains_iff_mem.mp hx)
+      exact ⟨he, hc, hd, hcorr⟩
   · rw [if_neg hpr]
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -202,6 +202,80 @@ def DenseExpr.sharesVarIn (xs : List VarId) : DenseExpr p → Bool
 
 /-! ## The build/step/loop/pass layer -/
 
+inductive DenseReencodeRootPlan (p : ℕ)
+  | any (roots : List (ZMod p))
+  | one (var : VarId) (roots : List (ZMod p))
+
+def denseReencodeRootPlanMul :
+    DenseReencodeRootPlan p → DenseReencodeRootPlan p → Option (DenseReencodeRootPlan p)
+  | .any left, .any right => some (.any (left ++ right))
+  | .any left, .one var right => some (.one var (left ++ right))
+  | .one var left, .any right => some (.one var (left ++ right))
+  | .one leftVar left, .one rightVar right =>
+      if leftVar = rightVar then some (.one leftVar (left ++ right)) else none
+
+def denseBuildReencodeRootPlan : DenseExpr p → Option (DenseReencodeRootPlan p)
+  | .mul a b =>
+      match denseBuildReencodeRootPlan a, denseBuildReencodeRootPlan b with
+      | some left, some right => denseReencodeRootPlanMul left right
+      | _, _ => none
+  | e =>
+      match denseLinearize e with
+      | none => none
+      | some l =>
+          let l := l.norm
+          match l.terms with
+          | [] => if l.const = 0 then none else some (.any [])
+          | [(i, _)] => (denseRootsOfTerms i l.const l.terms).map (.one i)
+          | _ => none
+
+def denseReencodeRootPlanLookup (i : VarId) :
+    DenseReencodeRootPlan p → Option (List (ZMod p))
+  | .any roots => some roots
+  | .one var roots => if var = i then some roots else none
+
+abbrev DenseReencodeRootCache (p : ℕ) :=
+  Std.HashMap Nat (Option (DenseReencodeRootPlan p))
+
+def denseReencodeRootAt (cache : DenseReencodeRootCache p) (pos : Nat) (c : DenseExpr p) :
+    Option (DenseReencodeRootPlan p) × DenseReencodeRootCache p :=
+  match cache[pos]? with
+  | some plan => (plan, cache)
+  | none =>
+      let plan := denseBuildReencodeRootPlan c
+      (plan, cache.insert pos plan)
+
+def denseFindDomainCached (i : VarId) :
+    List (Nat × DenseExpr p) → DenseReencodeRootCache p →
+      Option (List (ZMod p)) × DenseReencodeRootCache p
+  | [], cache => (none, cache)
+  | c :: rest, cache =>
+      if c.2.mentions i then
+        let (plan, cache) := denseReencodeRootAt cache c.1 c.2
+        match plan.bind (denseReencodeRootPlanLookup i) with
+        | some roots => (some roots, cache)
+        | none => denseFindDomainCached i rest cache
+      else denseFindDomainCached i rest cache
+
+def denseGroupDomsCached (es : List (Nat × DenseExpr p)) :
+    List VarId → DenseReencodeRootCache p →
+      Option (List (VarId × List (ZMod p))) × DenseReencodeRootCache p
+  | [], cache => (some [], cache)
+  | i :: rest, cache =>
+      let (head, cache) := denseFindDomainCached i es cache
+      let (tail, cache) := denseGroupDomsCached es rest cache
+      match head, tail with
+      | some d, some ds => (some ((i, d) :: ds), cache)
+      | _, _ => (none, cache)
+
+def denseCoveredIdxPos (idx : DenseCovIndex) (arr : Array (DenseExpr p))
+    (xs : List VarId) : List (Nat × DenseExpr p) :=
+  let uniq := ((denseCandidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+  (uniq.mergeSort (· ≤ ·)).filterMap (fun i =>
+    if h : i < arr.size then
+      if denseCoveredBy xs arr[i] then some (i, arr[i]) else none
+    else none)
+
 /-- Build the inverted index (`VarId`-keyed twin of `CoveredIndex.buildPruned`), skipping items
     with more than `maxVars` distinct variables. -/
 def denseBuildPruned {α : Type} (varsOf : α → List VarId) (maxVars : Nat) (items : List α) :
@@ -251,6 +325,41 @@ def denseBuildReencode (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovInde
         else (reg, none)
       else (reg, none)
     else (reg, none)
+
+/-- Construct a candidate using the retained per-constraint root cache. -/
+def denseBuildReencodeCached (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovIndex)
+    (arrCs : Array (DenseExpr p)) (cache : DenseReencodeRootCache p)
+    (xs : List VarId) (freshBase : String) :
+    VarRegistry × Option (List VarId × Std.HashMap VarId (DenseExpr p)) ×
+      DenseReencodeRootCache p :=
+  let planned := if useIdx then denseCoveredIdxPos csIdx arrCs xs
+    else arrCs.toList.zipIdx.foldr
+      (fun c acc => if denseCoveredBy xs c.1 then (c.2, c.1) :: acc else acc) []
+  let es := planned.map Prod.snd
+  let (doms?, cache) := denseGroupDomsCached planned xs cache
+  match doms? with
+  | none => (reg, none, cache)
+  | some doms =>
+    let boxSize := (doms.map (fun yd => yd.2.length)).prod
+    if boxSize ≤ 256 then
+      if es.length == xs.length && es.all (fun c => c.vars.eraseDups.length == 1)
+          && xs.length ≤ Nat.clog 2 boxSize then
+        (reg, none, cache)
+      else
+      let survs := denseGroupSurvivorsE es doms
+      if 2 ≤ survs.length then
+        let k := Nat.clog 2 survs.length
+        if k < xs.length then
+          let (reg1, bits) := denseRegisterBits reg freshBase k
+          let patts := denseAssignments (denseBitBox bits)
+          let survsP := survs ++ List.replicate (patts.length - survs.length) (survs.headD [])
+          let pz := patts.zip survsP
+          (reg1,
+            some (bits, Std.HashMap.ofList (xs.map (fun x => (x, (denseInterpPoly pz x).fold)))),
+            cache)
+        else (reg, none, cache)
+      else (reg, none, cache)
+    else (reg, none, cache)
 
 /-- Degree pre-gate (untrusted): rewrite only the items sharing a variable with the group and fire
     when a rewritten item already exceeds the bound. -/
@@ -308,6 +417,45 @@ def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
     else (reg1, d, [], csIdx, arrCs, varSet)
   else (reg, d, [], csIdx, arrCs, varSet)
 
+structure DenseReencodeCacheState (p : ℕ) where
+  csIdx : DenseCovIndex
+  arrCs : Array (DenseExpr p)
+  rootCache : DenseReencodeRootCache p
+  varSet : Std.HashSet VarId
+
+def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
+    (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
+    (xs : List VarId) (freshBase : String) :
+    VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseReencodeCacheState p :=
+  if xs.all (fun x => reg.isInput x) then
+  if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
+      | some i => state.varSet.contains i
+      | none => false) then
+    (reg, d, [], state)
+  else
+  match denseBuildReencodeCached reg useIdx state.csIdx state.arrCs state.rootCache xs freshBase with
+  | (reg1, none, rootCache) => (reg1, d, [], { state with rootCache })
+  | (reg1, some (bits, hm), rootCache) =>
+    let state := { state with rootCache }
+    if denseDegPreReject b d xs bits hm then (reg1, d, [], state)
+    else
+    if xs.all (fun x => state.varSet.contains x) then
+    if xs.all (fun x => decide (x ∉ bits)) then
+    if bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
+    if denseCheckReencode d xs bits hm then
+      let ro := denseReencodeOut d xs bits hm
+      if ro.withinDegreeB b then
+        (reg1, ro,
+         bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
+         ⟨(if useIdx then denseBuildPruned DenseExpr.vars 8 ro.algebraicConstraints else ⟨∅, []⟩),
+          ro.algebraicConstraints.toArray, ∅, Std.HashSet.ofList ro.occ⟩)
+      else (reg1, d, [], state)
+    else (reg1, d, [], state)
+    else (reg1, d, [], state)
+    else (reg1, d, [], state)
+    else (reg1, d, [], state)
+  else (reg, d, [], state)
+
 /-- Process the candidate groups sequentially, threading the registry, index, and variable set. -/
 def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p → DenseCovIndex →
@@ -320,6 +468,19 @@ def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
         (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
     let (reg2, d2, derivs2) :=
       denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
+    (reg2, d2, derivs1 ++ derivs2)
+
+def denseReencodeLoopCached (b : DegreeBound) (useIdx : Bool) :
+    List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
+      DenseReencodeCacheState p →
+      VarRegistry × DenseConstraintSystem p × DenseDerivations p
+  | [], _, reg, d, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, state =>
+    let (reg1, d1, derivs1, state1) :=
+      denseReencodeStepCached b useIdx reg d state xs
+        (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+    let (reg2, d2, derivs2) :=
+      denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
     (reg2, d2, derivs1 ++ derivs2)
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
@@ -344,11 +505,21 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         -- order-sensitive accept/reject sequence, so the group order determines the outcome.
         some (vs.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
       else none))
+    let targetSlots := (targets.map List.length).sum
+    let targetVars := targets.foldl
+      (fun vars xs => xs.foldl (fun vars x => vars.insert x) vars)
+      (∅ : Std.HashSet VarId)
+    let useRootCache := 64 ≤ targetSlots - targetVars.size
     let useIdx := 8192 ≤ d.algebraicConstraints.length
-    denseReencodeLoop b useIdx targets 0 reg d
-      (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-      d.algebraicConstraints.toArray
-      (Std.HashSet.ofList d.occ)
+    if useIdx ∧ useRootCache then
+      denseReencodeLoopCached b useIdx targets 0 reg d
+        ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
+         d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩
+    else
+      denseReencodeLoop b useIdx targets 0 reg d
+        (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
+        d.algebraicConstraints.toArray
+        (Std.HashSet.ofList d.occ)
   else (reg, d, [])
 
 end ApcOptimizer.Dense

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -208,6 +208,10 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
    - ~~domainFold's direct-path double `coveredBy` sweep~~ **done**: one `partition` per target
      feeds both the covered set and the no-op gate (`systemHasFoldableW`).
    - ~~both passes' doubled `c.vars.dedup` setup~~ **done** (`hashedDedup`, computed once).
+   - ~~reencode's repeated finite-domain factorization across overlapping targets~~ **done (entry
+     136)**: large indexed runs cache one compact root plan per source constraint, retaining source
+     positions and clearing the cache after each accepted rewrite. A reuse gate keeps small/direct
+     runs on the original path.
    - ~~domainFold's per-accept rebuild~~ **done (entry 109)**: `foldOut` is order-preserving
      (in-place rewrite), `FoldIdx` carries bucket-completeness invariants (stale supersets fine,
      re-checked at use), `refresh` keeps the buckets with no rebuild, and the fold itself is

--- a/docs/log.md
+++ b/docs/log.md
@@ -4698,3 +4698,28 @@ unused-theorem checks pass.
 
 **Worked locally: yes (representative Gauss runtime win with unchanged final sizes; full-set
 result pending CI).**
+
+### 136. Runtime: cache reencode finite-domain factor plans
+
+Reencode now factorizes an eligible product constraint into a compact root plan the first time an
+overlapping target asks for its domain. The plan records either a source-order root list for one
+variable, a variable-independent root list, or failure; later targets look it up by the
+constraint's stable position instead of repeating `denseLinearize`, normalization, and root checks.
+The cache is cleared after an accepted rewrite, and source positions are recovered from the
+existing pruned index without allocating a second constraint array. A reuse estimate enables this
+path only for indexed systems with at least 64 repeated target slots; smaller systems retain the
+original loop.
+
+The cache is proof-irrelevant planning data. Every candidate still passes the original
+`denseCheckReencode`, freshness, and degree checks, and the cached loop has its own
+`DensePassCorrect` composition proof. `lake build` is warning-free and proof integrity passes.
+Optimized exports matched `origin/main` byte-for-byte on the SHA-256 profile corpus,
+`openvm-eth/apc_044`, and SP1 RSP `apc_030`.
+
+On `sha256_apc_pre_opt_25pct.json.gz`, reencode fell from 20,596 to 19,306 ms (−6.3%) and the full
+profile from 96,610 to 94,307 ms (−2.4%). On `wasm-eth/apc_036`, reencode fell from 4,108 to
+3,965 ms (−3.5%) and the full profile from 45,359 to 44,121 ms (−2.7%). The smaller OpenVM and SP1
+representatives remained on the original path and were runtime-neutral within local timing noise.
+
+**Worked locally: yes (reencode and whole-profile wins on large overlapping workloads; unchanged
+outputs on representative OpenVM and SP1 inputs; full-set result pending CI).**


### PR DESCRIPTION
## Summary

Implements proposal 3 from `reencodeProposals.md` for large, overlapping reencode workloads.

- factorizes each requested constraint once into a compact root plan and caches it by stable source position
- preserves source-order domain selection and clears the cache after every accepted rewrite
- reuses the existing pruned constraint index/array instead of allocating a parallel constraint representation
- gates the cached path on indexed systems with at least 64 repeated target slots; small/direct workloads keep the original path
- keeps the cache proof-irrelevant: the existing `denseCheckReencode`, freshness, and degree checks remain authoritative

No CI or benchmark scripts are changed.

## Local results

| corpus | metric | `origin/main` | this PR | change |
|---|---:|---:|---:|---:|
| SHA-256 pre-opt 25% | reencode | 20,596 ms | 19,306 ms | -6.3% |
| SHA-256 pre-opt 25% | total profile | 96,610 ms | 94,307 ms | -2.4% |
| wasm-eth `apc_036` | reencode | 4,108 ms | 3,965 ms | -3.5% |
| wasm-eth `apc_036` | total profile | 45,359 ms | 44,121 ms | -2.7% |

Smaller OpenVM `apc_044` and SP1 RSP `apc_030` stay on the original path and were neutral within local timing noise.

Optimized exports matched `origin/main` byte-for-byte on SHA-256, OpenVM `apc_044`, and SP1 RSP `apc_030`.

## Validation

- `lake build`
- `Scripts/check-proof-integrity.sh`
- generated C inspection
- `git diff --check`