### PR TITLE
perf(busUnify,busPairCancel): linear busId dedup

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -355,7 +355,9 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
 def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVerifiedPassW p :=
   fun reg d hcov bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
-    let busIds := (d.busInteractions.map (fun bi => bi.busId)).dedup
+    -- `hashedDedup` = `List.dedup` (`hashedDedup_eq`), one bucket per id instead of the
+    -- quadratic full-list membership walk (the interaction list is system-sized).
+    let busIds := HashedDedup.hashedDedup (hash ·) (d.busInteractions.map (fun bi => bi.busId))
     let deep : Bool := pw.isPrime
     let arr := d.busInteractions.toArray
     let ops : DenseZModOps p := denseZModOps

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -283,7 +283,9 @@ def denseBusUnifyF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConst
     let nw : Thunk (DenseNonzeroWits p) :=
       Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints
     let eqs := denseCollectAllBuses d bs facts T nw
-      ((d.busInteractions.map (fun bi => bi.busId)).dedup)
+      -- `hashedDedup` = `List.dedup` (`hashedDedup_eq`), one bucket per id instead of the
+      -- quadratic full-list membership walk (the interaction list is system-sized).
+      (HashedDedup.hashedDedup (hash ·) (d.busInteractions.map (fun bi => bi.busId)))
     if eqs.isEmpty then d
     else
       -- No-new-variable side condition holds by construction (`denseMemEqConstraints_vars`); the

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
@@ -529,7 +529,7 @@ def denseBusUnifyNew (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseCon
   let nw : Thunk (DenseNonzeroWits p) :=
     Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints
   let eqs := denseCollectAllBuses d bs facts T nw
-    ((d.busInteractions.map (fun bi => bi.busId)).dedup)
+    (HashedDedup.hashedDedup (hash ·) (d.busInteractions.map (fun bi => bi.busId)))
   let dHashes : Std.HashMap UInt64 (List (DenseExpr p)) :=
     d.algebraicConstraints.foldl (fun m c =>
       let h := c.bHash
@@ -578,7 +578,8 @@ theorem denseBusUnifyNew_sound (bs : BusSemantics p) (facts : BusFacts p bs) (re
   have hmem : c ∈ denseCollectAllBuses d bs facts
       (Thunk.mk fun _ => DenseTwoRootMap.build d.algebraicConstraints)
       (Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints)
-      ((d.busInteractions.map (fun bi => bi.busId)).dedup) := List.mem_of_mem_filter hc
+      (HashedDedup.hashedDedup (hash ·) (d.busInteractions.map (fun bi => bi.busId)))
+    := List.mem_of_mem_filter hc
   exact denseCollectAllBuses_sound d bs facts hp1 reg hcov denv hadm hsat _ c hmem
 
 theorem denseBusUnifyF_covered (reg : VarRegistry) (bs : BusSemantics p) (facts : BusFacts p bs)


### PR DESCRIPTION
## What

Stacked on #206. Both `denseBusUnifyF` and `denseBusPairCancelPass` deduplicate the per-interaction busId list with `List.dedup` — an **O(n²)** membership walk over the system-sized interaction list (71k interactions in sha256_big's first cleanup cycle), re-run every cleanup cycle by both passes.

`HashedDedup.hashedDedup` is proven identical (`hashedDedup_eq : hashedDedup hf l = l.dedup`) and buckets membership tests by hash, so the walk is linear. The structural twin `denseBusUnifyNew` in `Proofs/BusUnify.lean` is updated in lockstep (it must mirror the transform's body).

## Expected effect

Sum over cycles of (#interactions)² comparisons disappears from **both** passes (busPairCancel 106s, busUnify 51s on 170k sha256 before this change). Exact numbers will show in the sha bench; local measurement to follow in a comment.

Output is provably unchanged (`hashedDedup_eq`); `run` byte-identical across all openvm-eth fixtures; `Scripts/check-proof-integrity.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)