### PR TITLE
perf: 1.8x faster on large APCs — domainFold/flagFold/rootPairUnify/busPairCancel (989s → 550s on 170k sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -202,18 +202,16 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
             by_contra hc
             rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hR; simp at hR
           have hSget : arr[i]? = some S := Array.getElem?_eq_getElem hi
-          let B := denseLiveArr arr alive hsz (i + 1) (j - i - 1) (by omega)
-          if hmidB : B.all (denseMidRefuted ops shape T busId S) = true then
-          let A := denseLiveArr arr alive hsz 0 i (by omega)
-          if hshieldA : denseShieldOk ops shape T busId S A = true then
-          have hBeq : B = denseLiveSeg arr alive (i + 1) (j - i - 1) :=
-            denseLiveArr_eq arr alive hsz (i + 1) (j - i - 1) (by omega)
-          have hAeq : A = denseLiveSeg arr alive 0 i := denseLiveArr_eq arr alive hsz 0 i (by omega)
+          if hmidB : denseLiveAllSeg arr alive (denseMidRefuted ops shape T busId S)
+              (i + 1) (j - i - 1) = true then
+          if hshieldA : (denseShieldScanSeg ops shape T busId S arr alive 0 i).2 = true then
           have hmid : ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
               denseMidRefuted ops shape T busId S m0 = true := by
-            rw [← hBeq]; exact fun m0 hm0 => List.all_eq_true.mp hmidB m0 hm0
+            rw [denseLiveAllSeg_eq] at hmidB
+            exact fun m0 hm0 => List.all_eq_true.mp hmidB m0 hm0
           have hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
-            rw [← hAeq]; exact hshieldA
+            rw [denseShieldScanSeg_eq] at hshieldA
+            exact hshieldA
           match hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) with
           | none => next ()
           | some (slots, bound) =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelIndex
+import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelLive
 
 set_option autoImplicit false
 
@@ -75,6 +76,45 @@ def denseShieldOk (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (S : BusInteraction (DenseExpr p)) (l : List (BusInteraction (DenseExpr p))) : Bool :=
   (denseShieldScan ops shape T busId S l).2
+
+/-- `denseShieldScan` over a live array segment, structurally mirrored — no intermediate list. -/
+def denseShieldScanSeg (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S : BusInteraction (DenseExpr p))
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
+    (lo n : Nat) → Bool × Bool
+  | _, 0 => (false, true)
+  | lo, n + 1 =>
+    let r := denseShieldScanSeg ops shape T busId S arr alive (lo + 1) n
+    if alive[lo]?.getD false then
+      match arr[lo]? with
+      | some m0 =>
+          (r.1 || denseProvRecv ops shape busId S m0,
+            r.2 && (densePreRefuted ops shape T busId S m0 || r.1))
+      | none => r
+    else r
+
+theorem denseShieldScanSeg_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S : BusInteraction (DenseExpr p))
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
+    ∀ (lo n : Nat),
+      denseShieldScanSeg ops shape T busId S arr alive lo n
+        = denseShieldScan ops shape T busId S (denseLiveSeg arr alive lo n) := by
+  intro lo n
+  induction n generalizing lo with
+  | zero => rfl
+  | succ n ih =>
+      rw [denseShieldScanSeg, ih (lo + 1)]
+      cases halive : alive[lo]?.getD false with
+      | false => rw [denseLiveSeg_skip arr alive lo n halive, if_neg (by simp)]
+      | true =>
+          rw [if_pos rfl]
+          cases harr : arr[lo]? with
+          | some m0 =>
+              rw [denseLiveSeg_peel arr alive lo n m0 halive harr]
+              rfl
+          | none =>
+              rw [denseLiveSeg, halive, harr, if_pos rfl]
+              simp
 
 /-- Single-value byte check on `e`, emitted through `spec` (multiplicity `1`). -/
 def denseMkByteCheck (spec : ByteXorSpec p) (busId : Nat) (e : DenseExpr p) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
@@ -197,6 +197,29 @@ theorem denseLiveArr_eq (arr : Array (BusInteraction (DenseExpr p))) (alive : Ar
     denseLiveArr arr alive halive lo n hb = denseLiveSeg arr alive lo n := by
   rw [denseLiveArr, denseLiveArrGo_eq]; simp
 
+/-! `denseLiveAllSeg` is `all` over the live projection computed directly on the array segment —
+the per-candidate region checks would otherwise materialize an O(segment) list each time. -/
+
+/-- `(denseLiveSeg arr alive lo n).all P` without the intermediate list. -/
+def denseLiveAllSeg (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
+    (P : BusInteraction (DenseExpr p) → Bool) : (lo n : Nat) → Bool
+  | _, 0 => true
+  | lo, n + 1 =>
+    (if alive[lo]?.getD false then (arr[lo]?).elim true P else true)
+      && denseLiveAllSeg arr alive P (lo + 1) n
+
+theorem denseLiveAllSeg_eq (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
+    (P : BusInteraction (DenseExpr p) → Bool) :
+    ∀ (lo n : Nat), denseLiveAllSeg arr alive P lo n = (denseLiveSeg arr alive lo n).all P := by
+  intro lo n
+  induction n generalizing lo with
+  | zero => rfl
+  | succ n ih =>
+      rw [denseLiveAllSeg, denseLiveSeg, ih (lo + 1), List.all_append]
+      cases halive : alive[lo]?.getD false
+      · simp
+      · cases harr : arr[lo]? <;> simp [Option.elim]
+
 /-- The logical constraint system at a point in the loop: the original system with its interactions
     replaced by the live projection followed by the checks emitted so far. -/
 def denseMkCs (cs0 : DenseConstraintSystem p) (arr : Array (BusInteraction (DenseExpr p)))

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
@@ -249,6 +249,51 @@ def denseFoldLoopV : List (List VarId) → DenseConstraintSystem p → DenseFold
     let r := denseFoldStepV d fidx xs
     denseFoldLoopV rest r.1 r.2
 
+/-! ## The array-native indexed fold loop (runtime twin)
+
+`denseFoldLoopV` threads the *list* system `d` and re-materializes it per accepted fold:
+`denseFoldOutIdxV` maps over `d.algebraicConstraints.zipIdx` / `d.busInteractions.zipIdx` (each an
+O(system) `toArray` + rebuild) and `DenseFoldIdx.refresh` converts the folded lists back to arrays.
+The twin below threads only the `DenseFoldIdx` (already array-backed) and applies an accepted fold
+with `Array.modify` at the touched positions — O(touched) per accept — materializing lists once at
+the pass exit. `denseDomainFoldFV_eq_fast` (`Proofs/DomainFold.lean`) proves it equal to
+`denseDomainFoldFV` and installs it with `@[csimp]`. -/
+
+/-- `denseFoldOutIdxV` + `refresh`, array-native: modify only the touched positions, in place. -/
+def denseFoldOutArrV (fidx : DenseFoldIdx p) (xs : List VarId)
+    (survsV : List (List (ZMod p))) : DenseFoldIdx p :=
+  match fidx with
+  | ⟨idx, arr, bisIdx, arrBis⟩ =>
+    ⟨idx,
+     (denseTouchedSet idx xs).toList.foldl
+       (fun a i => a.modify i
+         (fun c => if denseCoveredBy xs c then c else denseFoldRewriteIdxV xs survsV c)) arr,
+     bisIdx,
+     (denseTouchedSet bisIdx xs).toList.foldl
+       (fun a i => a.modify i
+         (fun bi => { bi with
+           multiplicity := denseFoldRewriteIdxV xs survsV bi.multiplicity,
+           payload := bi.payload.map (denseFoldRewriteIdxV xs survsV) })) arrBis⟩
+
+/-- `denseFoldStepV`, array-native: the identical probe/gate served from the shared index, with an
+    accepted fold applied sparsely by `denseFoldOutArrV`. -/
+def denseFoldStepArrV (fidx : DenseFoldIdx p) (xs : List VarId) : DenseFoldIdx p :=
+  let es := denseCoveredIdx fidx.idx fidx.arr (denseCoveredBy xs) xs
+  match denseGroupDoms es xs with
+  | none => fidx
+  | some doms =>
+    if (doms.map (fun yd => yd.2.length)).prod ≤ 256 then
+      let survsV := denseGroupSurvivorsEV es xs (doms.map Prod.snd)
+      if 1 ≤ survsV.length && denseSystemHasFoldableIdxV fidx xs survsV then
+        denseFoldOutArrV fidx xs survsV
+      else fidx
+    else fidx
+
+/-- Process the candidate groups sequentially, array-native. -/
+def denseFoldLoopArrV : List (List VarId) → DenseFoldIdx p → DenseFoldIdx p
+  | [], fidx => fidx
+  | xs :: rest, fidx => denseFoldLoopArrV rest (denseFoldStepArrV fidx xs)
+
 /-! ## The candidate group list -/
 
 /-- The candidate fold targets: every constraint's 2–8-distinct-variable group all of whose
@@ -273,6 +318,18 @@ def denseDomainFoldFV (pw : PrimeWitness p) (d : DenseConstraintSystem p) : Dens
     let targets := denseTargetsV d
     if domainFoldIndexThreshold ≤ d.algebraicConstraints.length then
       denseFoldLoopV targets d (DenseFoldIdx.mk' d)
+    else denseFoldLoopDirectV targets d
+  else d
+
+/-- `denseDomainFoldFV` with the array-native loop on the indexed path. Proven equal and installed
+    by `denseDomainFoldFV_eq_fast` (`Proofs/DomainFold.lean`). -/
+def denseDomainFoldFVFast (pw : PrimeWitness p) (d : DenseConstraintSystem p) :
+    DenseConstraintSystem p :=
+  if pw.isPrime = true then
+    let targets := denseTargetsV d
+    if domainFoldIndexThreshold ≤ d.algebraicConstraints.length then
+      let fidx := denseFoldLoopArrV targets (DenseFoldIdx.mk' d)
+      { algebraicConstraints := fidx.arr.toList, busInteractions := fidx.arrBis.toList }
     else denseFoldLoopDirectV targets d
   else d
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
+import ApcOptimizer.Implementation.OptimizerPasses.SearchBudgets
 
 set_option autoImplicit false
 
@@ -160,12 +161,38 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
     Std.HashMap UInt64 (List (BusInteraction (DenseExpr p))) := Id.run do
   -- Per coarse key (bus id, constant multiplicity, payload length), keep only the first-of-class
   -- *representatives* seen so far; a later interaction certified equal to a representative is a
-  -- drop. Storing representatives only (never the dropped entries) keeps the per-interaction scan
-  -- proportional to the number of distinct classes in a bucket rather than its total size, and
-  -- makes the first-of-class memo unnecessary (a stored representative is first-of-class by
-  -- construction). Only a heuristic drop *proposal*: `densePointwiseDupDropF` re-verifies every
-  -- proposal against `densePdKeep`, so this carries no soundness obligation.
-  let mut reps : Std.HashMap UInt64 (List (DensePdEntry p)) := ∅
+  -- drop. Representatives are indexed by their first payload slot: a certified twin's slot pair
+  -- is value-equal or shares a decomposition carrier (`denseSlotEqCert`), so every true match has
+  -- a representative whose slot 0 is hash-equal to — or shares a variable with — the incoming
+  -- slot 0, and only those buckets are scanned (huge same-key classes, e.g. range checks, would
+  -- otherwise cost O(classes) per interaction). Candidates are re-checked with the full
+  -- signature + certificate tests, so the drop set is unchanged. Only a heuristic drop
+  -- *proposal*: `densePointwiseDupDropF` re-verifies every proposal against `densePdKeep`, so
+  -- this carries no soundness obligation.
+  if bis.length < pointwiseDupDropIndexThreshold then
+    -- Fixture-scale direct scan: same checks against the whole per-class representative list.
+    let mut reps : Std.HashMap UInt64 (List (DensePdEntry p)) := ∅
+    let mut drops : Std.HashMap UInt64 (List (BusInteraction (DenseExpr p))) := ∅
+    for bi in bis do
+      if !bs.isStateful bi.busId then
+        match bi.multiplicity.constValue? with
+        | none => pure ()
+        | some m =>
+          let key := mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length))
+          let sigs : Array (UInt64 × UInt64) :=
+            (bi.payload.map (fun e => (e.bHash, e.pdVarBloom))).toArray
+          let entries := reps.getD key []
+          if entries.any (fun e =>
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi) then
+            let vk := densePdValHash bi
+            drops := drops.insert vk (bi :: (drops.getD vk []))
+          else
+            reps := reps.insert key ({ pos := 0, bi, sigs, kept := true } :: entries)
+    return drops
+  else
+  let mut repsByHash : Std.HashMap (UInt64 × UInt64) (List (DensePdEntry p)) := ∅
+  let mut repsByVar : Std.HashMap (UInt64 × VarId) (List (DensePdEntry p)) := ∅
+  let mut repsEmpty : Std.HashMap UInt64 (List (DensePdEntry p)) := ∅
   let mut drops : Std.HashMap UInt64 (List (BusInteraction (DenseExpr p))) := ∅
   for bi in bis do
     if !bs.isStateful bi.busId then
@@ -175,13 +202,29 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
         let key := mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length))
         let sigs : Array (UInt64 × UInt64) :=
           (bi.payload.map (fun e => (e.bHash, e.pdVarBloom))).toArray
-        let entries := reps.getD key []
-        if entries.any (fun e => densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi)
-        then
+        let hit :=
+          match bi.payload with
+          | [] =>
+            (repsEmpty.getD key []).any (fun e =>
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi)
+          | e0 :: _ =>
+            let check := fun (e : DensePdEntry p) =>
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi
+            (repsByHash.getD (key, e0.bHash) []).any check ||
+              (HashedDedup.hashedEraseDups (hash ·) e0.vars).any (fun v =>
+                (repsByVar.getD (key, v) []).any check)
+        if hit then
           let vk := densePdValHash bi
           drops := drops.insert vk (bi :: (drops.getD vk []))
         else
-          reps := reps.insert key ({ pos := 0, bi, sigs, kept := true } :: entries)
+          let entry : DensePdEntry p := { pos := 0, bi, sigs, kept := true }
+          match bi.payload with
+          | [] => repsEmpty := repsEmpty.insert key (entry :: repsEmpty.getD key [])
+          | e0 :: _ =>
+            repsByHash := repsByHash.insert (key, e0.bHash)
+              (entry :: repsByHash.getD (key, e0.bHash) [])
+            for v in HashedDedup.hashedEraseDups (hash ·) e0.vars do
+              repsByVar := repsByVar.insert (key, v) (entry :: repsByVar.getD (key, v) [])
   return drops
 
 /-- Drop `bi` iff its value bucket holds a certified dropped twin. The `{b // densePdKeep … = false}`
@@ -215,12 +258,13 @@ def densePointwiseDupDropF (pw : PrimeWitness p) (bs : BusSemantics p)
   if pw.isPrime = true then
     let singles := denseSingleVarCs d.algebraicConstraints
     let drops := densePdDropSet bs singles d.busInteractions
+    -- `singles` is reused in the re-verification below: spelling the filter out again inside the
+    -- `filterMap` closure would recompute the O(system) single-variable scan per proposed drop.
     let verdicts : Std.HashMap UInt64 (List { b : BusInteraction (DenseExpr p) //
-        densePdKeep bs (denseSingleVarCs d.algebraicConstraints) d.busInteractions b = false }) :=
+        densePdKeep bs singles d.busInteractions b = false }) :=
       drops.fold (init := ∅) fun m h l =>
         m.insert h (l.eraseDups.filterMap (fun b =>
-          if hpd : densePdKeep bs (denseSingleVarCs d.algebraicConstraints)
-              d.busInteractions b = false
+          if hpd : densePdKeep bs singles d.busInteractions b = false
           then some ⟨b, hpd⟩ else none))
     d.filterBus (densePdVerdictKeep verdicts)
   else d

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
@@ -146,13 +146,17 @@ def densePdValHash (bi : BusInteraction (DenseExpr p)) : UInt64 :=
   mixHash (hash bi.busId) (mixHash bi.multiplicity.bHash
     (bi.payload.foldl (fun h e => mixHash h e.bHash) 7))
 
