### PR TITLE
perf(busPairCancel): per-variable domain index for byte justification (90s -> 50s on 170k sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -71,7 +71,8 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound cs0.algebraicConstraints)
-    (domCs : List (DenseExpr p)) (hdomCs : ∀ c ∈ domCs, c ∈ cs0.algebraicConstraints)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ cs0.algebraicConstraints)
     (candsOf : VarId → List (DenseExpr p))
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs0.algebraicConstraints)
     (fidx bidx : Std.HashMap VarId (List Nat))
@@ -90,7 +91,7 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (hmid : ∀ m0 ∈ denseLiveSeg arr alive (iP + 1) (jP - iP - 1),
       denseMidRefuted ops shape T busId S m0 = true)
     (hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 iP) = true)
-    (hchk : denseCheckCancel ops deep bs facts M domCs candsOf
+    (hchk : denseCheckCancel ops deep bs facts M domIdx candsOf
       (denseDropWits facts bidx arr alive S R checksOld checks) (denseDropFormWits fidx arr alive S R)
       busId shape slots bound S R checks = true) :
     DenseDropResult cs0 bs arr alive checksOld := by
@@ -130,10 +131,10 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     sizeNew := by simp only [aliveNew, Array.size_setIfInBounds]; exact hsz
     step := fun isInput reg hsys => heq ▸
       denseCheckCancel_sound isInput (denseMkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep ops
-        reg hsys busId shape hshape slots bound T hTtworoot hTnonzero M hM domCs candsOf
+        reg hsys busId shape hshape slots bound T hTtworoot hTnonzero M hM domIdx candsOf
         (denseDropWits facts bidx arr alive S R checksOld checks)
         (denseDropFormWits fidx arr alive S R)
-        A S B R (C' ++ checksOld) hslots checks hsplit hdomCs hcands
+        A S B R (C' ++ checksOld) hslots checks hsplit hdomIdx hcands
         (denseDropWits_mem facts bidx arr alive S R checksOld checks horig hchecks)
         (denseDropFormWits_mem fidx arr alive S R horig checks) hmid hshield hchk
     decreases := ?_
@@ -172,7 +173,8 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound cs0.algebraicConstraints)
-    (domCsT : Thunk { l : List (DenseExpr p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
+    (domIdxT : Thunk { m : Std.HashMap VarId (List (DenseExpr p)) //
+      ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
@@ -184,7 +186,7 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
   if hi : i < arr.size then
     let S := arr[i]
     let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
-      shape hshape T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? fidx bidx arr alive
+      shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive
       checksOld hsz idx (i + 1)
     if haliveS : alive[i]?.getD false = true then
     if decide (S.busId = busId) &&
@@ -215,16 +217,16 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           match hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) with
           | none => next ()
           | some (slots, bound) =>
-          if hchk0 : denseCheckCancel ops deep bs facts M domCsT.get.val candsT.get.lookup
+          if hchk0 : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
               (denseDropWits facts bidx arr alive S R checksOld []) (denseDropFormWits fidx arr alive S R)
               busId shape slots bound S R [] = true then
             some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
-              hTnonzero M hM domCsT.get.val domCsT.get.property candsT.get.lookup hcands
+              hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
               fidx bidx arr alive checksOld hsz i j S R slots bound [] checksOld
               (List.append_nil checksOld).symm (fun reg _ bi hbi => absurd hbi (by simp))
               false 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk0)
           else
-          let unjust := denseUnjustifiedSlots bound deep domCsT.get.val candsT.get.lookup bs facts
+          let unjust := denseUnjustifiedSlots bound deep domIdxT.get.val candsT.get.lookup bs facts
             (denseDropWits facts bidx arr alive S R checksOld []) (denseDropFormWits fidx arr alive S R)
             slots R
           let checks : List (BusInteraction (DenseExpr p)) :=
@@ -233,12 +235,12 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
                 [denseMkByteCheck spec bcBus e])
             | _, _ => []
           if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
-            if hchk : denseCheckCancel ops deep bs facts M domCsT.get.val candsT.get.lookup
+            if hchk : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
                 (denseDropWits facts bidx arr alive S R checksOld checks)
                 (denseDropFormWits fidx arr alive S R)
                 busId shape slots bound S R checks = true then
               some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
-                hTnonzero M hM domCsT.get.val domCsT.get.property candsT.get.lookup hcands
+                hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
                 fidx bidx arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
                 (fun reg hRpay bi hbi => denseEmittedChecks_covered unjust bcBus? R reg hRpay bi hbi)
                 true 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk)
@@ -262,7 +264,8 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound cs0.algebraicConstraints)
-    (domCsT : Thunk { l : List (DenseExpr p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
+    (domIdxT : Thunk { m : Std.HashMap VarId (List (DenseExpr p)) //
+      ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (fidx bidx : Std.HashMap VarId (List Nat))
@@ -274,21 +277,21 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
   | _, [] => none
   | curIdx, busId :: rest =>
     if curIdx < resumeIdx then
-      denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT candsT
+      denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
         hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
-            T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? fidx bidx arr alive checksOld
+            T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive checksOld
             hsz idx startPos with
         | some dr => some { dr with dropIdx := curIdx }
         | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-            domCsT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
+            domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
             (curIdx + 1) rest
       | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-          domCsT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
+          domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
           (curIdx + 1) rest
 
 /-! The materialized final system plus (erased) correctness and coverage proofs that
@@ -309,7 +312,8 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hTtworoot : T.get.tworoot.Sound cs0.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build cs0.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound cs0.algebraicConstraints)
-    (domCsT : Thunk { l : List (DenseExpr p) // ∀ c ∈ l, c ∈ cs0.algebraicConstraints })
+    (domIdxT : Thunk { m : Std.HashMap VarId (List (DenseExpr p)) //
+      ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p)) (busIds : List Nat)
@@ -323,7 +327,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hsyscov : ∀ (reg : VarRegistry), cs0.CoveredBy reg →
       (denseMkCs cs0 arr alive checksOld).CoveredBy reg) :
     DenseCancelBundle cs0 bs :=
-  match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT
+  match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT
       candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 busIds with
   | none =>
     { out := { cs0 with
@@ -341,7 +345,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
   | some dr =>
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
-    denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domCsT candsT
+    denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
       hcands bcBus? busIds fidx bidx arr idx dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos
       (fun isInput reg hcs0 => (hcur isInput reg hcs0).andThen (dr.step isInput reg (hsyscov reg hcs0)))
       (fun reg hcs0 => dr.covNew reg (hsyscov reg hcs0))
@@ -365,9 +369,15 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
       Thunk.mk fun _ =>
         if aggressive then DenseEqConstraintMap.build d.algebraicConstraints
         else DenseEqConstraintMap.empty
-    let domCsT : Thunk { l : List (DenseExpr p) // ∀ c ∈ l, c ∈ d.algebraicConstraints } :=
-      Thunk.mk fun _ => ⟨d.algebraicConstraints.filter DenseExpr.isSingleVar,
-        fun _ hc => List.mem_of_mem_filter hc⟩
+    -- The domain lookups (`denseFindDomainAlg`) skip every constraint not mentioning their
+    -- variable, so the per-variable buckets of the single-variable constraints answer them
+    -- identically without a per-query scan of the whole list.
+    let domIdxT : Thunk { m : Std.HashMap VarId (List (DenseExpr p)) //
+        ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ d.algebraicConstraints } :=
+      Thunk.mk fun _ =>
+        ⟨denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar),
+         fun v c hc => List.mem_of_mem_filter
+           (denseVarBucket_mem DenseExpr.vars _ v c hc)⟩
     let candsT : Thunk (DenseVarCsIdx p) :=
       Thunk.mk fun _ => DenseVarCsIdx.build d.algebraicConstraints
     have hsz : alive.size = arr.size := by simp only [alive, Array.size_replicate]
@@ -398,7 +408,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
         (denseMkCs d arr alive []).CoveredBy reg :=
       fun _ hcs0 => by rw [denseMkCs_all d arr rfl alive halltrue]; exact hcs0
     let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive ops
-      T hTtworoot hTnonzero M hM domCsT candsT hcands bcBus? busIds fidx bidx arr idx alive [] hsz 0 0
+      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? busIds fidx bidx arr idx alive [] hsz 0 0
       hcur0 hsyscov0
     { reg' := reg
       out := bundle.out

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -152,13 +152,14 @@ def denseEmitOk (ops : DenseZModOps p) (bs : BusSemantics p) (facts : BusFacts p
      | none => false)
 
 /-- The declared byte slots of `R` whose payload entries the witnesses do not justify. -/
-def denseUnjustifiedSlots (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
+def denseUnjustifiedSlots (bound : Nat) (deep : Bool)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
     (slots : List Nat) (R : BusInteraction (DenseExpr p)) : List Nat :=
   slots.filter (fun slot =>
     match R.payload[slot]? with
-    | some e => !denseByteJustifiedW bound deep domCs candsOf bs facts wits fwits e
+    | some e => !denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e
     | none => false)
 
 /-- The per-candidate certificate: bus/multiplicity/payload of the pair, the emitted checks'
@@ -168,7 +169,7 @@ def denseUnjustifiedSlots (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p
 def denseCheckCancel (ops : DenseZModOps p) (deep : Bool) (bs : BusSemantics p)
     (facts : BusFacts p bs)
     (M : Thunk (DenseEqConstraintMap p))
-    (domCs : List (DenseExpr p)) (candsOf : VarId → List (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (candsOf : VarId → List (DenseExpr p))
     (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
     (busId : Nat) (shape : MemoryBusShape) (slots : List Nat) (bound : Nat)
     (S R : BusInteraction (DenseExpr p))
@@ -178,6 +179,6 @@ def denseCheckCancel (ops : DenseZModOps p) (deep : Bool) (bs : BusSemantics p)
     decide (denseMultConst R = some (denseGetPreviousMult ops shape)) &&
   densePayloadEntailedEq M S.payload R.payload &&
   checks.all (denseEmitOk ops bs facts busId shape slots R) &&
-  denseRecvSlotsJustified bound deep domCs candsOf bs facts wits fwits slots R
+  denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fwits slots R
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
@@ -69,20 +69,21 @@ def denseDeepByteVars (bs : BusSemantics p) (facts : BusFacts p bs)
 
 /-- The variables of `c` other than `x` that carry a small proven *constraint-derived* finite domain
     (selector flags) — the candidates for enumeration in the deep justification. -/
-def denseDeepEnumDoms (domCs : List (DenseExpr p)) (x : VarId) (c : DenseExpr p) :
+def denseDeepEnumDoms (domIdx : Std.HashMap VarId (List (DenseExpr p))) (x : VarId)
+    (c : DenseExpr p) :
     List (VarId × List (ZMod p)) :=
   (c.vars.dedup.filter (fun v => v ≠ x)).filterMap (fun v =>
-    match denseFindDomainAlg domCs v with
+    match denseFindDomainAlg (denseVarBucketLookup domIdx v) v with
     | some d => if d.length ≤ maxDeepDomain then some (v, d) else none
     | none => none)
 
 /-- Deep byte bound for `x` from one constraint `c`: enumerate the small proven finite domains of
     `c`'s other variables (e.g. one-hot selector flags) and require `densePointByteOk` at every
     point. -/
-def denseDeepBoundOk (domCs : List (DenseExpr p)) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (wits : VarId → List (BusInteraction (DenseExpr p))) (x : VarId) (c : DenseExpr p) :
-    Bool :=
-  let enum := denseDeepEnumDoms domCs x c
+def denseDeepBoundOk (domIdx : Std.HashMap VarId (List (DenseExpr p))) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (wits : VarId → List (BusInteraction (DenseExpr p))) (x : VarId)
+    (c : DenseExpr p) : Bool :=
+  let enum := denseDeepEnumDoms domIdx x c
   if (c.vars.dedup.filter (fun v => v ≠ x)).length ≤ maxDeepVars &&
       (enum.map (fun vd => vd.2.length)).prod ≤ maxDeepPoints then
     (denseAssignments enum).all
@@ -91,10 +92,10 @@ def denseDeepBoundOk (domCs : List (DenseExpr p)) (bs : BusSemantics p) (facts :
 
 /-- Deep byte justification for `x`: one of the first `maxDeepConstraints` constraints mentioning `x`
     (the caller passes them as `cands`) pins it via `denseDeepBoundOk`. -/
-def denseDeepByteJustified (domCs cands : List (DenseExpr p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs)
+def denseDeepByteJustified (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (cands : List (DenseExpr p)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (wits : VarId → List (BusInteraction (DenseExpr p))) (x : VarId) : Bool :=
-  (cands.take maxDeepConstraints).any (fun c => denseDeepBoundOk domCs bs facts wits x c)
+  (cands.take maxDeepConstraints).any (fun c => denseDeepBoundOk domIdx bs facts wits x c)
 
 /-- Evaluate the single-variable expression `e` with its variable fixed to `d` and check the result
     is a byte constant. -/
@@ -105,10 +106,11 @@ def denseExprPointByte (e : DenseExpr p) (x : VarId) (d : ZMod p) : Bool :=
 
 /-- Is `e` a byte because its single variable `x` ranges over a small constraint-derived finite
     domain at every point of which `e` evaluates to a byte? -/
-def denseDomainByteJustified (domCs : List (DenseExpr p)) (e : DenseExpr p) : Bool :=
+def denseDomainByteJustified (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (e : DenseExpr p) : Bool :=
   match e.singleVarAux with
   | some (some x) =>
-    match denseFindDomainAlg domCs x with
+    match denseFindDomainAlg (denseVarBucketLookup domIdx x) x with
     | some d => decide (d.length ≤ maxDeepDomain) && d.all (denseExprPointByte e x)
     | none => false
   | _ => false
@@ -190,9 +192,11 @@ def denseBasisJustified (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSema
     a constant `< bound`; a variable with a bus-fact bound `≤ bound`; (when `deep`) a
     selector-flag-domain deep justification or a single-variable finite-domain justification; an
     affine recomposition of bounded limbs; or a basis reduction against range-checked slot forms
-    (`fwits`). Remaining interactions are consulted through `wits`; `domCs`/`candsOf` are precomputed
-    by the caller. -/
-def denseByteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
+    (`fwits`). Remaining interactions are consulted through `wits`; `domIdx`/`candsOf` are
+    precomputed per-variable indexes (passed as values — a closure payload would be re-evaluated
+    per call, cf. `agent-docs/log.md` entry 106). -/
+def denseByteJustifiedW (bound : Nat) (deep : Bool)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
     (e : DenseExpr p) : Bool :=
@@ -205,21 +209,22 @@ def denseByteJustifiedW (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
         | some b => decide (b ≤ bound)
         | none => false) ||
        (deep && decide (256 ≤ bound) &&
-         denseDeepByteJustified domCs (candsOf x) bs facts wits x)
+         denseDeepByteJustified domIdx (candsOf x) bs facts wits x)
      | _ => false) ||
-    (deep && decide (256 ≤ bound) && denseDomainByteJustified domCs e) ||
+    (deep && decide (256 ≤ bound) && denseDomainByteJustified domIdx e) ||
     denseAffineJustified bound (fun x => denseFindVarBound bs facts (wits x) x) e ||
     denseBasisJustified bound (fun x => denseFindVarBound bs facts (wits x) x) facts fwits e
 
 /-- Are all of `R`'s payload entries at the declared byte slots justified (through the witness
-    lookup `wits` and precomputed `domCs`/`candsOf`, see `denseByteJustifiedW`)? -/
-def denseRecvSlotsJustified (bound : Nat) (deep : Bool) (domCs : List (DenseExpr p))
+    lookup `wits` and precomputed `domIdx`/`candsOf`, see `denseByteJustifiedW`)? -/
+def denseRecvSlotsJustified (bound : Nat) (deep : Bool)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
     (slots : List Nat) (R : BusInteraction (DenseExpr p)) : Bool :=
   slots.all (fun slot =>
     match R.payload[slot]? with
-    | some e => denseByteJustifiedW bound deep domCs candsOf bs facts wits fwits e
+    | some e => denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e
     | none => true)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
@@ -291,7 +291,7 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (hTtworoot : T.get.tworoot.Sound d.algebraicConstraints)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build d.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound d.algebraicConstraints)
-    (domCs : List (DenseExpr p)) (candsOf : VarId → List (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (candsOf : VarId → List (DenseExpr p))
     (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
     (A : List (BusInteraction (DenseExpr p))) (S : BusInteraction (DenseExpr p))
     (B : List (BusInteraction (DenseExpr p))) (R : BusInteraction (DenseExpr p))
@@ -299,13 +299,13 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) = some (slots, bound))
     (checks : List (BusInteraction (DenseExpr p)))
     (hsplit : d.busInteractions = A ++ S :: B ++ R :: C)
-    (hdomCs : ∀ c ∈ domCs, c ∈ d.algebraicConstraints)
+    (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ d.algebraicConstraints)
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ d.algebraicConstraints)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ A ++ B ++ C ++ checks)
     (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ A ++ B ++ C ++ checks)
     (hmid : ∀ m0 ∈ B, denseMidRefuted ops shape T busId S m0 = true)
     (hshield : denseShieldOk ops shape T busId S A = true)
-    (h : denseCheckCancel ops deep bs facts M domCs candsOf wits fwits busId shape slots bound S R checks
+    (h : denseCheckCancel ops deep bs facts M domIdx candsOf wits fwits busId shape slots bound S R checks
       = true) :
     DensePassCorrect isInput d { d with busInteractions := A ++ B ++ C ++ checks } [] bs := by
   unfold denseCheckCancel at h
@@ -322,8 +322,8 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (fun denv => denseMatches_evalPattern R.payload denv) checks
     (fun ck hck => denseEmitOk_sound ops bs facts busId shape slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
-    (fun denv hall hbus => denseRecvSlotsJustified_sound bound deep d.algebraicConstraints domCs
-      candsOf bs facts (A ++ B ++ C ++ checks) wits fwits slots R hdeep hdomCs hcands hwits hfwits
+    (fun denv hall hbus => denseRecvSlotsJustified_sound bound deep d.algebraicConstraints domIdx
+      candsOf bs facts (A ++ B ++ C ++ checks) wits fwits slots R hdeep hdomIdx hcands hwits hfwits
       hjust denv hall hbus)
     hsplit
     (of_decide_eq_true hSb) (of_decide_eq_true hRb)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
@@ -13,6 +13,46 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+/-! ## Soundness of the per-variable bucket index: every looked-up item was indexed -/
+
+/-- Inserting `a` (already in `S`) under any variable list preserves "every bucket value is in
+    `S`". -/
+theorem denseVarBucketAdd_mem {α : Type} {S : List α} (a : α) (ha : a ∈ S) :
+    ∀ (vs : List VarId) (m : Std.HashMap VarId (List α)),
+      (∀ x, ∀ b ∈ m.getD x [], b ∈ S) →
+      ∀ x, ∀ b ∈ (denseVarBucketAdd m vs a).getD x [], b ∈ S := by
+  intro vs
+  induction vs with
+  | nil => intro m hm; simpa [denseVarBucketAdd] using hm
+  | cons y rest ih =>
+    intro m hm
+    have hstep : ∀ x, ∀ b ∈ (m.insert y (a :: m.getD y [])).getD x [], b ∈ S := by
+      intro x b hb
+      by_cases hxy : y = x
+      · subst hxy
+        rw [Std.HashMap.getD_insert_self] at hb
+        rcases List.mem_cons.1 hb with h | h
+        · exact h ▸ ha
+        · exact hm y b h
+      · rw [Std.HashMap.getD_insert, if_neg (by simpa using hxy)] at hb
+        exact hm x b hb
+    have := ih (m.insert y (a :: m.getD y [])) hstep
+    simpa [denseVarBucketAdd, List.foldl_cons] using this
+
+/-- Every item returned by a bucket lookup was one of the indexed items. -/
+theorem denseVarBucket_mem {α : Type} (varsOf : α → List VarId) (items : List α) :
+    ∀ x, ∀ a ∈ denseVarBucketLookup (denseVarBucket varsOf items) x, a ∈ items := by
+  unfold denseVarBucketLookup denseVarBucket
+  induction items with
+  | nil =>
+    intro x a ha; simp only [List.foldr_nil, Std.HashMap.getD_empty, List.not_mem_nil] at ha
+  | cons c rest ih =>
+    intro x a ha
+    rw [List.foldr_cons] at ha
+    exact denseVarBucketAdd_mem c (List.mem_cons_self ..) ((varsOf c).eraseDups)
+      (List.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅ rest)
+      (fun x' b hb => List.mem_cons_of_mem _ (ih x' b hb)) x a ha
+
 /-- If the per-point certificate accepts, the enumerated `keys` of `c` are pinned to `pt` under
     `denv`, `c` is satisfied, and the precomputed `byteVars` are bytes, then `x` is a byte here. -/
 theorem densePointByteOk_sound [Fact p.Prime] (x : VarId) (c : DenseExpr p)
@@ -111,24 +151,24 @@ theorem densePointByteOk_sound [Fact p.Prime] (x : VarId) (c : DenseExpr p)
             | cons t3 tail3 =>
               rw [hterms] at h; simp at h
 
-/-- If the deep bound certificate accepts for `x` from `c`, `c` and every `domCs` hold, and each
-    witness interaction never violates when active, then `x` is a byte. -/
-theorem denseDeepBoundOk_sound [Fact p.Prime] (domCs : List (DenseExpr p))
+/-- If the deep bound certificate accepts for `x` from `c`, `c` and every looked-up domain
+    constraint hold, and each witness interaction never violates when active, then `x` is a byte. -/
+theorem denseDeepBoundOk_sound [Fact p.Prime] (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bs : BusSemantics p) (facts : BusFacts p bs)
     (wits : VarId → List (BusInteraction (DenseExpr p))) (x : VarId) (c : DenseExpr p)
-    (h : denseDeepBoundOk domCs bs facts wits x c = true) (denv : VarId → ZMod p)
-    (hdom : ∀ c' ∈ domCs, c'.eval denv = 0) (hc0 : c.eval denv = 0)
+    (h : denseDeepBoundOk domIdx bs facts wits x c = true) (denv : VarId → ZMod p)
+    (hdom : ∀ v, ∀ c' ∈ denseVarBucketLookup domIdx v, c'.eval denv = 0) (hc0 : c.eval denv = 0)
     (hbus : ∀ v, ∀ bi ∈ wits v, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval bi denv) = false) :
     (denv x).val < 256 := by
   unfold denseDeepBoundOk at h
   simp only [] at h
   split_ifs at h with hcap
-  have hdomsound : ∀ vd ∈ denseDeepEnumDoms domCs x c, denv vd.1 ∈ vd.2 := by
+  have hdomsound : ∀ vd ∈ denseDeepEnumDoms domIdx x c, denv vd.1 ∈ vd.2 := by
     intro vd hvd
     unfold denseDeepEnumDoms at hvd
     obtain ⟨v, _, hfn⟩ := List.mem_filterMap.mp hvd
-    cases hfd : denseFindDomainAlg domCs v with
+    cases hfd : denseFindDomainAlg (denseVarBucketLookup domIdx v) v with
     | none => rw [hfd] at hfn; exact absurd hfn (by simp)
     | some d =>
       rw [hfd] at hfn
@@ -136,7 +176,7 @@ theorem denseDeepBoundOk_sound [Fact p.Prime] (domCs : List (DenseExpr p))
       split_ifs at hfn
       simp only [Option.some.injEq] at hfn
       subst hfn
-      exact denseFindDomainAlg_sound denv domCs v d hfd hdom
+      exact denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx v) v d hfd (hdom v)
   have hbyteVars : ∀ v ∈ denseDeepByteVars bs facts wits x c, (denv v).val < 256 := by
     intro v hv
     unfold denseDeepByteVars at hv
@@ -148,33 +188,34 @@ theorem denseDeepBoundOk_sound [Fact p.Prime] (domCs : List (DenseExpr p))
       dsimp only at hv2
       exact lt_of_lt_of_le (denseFindVarBound_sound bs facts (wits v) v b hb denv (hbus v))
         (of_decide_eq_true hv2)
-  have hmem : (denseDeepEnumDoms domCs x c).map (fun vd => (vd.1, denv vd.1))
-      ∈ denseAssignments (denseDeepEnumDoms domCs x c) :=
+  have hmem : (denseDeepEnumDoms domIdx x c).map (fun vd => (vd.1, denv vd.1))
+      ∈ denseAssignments (denseDeepEnumDoms domIdx x c) :=
     mem_denseAssignments _ denv hdomsound
   have hpoint := List.all_eq_true.mp h _ hmem
   refine densePointByteOk_sound x c (denseDeepByteVars bs facts wits x c)
-    ((denseDeepEnumDoms domCs x c).map Prod.fst)
-    ((denseDeepEnumDoms domCs x c).map (fun vd => (vd.1, denv vd.1))) hpoint denv ?_
+    ((denseDeepEnumDoms domIdx x c).map Prod.fst)
+    ((denseDeepEnumDoms domIdx x c).map (fun vd => (vd.1, denv vd.1))) hpoint denv ?_
     hc0 hbyteVars
   intro y hy
-  exact denseEnvOfFast_map (denseDeepEnumDoms domCs x c) denv y (List.contains_iff_mem.mp hy)
+  exact denseEnvOfFast_map (denseDeepEnumDoms domIdx x c) denv y (List.contains_iff_mem.mp hy)
 
 /-- If one candidate constraint deep-justifies `x` as a byte, every constraint in `all` (⊇
-    `domCs`/`cands`) holds, and each witness interaction never violates, then `x` is a byte. -/
+    `domOf`/`cands`) holds, and each witness interaction never violates, then `x` is a byte. -/
 theorem denseDeepByteJustified_sound [Fact p.Prime] [NeZero p]
-    (all domCs cands : List (DenseExpr p))
+    (all cands : List (DenseExpr p)) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bs : BusSemantics p) (facts : BusFacts p bs)
     (wits : VarId → List (BusInteraction (DenseExpr p))) (x : VarId)
-    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ c ∈ cands, c ∈ all)
-    (h : denseDeepByteJustified domCs cands bs facts wits x = true) (denv : VarId → ZMod p)
+    (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ all)
+    (hcands : ∀ c ∈ cands, c ∈ all)
+    (h : denseDeepByteJustified domIdx cands bs facts wits x = true) (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ v, ∀ bi ∈ wits v, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval bi denv) = false) :
     (denv x).val < 256 := by
   obtain ⟨c, hc, hck⟩ := List.any_eq_true.1 h
   have hc' : c ∈ all := hcands c (List.mem_of_mem_take hc)
-  exact denseDeepBoundOk_sound domCs bs facts wits x c hck denv
-    (fun c' hc'' => hall c' (hdomCs c' hc'')) (hall c hc') hbus
+  exact denseDeepBoundOk_sound domIdx bs facts wits x c hck denv
+    (fun v c' hc'' => hall c' (hdomIdx v c' hc'')) (hall c hc') hbus
 
 /-- If the single-variable expression `e` evaluates (with its variable fixed to `denv x`) to a byte
     constant, then `e` is a byte under `denv`. -/
@@ -208,9 +249,10 @@ theorem denseExprPointByte_sound (e : DenseExpr p) (x : VarId) (denv : VarId →
 /-- If `e` is a single-variable expression whose variable's constraint-derived finite domain makes
     `e` a byte at every point, then `e` is a byte under any assignment zeroing the domain
     constraints. -/
-theorem denseDomainByteJustified_sound [Fact p.Prime] (domCs : List (DenseExpr p)) (e : DenseExpr p)
-    (h : denseDomainByteJustified domCs e = true) (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ domCs, c.eval denv = 0) :
+theorem denseDomainByteJustified_sound [Fact p.Prime]
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (e : DenseExpr p)
+    (h : denseDomainByteJustified domIdx e = true) (denv : VarId → ZMod p)
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0) :
     (e.eval denv).val < 256 := by
   unfold denseDomainByteJustified at h
   cases hsv : e.singleVarAux with
@@ -221,12 +263,13 @@ theorem denseDomainByteJustified_sound [Fact p.Prime] (domCs : List (DenseExpr p
     | some x =>
       rw [hsv] at h
       dsimp only at h
-      cases hfd : denseFindDomainAlg domCs x with
+      cases hfd : denseFindDomainAlg (denseVarBucketLookup domIdx x) x with
       | none => rw [hfd] at h; simp at h
       | some d =>
         rw [hfd, Bool.and_eq_true] at h
         obtain ⟨_, hall⟩ := h
-        have hmem : denv x ∈ d := denseFindDomainAlg_sound denv domCs x d hfd hdom
+        have hmem : denv x ∈ d :=
+          denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx x) x d hfd (hdom x)
         have hpt : denseExprPointByte e x (denv x) = true := List.all_eq_true.mp hall _ hmem
         exact denseExprPointByte_sound e x denv hpt
 
@@ -463,18 +506,20 @@ theorem denseBasisJustified_sound (bound : Nat) (bnd : VarId → Option Nat) {bs
 `denseRecvSlotsJustified_sound`'s conclusion is exactly `denseDropPair_correct`'s `hbyte` obligation
 (with `all := d.algebraicConstraints`, `rest := A ++ B ++ C ++ checks`). -/
 
-/-- If the dispatcher accepts, every constraint in the superset `all` (⊇ `domCs`/`candsOf`) holds,
+/-- If the dispatcher accepts, every constraint in the superset `all` (⊇ `domOf`/`candsOf`) holds,
     and every witnessed remaining interaction (`wits`/`fwits ⊆ rest`) never violates when active,
     then `e` is a byte/limb (`< bound`) under `denv`. -/
-theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List (DenseExpr p))
+theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all : List (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (DenseExpr p)))
     (wits fwits : VarId → List (BusInteraction (DenseExpr p))) (e : DenseExpr p)
     (hdeep : deep = true → p.Prime)
-    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
+    (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ all)
+    (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
     (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ rest)
-    (h : denseByteJustifiedW bound deep domCs candsOf bs facts wits fwits e = true)
+    (h : denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e = true)
     (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
@@ -513,7 +558,7 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List 
           haveI : Fact p.Prime := ⟨hdeep h'.1.1⟩
           haveI : NeZero p := ⟨(hdeep h'.1.1).ne_zero⟩
           exact lt_of_lt_of_le
-            (denseDeepByteJustified_sound all domCs (candsOf x) bs facts wits x hdomCs (hcands x)
+            (denseDeepByteJustified_sound all (candsOf x) domIdx bs facts wits x hdomIdx (hcands x)
               h'.2 denv hall hbusW)
             (of_decide_eq_true h'.1.2)
       | const n => simp at h
@@ -523,7 +568,8 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List 
       rw [Bool.and_eq_true, Bool.and_eq_true] at h
       haveI : Fact p.Prime := ⟨hdeep h.1.1⟩
       exact lt_of_lt_of_le
-        (denseDomainByteJustified_sound domCs e h.2 denv (fun c' hc' => hall c' (hdomCs c' hc')))
+        (denseDomainByteJustified_sound domIdx e h.2 denv
+          (fun v c' hc' => hall c' (hdomIdx v c' hc')))
         (of_decide_eq_true h.1.2)
     ·
       exact denseAffineJustified_sound bound (fun x => denseFindVarBound bs facts (wits x) x) e denv
@@ -536,15 +582,17 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all domCs : List 
 /-- If every declared byte slot of `R` is justified, then at every such slot the evaluated payload
     entry of `R` (under any `denv` zeroing `all` and never violating the remaining witnessed
     interactions) is a byte/limb (`< bound`) — `denseDropPair_correct`'s `hbyte` obligation. -/
-theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all domCs : List (DenseExpr p))
+theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all : List (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (DenseExpr p)))
     (wits fwits : VarId → List (BusInteraction (DenseExpr p))) (slots : List Nat)
     (R : BusInteraction (DenseExpr p)) (hdeep : deep = true → p.Prime)
-    (hdomCs : ∀ c ∈ domCs, c ∈ all) (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
+    (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ all)
+    (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
     (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ rest)
-    (h : denseRecvSlotsJustified bound deep domCs candsOf bs facts wits fwits slots R = true)
+    (h : denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fwits slots R = true)
     (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
@@ -561,7 +609,7 @@ theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all domCs : L
     rw [he] at hget' hcheck
     simp only [Option.map_some, Option.some.injEq] at hget'
     subst hget'
-    exact denseByteJustifiedW_sound bound deep all domCs candsOf bs facts rest wits fwits e hdeep
-      hdomCs hcands hwits hfwits hcheck denv hall hbus
+    exact denseByteJustifiedW_sound bound deep all domIdx candsOf bs facts rest wits fwits e hdeep
+      hdomIdx hcands hwits hfwits hcheck denv hall hbus
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
@@ -18,46 +18,6 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
-/-! ## Soundness of the per-variable bucket index: every looked-up item was indexed -/
-
-/-- Inserting `a` (already in `S`) under any variable list preserves "every bucket value is in
-    `S`". -/
-theorem denseVarBucketAdd_mem {α : Type} {S : List α} (a : α) (ha : a ∈ S) :
-    ∀ (vs : List VarId) (m : Std.HashMap VarId (List α)),
-      (∀ x, ∀ b ∈ m.getD x [], b ∈ S) →
-      ∀ x, ∀ b ∈ (denseVarBucketAdd m vs a).getD x [], b ∈ S := by
-  intro vs
-  induction vs with
-  | nil => intro m hm; simpa [denseVarBucketAdd] using hm
-  | cons y rest ih =>
-    intro m hm
-    have hstep : ∀ x, ∀ b ∈ (m.insert y (a :: m.getD y [])).getD x [], b ∈ S := by
-      intro x b hb
-      by_cases hxy : y = x
-      · subst hxy
-        rw [Std.HashMap.getD_insert_self] at hb
-        rcases List.mem_cons.1 hb with h | h
-        · exact h ▸ ha
-        · exact hm y b h
-      · rw [Std.HashMap.getD_insert, if_neg (by simpa using hxy)] at hb
-        exact hm x b hb
-    have := ih (m.insert y (a :: m.getD y [])) hstep
-    simpa [denseVarBucketAdd, List.foldl_cons] using this
-
-/-- Every item returned by a bucket lookup was one of the indexed items. -/
-theorem denseVarBucket_mem {α : Type} (varsOf : α → List VarId) (items : List α) :
-    ∀ x, ∀ a ∈ denseVarBucketLookup (denseVarBucket varsOf items) x, a ∈ items := by
-  unfold denseVarBucketLookup denseVarBucket
-  induction items with
-  | nil =>
-    intro x a ha; simp only [List.foldr_nil, Std.HashMap.getD_empty, List.not_mem_nil] at ha
-  | cons c rest ih =>
-    intro x a ha
-    rw [List.foldr_cons] at ha
-    exact denseVarBucketAdd_mem c (List.mem_cons_self ..) ((varsOf c).eraseDups)
-      (List.foldr (fun a m => denseVarBucketAdd m ((varsOf a).eraseDups) a) ∅ rest)
-      (fun x' b hb => List.mem_cons_of_mem _ (ih x' b hb)) x a ha
-
 /-- A recognized byte check lives on a stateless bus. -/
 theorem denseByteCheckOperands?_stateless (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (ops : List (DenseExpr p))
@@ -92,7 +52,8 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
     DensePassCorrect isInput d (denseRedundantByteDropF pw bs facts d) [] bs := by
   unfold denseRedundantByteDropF
   refine DensePassCorrect.denseFilterBusEntailed d bs isInput
-    (denseByteDropKeepW pw bs facts (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+    (denseByteDropKeepW pw bs facts
+      (denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar))
       (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
       (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))) ?_ ?_
   · intro bi _ hkf
@@ -107,7 +68,7 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
     | some ops =>
       rw [hro] at hkf
       have hjust : ops.all (fun e => denseByteJustifiedW 256 pw.isPrime
-          (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+          (denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar))
           (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
           bs facts
           (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
@@ -123,7 +84,7 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
           rw [Option.isNone_iff_eq_none] at h
           simpa using h
         have hkeep : denseByteDropKeepW pw bs facts
-            (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+            (denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar))
             (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
             (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
             bi' = true := by
@@ -131,13 +92,13 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
         exact hsat.2 bi' (List.mem_filter.2 ⟨(List.mem_filter.1 hbi').1, hkeep⟩) hmult
       refine denseByteCheckOperands?_accepted bs facts bi ops hro denv (fun e he => ?_)
       exact denseByteJustifiedW_sound 256 pw.isPrime d.algebraicConstraints
-        (d.algebraicConstraints.filter DenseExpr.isSingleVar)
+        (denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar))
         (denseVarBucketLookup (denseVarBucket DenseExpr.vars d.algebraicConstraints))
         bs facts (denseByteDropBase bs facts d)
         (denseVarBucketLookup (denseVarBucket denseBIVars (denseByteDropBase bs facts d)))
         (fun _ => []) e
         (fun h => pw.correct h)
-        (fun c hc => List.mem_of_mem_filter hc)
+        (fun v c hc => List.mem_of_mem_filter (denseVarBucket_mem DenseExpr.vars _ v c hc))
         (fun x c hc => denseVarBucket_mem DenseExpr.vars d.algebraicConstraints x c hc)
         (fun v bi'' hbi'' =>
           denseVarBucket_mem denseBIVars (denseByteDropBase bs facts d) v bi'' hbi'')

--- a/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RedundantByteDrop.lean
@@ -37,17 +37,17 @@ def denseByteDropBase (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseCo
   d.busInteractions.filter (fun bi => (denseByteCheckOperands? bs facts bi).isNone)
 
 /-- Keep `bi` unless it is a recognized byte check whose operands are all byte-justified through the
-    prebuilt per-variable indexes `domCs`/`candsOf` (constraints) and `wits` (base interactions).
+    prebuilt per-variable indexes `domIdx`/`candsOf` (constraints) and `wits` (base interactions).
     Consumes `denseByteJustifiedW`, so the O(system) per-operand scans in `denseByteJustified` become
     per-variable bucket lookups. -/
 def denseByteDropKeepW (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domCs : List (DenseExpr p)) (candsOf : VarId → List (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (candsOf : VarId → List (DenseExpr p))
     (wits : VarId → List (BusInteraction (DenseExpr p)))
     (bi : BusInteraction (DenseExpr p)) : Bool :=
   match denseByteCheckOperands? bs facts bi with
   | some ops =>
     !(ops.all (fun e =>
-      denseByteJustifiedW 256 pw.isPrime domCs candsOf bs facts wits (fun _ => []) e))
+      denseByteJustifiedW 256 pw.isPrime domIdx candsOf bs facts wits (fun _ => []) e))
   | none => true
 
 /-- Drops a byte-check interaction when all its operands are already proven to be bytes elsewhere —
@@ -57,10 +57,10 @@ def denseByteDropKeepW (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusF
 def denseRedundantByteDropF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   let base := denseByteDropBase bs facts d
-  let domCs := d.algebraicConstraints.filter DenseExpr.isSingleVar
+  let domIdx := denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar)
   let candsIdx := denseVarBucket DenseExpr.vars d.algebraicConstraints
   let witsIdx := denseVarBucket denseBIVars base
-  d.filterBus (denseByteDropKeepW pw bs facts domCs
+  d.filterBus (denseByteDropKeepW pw bs facts domIdx
     (denseVarBucketLookup candsIdx) (denseVarBucketLookup witsIdx))
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/VarBucket.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/VarBucket.lean
@@ -6,8 +6,10 @@ set_option autoImplicit false
 
 Maps each variable to the items mentioning it (`denseVarBucket`), uncapped and order-preserving so
 a lookup returns exactly the same list a `filter (mentions x)` would. Shared by
-`RedundantByteDrop.lean` (operand justification) and `RootPairUnify.lean` (per-variable bound
-lookups); the soundness/exactness lemmas live with their consumers. -/
+`RedundantByteDrop.lean` (operand justification), `RootPairUnify.lean` (per-variable bound lookups)
+and the `busPairCancel` justification chain (domain lookups). Membership soundness is
+`denseVarBucket_mem` (`Proofs/BusPairCancelJustify.lean`); the exactness lemmas live with their
+consumers. -/
 
 namespace ApcOptimizer.Dense
 

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -150,16 +150,17 @@ keccak, so anything superlinear is fatal there.
 - gdb samples (keccak, mid-run): `findConsumer` (busUnify), `reencodeLoop`, `foldLoopDirect`
   (domainFold's unindexed path), `collectForBus` — matching the analysis below.
 
-### Where the time goes at SHA scale (2026-07-26, PRs #205–#210 + entry 142)
+### Where the time goes at SHA scale (2026-07-26, PRs #205–#210 + entries 142–143)
 
 sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):
 **989 s (main-of-2026-07-24) → 550 s** across #205 (registry array-copy, encode 80.5 → 0.8 s),
 #206 (domainFold Array.modify accepts, 173 → 6.9 s, reencode −86 s from allocator pressure alone),
 #208 (pointwiseDupDrop slot-0 index + hoisted singles, flagFold 85 → 15.6 s), #209 (rootPairUnify
 per-variable bound indexes, 49.6 → 33.7 s), #210 (busPairCancel segment scans, 107 → 89.5 s), then
-**524 → 445 s** with entry 142 (reencode's two per-candidate whole-system scans, 184 → 97 s).
-Remaining per-pass: **reencode 97 s, busPairCancel 90 s, busUnify 54 s, gauss 36 s, domainBatch
-20 s (parallel), bytePack 17 s, flagFold 16 s, normalize1 14 s, rootPairUnify 13 s, carryBranch
+**524 → 445 s** with entry 142 (reencode's two per-candidate whole-system scans, 184 → 97 s) and
+**445 → 404 s** with entry 143 (busPairCancel's per-query domain scans, 90 → 50 s).
+Remaining per-pass: **reencode 98 s, busUnify 54 s, busPairCancel 50 s, gauss 36 s, domainBatch
+20 s (parallel), bytePack 17 s, flagFold 15 s, normalize1 14 s, rootPairUnify 13 s, carryBranch
 13 s**; the tail below that is ~60 s over 25 passes. Cycles 0–2 are still ~78 % of the total.
 Whole-run perf: ~25 % `lean_dec_ref_cold` + ~17 % allocator + ~8 % `lean_apply_1` — the budget is
 still memory traffic, not arithmetic. `DenseTwoRootMap.build` (busUnify/busPairCancel certificate
@@ -186,6 +187,13 @@ these need no new proof.
      thunked; the pass body's per-invocation `HashSet.ofList cs.vars` replaced by the
      by-construction variable guarantee (`memEqConstraints_vars`) and the hash-bucket build
      gated on nonempty candidates. Output byte-identical.
+   - ~~`busPairCancel`/`redundantByteDrop` byte-justification domain scans~~ **done (entry 143)**:
+     `denseFindDomainAlg` is served from a `denseVarBucket` over the single-variable constraints
+     (uncapped, order-preserving → identical first match), threaded as a *value* — a lookup closure
+     in the thunk payload re-ran the whole index build per query (13× regression, see the entry).
+     busPairCancel 90 → 50 s. `flagUnify`, `flagFoldDrops`, `boxRewrite`, `fxSubst` and
+     `rootPairUnify` still call `denseFindDomainAlg` on whole lists; same fix applies if they show
+     up in a profile (flagFold 15 s and rootPairUnify 13 s are the candidates).
    - `busPairCancel`: ~~`liveArr` materialization per candidate~~ **done (#210)** — see R8.
      The O(B²) *certificate* scans remain (R8 design (b)); in coda mode the `addrHash`
      bucket is O(B) per hot address — add a position cursor. ~~`dropWits` from-0 array scan per
@@ -331,10 +339,11 @@ sequential scans (window state).
 
 **R8. busPairCancel residual quadratics** (formerly part of R1). Design (a) — array-segment
 twins of `liveArr`+`shieldScan`/`List.all` (`denseLiveAllSeg`/`denseShieldScanSeg` with `…_eq`
-lemmas) — is **done (#210)**: sha256_big busPairCancel 107 → 89.5 s. The remaining 89 s
-(~16 % of the SHA run, now promoted) is the O(live²) certificate work itself: `shieldOk` still
-evaluates `densePreRefuted` over the whole live prefix per candidate send, and `midRefuted` over
-the between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldOk` left-folds
+lemmas) — is **done (#210)**: sha256_big busPairCancel 107 → 89.5 s, and entry 143 took the
+justification's domain scans out (89.5 → 50 s). The remaining 50 s is the O(live²) certificate work
+itself — `denseShieldScanSeg` is ~4 % of whole-run CPU: `shieldOk` still evaluates
+`densePreRefuted` over the whole live prefix per candidate send, and `midRefuted` over the
+between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldOk` left-folds
 to a single per-address-key `pending` bit, maintainable across one sweep — but the pass's
 tombstone-and-restart structure (drops invalidate prefix state: removing a consumed receive
 un-shields earlier messages) forces a recompute-on-drop scheme, bounded by #drops × O(B).

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4836,3 +4836,37 @@ sha256_big (`profile`, quiet 48-core box): reencode **183.7 → 97.4 s (−47 %)
 
 **Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak,
 wasm-eth apc_036 and the 168k-var OpenVM sha256 case).**
+
+### 143. Runtime: busPairCancel serves domain lookups from a per-variable index
+
+`denseFindDomainAlg domCs v` — the finite-domain lookup behind the byte justification — scanned the
+**whole** single-variable-constraint list per query (55k constraints in sha256_big's cycle 0),
+testing `mentions` on each. `perf` charged 4.7 % of whole-run CPU to `denseFindDomainAlg` and
+another 1.5 % to `DenseExpr.mentions`, all under `denseUnjustifiedSlots`/`denseCheckCancel`, i.e.
+per candidate send/receive pair per declared byte slot.
+
+The justification chain (`denseDeepEnumDoms`, `denseDomainByteJustified`, `denseByteJustifiedW`,
+`denseRecvSlotsJustified`, `denseUnjustifiedSlots`, `denseCheckCancel`) now takes a per-variable
+index instead of the list, and looks each variable's domain up in it. The index is `denseVarBucket`
+(`VarBucket.lean`) over the single-variable constraints — uncapped and order-preserving, so the
+bucket for `v` is exactly the sublist a `filter (mentions v)` would give and `denseFindDomainAlg`
+returns the identical first match. Soundness needs only membership (`denseVarBucket_mem`, moved to
+`Proofs/BusPairCancelJustify.lean` so all three consumers see it), so the hypotheses just changed
+shape: `∀ c ∈ domCs, P c` → `∀ v, ∀ c ∈ lookup domIdx v, P c`. `redundantByteDrop` builds the same
+index for its own domain queries.
+
+**The index must be passed as a value, not as a lookup closure.** The first version put
+`denseVarBucketLookup (denseVarBucket … (filter isSingleVar …))` into the threaded thunk's subtype
+payload; the compiler re-evaluated the filter *and* the index build **per query** — wasm-eth
+apc_036 busPairCancel 8.5 → 113 s (32 % of the run in `DenseExpr.singleVarAux`). Passing the
+`HashMap` itself and applying `denseVarBucketLookup` inside the callees fixed it (7.3 s). This
+extends entry 106's arity rule: **a partial application stored in a structure (or a thunk payload)
+re-runs its argument's computation per call, exactly like `let heavy := …; fun y => …`** — store
+the data, apply the lookup at the use site.
+
+sha256_big (`profile`, quiet 48-core box): busPairCancel **90.2 → 50.1 s (−44 %)**, total
+**444.7 → 404.4 s (−9 %)**; cumulative with entry 142, 523.9 → 404.4 s (−23 %). wasm-eth apc_036:
+busPairCancel 8.5 → 7.3 s, redundantByteDrop 172 → 61 ms.
+
+**Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak, wasm-eth
+apc_036 and the 168k-var OpenVM sha256 case).**


### PR DESCRIPTION
Stacked on #211 (already merged). With reencode fixed, `busPairCancel` was the top pass on the
168k-variable sha256 APC, and `perf` (LBR) put **6.2 % of whole-run CPU** in one place:
`denseFindDomainAlg` (4.7 %) plus `DenseExpr.mentions` (1.5 %), all under
`denseUnjustifiedSlots`/`denseCheckCancel`.

## What changed

`denseFindDomainAlg domCs v` — the finite-domain lookup behind the byte justification — scanned the
**whole** single-variable-constraint list (55k constraints in sha256_big's cycle 0), testing
`mentions` on each, and it runs per candidate send/receive pair per declared byte slot.

The justification chain (`denseDeepEnumDoms`, `denseDomainByteJustified`, `denseByteJustifiedW`,
`denseRecvSlotsJustified`, `denseUnjustifiedSlots`, `denseCheckCancel`) now takes a per-variable
index and looks each variable's domain up in it. The index is the existing `denseVarBucket`
(`VarBucket.lean`) over the single-variable constraints — uncapped and order-preserving, so a
bucket is exactly the sublist `filter (mentions v)` gives and `denseFindDomainAlg` returns the
identical first match. Soundness needs only membership (`denseVarBucket_mem`, moved to
`Proofs/BusPairCancelJustify.lean` so all three consumers see it), so the hypotheses only change
shape: `∀ c ∈ domCs, P c` → `∀ v, ∀ c ∈ lookup domIdx v, P c`. `redundantByteDrop` builds the same
index for its own domain queries (172 → 61 ms on wasm-eth apc_036).

**The index is passed as a value, not as a lookup closure** — worth knowing for future index work:
the first version stored `denseVarBucketLookup (denseVarBucket … (filter isSingleVar …))` in the
threaded thunk's subtype payload, and the compiler re-ran the filter *and* the index build **per
query** (wasm-eth apc_036 busPairCancel 8.5 → 113 s, 32 % of the run in `DenseExpr.singleVarAux`).
Entry 106's arity rule extends to partial applications stored in structures.

## Impact

sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):

| | main (a812c76) | this PR |
|---|---|---|
| busPairCancel | 90.2 s | **50.1 s** (−44 %) |
| total | 444.7 s | **404.4 s** (−9 %) |

Cumulative with #211 on the same box: 523.9 → 404.4 s (−23 %). Every other pass is unchanged within
noise. wasm-eth apc_036 (`profile`): 41.2 → 40.5 s total, busPairCancel 8.5 → 7.3 s.

## Validation

- `lake build` (warning-free), `Scripts/check-proof-integrity.sh`
- byte-identical `opt-export` vs. main on openvm-eth apc_044 / apc_067, keccak apc_001, wasm-eth
  apc_036 and OpenVM sha256 apc_001 (the 168k-var case: 427 s → 392 s on that run)
- `agent-docs/log.md` entry 143; `agent-docs/ideas.md` R1/R8 updated — busPairCancel's residual is
  now the shield/mid certificate scans (~4 % of CPU), and `flagUnify`/`flagFoldDrops`/`boxRewrite`/
  `fxSubst`/`rootPairUnify` still call `denseFindDomainAlg` on whole lists if they show up next

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKR42FVxb2GLyEesKGgyvK