### PR TITLE
Document optimizer scaling analysis and add R13–R15 to ideas.md

### DIFF
--- a/agent-docs/README.md
+++ b/agent-docs/README.md
@@ -10,6 +10,9 @@ documents — not part of the audited surface, and not a substitute for it.
   don't fit the current session and remove ones that have been implemented.
 - [`log.md`](log.md) — an append-only history of optimizer changes: each entry records the idea,
   whether it worked, and its effect on effectiveness. Earlier entries describe superseded designs.
+- [`runtime-scaling.md`](runtime-scaling.md) — why the optimizer's wall time is superlinear in
+  circuit size (~N^1.5–1.8 against Rust's ~N^1.0), with the measurements, the per-pass attribution,
+  and the quadratic code sites. Read before working on runtime.
 
 For humans, the entry points are the top-level [`README.md`](../README.md) (which defines the
 auditing surface) and [`AGENTS.md`](../AGENTS.md) (the agent instructions).

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -120,6 +120,11 @@ touching these files anyway):
 
 ## Runtime
 
+For the cross-implementation picture — Lean at ~N^1.5–1.8 against powdr Rust's ~N^1.0, the
+disjoint-replica scaling experiment that isolates per-pass cost from fixpoint rounds, and why the
+gap is a proof-obligation shape rather than a port defect — see
+[`runtime-scaling.md`](runtime-scaling.md).
+
 Rewritten 2026-07-18 from a fresh profiling session (per-pass `profile`, per-cycle timing, gdb
 stack sampling, and a size-scaling sweep — all on this container, serial). **Runtime is
 end-to-end quadratic in circuit size** (openvm-eth sweep: input 2.3k → 8.8k items costs
@@ -374,6 +379,49 @@ same pattern).
 the per-variable bucket maps (`DenseCovIndex.buckets`, `denseVarBucket`, `denseTouchedSet`) could
 be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide but mechanical;
 worth a prototype on one index first.