-/-- One bucket entry of the sweep: position, the interaction, its slot signatures, and whether it
-    was kept. -/
+/-- One sweep representative: the interaction and its per-slot signatures. -/
 structure DensePdEntry (p : ℕ) where
-  pos : Nat
   bi : BusInteraction (DenseExpr p)
   sigs : Array (UInt64 × UInt64)
-  kept : Bool
+
+/-- The coarse class key (bus id, constant multiplicity, payload length) and per-slot signatures
+    of one interaction — shared by both sweep paths. -/
+@[inline] def densePdKeySigs (bi : BusInteraction (DenseExpr p)) (m : ZMod p) :
+    UInt64 × Array (UInt64 × UInt64) :=
+  (mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length)),
+    (bi.payload.map (fun e => (e.bHash, e.pdVarBloom))).toArray)
 
 /-- The value-keyed set of interactions the sweep decides to drop — the same set `densePdKeep`
     would drop (drops are value-based: `findIdx?` evaluates each duplicate at its first occurrence). -/
@@ -178,16 +182,14 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
         match bi.multiplicity.constValue? with
         | none => pure ()
         | some m =>
-          let key := mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length))
-          let sigs : Array (UInt64 × UInt64) :=
-            (bi.payload.map (fun e => (e.bHash, e.pdVarBloom))).toArray
+          let (key, sigs) := densePdKeySigs bi m
           let entries := reps.getD key []
           if entries.any (fun e =>
               densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi) then
             let vk := densePdValHash bi
             drops := drops.insert vk (bi :: (drops.getD vk []))
           else
-            reps := reps.insert key ({ pos := 0, bi, sigs, kept := true } :: entries)
+            reps := reps.insert key ({ bi, sigs } :: entries)
     return drops
   else
   let mut repsByHash : Std.HashMap (UInt64 × UInt64) (List (DensePdEntry p)) := ∅
@@ -199,9 +201,7 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
       match bi.multiplicity.constValue? with
       | none => pure ()
       | some m =>
-        let key := mixHash (hash bi.busId) (mixHash (hash m.val) (hash bi.payload.length))
-        let sigs : Array (UInt64 × UInt64) :=
-          (bi.payload.map (fun e => (e.bHash, e.pdVarBloom))).toArray
+        let (key, sigs) := densePdKeySigs bi m
         let hit :=
           match bi.payload with
           | [] =>
@@ -217,7 +217,7 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
           let vk := densePdValHash bi
           drops := drops.insert vk (bi :: (drops.getD vk []))
         else
-          let entry : DensePdEntry p := { pos := 0, bi, sigs, kept := true }
+          let entry : DensePdEntry p := { bi, sigs }
           match bi.payload with
           | [] => repsEmpty := repsEmpty.insert key (entry :: repsEmpty.getD key [])
           | e0 :: _ =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
@@ -955,6 +955,178 @@ theorem denseDomainFoldFV_covered (pw : PrimeWitness p) (reg : VarRegistry)
       exact denseFoldLoopDirectV_covered reg (denseTargetsV d) d hcov
   · rw [if_neg hpB]; exact hcov
 
