### PR TITLE
perf(reencode): sparse whole-system rewrite in denseReencodeOut

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -405,6 +405,83 @@ theorem denseGroupRewrite_vars (xs bits : List VarId)
           · exact Or.inl (Or.inr h)
           · exact Or.inr h
 
+/-- An expression that has a variable but none in `xs` is not wholly inside `xs`. -/
+theorem denseVarsInF_false_of_hasVar (xs : List VarId) (e : DenseExpr p) :
+    e.hasVar = true → e.anyVarIn xs = false → e.varsInF xs = false := by
+  induction e with
+  | const n => intro h _; simp [DenseExpr.hasVar] at h
+  | var y => intro _ h; simpa [DenseExpr.varsInF, DenseExpr.anyVarIn] using h
+  | add a b iha ihb =>
+      intro hv hany
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hany
+      simp only [DenseExpr.varsInF, Bool.and_eq_false_iff]
+      rcases hv with hv | hv
+      · exact Or.inl (iha hv hany.1)
+      · exact Or.inr (ihb hv hany.2)
+  | mul a b iha ihb =>
+      intro hv hany
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hany
+      simp only [DenseExpr.varsInF, Bool.and_eq_false_iff]
+      rcases hv with hv | hv
+      · exact Or.inl (iha hv hany.1)
+      · exact Or.inr (ihb hv hany.2)
+
+/-- `denseGroupRewrite` returns an untouched expression verbatim: one sharing no variable with the
+    group and holding no variable-free node still to fold is rebuilt identically. -/
+theorem denseGroupRewrite_id_of_untouched (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) :
+    e.anyVarIn xs = false → e.hasConstFoldableNode = false →
+    denseGroupRewrite xs bits σfn patts e = e := by
+  induction e with
+  | const n => intro _ _; rfl
+  | var y =>
+      intro hany _
+      simp only [denseGroupRewrite]
+      rw [if_neg (by simpa [DenseExpr.anyVarIn] using hany)]
+  | add a b iha ihb =>
+      intro hany hcfn
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hany
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff] at hcfn
+      have hHasVar : (DenseExpr.add a b).hasVar = true := by simpa using hcfn.1.1
+      simp only [denseGroupRewrite]
+      rw [if_neg (by
+            have hvif : (DenseExpr.add a b).varsInF xs = false :=
+              denseVarsInF_false_of_hasVar xs (.add a b) hHasVar
+                (by simp [DenseExpr.anyVarIn, hany.1, hany.2])
+            simp [hvif]),
+          iha hany.1 hcfn.1.2, ihb hany.2 hcfn.2]
+  | mul a b iha ihb =>
+      intro hany hcfn
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hany
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff] at hcfn
+      have hHasVar : (DenseExpr.mul a b).hasVar = true := by simpa using hcfn.1.1
+      simp only [denseGroupRewrite]
+      rw [if_neg (by
+            have hvif : (DenseExpr.mul a b).varsInF xs = false :=
+              denseVarsInF_false_of_hasVar xs (.mul a b) hHasVar
+                (by simp [DenseExpr.anyVarIn, hany.1, hany.2])
+            simp [hvif]),
+          iha hany.1 hcfn.1.2, ihb hany.2 hcfn.2]
+
+/-- `denseGroupRewriteFast` agrees with `denseGroupRewrite`: on the skipped branch the expression is
+    untouched (`denseGroupRewrite_id_of_untouched`), so the two produce identical output. -/
+theorem denseGroupRewriteFast_eq (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) :
+    denseGroupRewriteFast xs bits σfn patts e = denseGroupRewrite xs bits σfn patts e := by
+  unfold denseGroupRewriteFast
+  by_cases h : (e.anyVarIn xs || e.hasConstFoldableNode) = true
+  · rw [if_pos h]
+  · rw [if_neg h]
+    simp only [Bool.not_eq_true, Bool.or_eq_false_iff] at h
+    exact (denseGroupRewrite_id_of_untouched xs bits σfn patts e h.1 h.2).symm
+
+theorem denseGroupRewriteFast_eq_fun (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) :
+    denseGroupRewriteFast xs bits σfn patts = denseGroupRewrite xs bits σfn patts := by
+  funext e; exact denseGroupRewriteFast_eq xs bits σfn patts e
+
 /-- Every variable of the re-encoded system is either an original variable of `d` or a fresh bit —
     proven by construction from the certified substitution, so the pass needs no scan. -/
 theorem denseReencodeOut_vars_subset (d : DenseConstraintSystem p) (xs bits : List VarId)