+
+**R13. Finish the candidate-group family: `domainFold`'s per-target gates and
+`denseCheckReencode`**  ·  *high value / medium effort*. `reencode`'s degree pre-gate is **done
+(#211 / entry 142)** — but `reencode` and `domainFold` enumerate the *identical* candidate shape
+(2-to-8-variable groups pinned by single-variable constraints: `denseTargetsV` vs `reencode`'s
+`targets`, same predicate), so the cost is shared and moves between them. Measured on the
+disjoint-replica ladder at `ff15446`: deleting `reencode` from `cleanupPasses` sped the pipeline up
+by **nothing** (k=4: 90.1 s vs 91.5 s) because its 44 s reappeared as `domainFold` growing
+26.0 → 57.1 s (and the output got worse, 7546 vs 5498 vars). Remaining work:
+   - `domainFold`'s per-target gates: the direct path (`DomainFoldRuntime.lean:170`
+     `denseFoldLoopDirectV` → `denseSystemHasFoldableWV`) still walks the whole system per target
+     below the 8192-constraint gate, which is where big circuits spend their *tail* cycles
+     (keccak 28 627 → 4 529 constraints by cycle 2; sha256 199 740 → 3 194 by cycle 6). Heed entry
+     107: retiring the analogous `reencode` gate measured 1.19× *worse* on dense openvm-eth, so
+     A/B on the same runner. Separately the *indexed* path measured exponent ≈ 2.0 between k=2 and
+     k=3 on the replica ladder — re-measure directly before acting.
+   - `denseCheckReencode` (`Reencode.lean:135`): its `denseCoveredCsOf` filter and its
+     explicitly-`O(bits × system)` freshness scan are the two per-candidate whole-system scans
+     #211 did not touch (already flagged open under R3; #211's fresh-name counts made the
+     freshness conjunct the only remaining one).
+
+   See [`runtime-scaling.md`](runtime-scaling.md) §3–§4.
+
+**R14. `subsumedRange`/`subsumedCheck`: reuse the #209 bound index**  ·  *low effort, cheap win*.
+`SubsumedCheck.lean:53` `denseSubsumedDropKeep` calls `denseFindVarBound` — a linear scan of the
+whole `base` interaction list — once per recognized check: Θ(checks × interactions), the cleanest
+quadratic left in the tree (exponent 2.24 on the disjoint-replica ladder; 9.0 s on sha256 today,
+small only because coda passes run once on the shrunk system). `RootPairUnify.lean` already has the
+indexed twin, `denseAnyVarBoundIdx` over the per-variable `witsOf` map. Drop-side is
+untrusted-then-rechecked, so no new proof.
+
+**R15. `bytePack`/`tupleRange`: stop restarting the scan at the list head**  ·  *low-medium value /
+low effort*. `ByteCheckPack.lean:102` `denseFindGo` is driven by `DenseNativeStep.drain` and
+re-scans the prefix (plus a fresh `revPre.reverse`) for every packed pair; `TupleRange.lean:98/104`
+is the same shape. Θ(rewrites × B), 5 % of the sha256 run (`bytePack` 33.6 s + `bytePackLate`
+11.7 s + `tupleRange` 5.7 s), `tupleRange` exponent 2.10 on the replica ladder. A resume cursor
+(`denseCancelLoop`'s `resumeIdx`/`resumePos` pattern) keeps the output byte-identical: the step
+emits `pre ++ pairCheck :: mid ++ post`, `pre` is unchanged and by construction holds no recognized
+single-value check, and the emitted `.pair` check is not one either (`denseSvCheck?` fires only for
+single-operand shapes), so resuming at `|pre| + 1` visits the same candidates in the same order.
+Also fold in `flagUnify`'s `denseFuPairData?` (`FlagUnify.lean:34`), which
+still resolves domains with the unindexed `denseFindDomainAlg` per variable per matched pair while
+`rootPairUnify` tabulates them once (`denseFindDomainMap`, #209); exponent 1.54.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 

--- a/agent-docs/runtime-scaling.md
+++ b/agent-docs/runtime-scaling.md
@@ -1,0 +1,257 @@
+# Why the optimizer is superlinear in circuit size
+
+Session note (2026-07-26), triggered by powdr's Rust-vs-Lean timing comparison
+(`apc-timing/apc_optimizer_timing.json` on powdr's `apc-optimizer-timing-comparison` branch:
+20 115 APCs across 9 guest programs, both optimizers timed on the same machine). Every number below
+was measured on a 4-core container against **`ff15446`** (post PRs #205–#210), which is also the
+commit the reference JSON was generated from. #211 (reencode's per-candidate whole-system scans,
+184 → 97 s on sha256) landed while this was being measured; §7 re-measures on top of it. Absolute
+times on this container run ~2× the 48-core box used for the `ideas.md` numbers, and run-to-run
+variance is ±15 % — read exponents and shares, not seconds.
+
+**Headline: the Lean optimizer's wall time grows as ~N^1.5–1.8 in circuit size; powdr's Rust
+optimizer is ~N^1.0.** On small APCs Lean is *faster* than Rust; at ~170k columns it is ~6× slower.
+The growth is **not** the fixpoint needing more rounds — it is per-pass cost, and it comes from one
+recurring shape: **Θ(system) work per optimization candidate**, with Θ(N) candidates.
+
+This file records the cross-implementation measurement, a controlled scaling experiment that
+isolates the effect, and the per-pass attribution. It complements the runtime section of
+[`ideas.md`](ideas.md), which holds the ranked fix list; findings here are cross-referenced to its
+`R*` entries, and the three previously-unlisted quadratic sites in §4 were added there as R13–R15.
+
+## 1. The cross-implementation gap
+
+Median wall time **per input variable**, bucketed by circuit size, from the reference JSON:
+
+| input variables | APCs | Rust µs/var | Lean µs/var | Lean / Rust |
+| --- | --- | --- | --- | --- |
+| < 500 | 15056 | 1248 | 923 | 0.74 |
+| 500–1k | 3064 | 1833 | 992 | 0.54 |
+| 1k–2k | 1400 | 1668 | 1120 | 0.67 |
+| 2k–4k | 402 | 1907 | 1215 | 0.64 |
+| 4k–8k | 159 | 4170 | 1573 | 0.38 |
+| 8k–16k | 13 | 2049 | 2116 | 1.03 |
+| 16k–32k | 12 | 1579 | 3631 | 2.30 |
+| 32k–64k | 7 | 1160 | 3065 | 2.64 |
+| 64k–300k | 2 | 679 | 4083 | **6.01** |
+
+Rust's per-variable cost is flat-to-declining across four orders of magnitude; Lean's grows 4.4×.
+A log-log fit over the APCs with ≥ 5000 variables gives exponent **1.26 for Lean** against **0.42
+for Rust** (Rust's sub-linear fit is an artifact of noise in the mid range — the honest reading is
+"flat" — while Lean's is a real upward trend). The crossover is around 8k–10k variables.
+
+The two data points in the top bucket are this repo's own stress benchmarks: `sha256`
+(168 915 vars) and the largest `openvm-eth` block (170 361 vars).
+
+## 2. The controlled experiment: k disjoint copies
+
+Real APCs differ in shape, so the scaling was re-measured on a synthetic family: `k` copies of
+`openvm-eth/apc_005` (5406 vars, 4652 constraints, 2253 interactions), copy `c` renaming every
+variable `<name>@<id>` to `<name>@<id + c·stride>` so the copies share nothing. A linear optimizer
+must take exactly `k ×` the single-copy time on this input.
+
+| k | vars | total | vs. linear |
+| --- | --- | --- | --- |
+| 1 | 5 406 | 8.0 s | 1.0× |
+| 2 | 10 812 | 23.3 s | 1.5× |
+| 3 | 16 218 | 49.2 s | 2.1× |
+| 4 | 21 624 | 91.5 s | 2.9× |
+| 6 | 32 436 | 164.8 s | 3.5× |
+| 8 | 43 248 | 315.8 s | **5.0×** |
+
+Exponent **1.77**. Cleanup iterations: 5 at k=1, 6 at k=8 — so on this input the growth is
+*entirely* per-pass cost, not extra fixpoint rounds. Per-pass exponents (entries ≥ 150 ms at k=8):
+
+| pass | k=1 (ms) | k=8 (ms) | exponent | vs. linear |
+| --- | --- | --- | --- | --- |
+| `reencode` | 2418 | 256950 | **2.24** | 13.3× |
+| `subsumedRange` | 28 | 2977 | **2.24** | 13.3× |
+| `tupleRange` | 5 | 391 | **2.10** | 9.8× |
+| `busPairCancel` | 196 | 6340 | **1.67** | 4.0× |
+| `flagUnify` | 110 | 2732 | 1.54 | 3.1× |
+| `flagFold` | 420 | 9577 | 1.50 | 2.9× |
+| `busUnify` | 267 | 3656 | 1.26 | 1.7× |
+| `gauss` | 549 | 5962 | 1.15 | 1.4× |
+| everything else | — | — | 1.08–1.28 | 1.2–1.8× |
+
+`domainFold` is omitted because it is not monotone here: 1.7 s → 26.0 s over k=1…4 (exponent ≈ 2.0
+between k=2 and k=3, both on the *indexed* path), then collapsing to 1.4 s / 2.1 s at k=6 / k=8
+once `reencode` has grown large enough to consume the same candidate groups first. See the ablation
+below.
+
+The 1.08–1.28 band covers passes that are linear by construction (`encode`, `constFold`, `dedup`,
+`tautoBus`): allocation and locality cost from a larger working set, consistent with the
+"budget is memory traffic, not arithmetic" finding in `ideas.md`. It is the floor to beat, not a
+bug.
+
+Real-circuit ladders agree on the shape: a 12-circuit ladder from 852 to 27 521 variables
+(`openvm-eth`, `wasm-eth`, `keccak`) fits exponent **1.48**; `keccak` → `sha256` (6.14× the
+variables) costs 26.0× the time, exponent **1.79**.
+
+## 3. Where the time goes, and the ablation
+
+`sha256` (168 915 vars; 1046.7 s on this 4-core container — slower than the 48-core box used for
+the #205–#210 numbers in `ideas.md`, but the same ranking):
+
+| pass | ms | share |
+| --- | --- | --- |
+| `reencode` | 399 276 | 38.1 % |
+| `busPairCancel` | 186 121 | 17.8 % |
+| `busUnify` | 117 529 | 11.2 % |
+| `gauss` | 48 903 | 4.7 % |
+| `domainBatch` | 47 700 | 4.6 % |
+| `bytePack` | 33 643 | 3.2 % |
+| `flagFold` | 31 717 | 3.0 % |
+| rest (30 passes) | 181 855 | 17.4 % |
+
+`keccak` (27 521 vars, 40.3 s): `busUnify` 21 %, `domainFold` 13 %, `reencode` 10 %, `gauss` 9.5 %,
+`busPairCancel` 9 %, `domainBatch` 6.4 %. Cycle 0 alone is 36 % of the sha256 run and cycles 0–2
+are 68 %, matching the earlier per-cycle finding.
+
+gdb stack sampling of the live sha256 process (260 stacks, `thread apply all bt` — the work runs on
+a Lean worker thread) puts the innermost frames exactly where §4 predicts:
+`denseDegPreReject → List.any → DenseExpr.sharesVarIn` under `denseReencodeStep`/`denseReencodeLoop`,
+and `denseCheckPair → denseAddrTwoRootNeq → densePtrReductions` under `denseCollectForBus`
+(`busUnify`) and `denseFindCancelGoIdx` (`busPairCancel`).
+
+### Ablation: the cost is shared, not owned by one pass
+
+Dropping `reencode` from `cleanupPasses` and re-running the replica ladder speeds up **nothing**
+(k=4: 90.1 s without vs 91.5 s with; k=1 and k=2 are slightly *slower* without it). The 44 s
+`reencode` spent at k=4 reappears as `domainFold` growing 26.0 s → 57.1 s, and the output is worse
+(7546 vs 5498 variables).
+
+The reason is that both passes enumerate the *same* candidate shape — 2-to-8-variable groups whose
+variables are pinned by single-variable constraints (`denseTargetsV` in `DomainFoldRuntime.lean`
+vs. `reencode`'s `targets` in `Reencode.lean`, identical predicates) — and each spends Θ(system)
+per group. With `reencode` gone the groups survive and `domainFold` re-processes them every cycle.
+
+**So the target is the pattern, not one pass.** Whoever consumes the candidate groups pays
+Θ(groups × system) unless the per-group work is served from an index. Indexing `reencode` alone
+should therefore move part of the cost rather than remove it — #211 did exactly that indexing, so
+§7 is the test of this prediction.
+
+## 4. The pattern, and three sites not yet in `ideas.md`
+
+Three recurring shapes produce all of the measured superlinearity:
+
+1. **Per-candidate whole-system scan** — a gate or certificate walks every constraint and every
+   interaction, once per candidate (`reencode`, `domainFold`, and the three sites below).
+2. **Per-candidate whole-interval scan** — for stateful buses, a matched send/receive pair's
+   certificate quantifies over every interaction *between* them, and for `busPairCancel` over the
+   entire *prefix* before the send. Cost is Σ over pairs of the gap length: Θ(N²) when matched
+   pairs are far apart, which is precisely what a long basic block like sha256/keccak looks like.
+   Already tracked as R8 (`busPairCancel`) and R10 (`busUnify`).
+3. **Find-first-then-restart drains** — "find the first rewritable pair from the head, rewrite,
+   repeat" re-scans the prefix and rebuilds `revPre.reverse` for every rewrite: Θ(rewrites × N).
+
+Sites not currently listed in `ideas.md`:
+
+### 4a. `subsumedRange` / `subsumedCheck` — exponent 2.24
+
+`SubsumedCheck.lean:53` `denseSubsumedDropKeep` calls `denseFindVarBound`
+(`RootPairUnify.lean:92`) — a linear scan of the whole `base` interaction list — once per
+recognized check, so the pass is Θ(checks × interactions). Only 9.0 s of the sha256 run today
+(coda passes run once, on the shrunk system), but it is the cleanest quadratic in the tree and
+`RootPairUnify.lean` already has the indexed twin to reuse: `denseAnyVarBoundIdx`, served from the
+per-variable `witsOf` map built by #209. Cheap, and the drop is untrusted-then-rechecked, so no new
+soundness proof.
+
+### 4b. `bytePack` / `tupleRange` — find-first-then-restart drains
+
+`ByteCheckPack.lean:102` `denseFindGo` (with `denseFindSecond` at :88) is driven by
+`DenseNativeStep.drain` (`Proofs/ByteCheckPack.lean:598`) with fuel = interaction count: each
+packed pair restarts the scan at the head of the list and materializes `revPre.reverse`.
+`TupleRange.lean:98`/`:104` has the identical shape. Measured 33.6 s (`bytePack`) + 11.7 s
+(`bytePackLate`) + 5.7 s (`tupleRange`) = 5 % of the sha256 run, exponent 2.10 for `tupleRange` on
+the replica ladder. A resume cursor (`denseCancelLoop`'s `resumeIdx`/`resumePos` pattern) is exactly
+sound here: the step's output is `pre ++ pairCheck :: mid ++ post`, `pre` is unchanged and by
+construction holds no recognized single-value check, and the emitted `.pair` check is not one
+either (`denseSvCheck?` only fires for single-operand shapes) — so resuming at `|pre| + 1` visits
+the same candidates in the same order and keeps the output byte-identical.
+
+### 4c. `flagUnify` — exponent 1.54
+
+`FlagUnify.lean:34` `denseFuPairData?` resolves each joint variable's domain with
+`denseFindDomainAlg domCs v` (`DomainFold.lean:43`), a full constraint-list scan per variable per
+matched pair. `RootPairUnify.lean` already tabulates exactly this once per invocation
+(`denseFindDomainMap`, #209) — share it. Its `seen` buckets are also never pruned, so a match key
+shared by many interactions is re-certified against every later candidate.
+
+### Already-tracked sites, with this session's numbers attached
+
+- `reencode` (R3, R13): `denseDegPreReject` was `d.algebraicConstraints.any … ||
+  d.busInteractions.any …` per candidate group, ahead of the cheap gates — the single hottest loop
+  in the optimizer at sha scale in every measurement above, and the frame gdb landed in. It had been
+  *added* (entry 113) to avoid the far worse freshness-scan-plus-`reencodeOut` on the 1276-of-1276
+  degree-rejected groups: it cut the constant but kept the Θ(targets × system) shape. **#211 / entry
+  142 indexed it** (a thunked whole-system posting index, rebuilt on accept) with no soundness proof
+  needed, since the gate is untrusted (both branches sound) and only items sharing a variable with
+  `xs` can make the `any` true. Still open: `denseCheckReencode` (`Reencode.lean:135`) — its
+  `denseCoveredCsOf` filter and its explicitly-`O(bits × system)` freshness scan are the same shape.
+- `domainFold` (R3): the direct path (`denseFoldLoopDirectV`, `DomainFoldRuntime.lean:170`) runs
+  `denseSystemHasFoldableWV` over the whole system per target, and is taken below
+  `domainFoldIndexThreshold = 8192` constraints — which includes big circuits *mid-fixpoint*
+  (keccak 28 627 → 4 529 constraints by cycle 2; sha256 199 740 → 3 194 by cycle 6), so both spend
+  their tail cycles there. Note entry 107's warning: the analogous gate in `reencode` was measured
+  1.19× *worse* when retired on dense openvm-eth blocks, so any change here needs a same-runner
+  A/B, not just a keccak/sha number. Separately, the indexed path measured exponent ≈ 2.0 between
+  k=2 and k=3 on the replica ladder — the per-target cost is the union of the `xs` variables' index
+  buckets and group variables are typically flags with very long buckets. Worth re-measuring
+  directly before acting on.
+- `busPairCancel` (R8): `BusPairCancel.lean:207` `denseShieldScanSeg … arr alive 0 i` is a full
+  live-prefix scan per candidate send, and `:205` `denseLiveAllSeg … (i+1) (j-i-1)` the
+  between-region scan. 17.8 % of sha256 here (89.5 s / ~16 % on the 48-core box post-#210) — the
+  R8 design (b) sweep remains the fix.
+- `busUnify` (R10): `denseCheckPair` (`BusUnify.lean:82`) re-verifies `mid.all` for each candidate
+  the sweep proposed, and `denseEmitCand` (`:159`) materializes `w.revPre.reverse` — a fresh copy
+  of the whole prefix — per emitted candidate, even though `denseCollectForBus` (`:248`) never
+  reads `pre`/`post` (they exist only so the positional split can be stated). Making those two
+  fields lazy or position-only removes Θ(N) per candidate without touching the sweep's decisions,
+  which R10 correctly insists must stay bit-identical.
+
+## 5. Why Rust does not have this
+
+`powdr_autoprecompiles::memory_optimizer::redundant_memory_interactions_indices` is a **single
+left-to-right sweep** over the bus interactions holding a `HashMap<Address, MemoryContent>` of live
+sends: a receive consumes the entry for its address and emits the data/timestamp equalities; a send
+evicts only entries it cannot prove disjoint. Nothing is re-verified against the interval between a
+send and its receive, and one sweep's drops are applied in one batch. The surrounding
+`optimize_rust` loop wraps everything in an `IndexedConstraintSystem`, so per-variable lookups are
+O(1) by construction.
+
+The Lean code *has* that sweep — `denseSweepGo` mirrors it closely — but then re-verifies each
+candidate it proposed, because that is the form the machine-checked certificate takes. The extra
+cost is not sloppiness in the port: it is the shape of the proof obligation. Making it linear means
+proving that the sweep's invariant *implies* the per-pair conditions, rather than re-deriving each
+pair's conditions from the raw list. That is the standing R8/R10 design, and it is the structural
+difference to close if the goal is Rust-comparable scaling rather than a better constant.
+
+The candidate-group family (§3 ablation) has an easier answer: those gates are untrusted, so
+indexing them needs no proof — only the discipline of keeping the index complete across accepts.
+
+## 6. Reproducing
+
+```bash
+# per-pass attribution for one circuit
+lake exe apc-optimizer profile Benchmarks/OpenVM/keccak/apc_001_pckeccak.json.gz
+
+# runtime across a benchmark set, serial, with per-pass totals and A/B against a baseline
+Benchmarks/runtime_bench.py --n 20 --repeat 3 --json out.json
+```
+
+Disjoint-replica scaling input: emit `k` copies of one APC's `machine.constraints` and
+`machine.bus_interactions`, renaming every `<name>@<id>` in copy `c` to `<name>@<id + c·stride>`
+(`stride` = max id + 1), keeping `bus_map` and setting `next_free_id = k·stride`. The parser reads
+only those keys. A linear optimizer takes `k ×` the single-copy time; anything above that is the
+per-pass superlinearity, with the fixpoint's round count held fixed.
+
+Stack sampling a long run (no `perf` in this container; the optimizer runs on a Lean worker
+thread, so `thread apply all` is required, and `bt -N` gives the outermost frames that identify the
+pass):
+
+```bash
+gdb -p <pid> -batch -ex "thread apply all bt 40" -ex "thread apply all bt -8"
+```
+
+Sampling inflates the sampled run (~30 %); use it for attribution, not for timings.

--- a/agent-docs/runtime-scaling.md
+++ b/agent-docs/runtime-scaling.md
@@ -40,8 +40,15 @@ A log-log fit over the APCs with ≥ 5000 variables gives exponent **1.26 for Le
 for Rust** (Rust's sub-linear fit is an artifact of noise in the mid range — the honest reading is
 "flat" — while Lean's is a real upward trend). The crossover is around 8k–10k variables.
 
-The two data points in the top bucket are this repo's own stress benchmarks: `sha256`
-(168 915 vars) and the largest `openvm-eth` block (170 361 vars).
+The same table with sums instead of medians gives the same picture in every bucket above 16k vars.
+The five largest APCs in the set: three at 53 238 vars (Rust 62 s, Lean 166–191 s) and two at
+~170k (Rust 113 / 117 s, Lean 633 / 752 s) — the latter are this repo's `sha256` stress benchmark
+and the largest `openvm-eth` block.
+
+Worth keeping in proportion: summed over all 20 115 APCs, Lean is still **32 % faster** than Rust
+(13 700 s vs 20 161 s), because almost every APC is small and Lean wins there. The problem is
+confined to the large tail — but that tail is where a single call costs minutes, so it is what
+bounds the worst case.
 
 ## 2. The controlled experiment: k disjoint copies
 
@@ -102,7 +109,7 @@ the #205–#210 numbers in `ideas.md`, but the same ranking):
 | `domainBatch` | 47 700 | 4.6 % |
 | `bytePack` | 33 643 | 3.2 % |
 | `flagFold` | 31 717 | 3.0 % |
-| rest (30 passes) | 181 855 | 17.4 % |
+| rest (33 entries + encode/decode) | 181 855 | 17.4 % |
 
 `keccak` (27 521 vars, 40.3 s): `busUnify` 21 %, `domainFold` 13 %, `reencode` 10 %, `gauss` 9.5 %,
 `busPairCancel` 9 %, `domainBatch` 6.4 %. Cycle 0 alone is 36 % of the sha256 run and cycles 0–2
@@ -209,6 +216,15 @@ shared by many interactions is re-certified against every later candidate.
   reads `pre`/`post` (they exist only so the positional split can be stated). Making those two
   fields lazy or position-only removes Θ(N) per candidate without touching the sweep's decisions,
   which R10 correctly insists must stay bit-identical.
+
+### Secondary: the cleanup fixpoint's round count
+
+On *real* circuits the number of cleanup iterations grows with size — 3–7 below 8k variables, 8–10
+at 15k–170k (fit exponent ≈ 0.2) — multiplying every pass's cost. It stays at 5–6 under disjoint
+replication, so this is a property of real circuits (longer substitution chains need more rounds),
+not of the schedule, and it is a real but second-order contribution: N^0.2 against the N^0.5–0.8
+from the per-candidate scans. The cost is also front-loaded — cycles 0–2 are 68 % of the sha256 run
+— so the tail rounds are cheap.
 
 ## 5. Why Rust does not have this
 

--- a/agent-docs/runtime-scaling.md
+++ b/agent-docs/runtime-scaling.md
@@ -144,11 +144,13 @@ Three recurring shapes produce all of the measured superlinearity:
 
 1. **Per-candidate whole-system scan** — a gate or certificate walks every constraint and every
    interaction, once per candidate (`reencode`, `domainFold`, and the three sites below).
-2. **Per-candidate whole-interval scan** — for stateful buses, a matched send/receive pair's
-   certificate quantifies over every interaction *between* them, and for `busPairCancel` over the
-   entire *prefix* before the send. Cost is Σ over pairs of the gap length: Θ(N²) when matched
-   pairs are far apart, which is precisely what a long basic block like sha256/keccak looks like.
-   Already tracked as R8 (`busPairCancel`) and R10 (`busUnify`).
+2. **Per-candidate prefix scan** — for stateful buses, `busPairCancel`'s shield condition
+   quantifies over the entire live *prefix* before the candidate send, so the cost is Σ over
+   candidates of their position: Θ(N²) unconditionally, independent of circuit shape. Tracked as R8.
+   The sibling *between-region* scans are cheap on these circuits — measured on the raw exports,
+   **every** same-address memory pair is adjacent (gap = 1 at p100 on both sha256 and keccak:
+   powdr emits each access as a read/write pair), so Σ gap lengths is O(N), not O(N²). Do not
+   spend effort capping the mid scans; the prefix scan is the one that matters.
 3. **Find-first-then-restart drains** — "find the first rewritable pair from the head, rewrite,
    repeat" re-scans the prefix and rebuilds `revPre.reverse` for every rewrite: Θ(rewrites × N).
 
@@ -207,15 +209,28 @@ shared by many interactions is re-certified against every later candidate.
   buckets and group variables are typically flags with very long buckets. Worth re-measuring
   directly before acting on.
 - `busPairCancel` (R8): `BusPairCancel.lean:207` `denseShieldScanSeg … arr alive 0 i` is a full
-  live-prefix scan per candidate send, and `:205` `denseLiveAllSeg … (i+1) (j-i-1)` the
-  between-region scan. 17.8 % of sha256 here (89.5 s / ~16 % on the 48-core box post-#210) — the
-  R8 design (b) sweep remains the fix.
-- `busUnify` (R10): `denseCheckPair` (`BusUnify.lean:82`) re-verifies `mid.all` for each candidate
-  the sweep proposed, and `denseEmitCand` (`:159`) materializes `w.revPre.reverse` — a fresh copy
-  of the whole prefix — per emitted candidate, even though `denseCollectForBus` (`:248`) never
-  reads `pre`/`post` (they exist only so the positional split can be stated). Making those two
-  fields lazy or position-only removes Θ(N) per candidate without touching the sweep's decisions,
-  which R10 correctly insists must stay bit-identical.
+  live-prefix scan per candidate send — the unconditional Θ(N²), and the strongest genuine
+  quadratic left after `reencode` (exponent 1.67, 21 % of sha256 post-#211). `:205`
+  `denseLiveAllSeg … (i+1) (j-i-1)` is the between-region scan and is cheap (gap = 1 in practice).
+  Beyond R8's design (b): the pass drops **one pair per `denseFindCancel` call and re-enters**,
+  whereas Rust's sweep collects every removable index in one pass and applies them together, so its
+  cost is O(rounds × B) rather than O(drops × B). Batching the drops is the shape to aim for; the
+  obstacle R8 already names is that dropping a consumed receive can un-shield an earlier message,
+  so a batch has to establish that the pairs it drops together do not interfere.
+- `busUnify` (R10, R9): 13 % of sha256 but exponent only **1.26** on the replica ladder — barely
+  above the 1.08–1.28 floor, so on these circuits it is a *constant-factor* problem, not a
+  quadratic one. The gdb stacks show why: `denseCheckPair` (`BusUnify.lean:82`) re-verifies
+  `mid.all` per candidate, and each element runs
+  `denseAddrTwoRootNeq → densePtrReductions → DenseLinExpr.scale`, which rebuilds the Mathlib
+  `ZMod.commRing` structure per call (R9). `mid` is short (see shape 2 above); the per-element
+  constant is what costs. R10's latent quadratic — `symOpen` windows tested against every later
+  message — is real but not triggered by this fixture.
+
+  One free win regardless: `denseEmitCand` (`:159`) materializes `w.revPre.reverse`, a fresh copy of
+  the whole prefix, per emitted candidate, even though `denseCollectForBus` (`:248`) never reads
+  `pre`/`post` — they exist only so the positional split can be *stated*. Store `revPre` and phrase
+  the split lemma with `revPre.reverse`: proofs are erased, so the runtime stops reversing and the
+  sweep's decisions are untouched.
 
 ### Secondary: the cleanup fixpoint's round count
 
@@ -271,3 +286,34 @@ gdb -p <pid> -batch -ex "thread apply all bt 40" -ex "thread apply all bt -8"
 ```
 
 Sampling inflates the sampled run (~30 %); use it for attribution, not for timings.
+
+## 7. Re-measured on top of #211
+
+Same container, same input, `a812c76`: sha256 **1046.7 s → 790.3 s (−25 %)**, `reencode`
+399.3 → 182.4 s (−54 %).
+
+| pass | `ff15446` | `a812c76` | share |
+| --- | --- | --- | --- |
+| `reencode` | 399 276 | 182 405 | 23.1 % |
+| `busPairCancel` | 186 121 | 166 493 | 21.1 % |
+| `busUnify` | 117 529 | 103 927 | 13.2 % |
+| `gauss` | 48 903 | 53 474 | 6.8 % |
+| `domainBatch` | 47 700 | 43 186 | 5.5 % |
+| `flagFold` | 31 717 | 32 917 | 4.2 % |
+| `bytePack` (+ `bytePackLate`) | 45 327 | 43 965 | 5.6 % |
+| `rootPairUnify` | 22 888 | 23 568 | 3.0 % |
+| `domainFold` | 9 528 | 9 855 | 1.2 % |
+
+Two things to take from this:
+
+- **The cost did not shift here.** `domainFold` stayed at ~9.9 s, so on sha256 the reencode
+  indexing was a clean win. The §3 ablation's cost-shifting is real but *circuit-dependent*: it
+  showed up on the replica fixture, where `domainFold` was the pass holding the candidate groups.
+  Check both passes when touching either, but do not assume the shift.
+- **`reencode` is still the largest single pass** at 23 %, because #211 indexed the degree pre-gate
+  and the fresh-name counts, not `denseCheckReencode`'s `denseCoveredCsOf` filter or its
+  `O(bits × system)` freshness scan. Those two are the remaining per-candidate whole-system scans
+  (R13).
+
+The top three passes are 57 % of the run and all three are still quadratic; the per-cycle
+front-loading is unchanged (cycles 0–2 are 78 %).

--- a/agent-docs/runtime-scaling.md
+++ b/agent-docs/runtime-scaling.md
@@ -315,5 +315,75 @@ Two things to take from this:
   `O(bits × system)` freshness scan. Those two are the remaining per-candidate whole-system scans
   (R13).
 
-The top three passes are 57 % of the run and all three are still quadratic; the per-cycle
-front-loading is unchanged (cycles 0–2 are 78 %).
+The top three passes are 57 % of the run; the per-cycle front-loading is unchanged (cycles 0–2 are
+78 %).
+
+## 8. What it would take to remove the superlinearity
+
+Four tiers, in descending value per unit of work. Effort figures are estimates for focused agent
+work; the projected times are *projections*, not measurements — re-measure with the §6 replica
+ladder after each tier, since that is the only instrument here that makes the exponent visible
+(adding a generator for it under `Benchmarks/` is itself ~half a day and worth doing first).
+
+### Tier 1 — index the untrusted gates. ~1–2 weeks, 5–6 PRs, outputs byte-identical
+
+Every item here is a gate that is either untrusted (both branches sound, so rejecting a candidate
+only forgoes an optimization) or a witness re-checked at use, and every one has an existing pattern
+in the tree to copy. No new soundness arguments.
+
+| change | reuses | effort |
+| --- | --- | --- |
+| `denseCheckReencode`: index the `denseCoveredCsOf` filter; decide freshness from #211's posting index (empty bucket ⇒ bit unused) | the pruned `csIdx`; `denseBuild_complete` (`Proofs/DomainFold.lean`) for the freshness direction, which *is* trusted | ~1 d |
+| `domainFold`: index the direct path's `partition` + `denseSystemHasFoldableWV` — **not** by flipping the 8192 gate (entry 107 measured that 1.19× worse on dense openvm-eth) | `denseCoveredIdx_eq_filter_of_complete` | ~1–2 d |
+| `subsumedRange`/`subsumedCheck`: replace the per-check `denseFindVarBound` full scan | #209's `denseAnyVarBoundIdx` + `witsOf` | ~0.5 d |
+| `flagUnify`: tabulate domains once instead of per variable per pair | `denseFindDomainMap` (#209) | ~0.5 d |
+| `bytePack`/`tupleRange`: resume cursor in the drain's `σ`, and return `revPre` instead of `revPre.reverse` | `denseCancelLoop`'s `resumeIdx`/`resumePos` | ~1–2 d |
+| `busUnify`: store `revPre`, phrase the split lemma with `revPre.reverse` (proofs are erased, so the runtime stops copying the prefix) | — | ~0.5 d |
+
+Projected: sha256 790 s → ~350–450 s, replica-ladder exponent ~1.77 → ~1.25.
+
+### Tier 2 — the constant factors that then dominate. ~1.5 weeks, 2–3 PRs
+
+Neither changes the exponent, but together they are 20–30 % of CPU, and after tier 1 they are most
+of what is left (`busUnify`'s 104 s is essentially all of R9).
+
+- **R9**: thread `DenseZModOps` through the hot helper chain (`denseLinearize`,
+  `DenseLinExpr.norm/scale/coeff/others`, `denseTwoRootOf?`, `densePtrReductions`, `denseRootsIn`)
+  via `@[csimp]` twins — the entries 118–119 pattern. Repetitive but mechanical. ~1 week.
+- **R12**: array-index the per-variable bucket maps (`VarId` is dense and registry-bounded), killing
+  the boxed `BEq`/`Hashable` dispatch. Prototype one index first. ~3–5 d.
+
+Projected: → ~200–280 s.
+
+### Tier 3 — the one genuine proof project: `busPairCancel`. ~2–4 weeks
+
+This is the part that is expensive *because* the optimizer is verified. Two things have to change
+together:
+
+1. The shield condition must become **incremental** — prove that the sweep's invariant implies each
+   candidate's shield condition, instead of re-deriving it from the live prefix per candidate. This
+   is a proof-carrying fold with an inductive invariant relating the sweep state to the prefix
+   classification. Budget a week on the invariant alone before writing Lean.
+2. Drops must be **batched** per sweep, the way Rust's `to_remove` is, so cost is O(rounds × B)
+   instead of O(drops × B). The obstacle R8 names is real: dropping a consumed receive can un-shield
+   an earlier message, so a batch must establish that the pairs it drops together do not interfere.
+
+Projected: → ~130–200 s, and the last unconditional Θ(N²) is gone — exponent ~1.1–1.2, i.e. the same
+*shape* as Rust. R10's latent `symOpen` quadratic can wait until a benchmark triggers it.
+
+### Tier 4 — the floor. Weeks more; probably not worth it
+
+What remains after tiers 1–3 is ~N^1.1–1.2 from two sources: allocation/refcount traffic (~40 % of
+CPU today, partly addressed by tier 2) and the cleanup fixpoint's round count growing ~N^0.2 on real
+circuits. Removing the latter means fine-grained cross-cycle dirtiness — powdr's worklist
+architecture, R6 — which `ideas.md` records as a multi-week refactor whose cheap version was
+measured as a dead end (keccak reuses 62 of 16 748 enumerations). Rust's own curve is not perfectly
+flat either, so parity does not require this.
+
+### Risk
+
+Tiers 1 and 2 should be byte-identical by construction, so the CI effectiveness matrix is a
+sufficient guard. Tier 3 must also be byte-identical, which is the main reason to budget design time
+up front. The one non-obvious trap is the `reencode`↔`domainFold` coupling in §3: they consume the
+same candidate groups, so indexing one can move cost to the other on some circuits (it did on the
+replica fixture, it did not on sha256). Always read both passes' rows.


### PR DESCRIPTION
## Summary

Add comprehensive documentation of the Lean optimizer's superlinear scaling behavior relative to circuit size, with cross-implementation comparison to powdr's Rust optimizer and detailed per-pass attribution. Integrate findings into the runtime section of `ideas.md` with three new ranked fix entries (R13–R15).

## Changes

- **New file: `agent-docs/runtime-scaling.md`** — A detailed session note (2026-07-26) analyzing why the Lean optimizer scales as ~N^1.5–1.8 in circuit size while powdr's Rust optimizer is ~N^1.0:
  - §1: Cross-implementation gap from reference benchmark data (20,115 APCs)
  - §2: Controlled scaling experiment using k disjoint copies of a single APC, isolating per-pass cost from fixpoint rounds (exponent 1.77)
  - §3: Per-pass attribution on sha256 (168,915 vars) and ablation showing cost is shared between passes, not owned by one
  - §4: Three recurring patterns producing superlinearity, with three previously-unlisted quadratic sites
  - §5–8: Why Rust avoids this, reproduction instructions, post-#211 re-measurement, and a four-tier roadmap to remove superlinearity

- **Modified: `agent-docs/ideas.md`** — Updated runtime section:
  - Added cross-reference to `runtime-scaling.md` with brief summary
  - Added **R13** (finish candidate-group family: `domainFold` and `denseCheckReencode` gates)
  - Added **R14** (`subsumedRange`/`subsumedCheck` bound index reuse, exponent 2.24)
  - Added **R15** (`bytePack`/`tupleRange` resume cursor and `flagUnify` domain tabulation, exponent 2.10)

- **Modified: `agent-docs/README.md`** — Added note that runtime analysis is documented in `runtime-scaling.md`

## Key Findings

The superlinearity is not a port defect but a structural difference in proof obligations: the Lean optimizer re-verifies each candidate against the full system (Θ(candidates × system) work), while Rust's single sweep applies all drops in one batch. The cost is concentrated in six passes (`reencode`, `busPairCancel`, `busUnify`, `domainFold`, `bytePack`, `flagUnify`), with `reencode` alone accounting for 38 % of sha256's runtime at ff15446 (reduced to 23 % by #211's indexing).

The disjoint-replica ladder is the key measurement instrument: it holds the fixpoint round count constant while scaling circuit size, making per-pass exponents visible and distinguishing genuine quadratics from constant-factor problems.

https://claude.ai/code/session_01NdrwAL7S5jwmeibazAxwcd