### PR TITLE
perf(reencode): stop rescanning the whole system per candidate group (184s -> 97s on 170k sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1304,25 +1304,26 @@ theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry} {useI
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId) (xs : List VarId)
+    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId)
     (freshBase : String) (bs : BusSemantics p)
     (hcov : d.CoveredBy reg) (hvs : ∀ x, varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
-    ∧ (∀ i, (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1.isInput i
+    reg.Extends (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
+    ∧ (∀ i, (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1.isInput i
         = reg.isInput i)
-    ∧ (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
+    ∧ (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1.CoveredBy
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
     ∧ DenseDerivations.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.1
-    ∧ (∀ x, (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.2.2.2.contains x
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.1
+    ∧ (∀ x, (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.2.2.2.contains x
           = true →
-        x ∈ (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1.occ)
+        x ∈ (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1.occ)
     ∧ DensePassCorrect
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).1.isInput d
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStep b useIdx reg d csIdx arrCs varSet xs freshBase
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1.isInput d
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1
+        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase
   case case4 =>
     rename_i hgate hcoll reg1 bits hm hbeq hdpr hA hB hC hD ro hwd
     have hbext : reg.Extends reg1 := denseBuildReencode_ext_of_eq hbeq
@@ -1353,25 +1354,26 @@ theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Boo
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
+    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId) (freshBase : String)
+    (bs : BusSemantics p)
     (hcov : d.CoveredBy reg) (hvs : ∀ x, state.varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends (denseReencodeStepCached b useIdx reg d state xs freshBase).1
-    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput i
+    reg.Extends (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
+    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state use xs freshBase).1.isInput i
         = reg.isInput i)
-    ∧ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+    ∧ (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1.CoveredBy
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
     ∧ DenseDerivations.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.1
     ∧ (∀ x,
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.2.varSet.contains x
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.2.varSet.contains x
           = true →
-        x ∈ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.occ)
+        x ∈ (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1.occ)
     ∧ DensePassCorrect
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput d
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStepCached b useIdx reg d state xs freshBase
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1.isInput d
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1
+        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStepCached b useIdx reg d state use xs freshBase
   case case4 =>
     rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
     have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
@@ -1415,42 +1417,46 @@ set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (bs : BusSemantics p) :
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
-      (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId),
+      (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+      (use : Thunk (DenseReencodeUseIdx p)) (nc nb : Nat),
       d.CoveredBy reg → (∀ x, varSet.contains x = true → x ∈ d.occ) →
-      reg.Extends (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
-      ∧ (∀ i, (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1.isInput i
+      reg.Extends (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
+      ∧ (∀ i, (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1.isInput i
           = reg.isInput i)
-      ∧ (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.1.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
+      ∧ (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.1.CoveredBy
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
       ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.2
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.2
       ∧ DensePassCorrect
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).1.isInput d
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet).2.2 bs := by
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1.isInput d
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.1
+          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
-      intro idx reg d csIdx arrCs varSet hcov hvs
+      intro idx reg d csIdx arrCs varSet use nc nb hcov hvs
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
         ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov, (by intro x hx; simp at hx),
         DensePassCorrect.refl reg.isInput d bs⟩
   | cons xs rest ih =>
-      intro idx reg d csIdx arrCs varSet hcov hvs
+      intro idx reg d csIdx arrCs varSet use nc nb hcov hvs
       simp only [denseReencodeLoop]
-      rcases hstep : denseReencodeStep b useIdx reg d csIdx arrCs varSet xs
-          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
-          with ⟨reg1, d1, derivs1, csIdx1, arrCs1, varSet1⟩
-      have hsp := denseReencodeStep_correct b useIdx reg d csIdx arrCs varSet xs
-          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}") bs hcov hvs
+      rcases hstep : denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs
+          s!"rnc{nc}_{nb}_{idx}" with ⟨reg1, d1, derivs1, csIdx1, arrCs1, varSet1⟩
+      have hsp := denseReencodeStep_correct b useIdx reg d csIdx arrCs varSet use xs
+          s!"rnc{nc}_{nb}_{idx}" bs hcov hvs
       simp only [hstep] at hsp
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
       rcases hrec : denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
+          (denseReencodeUseNext derivs1 d1 use)
+          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
           with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 hs_cov hs_vs
+      have hih := ih (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 (denseReencodeUseNext derivs1 d1 use)
+          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
+          hs_cov hs_vs
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1465,42 +1471,45 @@ set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (bs : BusSemantics p) :
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
-      (state : DenseReencodeCacheState p),
+      (state : DenseReencodeCacheState p) (use : Thunk (DenseReencodeUseIdx p)) (nc nb : Nat),
       d.CoveredBy reg → (∀ x, state.varSet.contains x = true → x ∈ d.occ) →
-      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state).1
-      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state).1.isInput i
+      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
+      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1.isInput i
           = reg.isInput i)
-      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state).2.1.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state).1
+      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.1.CoveredBy
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
       ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state).1
-          (denseReencodeLoopCached b useIdx targets idx reg d state).2.2
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.2
       ∧ DensePassCorrect
-          (denseReencodeLoopCached b useIdx targets idx reg d state).1.isInput d
-          (denseReencodeLoopCached b useIdx targets idx reg d state).2.1
-          (denseReencodeLoopCached b useIdx targets idx reg d state).2.2 bs := by
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1.isInput d
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.1
+          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
-      intro idx reg d state hcov hvs
+      intro idx reg d state use nc nb hcov hvs
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
         ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
         (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput d bs⟩
   | cons xs rest ih =>
-      intro idx reg d state hcov hvs
+      intro idx reg d state use nc nb hcov hvs
       simp only [denseReencodeLoopCached]
-      rcases hstep : denseReencodeStepCached b useIdx reg d state xs
-          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+      rcases hstep : denseReencodeStepCached b useIdx reg d state use xs s!"rnc{nc}_{nb}_{idx}"
           with ⟨reg1, d1, derivs1, state1⟩
-      have hsp := denseReencodeStepCached_correct b useIdx reg d state xs
-          (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}") bs hcov hvs
+      have hsp := denseReencodeStepCached_correct b useIdx reg d state use xs
+          s!"rnc{nc}_{nb}_{idx}" bs hcov hvs
       simp only [hstep] at hsp
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
       rcases hrec : denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
+          (denseReencodeUseNext derivs1 d1 use)
+          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
           with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 state1 hs_cov hs_vs
+      have hih := ih (idx + 1) reg1 d1 state1 (denseReencodeUseNext derivs1 d1 use)
+          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
+          hs_cov hs_vs
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1532,7 +1541,9 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
       obtain ⟨he, _, hc, hd, hcorr⟩ :=
         denseReencodeLoopCached_correct b useIdx bs targets 0 reg d
           ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
-           d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩ hcov
+           d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩
+          (Thunk.mk (fun _ => denseBuildUseIdx d))
+          d.algebraicConstraints.length d.busInteractions.length hcov
           (fun x hx => by
             rw [Std.HashSet.contains_ofList] at hx
             exact List.contains_iff_mem.mp hx)
@@ -1540,7 +1551,9 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
     · rw [if_neg hcache]
       obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d
         (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ) hcov
+        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ)
+        (Thunk.mk (fun _ => denseBuildUseIdx d))
+        d.algebraicConstraints.length d.busInteractions.length hcov
         (fun x hx => by
           rw [Std.HashSet.contains_ofList] at hx
           exact List.contains_iff_mem.mp hx)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -361,27 +361,55 @@ def denseBuildReencodeCached (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseC
       else (reg, none, cache)
     else (reg, none, cache)
 
+/-- Whole-system posting index for the degree pre-gate, thunked so only runs that construct a
+    candidate pay for it. Positions are `d`'s list order, so they index `arrCs` and `arrBis`. -/
+structure DenseReencodeUseIdx (p : ℕ) where
+  csIdx : DenseCovIndex
+  biIdx : DenseCovIndex
+  arrBis : Array (BusInteraction (DenseExpr p))
+
+def denseBuildUseIdx (d : DenseConstraintSystem p) : DenseReencodeUseIdx p :=
+  ⟨denseCovBuild DenseExpr.vars d.algebraicConstraints,
+   denseCovBuild denseBIVars d.busInteractions,
+   d.busInteractions.toArray⟩
+
+/-- The index's candidate positions for `xs`, each once (an item is bucketed per variable
+    occurrence, and the gate below rewrites every position it visits). -/
+def denseUsePositions (idx : DenseCovIndex) (xs : List VarId) : List Nat :=
+  ((denseCandidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+
 /-- Degree pre-gate (untrusted): rewrite only the items sharing a variable with the group and fire
-    when a rewritten item already exceeds the bound. -/
-def denseDegPreReject (b : DegreeBound) (d : DenseConstraintSystem p)
-    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+    when a rewritten item already exceeds the bound. Only the indexed candidate positions are
+    visited — the buckets are complete, so every item outside them is variable-disjoint from `xs`
+    and cannot fire. -/
+def denseDegPreReject (b : DegreeBound) (use : Thunk (DenseReencodeUseIdx p))
+    (arrCs : Array (DenseExpr p)) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
   let σ := denseGroupSubst xs hm
   let patts := denseAssignments (denseBitBox bits)
-  d.algebraicConstraints.any (fun c =>
-    c.sharesVarIn xs && !denseCoveredBy xs c &&
-      decide (b.identities < (denseGroupRewrite xs bits σ patts c).degree)) ||
-  d.busInteractions.any (fun bi =>
-    (bi.multiplicity.sharesVarIn xs &&
-      decide (b.busInteractions < (denseGroupRewrite xs bits σ patts bi.multiplicity).degree)) ||
-    bi.payload.any (fun e =>
-      e.sharesVarIn xs &&
-        decide (b.busInteractions < (denseGroupRewrite xs bits σ patts e).degree)))
+  let use := use.get
+  (denseUsePositions use.csIdx xs).any (fun i =>
+    match arrCs[i]? with
+    | some c =>
+      c.sharesVarIn xs && !denseCoveredBy xs c &&
+        decide (b.identities < (denseGroupRewrite xs bits σ patts c).degree)
+    | none => false) ||
+  (denseUsePositions use.biIdx xs).any (fun i =>
+    match use.arrBis[i]? with
+    | some bi =>
+      (bi.multiplicity.sharesVarIn xs &&
+        decide (b.busInteractions < (denseGroupRewrite xs bits σ patts bi.multiplicity).degree)) ||
+      bi.payload.any (fun e =>
+        e.sharesVarIn xs &&
+          decide (b.busInteractions < (denseGroupRewrite xs bits σ patts e).degree))
+    | none => false)
 
 /-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
     gates in order, minting fresh bits and rewriting `d` only on full acceptance. -/
 def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId) (xs : List VarId)
+    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
+    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId)
     (freshBase : String) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseCovIndex ×
       Array (DenseExpr p) × Std.HashSet VarId :=
@@ -396,7 +424,7 @@ def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
   | (reg1, none) => (reg1, d, [], csIdx, arrCs, varSet)
   | (reg1, some (bits, hm)) =>
     -- Degree pre-gate: reject early what the final `withinDegreeB` gate would reject anyway.
-    if denseDegPreReject b d xs bits hm then (reg1, d, [], csIdx, arrCs, varSet)
+    if denseDegPreReject b use arrCs xs bits hm then (reg1, d, [], csIdx, arrCs, varSet)
     else
     if xs.all (fun x => varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
@@ -425,7 +453,7 @@ structure DenseReencodeCacheState (p : ℕ) where
 
 def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (xs : List VarId) (freshBase : String) :
+    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId) (freshBase : String) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseReencodeCacheState p :=
   if xs.all (fun x => reg.isInput x) then
   if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
@@ -437,7 +465,7 @@ def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
   | (reg1, none, rootCache) => (reg1, d, [], { state with rootCache })
   | (reg1, some (bits, hm), rootCache) =>
     let state := { state with rootCache }
-    if denseDegPreReject b d xs bits hm then (reg1, d, [], state)
+    if denseDegPreReject b use state.arrCs xs bits hm then (reg1, d, [], state)
     else
     if xs.all (fun x => state.varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
@@ -456,31 +484,47 @@ def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
     else (reg1, d, [], state)
   else (reg, d, [], state)
 
-/-- Process the candidate groups sequentially, threading the registry, index, and variable set. -/
+/-- `d`'s item counts for the fresh-name prefix, re-read only after a step that rewrote `d`
+    (a step derives one method per minted bit, so nonempty derivations mark exactly the accepts). -/
+def denseReencodeNameCounts (derivs : DenseDerivations p) (d : DenseConstraintSystem p)
+    (nc nb : Nat) : Nat × Nat :=
+  if derivs.isEmpty then (nc, nb)
+  else (d.algebraicConstraints.length, d.busInteractions.length)
+
+/-- The pre-gate index for the next step: kept while the steps leave `d` alone (see
+    `denseReencodeNameCounts` for the accept marker), rebuilt for a rewritten system. -/
+def denseReencodeUseNext (derivs : DenseDerivations p) (d : DenseConstraintSystem p)
+    (use : Thunk (DenseReencodeUseIdx p)) : Thunk (DenseReencodeUseIdx p) :=
+  if derivs.isEmpty then use else Thunk.mk (fun _ => denseBuildUseIdx d)
+
+/-- Process the candidate groups sequentially, threading the registry, indexes, variable set, and
+    `d`'s item counts (`nc`/`nb`, the fresh-name prefix). -/
 def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p → DenseCovIndex →
-      Array (DenseExpr p) → Std.HashSet VarId →
+      Array (DenseExpr p) → Std.HashSet VarId → Thunk (DenseReencodeUseIdx p) → Nat → Nat →
       VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _, _, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, csIdx, arrCs, varSet =>
+  | [], _, reg, d, _, _, _, _, _, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, csIdx, arrCs, varSet, use, nc, nb =>
     let (reg1, d1, derivs1, csIdx1, arrCs1, varSet1) :=
-      denseReencodeStep b useIdx reg d csIdx arrCs varSet xs
-        (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+      denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs s!"rnc{nc}_{nb}_{idx}"
+    let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
     let (reg2, d2, derivs2) :=
       denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
+        (denseReencodeUseNext derivs1 d1 use) nc1 nb1
     (reg2, d2, derivs1 ++ derivs2)
 
 def denseReencodeLoopCached (b : DegreeBound) (useIdx : Bool) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
-      DenseReencodeCacheState p →
+      DenseReencodeCacheState p → Thunk (DenseReencodeUseIdx p) → Nat → Nat →
       VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, state =>
+  | [], _, reg, d, _, _, _, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, state, use, nc, nb =>
     let (reg1, d1, derivs1, state1) :=
-      denseReencodeStepCached b useIdx reg d state xs
-        (s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}")
+      denseReencodeStepCached b useIdx reg d state use xs s!"rnc{nc}_{nb}_{idx}"
+    let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
     let (reg2, d2, derivs2) :=
       denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
+        (denseReencodeUseNext derivs1 d1 use) nc1 nb1
     (reg2, d2, derivs1 ++ derivs2)
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
@@ -515,11 +559,15 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
       denseReencodeLoopCached b useIdx targets 0 reg d
         ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
          d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩
+        (Thunk.mk (fun _ => denseBuildUseIdx d))
+        d.algebraicConstraints.length d.busInteractions.length
     else
       denseReencodeLoop b useIdx targets 0 reg d
         (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
         d.algebraicConstraints.toArray
         (Std.HashSet.ofList d.occ)
+        (Thunk.mk (fun _ => denseBuildUseIdx d))
+        d.algebraicConstraints.length d.busInteractions.length
   else (reg, d, [])
 
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -150,17 +150,25 @@ keccak, so anything superlinear is fatal there.
 - gdb samples (keccak, mid-run): `findConsumer` (busUnify), `reencodeLoop`, `foldLoopDirect`
   (domainFold's unindexed path), `collectForBus` — matching the analysis below.
 
-### Where the time goes at SHA scale (2026-07-24, PRs #205–#210)
+### Where the time goes at SHA scale (2026-07-26, PRs #205–#210 + entry 142)
 
 sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):
 **989 s (main-of-2026-07-24) → 550 s** across #205 (registry array-copy, encode 80.5 → 0.8 s),
 #206 (domainFold Array.modify accepts, 173 → 6.9 s, reencode −86 s from allocator pressure alone),
 #208 (pointwiseDupDrop slot-0 index + hoisted singles, flagFold 85 → 15.6 s), #209 (rootPairUnify
-per-variable bound indexes, 49.6 → 33.7 s), #210 (busPairCancel segment scans, 107 → 89.5 s).
-Remaining per-pass: reencode 188 s, busPairCancel 89 s, busUnify 52 s, gauss 36 s, rootPairUnify
-33 s, domainBatch 21 s (parallel), bytePack 17 s, flagFold 15 s, normalize1 14 s, carryBranch
-13 s. Cycles 0–2 are still ~80 % of the total. Whole-run perf: ~25 % `lean_dec_ref_cold` +
-~17 % allocator + ~8 % `lean_apply_1` — the budget is still memory traffic, not arithmetic.
+per-variable bound indexes, 49.6 → 33.7 s), #210 (busPairCancel segment scans, 107 → 89.5 s), then
+**524 → 445 s** with entry 142 (reencode's two per-candidate whole-system scans, 184 → 97 s).
+Remaining per-pass: **reencode 97 s, busPairCancel 90 s, busUnify 54 s, gauss 36 s, domainBatch
+20 s (parallel), bytePack 17 s, flagFold 16 s, normalize1 14 s, rootPairUnify 13 s, carryBranch
+13 s**; the tail below that is ~60 s over 25 passes. Cycles 0–2 are still ~78 % of the total.
+Whole-run perf: ~25 % `lean_dec_ref_cold` + ~17 % allocator + ~8 % `lean_apply_1` — the budget is
+still memory traffic, not arithmetic. `DenseTwoRootMap.build` (busUnify/busPairCancel certificate
+tables, via `denseLinearize`) is ~4 % of whole-run CPU on its own, and the `ZMod.commRing` rebuild
+chain (R9) another ~5 %.
+
+**Measurement note:** the profiler's per-pass wall times and `perf`'s CPU shares are not the same
+denominator — domainBatch is parallel, so it burns ~25 % of CPU for 4 % of wall. For a serial pass,
+`perf` share × total CPU ≈ its wall time; check both before sizing a change.
 
 ### Open runtime ideas, priority order
 
@@ -229,8 +237,20 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      `coveredIdx_eq_filter_of_complete`; reencode is the next candidate (its rewrite *adds* bit
      columns and drops covered constraints, so it needs the remap or a pruned-completeness
      argument).
+   - ~~reencode's per-candidate whole-system scans~~ **done (entry 142)**: the fresh-name prefix's
+     `List.length` of both item lists and the degree pre-gate's `sharesVarIn` walk are gone
+     (threaded counts + thunked posting index, both riding the "nonempty derivations = accept"
+     marker). reencode 184 → 97 s. Note PR #194 (open, stale on `docs/`) indexes the same pre-gate
+     with a per-invocation root-use plan plus a degree-only traversal twin — the traversal twin is
+     the part entry 142 does *not* do (it still builds the rewritten tree to measure its degree).
    - **Still open — reencode's `checkReencode`** re-runs the covered scan after `buildReencode`
      (`Reencode.lean:852/858`); rarely reached (post-gates), so low value now.
+   - **Still open — reencode's remaining 97 s**: `denseGroupSurvivorsE` filters the whole
+     `denseAssignments` box (≤256 points × covered constraints) for every target, and
+     `denseCoveredIdxPos` rebuilds a HashSet + `mergeSort` per target. The build path is
+     proof-free (`denseCheckReencode` re-verifies), so a prefix-pruned DFS enumeration with an
+     early abort once the survivor count passes `2 ^ (|xs| − 1)` (above which `k < xs.length`
+     fails) needs no new proof — only the same survivor *list order* to stay byte-identical.
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
    - **Variable interning-lite, `Implementation/`-only**: parse-time interning is **done (entry

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4803,3 +4803,36 @@ sha256_big busPairCancel: 107.4 → 89.5 s; stack total 989 → 550 s (−44 % v
 2.4× vs two days ago). The remaining 89 s is the certificate work itself — R8 design (b).
 
 **Worked locally: yes (byte-identical fixtures incl. ecrecover_53k).**
+
+### 142. Runtime: reencode stops rescanning the whole system per candidate group
+
+Two whole-system scans ran per candidate group, and `perf` (LBR, sha256_big) charged **77 % of
+the pass** to them: `List.lengthTR` 5.2 % and `DenseExpr.sharesVarIn` 8.4 % of all CPU, both
+under `denseReencodeLoop`/`denseReencodeLoopCached`.
+
+1. **The fresh-name prefix.** `s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}"`
+   walked both lists (146k + 71k nodes) per group just to name the bits a group might mint —
+   ~12.8k groups per cycle. `nc`/`nb` are threaded through the loops instead and re-read only
+   after a step that rewrote `d`. `denseReencodeNameCounts` recognizes those steps by their
+   derivations: a step derives one method per minted bit, so nonempty derivations mark exactly
+   the accepts (every reject branch returns `(_, d, [], _)`).
+2. **The degree pre-gate.** `denseDegPreReject` walked every constraint and interaction with
+   `sharesVarIn`, though only items sharing a variable with the group can fire. It now takes a
+   thunked whole-system posting index (`denseBuildUseIdx`: `denseCovBuild` buckets over
+   constraints and over interactions, plus the interaction array) and visits only the candidate
+   positions for `xs`, deduplicated (`denseUsePositions`) because each visit rewrites the item.
+   The index rides the same accept marker as the counts, and the thunk keeps invocations that
+   never construct a candidate from paying for it.
+
+Both are untrusted, so no proof obligation beyond threading the new arguments: the gate's `any`
+is order- and multiplicity-independent and `denseCovBuild`'s buckets are complete, so the indexed
+scan decides identically; the fresh name is re-checked by `denseCheckReencode`'s freshness
+conjunct. The `entry 106` arity rule applies to neither — this is the coarser mistake of
+recomputing a whole-system quantity inside a per-candidate loop; when a pass's profile is
+dominated by `lengthTR` or a whole-system predicate, look for that first.
+
+sha256_big (`profile`, quiet 48-core box): reencode **183.7 → 97.4 s (−47 %)**, total
+**523.9 → 444.7 s (−15 %)**; other passes unchanged within run-to-run noise. Cycle 0 202 → 161 s.
+
+**Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak,
+wasm-eth apc_036 and the 168k-var OpenVM sha256 case).**


### PR DESCRIPTION
`reencode` was the top pass on the 168k-variable sha256 APC (184 s of a 524 s run). Two
whole-system scans ran **per candidate group**, and `perf` (LBR) charged 77 % of the pass to them —
`List.lengthTR` 5.2 % and `DenseExpr.sharesVarIn` 8.4 % of all CPU, both under the reencode loops.

## What changed

- **Fresh-name prefix.** `s!"rnc{d.algebraicConstraints.length}_{d.busInteractions.length}_{idx}"`
  walked both item lists (146k + 71k nodes) for every one of ~12.8k candidate groups per cycle,
  just to name bits the group might mint. The counts are threaded through the loops and re-read
  only after a step that rewrote `d`; `denseReencodeNameCounts` recognizes those steps by their
  derivations (a step derives one method per minted bit, so nonempty derivations mark exactly the
  accepts — every reject branch returns `d` and `[]`).
- **Degree pre-gate.** `denseDegPreReject` walked every constraint and interaction with
  `sharesVarIn`, though only items sharing a variable with the group can fire. It now takes a
  thunked whole-system posting index (`denseBuildUseIdx`, `denseCovBuild` buckets over constraints
  and over interactions) and visits only the candidate positions for `xs`, deduplicated because
  each visit rewrites the item. The index rides the same accept marker; the thunk keeps
  invocations that construct no candidate from paying for it.

Both are untrusted, so the only proof work was threading the new arguments: the gate's `any` is
order- and multiplicity-independent and `denseCovBuild`'s buckets are complete, so the indexed scan
decides identically, and the fresh name is re-checked by `denseCheckReencode`'s freshness conjunct.

## Impact

sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):

| | main (ff15446) | this PR |
|---|---|---|
| reencode | 183.7 s | **97.4 s** (−47 %) |
| total | 523.9 s | **444.7 s** (−15 %) |
| cycle 0 | 202.5 s | 161.1 s |

Every other pass is unchanged within run-to-run noise (busPairCancel 87.4 → 90.2 s, busUnify
51.9 → 54.1 s — this box has ±15 % variance; the fixed hotspots are the only structural change).

## Validation

- `lake build` (warning-free), `Scripts/check-proof-integrity.sh` (three standard axioms, no unused
  theorems)
- byte-identical `opt-export` vs. main on openvm-eth apc_044 / apc_067, keccak apc_001, wasm-eth
  apc_036, and OpenVM sha256 apc_001 (the 168k-var case, where that run also dropped 540 s → 427 s)
- `agent-docs/log.md` entry 142 + refreshed SHA-scale runtime picture in `agent-docs/ideas.md`

Note for whoever picks up #194 (open, stale on the `docs/` rename): it indexes the same pre-gate via
a per-invocation root-use plan **plus** a degree-only traversal twin that avoids building the
rewritten tree. This PR does only the indexing; the traversal twin is still on the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKR42FVxb2GLyEesKGgyvK