@@ -416,7 +493,7 @@ theorem denseReencodeOut_vars_subset (d : DenseConstraintSystem p) (xs bits : Li
     (denseAssignments (denseBitBox bits)) hσ
   simp only [DenseConstraintSystem.occ, List.mem_append, List.mem_flatMap] at hv
   rcases hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
-  · simp only [denseReencodeOut, List.mem_append] at hc
+  · simp only [denseReencodeOut, denseGroupRewriteFast_eq_fun, List.mem_append] at hc
     rcases hc with hc | hc
     · rcases List.mem_map.1 hc with ⟨c0, hc0, rfl⟩
       rcases gr c0 v hcv with h | h
@@ -426,7 +503,7 @@ theorem denseReencodeOut_vars_subset (d : DenseConstraintSystem p) (xs bits : Li
       right
       have hvb : v = b := by simpa [denseBoolConstraint, DenseExpr.vars] using hcv
       exact hvb ▸ hb
-  · simp only [denseReencodeOut, List.mem_map] at hbi
+  · simp only [denseReencodeOut, denseGroupRewriteFast_eq_fun, List.mem_map] at hbi
     rcases hbi with ⟨bi0, hbi0, rfl⟩
     simp only [denseBIVars, List.mem_append, List.mem_flatMap] at hbiv
     rcases hbiv with hmv | ⟨e, he, hev⟩
@@ -1059,7 +1136,7 @@ theorem denseCheckReencode_sound [Fact p.Prime] (d : DenseConstraintSystem p) (b
     (fun c => !denseCoveredBy xs c)
     (bits.map denseBoolConstraint)
     (bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)))
-    rfl hfwd_D hbwd hVars
+    (by simp only [denseReencodeOut, denseGroupRewriteFast_eq_fun]) hfwd_D hbwd hVars
 
 
 /-! ## Step / loop correctness, pass assembly

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -91,6 +91,15 @@ def denseGroupRewrite (xs bits : List VarId) (σfn : VarId → Option (DenseExpr
       if (DenseExpr.mul a b).varsInF xs then denseGroupRewriteCand bits σfn patts (.mul a b)
       else .mul (denseGroupRewrite xs bits σfn patts a) (denseGroupRewrite xs bits σfn patts b)
 
+/-- `denseGroupRewrite` with a cheap top-level skip: an expression that shares no variable with the
+    group and holds no variable-free node to fold is returned untouched (`denseGroupRewrite` would
+    rebuild it identically — see `denseGroupRewriteFast_eq` in `Proofs/Reencode.lean`). This turns
+    the whole-system rewrite in `denseReencodeOut` sparse: the thousands of constraints untouched by
+    a small group skip the rebuild/interpolation entirely. -/
+def denseGroupRewriteFast (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) : DenseExpr p :=
+  if e.anyVarIn xs || e.hasConstFoldableNode then denseGroupRewrite xs bits σfn patts e else e
+
 /-! ## The re-encoded system -/
 
 /-- The re-encoded system: substitute the group everywhere, drop the now-covered constraints, and
@@ -99,14 +108,14 @@ def denseReencodeOut (d : DenseConstraintSystem p) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : DenseConstraintSystem p :=
   { algebraicConstraints :=
       ((d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).map
-        (denseGroupRewrite xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))))
+        (denseGroupRewriteFast xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))))
         ++ bits.map denseBoolConstraint,
     busInteractions := d.busInteractions.map (fun bi => { bi with
       multiplicity :=
-        denseGroupRewrite xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))
+        denseGroupRewriteFast xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))
           bi.multiplicity,
       payload := bi.payload.map
-        (denseGroupRewrite xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))) }) }
+        (denseGroupRewriteFast xs bits (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits))) }) }
 
 /-! ## The group's surviving values -/
 


### PR DESCRIPTION
Each accepted re-encoding rewrote every constraint and bus interaction of
the system through `denseGroupRewrite`, which re-checks `varsInF` at every
node (a subtree walk per node) and rebuilds the tree — even for the
thousands of items that share no variable with the small accepted group.
On the eth-scale cases the first cleanup iteration accepts dozens of groups
over a multi-thousand-item system, so this is the dominant reencode cost.

Gate the rewrite with `denseGroupRewriteFast`: an item sharing no group
variable and holding no variable-free foldable node is returned verbatim,
in one linear walk instead of the quadratic re-check-and-rebuild.
`denseGroupRewriteFast_eq` proves it equals `denseGroupRewrite` pointwise
(via `denseGroupRewrite_id_of_untouched`), so the optimizer output is
provably byte-identical and effectiveness is unchanged; only the proof
sites that unfold `denseReencodeOut` gain a one-lemma bridge.

Measured (min of 4, same runner): reencode -6% to -20% on the heaviest
cases, whole-optimizer -2% to -9%; negligible on small cases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KjckmWfySCnmooKuYZ1qNN