+/-! ## The array-native loop equals the list loop (`@[csimp]` runtime replacement)
+
+`denseFoldLoopArrV` (`DomainFoldRuntime.lean`) threads only the array-backed `DenseFoldIdx`,
+applying an accepted fold with `Array.modify` at the touched positions instead of re-materializing
+the whole list system per accept. The lemmas below relate it to `denseFoldLoopV` under the loop's
+array-sync invariant; `denseDomainFoldFV_eq_fast` installs the fast body via `@[csimp]`, so the
+correctness proofs above keep talking about the list-loop specification. -/
+
+/-- Folding `Array.modify` over distinct positions applies `f` exactly at the listed in-range
+    positions. -/
+theorem foldl_modify_getElem? {α : Type} (f : α → α) :
+    ∀ (l : List Nat), l.Nodup → ∀ (arr : Array α) (i : Nat),
+      (l.foldl (fun a j => a.modify j f) arr)[i]?
+        = if i ∈ l then arr[i]?.map f else arr[i]? := by
+  intro l
+  induction l with
+  | nil => intro _ arr i; simp
+  | cons j rest ih =>
+      intro hnd arr i
+      rw [List.foldl_cons, ih (List.Nodup.of_cons hnd) (arr.modify j f) i]
+      by_cases hij : j = i
+      · subst hij
+        have hnotin : j ∉ rest := (List.nodup_cons.mp hnd).1
+        rw [if_neg hnotin, if_pos (List.mem_cons_self ..), Array.getElem?_modify, if_pos rfl]
+      · rw [Array.getElem?_modify, if_neg hij]
+        by_cases hmem : i ∈ rest
+        · rw [if_pos hmem, if_pos (List.mem_cons_of_mem _ hmem)]
+        · rw [if_neg hmem, if_neg (by
+            rw [List.mem_cons]
+            rintro (rfl | h)
+            · exact hij rfl
+            · exact hmem h)]
+
+/-- The touched-position `Array.modify` fold computes the sparse positional map, list-level. -/
+theorem foldl_modify_toList {α : Type} (f : α → α) (s : Std.HashSet Nat) (l : List α) :
+    (s.toList.foldl (fun a j => a.modify j f) l.toArray).toList
+      = l.zipIdx.map (fun ai => if s.contains ai.2 then f ai.1 else ai.1) := by
+  have hnd : s.toList.Nodup := Std.HashSet.distinct_toList.imp (fun {a b} h => by simpa using h)
+  refine List.ext_getElem? (fun i => ?_)
+  rw [Array.getElem?_toList, foldl_modify_getElem? f s.toList hnd l.toArray i,
+    List.getElem?_map, List.getElem?_zipIdx]
+  have htoa : l.toArray[i]? = l[i]? := List.getElem?_toArray
+  have hmem : (i ∈ s.toList) ↔ s.contains i = true := by
+    rw [Std.HashSet.mem_toList, Std.HashSet.mem_iff_contains]
+  cases hl : l[i]? with
+  | none =>
+      rw [htoa, hl]
+      simp
+  | some a =>
+      rw [htoa, hl]
+      by_cases hc : s.contains i = true
+      · rw [if_pos (hmem.mpr hc)]
+        simp only [Option.map_some, Nat.zero_add]
+        rw [if_pos hc]
+      · rw [if_neg (fun h => hc (hmem.mp h))]
+        simp only [Option.map_some, Nat.zero_add]
+        rw [if_neg hc]
+
+/-- `denseFoldOutArrV` is `denseFoldOutIdxV` followed by the (no-rebuild) `refresh`, under array
+    sync. -/
+theorem denseFoldOutArrV_eq (d : DenseConstraintSystem p) (fidx : DenseFoldIdx p)
+    (xs : List VarId) (survsV : List (List (ZMod p)))
+    (harr : fidx.arr = d.algebraicConstraints.toArray)
+    (hbis : fidx.arrBis = d.busInteractions.toArray) :
+    denseFoldOutArrV fidx xs survsV = fidx.refresh (denseFoldOutIdxV d fidx xs survsV) := by
+  obtain ⟨idx, arr, bisIdx, arrBis⟩ := fidx
+  dsimp only at harr hbis
+  subst harr hbis
+  show DenseFoldIdx.mk idx _ bisIdx _ = DenseFoldIdx.mk idx _ bisIdx _
+  congr 1
+  · -- constraint side
+    have h := foldl_modify_toList
+      (fun c => if denseCoveredBy xs c then c else denseFoldRewriteIdxV xs survsV c)
+      (denseTouchedSet idx xs) d.algebraicConstraints
+    calc (denseTouchedSet idx xs).toList.foldl
+          (fun a i => a.modify i
+            (fun c => if denseCoveredBy xs c then c else denseFoldRewriteIdxV xs survsV c))
+          d.algebraicConstraints.toArray
+        = ((denseTouchedSet idx xs).toList.foldl
+            (fun a i => a.modify i
+              (fun c => if denseCoveredBy xs c then c else denseFoldRewriteIdxV xs survsV c))
+            d.algebraicConstraints.toArray).toList.toArray := by rw [Array.toArray_toList]
+      _ = _ := by rw [h]; simp only [denseFoldOutIdxV]
+  · -- interaction side
+    have h := foldl_modify_toList
+      (fun bi => { bi with
+        multiplicity := denseFoldRewriteIdxV xs survsV bi.multiplicity,
+        payload := bi.payload.map (denseFoldRewriteIdxV xs survsV) })
+      (denseTouchedSet bisIdx xs) d.busInteractions
+    calc (denseTouchedSet bisIdx xs).toList.foldl
+          (fun a i => a.modify i
+            (fun bi => { bi with
+              multiplicity := denseFoldRewriteIdxV xs survsV bi.multiplicity,
+              payload := bi.payload.map (denseFoldRewriteIdxV xs survsV) }))
+          d.busInteractions.toArray
+        = ((denseTouchedSet bisIdx xs).toList.foldl
+            (fun a i => a.modify i
+              (fun bi => { bi with
+                multiplicity := denseFoldRewriteIdxV xs survsV bi.multiplicity,
+                payload := bi.payload.map (denseFoldRewriteIdxV xs survsV) }))
+            d.busInteractions.toArray).toList.toArray := by rw [Array.toArray_toList]
+      _ = _ := by rw [h]; simp only [denseFoldOutIdxV]
+
+/-- Interaction-side analog of `denseFoldStepV_snd_arr`. -/
+theorem denseFoldStepV_snd_arrBis (d : DenseConstraintSystem p) (fidx : DenseFoldIdx p)
+    (xs : List VarId) (hbis : fidx.arrBis = d.busInteractions.toArray) :
+    (denseFoldStepV d fidx xs).2.arrBis
+      = (denseFoldStepV d fidx xs).1.busInteractions.toArray := by
+  simp only [denseFoldStepV]; split
+  · exact hbis
+  · split_ifs <;> first | rfl | exact hbis
+
+/-- One array-native step is exactly the list step's refreshed index, under array sync. -/
+theorem denseFoldStepArrV_eq (d : DenseConstraintSystem p) (fidx : DenseFoldIdx p)
+    (xs : List VarId)
+    (harr : fidx.arr = d.algebraicConstraints.toArray)
+    (hbis : fidx.arrBis = d.busInteractions.toArray) :
+    denseFoldStepArrV fidx xs = (denseFoldStepV d fidx xs).2 := by
+  simp only [denseFoldStepArrV, denseFoldStepV]
+  cases denseGroupDoms (denseCoveredIdx fidx.idx fidx.arr (denseCoveredBy xs) xs) xs with
+  | none => rfl
+  | some doms =>
+      dsimp only
+      split
+      · split
+        · exact denseFoldOutArrV_eq d fidx xs _ harr hbis
+        · rfl
+      · rfl
+
+/-- The array-native loop lands on the list loop's output arrays. -/
+theorem denseFoldLoopArrV_eq :
+    ∀ (targets : List (List VarId)) (d : DenseConstraintSystem p) (fidx : DenseFoldIdx p),
+      fidx.arr = d.algebraicConstraints.toArray →
+      fidx.arrBis = d.busInteractions.toArray →
+      (denseFoldLoopArrV targets fidx).arr
+          = (denseFoldLoopV targets d fidx).algebraicConstraints.toArray
+        ∧ (denseFoldLoopArrV targets fidx).arrBis
+          = (denseFoldLoopV targets d fidx).busInteractions.toArray := by
+  intro targets
+  induction targets with
+  | nil => intro d fidx harr hbis; exact ⟨harr, hbis⟩
+  | cons xs rest ih =>
+      intro d fidx harr hbis
+      show (denseFoldLoopArrV rest (denseFoldStepArrV fidx xs)).arr
+            = (denseFoldLoopV rest (denseFoldStepV d fidx xs).1
+                (denseFoldStepV d fidx xs).2).algebraicConstraints.toArray
+          ∧ (denseFoldLoopArrV rest (denseFoldStepArrV fidx xs)).arrBis
+            = (denseFoldLoopV rest (denseFoldStepV d fidx xs).1
+                (denseFoldStepV d fidx xs).2).busInteractions.toArray
+      rw [denseFoldStepArrV_eq d fidx xs harr hbis]
+      exact ih (denseFoldStepV d fidx xs).1 (denseFoldStepV d fidx xs).2
+        (denseFoldStepV_snd_arr d fidx xs harr) (denseFoldStepV_snd_arrBis d fidx xs hbis)
+
+/-- The pass transform with the array-native loop, installed as `denseDomainFoldFV`'s compiled
+    body. Every call site keeps the list-loop specification for its proofs. -/
+@[csimp] theorem denseDomainFoldFV_eq_fast : @denseDomainFoldFV = @denseDomainFoldFVFast := by
+  funext p pw d
+  unfold denseDomainFoldFV denseDomainFoldFVFast
+  by_cases hpB : pw.isPrime = true
+  · rw [if_pos hpB, if_pos hpB]
+    by_cases hthr : domainFoldIndexThreshold ≤ d.algebraicConstraints.length
+    · rw [if_pos hthr, if_pos hthr]
+      obtain ⟨h1, h2⟩ := denseFoldLoopArrV_eq (denseTargetsV d) d (DenseFoldIdx.mk' d) rfl rfl
+      show denseFoldLoopV (denseTargetsV d) d (DenseFoldIdx.mk' d)
+          = { algebraicConstraints :=
+                (denseFoldLoopArrV (denseTargetsV d) (DenseFoldIdx.mk' d)).arr.toList,
+              busInteractions :=
+                (denseFoldLoopArrV (denseTargetsV d) (DenseFoldIdx.mk' d)).arrBis.toList }
+      rw [h1, h2, List.toList_toArray, List.toList_toArray]
+    · rw [if_neg hthr, if_neg hthr]
+  · rw [if_neg hpB, if_neg hpB]
+
 /-- The registered domain-fold pass (transform `denseDomainFoldFV`, `DomainFoldRuntime.lean`). -/
 def denseDomainFoldPassV (pw : PrimeWitness p) : DenseVerifiedPassW p :=
   DenseVerifiedPassW.of

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
@@ -518,6 +518,514 @@ theorem denseRootPairUnifyF_correct (pw : PrimeWitness p) (reg : VarRegistry) (b
       (fun i t hti z hz => hinv.2 i t hti z hz)
   · exact DensePassCorrect.refl reg.isInput d bs
 
+/-! ## The indexed twins compute the same pass (`@[csimp]` runtime replacement)
+
+`denseRpLoopIdx` (`RootPairUnify.lean`) serves each bound query from a per-variable interaction
+index and a tabulated first-yield domain map instead of scanning the full interaction and
+constraint lists per candidate. The lemmas below show every query answer is unchanged — an
+interaction can only bound `x` if it mentions `x`, and the per-variable bucket is exactly the
+mention-filtered sublist in source order — so the pass is equal; `denseRootPairUnifyF_eq_fast`
+installs the fast body via `@[csimp]`. -/
+
+private theorem eraseDups_nodup {α : Type _} [BEq α] [LawfulBEq α] :
+    ∀ (l : List α), l.eraseDups.Nodup
+  | [] => by simp
+  | a :: as => by
+    rw [List.eraseDups_cons]
+    refine List.nodup_cons.mpr ⟨?_, eraseDups_nodup _⟩
+    intro hmem
+    have hf := (List.mem_filter.mp (List.mem_eraseDups.mp hmem)).2
+    rw [beq_self_eq_true] at hf
+    exact absurd hf (by decide)
+  termination_by l => l.length
+  decreasing_by
+    exact Nat.lt_add_one_of_le (List.length_filter_le ..)
+
+/-- `mentions` decides `vars` membership. -/
+private theorem denseMentions_iff_mem (i : VarId) (e : DenseExpr p) :
+    e.mentions i = true ↔ i ∈ e.vars := by
+  induction e with
+  | const n => simp [DenseExpr.mentions, DenseExpr.vars]
+  | var j =>
+      simp only [DenseExpr.mentions, DenseExpr.vars, List.mem_singleton, beq_iff_eq]
+      exact eq_comm
+  | add a b iha ihb => simp [DenseExpr.mentions, DenseExpr.vars, iha, ihb]
+  | mul a b iha ihb => simp [DenseExpr.mentions, DenseExpr.vars, iha, ihb]
+
+/-- `findSome?` under a pointwise-equal function. -/
+private theorem findSome?_congr' {α β : Type _} {f g : α → Option β} :
+    ∀ (l : List α), (∀ a ∈ l, f a = g a) → l.findSome? f = l.findSome? g := by
+  intro l
+  induction l with
+  | nil => intro _; rfl
+  | cons a rest ih =>
+      intro h
+      rw [List.findSome?_cons, List.findSome?_cons, h a (List.mem_cons_self ..)]
+      cases g a
+      · exact ih (fun b hb => h b (List.mem_cons_of_mem _ hb))
+      · rfl
+
+/-- Dropping list elements on which `f` is `none` keeps the first hit. -/
+private theorem findSome?_filter_eq {α β : Type _} (f : α → Option β) (P : α → Bool) :
+    ∀ (l : List α), (∀ a ∈ l, f a ≠ none → P a = true) →
+      (l.filter P).findSome? f = l.findSome? f := by
+  intro l
+  induction l with
+  | nil => intro _; rfl
+  | cons a rest ih =>
+      intro h
+      by_cases hPa : P a = true
+      · rw [List.filter_cons_of_pos hPa, List.findSome?_cons, List.findSome?_cons]
+        cases f a
+        · exact ih (fun b hb hf => h b (List.mem_cons_of_mem _ hb) hf)
+        · rfl
+      · have hfa : f a = none := by
+          by_contra hne
+          exact hPa (h a (List.mem_cons_self ..) hne)
+        rw [List.filter_cons_of_neg (by simpa using hPa)]
+        simp only [List.findSome?_cons, hfa]
+        exact ih (fun b hb hf => h b (List.mem_cons_of_mem _ hb) hf)
+
+/-- Dropping interactions that yield no bound keeps the first bound. -/
+private theorem denseFindVarBound_filter_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) (P : BusInteraction (DenseExpr p) → Bool) :
+    ∀ (l : List (BusInteraction (DenseExpr p))),
+      (∀ bi ∈ l, denseInteractionBound bs facts bi x ≠ none → P bi = true) →
+      denseFindVarBound bs facts (l.filter P) x = denseFindVarBound bs facts l x := by
+  intro l
+  induction l with
+  | nil => intro _; rfl
+  | cons bi rest ih =>
+      intro h
+      by_cases hP : P bi = true
+      · rw [List.filter_cons_of_pos hP]
+        simp only [denseFindVarBound]
+        cases denseInteractionBound bs facts bi x
+        · exact ih (fun b hb hf => h b (List.mem_cons_of_mem _ hb) hf)
+        · rfl
+      · have hno : denseInteractionBound bs facts bi x = none := by
+          by_contra hne
+          exact hP (h bi (List.mem_cons_self ..) hne)
+        rw [List.filter_cons_of_neg (by simpa using hP)]
+        simp only [denseFindVarBound, hno]
+        exact ih (fun b hb hf => h b (List.mem_cons_of_mem _ hb) hf)
+
+/-- A payload with a literal `.var i` slot mentions `i`. -/
+private theorem denseVarSlot_mem (i : VarId) :
+    ∀ (payload : List (DenseExpr p)) (slot : Nat), denseVarSlot i payload = some slot →
+      i ∈ payload.flatMap DenseExpr.vars := by
+  intro payload
+  induction payload with
+  | nil => intro slot h; simp [denseVarSlot] at h
+  | cons e rest ih =>
+      intro slot h
+      rw [denseVarSlot] at h
+      by_cases hv : denseIsVarOf i e = true
+      · cases e with
+        | var j =>
+            have : j = i := by simpa [denseIsVarOf] using hv
+            subst this
+            simp [DenseExpr.vars]
+        | const n => simp [denseIsVarOf] at hv
+        | add a b => simp [denseIsVarOf] at hv
+        | mul a b => simp [denseIsVarOf] at hv
+      · rw [if_neg hv] at h
+        cases hrec : denseVarSlot i rest with
+        | none => rw [hrec] at h; simp at h
+        | some s =>
+            simp only [List.flatMap_cons, List.mem_append]
+            exact Or.inr (ih s hrec)
+
+/-- An interaction can only bound `x` if it mentions `x`. -/
+private theorem denseInteractionBound_mem (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (x : VarId) (B : Nat)
+    (h : denseInteractionBound bs facts bi x = some B) : x ∈ denseBIVars bi := by
+  unfold denseInteractionBound at h
+  cases hm : bi.multiplicity.constValue? with
+  | none => simp only [hm] at h; exact absurd h.symm (Option.some_ne_none B)
+  | some mval =>
+      simp only [hm] at h
+      split_ifs at h with hz
+      cases hs : denseVarSlot x bi.payload with
+      | none => simp only [hs] at h; exact absurd h.symm (Option.some_ne_none B)
+      | some slot =>
+          rw [denseBIVars]
+          exact List.mem_append_right _ (denseVarSlot_mem x bi.payload slot hs)
+
+/-- A nonzero `splitAt` coefficient certifies occurrence. -/
+private theorem denseSplitAt_ne_zero_mem (x : VarId) :
+    ∀ (e : DenseExpr p) (k : ZMod p) (R : DenseExpr p),
+      e.splitAt x = some (k, R) → k ≠ 0 → x ∈ e.vars := by
+  intro e
+  induction e with
+  | const n =>
+      intro k R h hk
+      rw [DenseExpr.splitAt] at h
+      simp only [Option.some.injEq, Prod.mk.injEq] at h
+      exact absurd h.1.symm hk
+  | var y =>
+      intro k R h hk
+      rw [DenseExpr.splitAt] at h
+      by_cases hyx : y = x
+      · subst hyx; simp [DenseExpr.vars]
+      · rw [if_neg hyx] at h
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        exact absurd h.1.symm hk
+  | add a b iha ihb =>
+      intro k R h hk
+      rw [DenseExpr.splitAt] at h
+      cases ha : a.splitAt x with
+      | none => rw [ha] at h; simp at h
+      | some pa =>
+          cases hb : b.splitAt x with
+          | none => rw [ha, hb] at h; simp at h
+          | some pb =>
+              obtain ⟨ka, ra⟩ := pa
+              obtain ⟨kb, rb⟩ := pb
+              rw [ha, hb] at h
+              simp only [Option.some.injEq, Prod.mk.injEq] at h
+              have : ka ≠ 0 ∨ kb ≠ 0 := by
+                by_contra hc
+                rw [not_or, not_ne_iff, not_ne_iff] at hc
+                exact hk (by rw [← h.1, hc.1, hc.2, add_zero])
+              rw [DenseExpr.vars]
+              rcases this with h1 | h1
+              · exact List.mem_append_left _ (iha _ _ ha h1)
+              · exact List.mem_append_right _ (ihb _ _ hb h1)
+  | mul a b iha ihb =>
+      intro k R h hk
+      rw [DenseExpr.splitAt] at h
+      by_cases hmen : (a.mentions x || b.mentions x) = true
+      · rw [if_pos hmen] at h
+        cases hca : a.constValue? with
+        | some k0 =>
+            rw [hca] at h
+            cases hsb : b.splitAt x with
+            | none => rw [hsb] at h; simp at h
+            | some pb =>
+                obtain ⟨cb, rb⟩ := pb
+                rw [hsb] at h
+                simp only [Option.some.injEq, Prod.mk.injEq] at h
+                have hcb : cb ≠ 0 := fun hz => hk (by rw [← h.1, hz, mul_zero])
+                rw [DenseExpr.vars]
+                exact List.mem_append_right _ (ihb _ _ hsb hcb)
+        | none =>
+            rw [hca] at h
+            cases hcb : b.constValue? with
+            | some k0 =>
+                rw [hcb] at h
+                cases hsa : a.splitAt x with
+                | none => rw [hsa] at h; simp at h
+                | some pa =>
+                    obtain ⟨ca, ra⟩ := pa
+                    rw [hsa] at h
+                    simp only [Option.some.injEq, Prod.mk.injEq] at h
+                    have hca' : ca ≠ 0 := fun hz => hk (by rw [← h.1, hz, mul_zero])
+                    rw [DenseExpr.vars]
+                    exact List.mem_append_left _ (iha _ _ hsa hca')
+            | none => rw [hcb] at h; simp at h
+      · rw [if_neg hmen] at h
+        simp only [Option.some.injEq, Prod.mk.injEq] at h
+        exact absurd h.1.symm hk
+
+/-- The domain-served scaled bound equals the scanning one, pointwise in the domain lookup. -/
+private theorem denseScaledSlotBoundD_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domCs : List (DenseExpr p)) (dom : VarId → Option (List (ZMod p)))
+    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v) (bi : BusInteraction (DenseExpr p))
+    (x : VarId) :
+    denseScaledSlotBoundD bs facts dom bi x = denseScaledSlotBound bs facts domCs bi x := by
+  unfold denseScaledSlotBound denseScaledSlotBoundD
+  simp only [hdom]
+
+/-- A scaled slot can only bound `x` if the interaction mentions `x` (the accepted slot's
+    coefficient is nonzero once `1 ≠ 0`). -/
+private theorem denseScaledSlotBoundD_mem (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dom : VarId → Option (List (ZMod p))) (bi : BusInteraction (DenseExpr p)) (x : VarId)
+    (hp1 : (1 : ZMod p) ≠ 0) (B : Nat)
+    (h : denseScaledSlotBoundD bs facts dom bi x = some B) : x ∈ denseBIVars bi := by
+  unfold denseScaledSlotBoundD at h
+  cases hm : bi.multiplicity.constValue? with
+  | none => simp only [hm] at h; exact absurd h.symm (Option.some_ne_none B)
+  | some mval =>
+      simp only [hm] at h
+      split_ifs at h with hz
+      obtain ⟨slot, _hslot, hfs⟩ := List.exists_of_findSome?_eq_some h
+      cases hpay : bi.payload[slot]? with
+      | none => simp only [hpay] at hfs; exact absurd hfs.symm (Option.some_ne_none B)
+      | some O =>
+          simp only [hpay] at hfs
+          cases hb : facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) slot with
+          | none => simp only [hb] at hfs; exact absurd hfs.symm (Option.some_ne_none B)
+          | some bound =>
+              simp only [hb] at hfs
+              cases hsp : O.splitAt x with
+              | none => simp only [hsp] at hfs; exact absurd hfs.symm (Option.some_ne_none B)
+              | some kR =>
+                  obtain ⟨k, R⟩ := kR
+                  simp only [hsp] at hfs
+                  split_ifs at hfs with hcond hbnd
+                  have hk : k ≠ 0 := by
+                    intro hk0
+                    have h1 := hcond.1
+                    rw [hk0, zero_mul] at h1
+                    exact hp1 h1.symm
+                  have hxO : x ∈ O.vars := denseSplitAt_ne_zero_mem x O k R hsp hk
+                  rw [denseBIVars]
+                  exact List.mem_append_right _
+                    (List.mem_flatMap.mpr ⟨O, List.mem_of_getElem? hpay, hxO⟩)
+
+/-- The per-variable bucket is exactly the mention-filtered sublist, in source order. -/
+private theorem denseVarBucketAdd_getD {α : Type} (a : α) (x : VarId) :
+    ∀ (vs : List VarId), vs.Nodup → ∀ (m : Std.HashMap VarId (List α)),
+      (denseVarBucketAdd m vs a).getD x [] =
+        if x ∈ vs then a :: m.getD x [] else m.getD x [] := by
+  intro vs
+  induction vs with
+  | nil => intro _ m; simp [denseVarBucketAdd]
+  | cons w ws ih =>
+      intro hnd m
+      show (denseVarBucketAdd (m.insert w (a :: m.getD w [])) ws a).getD x []
+        = if x ∈ w :: ws then a :: m.getD x [] else m.getD x []
+      rw [ih (List.nodup_cons.mp hnd).2]
+      by_cases hxw : x = w
+      · subst hxw
+        have hnotin : x ∉ ws := (List.nodup_cons.mp hnd).1
+        rw [if_neg hnotin, if_pos (List.mem_cons_self ..), Std.HashMap.getD_insert_self]
+      · have hins : (m.insert w (a :: m.getD w [])).getD x [] = m.getD x [] := by
+          rw [Std.HashMap.getD_insert, if_neg (by simpa using fun h => hxw (eq_of_beq h).symm)]
+        rw [hins]
+        by_cases hxs : x ∈ ws
+        · rw [if_pos hxs, if_pos (List.mem_cons_of_mem _ hxs)]
+        · rw [if_neg hxs, if_neg (by
+            rw [List.mem_cons]
+            rintro (rfl | hmem)
+            · exact hxw rfl
+            · exact hxs hmem)]
+
+private theorem denseVarBucket_lookup_eq {α : Type} (varsOf : α → List VarId) (x : VarId) :
+    ∀ (items : List α),
+      denseVarBucketLookup (denseVarBucket varsOf items) x
+        = items.filter (fun a => decide (x ∈ varsOf a)) := by
+  intro items
+  induction items with
+  | nil => simp [denseVarBucket, denseVarBucketLookup]
+  | cons a rest ih =>
+      show (denseVarBucketAdd (denseVarBucket varsOf rest) ((varsOf a).eraseDups) a).getD x []
+        = List.filter (fun a => decide (x ∈ varsOf a)) (a :: rest)
+      rw [denseVarBucketAdd_getD a x _ (eraseDups_nodup _), List.filter_cons]
+      by_cases hxa : x ∈ varsOf a
+      · rw [if_pos (List.mem_eraseDups.mpr hxa), if_pos (by simpa using hxa)]
+        exact congrArg _ ih
+      · rw [if_neg (fun h => hxa (List.mem_eraseDups.mp h)), if_neg (by simpa using hxa)]
+        exact ih
+
+/-- A `denseDomStep` at another variable leaves `v`'s entry alone. -/
+private theorem denseDomStep_untouched (c : DenseExpr p) (v w : VarId) (hvw : v ≠ w)
+    (m : Std.HashMap VarId (List (ZMod p))) : (denseDomStep c m w)[v]? = m[v]? := by
+  rw [denseDomStep]
+  split
+  · rfl
+  · split
+    · rw [Std.HashMap.getElem?_insert, if_neg (by simpa using fun h => hvw (eq_of_beq h).symm)]
+    · rfl
+
+/-- A whole inner sweep not covering `v` leaves `v`'s entry alone. -/
+private theorem denseDomInner_untouched (c : DenseExpr p) (v : VarId) :
+    ∀ (vs : List VarId), v ∉ vs → ∀ (m : Std.HashMap VarId (List (ZMod p))),
+      (vs.foldl (denseDomStep c) m)[v]? = m[v]? := by
+  intro vs
+  induction vs with
+  | nil => intro _ m; rfl
+  | cons w ws ih =>
+      intro hv m
+      rw [List.foldl_cons, ih (fun h => hv (List.mem_cons_of_mem _ h))]
+      exact denseDomStep_untouched c v w (fun h => hv (h ▸ List.mem_cons_self ..)) m
+
+/-- An inner sweep covering `v` records `c`'s yield for `v` behind any earlier entry. -/
+private theorem denseDomInner_getElem (c : DenseExpr p) (v : VarId) :
+    ∀ (vs : List VarId), vs.Nodup → v ∈ vs → ∀ (m : Std.HashMap VarId (List (ZMod p))),
+      (vs.foldl (denseDomStep c) m)[v]? = (m[v]?).or (denseRootsIn v c) := by
+  intro vs
+  induction vs with
+  | nil => intro _ hv; simp at hv
+  | cons w ws ih =>
+      intro hnd hv m
+      rw [List.foldl_cons]
+      by_cases hvw : v = w
+      · subst hvw
+        have hnotin : v ∉ ws := (List.nodup_cons.mp hnd).1
+        rw [denseDomInner_untouched c v ws hnotin, denseDomStep]
+        by_cases hc : m.contains v = true
+        · rw [if_pos hc]
+          rw [Std.HashMap.contains_eq_isSome_getElem?] at hc
+          obtain ⟨d, hd⟩ := Option.isSome_iff_exists.mp hc
+          rw [hd]
+          rfl
+        · have hnone : m[v]? = none := by
+            rw [← Option.not_isSome_iff_eq_none, ← Std.HashMap.contains_eq_isSome_getElem?]
+            simpa using hc
+          rw [if_neg hc]
+          cases hr : denseRootsIn v c
+          · rw [hnone]
+            rfl
+          · rw [Std.HashMap.getElem?_insert_self, hnone]
+            rfl
+      · have hvs : v ∈ ws := by
+          rcases List.mem_cons.mp hv with h | h
+          · exact absurd h hvw
+          · exact h
+        rw [ih (List.nodup_cons.mp hnd).2 hvs, denseDomStep_untouched c v w hvw]
+
+/-- The outer sweep prepends the earlier constraints' yields, in `denseFindDomainAlg` order. -/
+private theorem denseDomFold_getElem (v : VarId) :
+    ∀ (all : List (DenseExpr p)) (m : Std.HashMap VarId (List (ZMod p))),
+      (all.foldl (fun m c =>
+          (HashedDedup.hashedEraseDups (hash ·) c.vars).foldl (denseDomStep c) m) m)[v]?
+        = (m[v]?).or (denseFindDomainAlg all v) := by
+  intro all
+  induction all with
+  | nil =>
+      intro m
+      show m[v]? = (m[v]?).or none
+      rw [Option.or_none]
+  | cons c rest ih =>
+      intro m
+      rw [List.foldl_cons, ih, HashedDedup.hashedEraseDups_eq]
+      by_cases hmem : v ∈ c.vars.eraseDups
+      · have hmen : c.mentions v = true :=
+          (denseMentions_iff_mem v c).mpr (List.mem_eraseDups.mp hmem)
+        rw [denseDomInner_getElem c v _ (eraseDups_nodup _) hmem, Option.or_assoc]
+        show _ = (m[v]?).or (denseFindDomainAlg (c :: rest) v)
+        rw [denseFindDomainAlg, if_pos hmen]
+        congr 1
+        cases denseRootsIn v c <;> rfl
+      · have hmen : c.mentions v = false := by
+          rw [Bool.eq_false_iff]
+          exact fun h => hmem (List.mem_eraseDups.mpr ((denseMentions_iff_mem v c).mp h))
+        rw [denseDomInner_untouched c v _ hmem]
+        show _ = (m[v]?).or (denseFindDomainAlg (c :: rest) v)
+        rw [denseFindDomainAlg, if_neg (by simp [hmen])]
+
+/-- The tabulated domain map answers exactly `denseFindDomainAlg`. -/
+private theorem denseFindDomainMap_getElem? (all : List (DenseExpr p)) (v : VarId) :
+    (denseFindDomainMap all)[v]? = denseFindDomainAlg all v := by
+  have h := denseDomFold_getElem v all ∅
+  rw [denseFindDomainMap, h]
+  simp
+
+/-- The indexed any-bound answers exactly the scanning one. -/
+private theorem denseAnyVarBoundIdx_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
+    (dom : VarId → Option (List (ZMod p)))
+    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v)
+    (hp1 : (1 : ZMod p) ≠ 0) (x : VarId) :
+    denseAnyVarBoundIdx bs facts
+      (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom x
+      = denseAnyVarBound bs facts bis domCs x := by
+  have hscaled : ∀ bi, denseScaledSlotBoundD bs facts dom bi x
+      = denseScaledSlotBound bs facts domCs bi x :=
+    fun bi => denseScaledSlotBoundD_eq bs facts domCs dom hdom bi x
+  unfold denseAnyVarBoundIdx denseAnyVarBound
+  rw [denseVarBucket_lookup_eq denseBIVars x bis,
+    denseFindVarBound_filter_eq bs facts x _ bis (fun bi _ hne => by
+      cases hb : denseInteractionBound bs facts bi x with
+      | none => exact absurd hb hne
+      | some B => exact decide_eq_true (denseInteractionBound_mem bs facts bi x B hb))]
+  cases denseFindVarBound bs facts bis x with
+  | some B => rfl
+  | none =>
+      rw [findSome?_congr' _ (fun bi _ => hscaled bi)]
+      exact findSome?_filter_eq _ _ bis (fun bi _ hne => by
+        cases hb : denseScaledSlotBound bs facts domCs bi x with
+        | none => exact absurd hb hne
+        | some B =>
+            refine decide_eq_true (denseScaledSlotBoundD_mem bs facts
+              (fun v => denseFindDomainAlg domCs v) bi x hp1 B ?_)
+            rw [denseScaledSlotBoundD_eq bs facts domCs _ (fun _ => rfl) bi x, hb])
+
+/-- The indexed pair certificate answers exactly the scanning one. -/
+private theorem denseRpCheckPairIdx_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
+    (dom : VarId → Option (List (ZMod p)))
+    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v)
+    (hp1 : (1 : ZMod p) ≠ 0) (cX cY : DenseExpr p) (x y : VarId) :
+    denseRpCheckPairIdx bs facts (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom
+        cX cY x y
+      = denseRpCheckPair bs facts bis domCs cX cY x y := by
+  unfold denseRpCheckPairIdx denseRpCheckPair
+  rw [denseAnyVarBoundIdx_eq bs facts bis domCs dom hdom hp1 x,
+    denseAnyVarBoundIdx_eq bs facts bis domCs dom hdom hp1 y]
+
+/-- The indexed scan loop computes the same solution map. -/
+private theorem denseRpLoopIdx_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
+    (dom : VarId → Option (List (ZMod p)))
+    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v)
+    (hp1 : (1 : ZMod p) ≠ 0) :
+    ∀ (cs : List (DenseExpr p)) (seen : Std.HashMap UInt64 (List (DenseRPSeen p)))
+      (σ : DenseSolved p),
+      denseRpLoopIdx bs facts (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom
+          cs seen σ
+        = denseRpLoop bs facts bis domCs cs seen σ := by
+  intro cs
+  induction cs with
+  | nil => intro seen σ; rfl
+  | cons c rest ih =>
+      intro seen σ
+      have hfind : (denseRpCandidates c).findSome? (fun xk =>
+          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
+            if e.key == xk.2 && e.x != xk.1 &&
+                denseRpCheckPairIdx bs facts
+                  (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom e.c c e.x xk.1
+            then some (e, xk.1) else none))
+          = (denseRpCandidates c).findSome? (fun xk =>
+          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
+            if e.key == xk.2 && e.x != xk.1 &&
+                denseRpCheckPair bs facts bis domCs e.c c e.x xk.1
+            then some (e, xk.1) else none)) := by
+        refine findSome?_congr' _ (fun xk _ => findSome?_congr' _ (fun e _ => ?_))
+        rw [denseRpCheckPairIdx_eq bs facts bis domCs dom hdom hp1]
+      simp only [denseRpLoopIdx, denseRpLoop]
+      rw [hfind]
+      cases (denseRpCandidates c).findSome? (fun xk =>
+          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
+            if e.key == xk.2 && e.x != xk.1 &&
+                denseRpCheckPair bs facts bis domCs e.c c e.x xk.1
+            then some (e, xk.1) else none)) with
+      | some ex => exact ih _ _
+      | none => exact ih _ _
+
+/-- The pass with indexed lookups, installed as `denseRootPairUnifyF`'s compiled body. -/
+@[csimp] theorem denseRootPairUnifyF_eq_fast :
+    @denseRootPairUnifyF = @denseRootPairUnifyFFast := by
+  funext p pw bs facts d
+  by_cases hp : pw.isPrime = true
+  · haveI : Fact p.Prime := ⟨pw.correct hp⟩
+    have hp1 : (1 : ZMod p) ≠ 0 := one_ne_zero
+    have hloop := denseRpLoopIdx_eq bs facts d.busInteractions d.algebraicConstraints
+      (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
+      (fun v => denseFindDomainMap_getElem? d.algebraicConstraints v) hp1
+      d.algebraicConstraints ∅ DenseSolved.empty
+    show (if pw.isPrime = true then
+        if (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
+            d.algebraicConstraints ∅ DenseSolved.empty).map.isEmpty then d
+        else d.substF (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
+            d.algebraicConstraints ∅ DenseSolved.empty).fn
+      else d)
+      = (if pw.isPrime = true then
+        if (denseRpLoopIdx bs facts
+            (denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions))
+            (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
+            d.algebraicConstraints ∅ DenseSolved.empty).map.isEmpty then d
+        else d.substF (denseRpLoopIdx bs facts
+            (denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions))
+            (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
+            d.algebraicConstraints ∅ DenseSolved.empty).fn
+      else d)
+    rw [hloop]
+  · show (if pw.isPrime = true then _ else d) = (if pw.isPrime = true then _ else d)
+    rw [if_neg hp, if_neg hp]
+
 /-- The dense `rootPairUnify` pass (see `denseRootPairUnifyF`). -/
 def denseRootPairUnifyPass (pw : PrimeWitness p) : DenseVerifiedPassW p :=
   DenseVerifiedPassW.of (denseRootPairUnifyF pw) (fun _ _ _ => [])

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.ByteCheckPack
 import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelJustify
+import ApcOptimizer.Implementation.OptimizerPasses.VarBucket
 
 set_option autoImplicit false
 
@@ -21,21 +22,6 @@ base interactions bounding it (`wits`). Computing those by filtering the whole s
 operand query is O(system) per query. We instead build, once per pass, a per-variable index mapping
 each variable to the items mentioning it, and feed those lookups to `denseByteJustifiedW`. Uncapped
 and order-preserving so a lookup returns exactly the same list a `filter (mentions x)` would. -/
-
-/-- Record `a` under each variable in `vs` (prepending, so a right-to-left build keeps source
-    order). -/
-def denseVarBucketAdd {α : Type} (m : Std.HashMap VarId (List α)) (vs : List VarId) (a : α) :
-    Std.HashMap VarId (List α) :=
-  vs.foldl (fun m x => m.insert x (a :: m.getD x [])) m
-
-/-- Index each item under every variable it mentions (via `varsOf`), keeping source order. -/
-def denseVarBucket {α : Type} (varsOf : α → List VarId) (items : List α) :
-    Std.HashMap VarId (List α) :=
-  items.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅
-
-/-- Look up the items indexed under `x`. -/
-def denseVarBucketLookup {α : Type} (I : Std.HashMap VarId (List α)) (x : VarId) : List α :=
-  I.getD x []
 
 /-- The operands whose byte-ness *implies* this interaction's acceptance (at any multiplicity):
     the checked operands of any fold-recognized shape, packed pair included (`denseByteShape?`);

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -1,6 +1,7 @@
 import ApcOptimizer.Implementation.OptimizerPasses.AddrDiseq
 import ApcOptimizer.Implementation.OptimizerPasses.DomainFold
 import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
+import ApcOptimizer.Implementation.OptimizerPasses.VarBucket
 
 set_option autoImplicit false
 
@@ -199,6 +200,118 @@ def denseRootPairUnifyF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : Bus
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
     let σ := denseRpLoop bs facts d.busInteractions d.algebraicConstraints
+      d.algebraicConstraints ∅ DenseSolved.empty
+    if σ.map.isEmpty then d else d.substF σ.fn
+  else d
+
+/-! ## Indexed bound lookups (runtime twins)
+
+`denseAnyVarBound` is queried per candidate pair with the *full* interaction and constraint lists:
+`denseFindVarBound` walks every interaction, and on failure `denseScaledSlotBound` walks every
+interaction again, resolving finite domains with an O(constraints) `denseFindDomainAlg` scan per
+offset variable. The twins below serve the same queries from a per-variable interaction index and
+a tabulated first-yield domain map, both built once per pass invocation.
+`denseRootPairUnifyF_eq_fast` (`Proofs/RootPairUnify.lean`) proves the pass equal and installs it
+via `@[csimp]`. -/
+
+/-- One tabulation step: record `c`'s root domain for `v` unless an earlier constraint already
+    yielded one. -/
+def denseDomStep (c : DenseExpr p) (m : Std.HashMap VarId (List (ZMod p))) (v : VarId) :
+    Std.HashMap VarId (List (ZMod p)) :=
+  if m.contains v then m
+  else match denseRootsIn v c with
+    | some d => m.insert v d
+    | none => m
+
+/-- `denseFindDomainAlg all` tabulated for every variable by one in-order sweep; insert-if-absent
+    keeps the first yielding constraint, matching the scan's first-hit semantics. -/
+def denseFindDomainMap (all : List (DenseExpr p)) : Std.HashMap VarId (List (ZMod p)) :=
+  all.foldl (fun m c =>
+    (HashedDedup.hashedEraseDups (hash ·) c.vars).foldl (denseDomStep c) m) ∅
+
+/-- `denseScaledSlotBound` with the offset variables' domains served by `dom`. -/
+def denseScaledSlotBoundD (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dom : VarId → Option (List (ZMod p))) (bi : BusInteraction (DenseExpr p)) (x : VarId) :
+    Option Nat :=
+  match bi.multiplicity.constValue? with
+  | none => none
+  | some mval =>
+    if mval = 0 then none else
+    (List.range bi.payload.length).findSome? (fun slot =>
+      match bi.payload[slot]? with
+      | none => none
+      | some O =>
+        match facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) slot with
+        | none => none
+        | some bound =>
+          match O.splitAt x with
+          | none => none
+          | some (k, R) =>
+            let m := k⁻¹
+            let others := R.vars.eraseDups
+            let doms := others.filterMap (fun v => (dom v).map (fun d => (v, d)))
+            if k * m = 1 ∧ doms.map Prod.fst = others ∧
+                (doms.map (fun vd => vd.2.length)).prod ≤ 16 then
+              if m.val * (bound - 1) + ((denseAssignments doms).map
+                    (fun pt => ((-m) * R.eval (denseEnvOfFast pt)).val)).foldl max 0 < p then
+                some (m.val * (bound - 1) + ((denseAssignments doms).map
+                  (fun pt => ((-m) * R.eval (denseEnvOfFast pt)).val)).foldl max 0 + 1)
+              else none
+            else none)
+
+/-- `denseAnyVarBound` served from the per-variable index `witsOf` and the domain lookup `dom`. -/
+def denseAnyVarBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs)
+    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
+    (dom : VarId → Option (List (ZMod p))) (x : VarId) : Option Nat :=
+  match denseFindVarBound bs facts (witsOf x) x with
+  | some B => some B
+  | none => (witsOf x).findSome? (fun bi => denseScaledSlotBoundD bs facts dom bi x)
+
+/-- `denseRpCheckPair` with indexed bound lookups. -/
+def denseRpCheckPairIdx (bs : BusSemantics p) (facts : BusFacts p bs)
+    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
+    (dom : VarId → Option (List (ZMod p)))
+    (cX cY : DenseExpr p) (x y : VarId) : Bool :=
+  match denseTwoRootOf? cX x, denseTwoRootOf? cY y with
+  | some (k, A, δ), some (k', A', δ') =>
+    decide (k' = k) && decide (A'.terms = A.terms) && decide (A'.const = A.const) &&
+    decide (δ' = δ) && decide (k * k⁻¹ = 1) &&
+    decide (x ∈ cX.vars) && decide (y ∈ cY.vars) &&
+    (match denseAnyVarBoundIdx bs facts witsOf dom x, denseAnyVarBoundIdx bs facts witsOf dom y with
+     | some Bx, some By =>
+       decide (max Bx By ≤ (k⁻¹ * δ).val) && decide (max Bx By ≤ p - (k⁻¹ * δ).val)
+     | _, _ => false)
+  | _, _ => false
+
+/-- `denseRpLoop` with indexed bound lookups. -/
+def denseRpLoopIdx (bs : BusSemantics p) (facts : BusFacts p bs)
+    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
+    (dom : VarId → Option (List (ZMod p))) :
+    List (DenseExpr p) → Std.HashMap UInt64 (List (DenseRPSeen p)) → DenseSolved p → DenseSolved p
+  | [], _, σ => σ
+  | c :: rest, seen, σ =>
+    let cands := denseRpCandidates c
+    match cands.findSome? (fun xk =>
+        (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
+          if e.key == xk.2 && e.x != xk.1 &&
+              denseRpCheckPairIdx bs facts witsOf dom e.c c e.x xk.1
+          then some (e, xk.1) else none)) with
+    | some ex =>
+        denseRpLoopIdx bs facts witsOf dom rest
+          (denseRpInsertAll seen ((cands.filter (fun xk => xk.1 != ex.2)).map
+            (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p))))
+          (σ.insertAll [(ex.2, DenseExpr.var ex.1.x)])
+    | none =>
+        denseRpLoopIdx bs facts witsOf dom rest
+          (denseRpInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p)))) σ
+
+/-- `denseRootPairUnifyF` with the per-variable interaction index and the tabulated domain map. -/
+def denseRootPairUnifyFFast (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  if pw.isPrime = true then
+    let witsIdx := denseVarBucket denseBIVars d.busInteractions
+    let domMap := denseFindDomainMap d.algebraicConstraints
+    let σ := denseRpLoopIdx bs facts (denseVarBucketLookup witsIdx) (fun v => domMap[v]?)
       d.algebraicConstraints ∅ DenseSolved.empty
     if σ.map.isEmpty then d else d.substF σ.fn
   else d

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -309,10 +309,14 @@ def denseRpLoopIdx (bs : BusSemantics p) (facts : BusFacts p bs)
 def denseRootPairUnifyFFast (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let witsIdx := denseVarBucket denseBIVars d.busInteractions
-    let domMap := denseFindDomainMap d.algebraicConstraints
-    let σ := denseRpLoopIdx bs facts (denseVarBucketLookup witsIdx) (fun v => domMap[v]?)
-      d.algebraicConstraints ∅ DenseSolved.empty
+    -- Thunked: bound queries only happen on key-matched candidate pairs, so systems without
+    -- two-root twins never pay for the index builds.
+    let witsIdx : Thunk (Std.HashMap VarId (List (BusInteraction (DenseExpr p)))) :=
+      Thunk.mk fun _ => denseVarBucket denseBIVars d.busInteractions
+    let domMap : Thunk (Std.HashMap VarId (List (ZMod p))) :=
+      Thunk.mk fun _ => denseFindDomainMap d.algebraicConstraints
+    let σ := denseRpLoopIdx bs facts (fun x => denseVarBucketLookup witsIdx.get x)
+      (fun v => (domMap.get)[v]?) d.algebraicConstraints ∅ DenseSolved.empty
     if σ.map.isEmpty then d else d.substF σ.fn
   else d
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/SearchBudgets.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SearchBudgets.lean
@@ -32,3 +32,9 @@ def maxEnumWork : Nat := 524288
     the direct per-target `coveredCsOf` scan. Purely a runtime gate — both paths compute the
     identical fold. -/
 def domainFoldIndexThreshold : Nat := 8192
+
+/-- Systems with at least this many bus interactions use the slot-0-indexed representative store in
+    `densePdDropSet`; smaller ones scan the per-class representative list directly (the index's
+    per-interaction map overhead outweighs the scan at fixture scale). Purely a runtime gate — both
+    paths propose the identical drop set. -/
+def pointwiseDupDropIndexThreshold : Nat := 4096

--- a/ApcOptimizer/Implementation/OptimizerPasses/VarBucket.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/VarBucket.lean
@@ -1,0 +1,29 @@
+import ApcOptimizer.Implementation.OptimizerPasses.Registry
+
+set_option autoImplicit false
+
+/-! # Per-variable item index
+
+Maps each variable to the items mentioning it (`denseVarBucket`), uncapped and order-preserving so
+a lookup returns exactly the same list a `filter (mentions x)` would. Shared by
+`RedundantByteDrop.lean` (operand justification) and `RootPairUnify.lean` (per-variable bound
+lookups); the soundness/exactness lemmas live with their consumers. -/
+
+namespace ApcOptimizer.Dense
+
+/-- Record `a` under each variable in `vs` (prepending, so a right-to-left build keeps source
+    order). -/
+def denseVarBucketAdd {α : Type} (m : Std.HashMap VarId (List α)) (vs : List VarId) (a : α) :
+    Std.HashMap VarId (List α) :=
+  vs.foldl (fun m x => m.insert x (a :: m.getD x [])) m
+
+/-- Index each item under every variable it mentions (via `varsOf`), keeping source order. -/
+def denseVarBucket {α : Type} (varsOf : α → List VarId) (items : List α) :
+    Std.HashMap VarId (List α) :=
+  items.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅
+
+/-- Look up the items indexed under `x`. -/
+def denseVarBucketLookup {α : Type} (I : Std.HashMap VarId (List α)) (x : VarId) : List α :=
+  I.getD x []
+
+end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -150,6 +150,18 @@ keccak, so anything superlinear is fatal there.
 - gdb samples (keccak, mid-run): `findConsumer` (busUnify), `reencodeLoop`, `foldLoopDirect`
   (domainFold's unindexed path), `collectForBus` — matching the analysis below.
 
+### Where the time goes at SHA scale (2026-07-24, PRs #205–#210)
+
+sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):
+**989 s (main-of-2026-07-24) → 550 s** across #205 (registry array-copy, encode 80.5 → 0.8 s),
+#206 (domainFold Array.modify accepts, 173 → 6.9 s, reencode −86 s from allocator pressure alone),
+#208 (pointwiseDupDrop slot-0 index + hoisted singles, flagFold 85 → 15.6 s), #209 (rootPairUnify
+per-variable bound indexes, 49.6 → 33.7 s), #210 (busPairCancel segment scans, 107 → 89.5 s).
+Remaining per-pass: reencode 188 s, busPairCancel 89 s, busUnify 52 s, gauss 36 s, rootPairUnify
+33 s, domainBatch 21 s (parallel), bytePack 17 s, flagFold 15 s, normalize1 14 s, carryBranch
+13 s. Cycles 0–2 are still ~80 % of the total. Whole-run perf: ~25 % `lean_dec_ref_cold` +
+~17 % allocator + ~8 % `lean_apply_1` — the budget is still memory traffic, not arithmetic.
+
 ### Open runtime ideas, priority order
 
 Priority = impact at SHA scale (8× keccak) ÷ effort. The pattern for all index work stays the
@@ -166,13 +178,9 @@ these need no new proof.
      thunked; the pass body's per-invocation `HashSet.ofList cs.vars` replaced by the
      by-construction variable guarantee (`memEqConstraints_vars`) and the hash-bucket build
      gated on nonempty candidates. Output byte-identical.
-   - `busPairCancel`: `shieldOk` re-scans (and `liveArr` **materializes**) the whole before-region
-     per candidate send (`BusPairCancel.lean` `shieldOk`/`findCancelGoIdx`) — O(B²) time *and*
-     allocation on the long same-address chains the pass exists for; in coda mode the `addrHash`
-     bucket is O(B) per hot address — add a position cursor. **Still open**, but whole-run
-     samples put busPairCancel at only ~4 % on keccak post-111; the same per-key sweep pattern
-     as busUnify applies (`shieldOk` left-folds to a single per-key `pending` bit), complicated
-     by the tombstone-drop restarts. ~~`dropWits` from-0 array scan per
+   - `busPairCancel`: ~~`liveArr` materialization per candidate~~ **done (#210)** — see R8.
+     The O(B²) *certificate* scans remain (R8 design (b)); in coda mode the `addrHash`
+     bucket is O(B) per hot address — add a position cursor. ~~`dropWits` from-0 array scan per
      queried variable~~ **done (entry 105)**: per-variable position index (`buildBoundIdx`),
      re-checked at use.
    - ~~`dedup` constraint-side `List.dedup` O(C²·E)~~ **done (entry 104)**: bucketed
@@ -301,17 +309,51 @@ reencode's per-target *gating* work is also independent between accepts, but the
 if their serial remainder grows relative to the rest. busPairCancel/busUnify are inherently
 sequential scans (window state).
 
-**R8. busPairCancel residual quadratics** (formerly part of R1)  ·  ~7 % of the post-114 keccak
-profile. `shieldOk` re-scans (and `liveArr` materializes) the whole live before-region per
-candidate send; `midRefuted` likewise materializes the between-region. Two designs, in
-increasing effort: (a) fuse the materialization away — array-index twins of
-`liveArr`+`shieldScan`/`List.all` with `…_eq` lemmas (the `liveArr_eq` pattern), removing the
-O(i) allocation per candidate but keeping the O(i) scan; (b) the busUnify entry-111 treatment —
-`shieldOk` left-folds to a single per-address-key `pending` bit, maintainable across one sweep,
-but the pass's tombstone-and-restart structure (drops invalidate prefix state: removing a
-consumed receive un-shields earlier messages) forces a recompute-on-drop scheme, bounded by
-#drops × O(B). The whole-run sample share (~5 %) says (a) first, (b) only if SHA-scale profiles
-promote it.
+**R8. busPairCancel residual quadratics** (formerly part of R1). Design (a) — array-segment
+twins of `liveArr`+`shieldScan`/`List.all` (`denseLiveAllSeg`/`denseShieldScanSeg` with `…_eq`
+lemmas) — is **done (#210)**: sha256_big busPairCancel 107 → 89.5 s. The remaining 89 s
+(~16 % of the SHA run, now promoted) is the O(live²) certificate work itself: `shieldOk` still
+evaluates `densePreRefuted` over the whole live prefix per candidate send, and `midRefuted` over
+the between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldOk` left-folds
+to a single per-address-key `pending` bit, maintainable across one sweep — but the pass's
+tombstone-and-restart structure (drops invalidate prefix state: removing a consumed receive
+un-shields earlier messages) forces a recompute-on-drop scheme, bounded by #drops × O(B).
+
+**R9. Stop rebuilding `ZMod.commRing` per helper call**  ·  *horizontal, medium value / medium
+effort*. Any helper doing `ZMod` arithmetic without a threaded `DenseZModOps` re-materializes the
+whole Mathlib `CommRing` structure (plus 3–4 hierarchy projections) **per call** — visible as
+`lp_mathlib_ZMod_commRing` + projections at ~3 % (sha) to ~10 % (ecrecover) of whole-run CPU
+*before* counting their allocator/dec_ref share; the generated C shows the rebuild at every entry
+(e.g. `denseRootsOfTerms`). Hot chain: `denseLinearize`, `DenseLinExpr.norm/scale/coeff/others`,
+`denseTwoRootOf?`, `DenseExpr.fold`, `denseRootsIn`, `denseBitCM` — called per constraint per
+cycle by the TwoRootMap/AddrCerts/candidate builders of busUnify/busPairCancel/rootPairUnify.
+Thread `ops` through `@[csimp]` fast twins (the gauss entries 118–119 pattern; rootPairUnify's
+remaining 33 s is mostly this).
+
+**R10. busUnify symbolic-window sweep at SHA scale**  ·  *52 s on sha256_big*. `denseSweepGo`
+tests every symbolic-address message against every open window: `constOpen.toList` is rebuilt per
+non-all-const message, and each open `symOpen` window pays the full `denseStepTest` certificate
+chain per message. The sweep is an untrusted proposal (`denseCheckPair` re-verifies), **but its
+consumer/excluded/blocker decisions choose which candidates are proposed**, so any restructuring
+must keep decisions bit-identical — memoize `denseStepTest` only under full structural keys, or
+index windows by address-expression hash with the existing tests re-run on hits.
+
+**R11. `decide (A ∧ B)` evaluates both sides eagerly**  ·  *latent bignum landmine, cheap fix*.
+`Decidable (A ∧ B)` instances are strict in both arguments in compiled code, so
+`decide (widthValue.val ≤ 17 ∧ xValue.val < 2 ^ widthValue.val)`
+(`DomainBatchRuntime.lean:166`, `.varRange` evaluator) computes `2 ^ widthValue.val` even when
+the guard fails — for a symbolic width slot that is a 2^31-bit GMP number per evaluated point.
+`OpenVmSemantics.lean:95` already uses the short-circuiting `decide … && decide …` form;
+rewrite the evaluator arms the same way (`Bool.decide_and` bridges proofs). Audit other
+`decide (… ∧ …)` in per-point code (`denseScaledSlotBound`'s guard is a cheaper instance of the
+same pattern).
+
+**R12. Array-index the dense per-variable maps**  ·  *speculative, measure first*. Every
+`Std.HashMap`/`HashSet` operation dispatches `BEq`/`Hashable` through boxed closures
+(`lean_apply_1/2`, ~8 % whole-run). `VarId.index` is dense and bounded by the registry size, so
+the per-variable bucket maps (`DenseCovIndex.buckets`, `denseVarBucket`, `denseTouchedSet`) could
+be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide but mechanical;
+worth a prototype on one index first.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
@@ -326,7 +368,9 @@ promote it.
   indexes are the pattern.
 - **Feeding whole regions into per-query justification arms**: 63 s/case for −3 interactions
   (entry 102). Use a position index or nothing.
-- CI notes: the effectiveness-matrix runtime row is parallel-contended (±10 % noise); the serial
+- CI notes (updated 2026-07-24): the effectiveness-matrix runtime row swung **+51 % → +15 % on
+  identical code** for openvm-eth while its own per-pass table showed ≤1.04× — treat the wall row
+  as ±50 % noise on the small parallel sets and read the per-pass table instead; the serial
   `Runtime Bench` workflow (dispatch-only, openvm sets only) is the real A/B. This container has
   ±15 % run-to-run variance; keccak numbers above were taken serially, and the per-cycle keccak
   run was inflated ~30 % by a concurrent gdb sampler — compare shapes, not absolutes, and let CI

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4723,3 +4723,83 @@ representatives remained on the original path and were runtime-neutral within lo
 
 **Worked locally: yes (reencode and whole-profile wins on large overlapping workloads; unchanged
 outputs on representative OpenVM and SP1 inputs; full-set result pending CI).**
+
+### 137. Runtime: registry `register` no longer copies `byId` per registration (#205)
+
+The struct literal in `VarRegistry.register` read `r.byId.size` after `r.byId.push v`, so the
+compiler kept `byId` alive across the push and `lean_array_push` copied the whole registry-sized
+array on every fresh registration (`lean_copy_expand_array`, 5.7 % of the sha256_big run,
+concentrated in the pipeline-entry encode). Binding `n := r.byId.size` before the push makes the
+push the array's last use. Definitionally transparent — proofs untouched.
+
+sha256_big encode: 80,486 → 1,074 ms. Working rule (generalizes entry 106's arity rule): in a
+struct literal or update, bind scalar reads of a field *before* the expression that consumes the
+field linearly, and check the generated C for `lean_copy_expand_array` when an array-heavy
+function is slow.
+
+**Worked locally: yes (75× on encode; byte-identical fixtures; merged as #205).**
+
+### 138. Runtime: domainFold applies accepted folds with `Array.modify` (#206)
+
+The indexed fold loop threaded the list system and re-materialized it per accepted fold:
+`denseFoldOutIdxV` mapped over `algebraicConstraints.zipIdx`/`busInteractions.zipIdx` (each an
+O(system) `toArray` — `List.length`'s pointer chase alone was ~8 % of the run — plus a full map
+rebuild), and `DenseFoldIdx.refresh` converted the folded lists back to arrays. The array-native
+loop (`denseFoldLoopArrV`) threads only the already-array-backed `DenseFoldIdx`, applies accepted
+folds with `Array.modify` at the touched (bucketed) positions, and materializes lists once at the
+pass exit. `denseDomainFoldFV_eq_fast` proves the twin equal (generic `foldl`-`Array.modify` =
+sparse positional map lemma) and installs it via `@[csimp]`, so the pass proofs stay on the list
+specification.
+
+sha256_big domainFold: 172,784 → 6,933 ms; reencode dropped 264 → 178 s with no reencode change
+(shared-subtree RC traffic and allocator pressure). Total for #205+#206: 989 → 643 s.
+
+**Worked locally: yes (25× on the pass; byte-identical fixtures incl. ecrecover_53k).**
+
+### 139. Runtime: pointwiseDupDrop slot-0-indexed representatives + hoisted singles (#208)
+
+The sweep tested each interaction against every representative in its (busId, mult, len) class
+(`densePdSigsCompatible` 3.4 % of whole-run CPU), and the verdicts construction spelled
+`denseSingleVarCs d.algebraicConstraints` inside the `filterMap` closure, recomputing the
+O(system) single-variable filter per proposed drop. A certified twin's slot pair is value-equal
+or shares a decomposition carrier (`denseSlotEqCert`), so representatives are now indexed by
+slot-0 value hash and per-variable buckets and only those candidates are re-checked with the
+unchanged full tests — the proposed drop set is identical, and `densePdKeep` still re-verifies
+every proposal. Systems under `pointwiseDupDropIndexThreshold = 4096` interactions keep the
+direct per-class scan (the index's pair-keyed map overhead measured +2.5 % on fixture-scale
+inputs; the CI wall row's +51 % was runner noise — its own per-pass table showed ≤1.04×).
+
+sha256_big flagFold: 85.0 → 15.6 s (from 296 s two days ago).
+
+**Worked locally: yes (byte-identical fixtures; gate restores fixture parity).**
+
+### 140. Runtime: rootPairUnify serves bound queries from per-variable indexes (#209)
+
+`denseAnyVarBound` was queried per candidate pair against the full lists: `denseFindVarBound`
+walked every interaction, on failure `denseScaledSlotBound` walked them again, and each offset
+variable's finite domain came from an O(constraints) `denseFindDomainAlg` scan. The pass now
+builds a per-variable interaction bucket (`denseVarBucket`, moved to the shared `VarBucket.lean`)
+and a tabulated first-yield domain map (`denseFindDomainMap`) once per invocation. An interaction
+can only bound `x` if it mentions `x` (a bounding slot is literally `.var x`; an accepted scaled
+slot has a nonzero `splitAt` coefficient once `1 ≠ 0`), and the bucket is exactly the
+mention-filtered sublist in source order, so every query answer is unchanged;
+`denseRootPairUnifyF_eq_fast` installs the indexed body via `@[csimp]`.
+
+sha256_big rootPairUnify: 49.6 → 33.7 s. The remainder is candidate/two-root machinery — R9's
+instance-reconstruction chain, not scanning.
+
+**Worked locally: yes (byte-identical fixtures incl. ecrecover_53k).**
+
+### 141. Runtime: busPairCancel scans candidate regions on array segments (#210)
+
+R8 design (a): per candidate pair, `denseFindCancelGoIdx` materialized the live prefix
+(`denseLiveArr`, an O(i)-node list) for the shield check and the mid segment for the between
+check — O(live²) allocation per pass invocation. `denseLiveAllSeg` and `denseShieldScanSeg`
+compute the same folds directly on the array segment, structurally mirroring `denseLiveSeg` so
+the proven equalities rewrite the region hypotheses back onto the `denseLiveSeg` forms the drop
+proofs consume.
+
+sha256_big busPairCancel: 107.4 → 89.5 s; stack total 989 → 550 s (−44 % vs main-of-today,
+2.4× vs two days ago). The remaining 89 s is the certificate work itself — R8 design (b).
+
+**Worked locally: yes (byte-identical fixtures incl. ecrecover_53k).**


### PR DESCRIPTION
Combined stack (one commit per change, formerly #206/#208/#209 + this PR's segment scans), targeting main directly. Each change keeps the optimizer's output **bit-identical** — either the fast body is proven equal to the specification and installed with `@[csimp]` (the pass proofs never move off the spec), or it is an untrusted proposal that the existing verified re-check consumes — and `Scripts/check-proof-integrity.sh` passes throughout.

## The changes

1. **domainFold: apply accepted folds with `Array.modify` at touched positions** (`denseFoldLoopArrV`, csimp twin). Previously every accepted fold re-materialized the whole system (`zipIdx`'s `toArray` + full-list map + `refresh`'s `toArray`) — `List.toArray`'s length pre-pass alone was ~8% of total runtime. **173s → 6.9s** on the pass, and reencode drops 264s → 178s untouched, purely from allocator/RC pressure.

2. **pointwiseDupDrop: slot-0-indexed sweep representatives + hoisted `singles`.** A certified twin's slot pair is value-equal or shares a decomposition carrier, so only representatives hash-equal to — or variable-sharing with — the incoming slot 0 are re-checked (identical drop set, still re-verified by `densePdKeep`); the verifier no longer recomputes the O(system) single-variable filter per proposed drop. Gated to systems ≥ `pointwiseDupDropIndexThreshold = 4096` interactions (fixture-scale systems keep the direct scan). **flagFold 85s → 15.6s.**

3. **rootPairUnify: bound queries served from per-variable indexes** (`denseVarBucket` in the new shared `VarBucket.lean` + tabulated first-yield domain map, csimp twin; an interaction can only bound `x` if it mentions `x`, so answers are unchanged). The builds are thunked, so systems without two-root twins never pay for them. **49.6s → 33.7s.**

4. **busPairCancel: candidate region checks fold the array segments directly** (`denseLiveAllSeg`/`denseShieldScanSeg` with proven `…_eq` lemmas) instead of materializing an O(prefix) list per candidate pair. **107.4s → 89.5s.**

Plus `agent-docs` log entries 137–141 and a runtime-ideas refresh.

## Measured (sha256_big, 170k vars, powdr dev server, quiet)

**989s (main) → 550s (−44%)**; with #205 (already merged) the two-day total is 1298s → 550s (**2.4×**). Local A/B on the other sets: openvm keccak 36s → 30s (−16%), sp1 keccak 97.3s → 97.3s (±0), openvm-eth fixtures at parity post-gate (98.1s vs 97.1s over 50 cases). Tip-of-stack CI: parity-or-better on all six sets (openvm-eth −0%, wasm-eth −12%, keccak −17%, sha256 −31%, sp1/rsp −33%, sp1/keccak −1%); the wild runtime rows on the intermediate PRs' runs (+55% sp1/rsp on a subset branch vs −33% on its superset) are runner noise — per-pass tables show ≤1.04× throughout. A serial local suite comparison is posted below.

## Verification

- `run` output byte-identical vs base across all 100 openvm-eth fixtures and ecrecover_53k at every step.
- `Scripts/check-proof-integrity.sh` green (three standard axioms only; csimp equalities among the checked roots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)