### PR TITLE
perf(addrDiseq): scope the two-root build to address slots, linearize factors once (404s -> 378s on 170k sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -14,6 +14,15 @@ variable {p : ℕ}
 
 /-! ## Recognizing a two-root constraint (dense) -/
 
+/-- The two-root entry for `x` from a product's already-linearized factors. -/
+def denseTwoRootOfLins (l1 l2 : DenseLinExpr p) (x : VarId) :
+    Option (ZMod p × DenseLinExpr p × ZMod p) :=
+  let k := l1.coeff x
+  let A := (l1.others x).norm
+  let A2 := (l2.others x).norm
+  if k ≠ 0 ∧ l2.coeff x = k ∧ A2.terms = A.terms then some (k, A, A2.const - A.const)
+  else none
+
 /-- The two-root decomposition of a dense constraint relative to `x`: `some (k, A, δ)` when the
     constraint is a product of two affine factors, both linear in `x` with the same nonzero
     coefficient `k`, whose `x`-free parts differ by the constant `δ`. -/
@@ -21,12 +30,7 @@ def denseTwoRootOf? (c : DenseExpr p) (x : VarId) : Option (ZMod p × DenseLinEx
   match c with
   | .mul f1 f2 =>
     match denseLinearize f1, denseLinearize f2 with
-    | some l1, some l2 =>
-      let k := l1.coeff x
-      let A := (l1.others x).norm
-      let A2 := (l2.others x).norm
-      if k ≠ 0 ∧ l2.coeff x = k ∧ A2.terms = A.terms then some (k, A, A2.const - A.const)
-      else none
+    | some l1, some l2 => denseTwoRootOfLins l1 l2 x
     | _, _ => none
   | _ => none
 
@@ -68,6 +72,70 @@ def addVars (c : DenseExpr p) : DenseTwoRootMap p → List VarId → DenseTwoRoo
       if k * k⁻¹ = 1 then addVars c (T.insertEntry v k A δ) vs
       else addVars c T vs
     | none => addVars c T vs
+
+/-- `addVars` from a product's linearized factors. -/
+def addVarsLins (l1 l2 : DenseLinExpr p) : DenseTwoRootMap p → List VarId → DenseTwoRootMap p
+  | T, [] => T
+  | T, v :: vs =>
+    match denseTwoRootOfLins l1 l2 v with
+    | some (k, A, δ) =>
+      if k * k⁻¹ = 1 then addVarsLins l1 l2 (T.insertEntry v k A δ) vs
+      else addVarsLins l1 l2 T vs
+    | none => addVarsLins l1 l2 T vs
+
+/-- `addVars` with the product's factors linearized once instead of once per variable; the compiled
+    twin of `addVars` (`addVars_eq_fast`). -/
+def addVarsFast (c : DenseExpr p) (T : DenseTwoRootMap p) (vs : List VarId) : DenseTwoRootMap p :=
+  match c with
+  | .mul f1 f2 =>
+    match denseLinearize f1, denseLinearize f2 with
+    | some l1, some l2 => addVarsLins l1 l2 T vs
+    | _, _ => T
+  | _ => T
+
+theorem addVarsLins_eq {f1 f2 : DenseExpr p} {l1 l2 : DenseLinExpr p}
+    (h1 : denseLinearize f1 = some l1) (h2 : denseLinearize f2 = some l2) :
+    ∀ (T : DenseTwoRootMap p) (vs : List VarId),
+      addVarsLins l1 l2 T vs = addVars (.mul f1 f2) T vs := by
+  have hentry : ∀ v, denseTwoRootOf? (.mul f1 f2) v = denseTwoRootOfLins l1 l2 v := by
+    intro v; simp only [denseTwoRootOf?, h1, h2]
+  intro T vs
+  induction vs generalizing T with
+  | nil => rfl
+  | cons v rest ih =>
+      rw [addVarsLins, addVars, hentry v]
+      cases denseTwoRootOfLins l1 l2 v with
+      | none => exact ih T
+      | some kAδ => obtain ⟨k, A, δ⟩ := kAδ; dsimp only; split <;> exact ih _
+
+/-- `addVars` never inserts when no variable has a two-root entry. -/
+theorem addVars_of_none {c : DenseExpr p} (h : ∀ v, denseTwoRootOf? c v = none) :
+    ∀ (T : DenseTwoRootMap p) (vs : List VarId), addVars c T vs = T := by
+  intro T vs
+  induction vs generalizing T with
+  | nil => rfl
+  | cons v rest ih => rw [addVars, h v]; exact ih T
+
+@[csimp] theorem addVars_eq_fast :
+    @DenseTwoRootMap.addVars = @DenseTwoRootMap.addVarsFast := by
+  funext q c T vs
+  cases c with
+  | const n => exact addVars_of_none (fun _ => rfl) T vs
+  | var i => exact addVars_of_none (fun _ => rfl) T vs
+  | add a b => exact addVars_of_none (fun _ => rfl) T vs
+  | mul f1 f2 =>
+      cases h1 : denseLinearize f1 with
+      | none =>
+          rw [addVars_of_none (fun _ => by simp [denseTwoRootOf?, h1]) T vs]
+          simp [addVarsFast, h1]
+      | some l1 =>
+          cases h2 : denseLinearize f2 with
+          | none =>
+              rw [addVars_of_none (fun _ => by simp [denseTwoRootOf?, h1, h2]) T vs]
+              simp [addVarsFast, h1, h2]
+          | some l2 =>
+              rw [← addVarsLins_eq h1 h2 T vs]
+              simp [addVarsFast, h1, h2]
 
 /-- Fold `addVars` over a constraint list. -/
 def addAll : DenseTwoRootMap p → (pending : List (DenseExpr p)) → DenseTwoRootMap p
@@ -192,14 +260,49 @@ def denseAddrNonzeroNeq (shape : MemoryBusShape) (nw : DenseNonzeroWits p)
     | some D => nw.wits.any (fun g => denseIsZeroLin (D.add (g.scale (-1))) || denseIsZeroLin (D.add g))
     | none => false)
 
+/-! ## Restricting the two-root map to the variables that can be queried -/
+
+/-- Does the expression mention a variable of `s`? -/
+def DenseExpr.mentionsAny (s : Std.HashSet VarId) : DenseExpr p → Bool
+  | .const _ => false
+  | .var i => s.contains i
+  | .add a b => a.mentionsAny s || b.mentionsAny s
+  | .mul a b => a.mentionsAny s || b.mentionsAny s
+
+/-- The variables at address-field positions of the declared memory shapes, over every interaction:
+    `denseAddrTwoRootNeq` reads exactly those payload slots (of the *candidate's* shape, so an
+    interaction on any bus can be read at another bus's address positions). -/
+def denseAddrSlotVars (memShape : Nat → Option MemoryBusShape)
+    (bis : List (BusInteraction (DenseExpr p))) : Std.HashSet VarId :=
+  let slots := (((bis.map (·.busId)).dedup.filterMap memShape).flatMap
+    MemoryBusShape.addressFields).dedup
+  bis.foldl (fun s bi =>
+    slots.foldl (fun s slot =>
+      match bi.payload[slot]? with
+      | some e => e.vars.foldl (fun s v => s.insert v) s
+      | none => s) s) ∅
+
+/-- The two-root map over just the constraints mentioning an address-slot variable. Every entry a
+    lookup can reach is unchanged: an entry for `v` is only ever inserted by a constraint mentioning
+    `v` (`addVars` folds over `c.vars`), and only address-slot variables are looked up
+    (`densePtrReductions` keys on the queried form's own variables). -/
+def DenseTwoRootMap.buildForAddrs (memShape : Nat → Option MemoryBusShape)
+    (bis : List (BusInteraction (DenseExpr p))) (constraints : List (DenseExpr p)) :
+    DenseTwoRootMap p :=
+  let vars := denseAddrSlotVars memShape bis
+  DenseTwoRootMap.build (constraints.filter (fun c => c.mentionsAny vars))
+
 /-- Both address-disequality certificate tables, bundled so they thread through a pass as one
     memoized value. -/
 structure DenseAddrCerts (p : ℕ) where
   tworoot : DenseTwoRootMap p
   nonzero : DenseNonzeroWits p
 
-/-- Build both certificate tables from the constraint list. -/
-def DenseAddrCerts.build (constraints : List (DenseExpr p)) : DenseAddrCerts p :=
-  ⟨DenseTwoRootMap.build constraints, DenseNonzeroWits.build constraints⟩
+/-- Build both certificate tables from the constraint list, the two-root map over the address-slot
+    constraints only (`DenseTwoRootMap.buildForAddrs`). -/
+def DenseAddrCerts.build (memShape : Nat → Option MemoryBusShape)
+    (bis : List (BusInteraction (DenseExpr p))) (constraints : List (DenseExpr p)) :
+    DenseAddrCerts p :=
+  ⟨DenseTwoRootMap.buildForAddrs memShape bis constraints, DenseNonzeroWits.build constraints⟩
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -364,7 +364,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     let idx := denseRecvIndexAll facts aggressive ops arr
     let alive : Array Bool := Array.replicate arr.size true
     let T : Thunk (DenseAddrCerts p) :=
-      Thunk.mk fun _ => DenseAddrCerts.build d.algebraicConstraints
+      Thunk.mk fun _ => DenseAddrCerts.build facts.memShape d.busInteractions d.algebraicConstraints
     let M : Thunk (DenseEqConstraintMap p) :=
       Thunk.mk fun _ =>
         if aggressive then DenseEqConstraintMap.build d.algebraicConstraints
@@ -385,7 +385,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
       intro k hk
       simp only [alive, Array.getElem?_replicate, hk, if_true, Option.getD_some]
     have hTtworoot : T.get.tworoot.Sound d.algebraicConstraints :=
-      DenseTwoRootMap.build_sound d.algebraicConstraints
+      DenseTwoRootMap.buildForAddrs_sound facts.memShape d.busInteractions d.algebraicConstraints
     have hTnonzero : T.get.nonzero = DenseNonzeroWits.build d.algebraicConstraints := rfl
     have hM : M.get.Sound d.algebraicConstraints := by
       show (if aggressive then DenseEqConstraintMap.build d.algebraicConstraints

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -279,7 +279,7 @@ def denseBusUnifyF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConst
   if (1 : ZMod p) ≠ 0 then
     -- Thunked: built only when a window test reaches the two-root / nonzero-witness arms.
     let T : Thunk (DenseTwoRootMap p) :=
-      Thunk.mk fun _ => DenseTwoRootMap.build d.algebraicConstraints
+      Thunk.mk fun _ => DenseTwoRootMap.buildForAddrs facts.memShape d.busInteractions d.algebraicConstraints
     let nw : Thunk (DenseNonzeroWits p) :=
       Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints
     let eqs := denseCollectAllBuses d bs facts T nw

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -162,6 +162,14 @@ theorem DenseTwoRootMap.Sound.addAll {dcs : List (DenseExpr p)} (hp : Nat.Prime 
       exact ih _ (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
         (DenseTwoRootMap.Sound.addVars hp (hmem c (List.mem_cons_self ..)) T _ hT)
 
+/-- `Sound` only asserts the existence of a witnessing constraint, so it survives passing to a
+    superset of the indexed list. -/
+theorem DenseTwoRootMap.Sound.mono {l1 l2 : List (DenseExpr p)} {T : DenseTwoRootMap p}
+    (hsub : ∀ c ∈ l1, c ∈ l2) (hT : T.Sound l1) : T.Sound l2 := by
+  intro v k A δ h
+  obtain ⟨hp, hu, c, hc, hwit⟩ := hT v k A δ h
+  exact ⟨hp, hu, c, hsub c hc, hwit⟩
+
 theorem DenseTwoRootMap.build_sound (dcs : List (DenseExpr p)) :
     (DenseTwoRootMap.build dcs).Sound dcs := by
   rw [DenseTwoRootMap.build]
@@ -170,6 +178,12 @@ theorem DenseTwoRootMap.build_sound (dcs : List (DenseExpr p)) :
     exact DenseTwoRootMap.Sound.addAll hp DenseTwoRootMap.empty dcs (fun _ h => h)
       (DenseTwoRootMap.empty_sound dcs)
   · rw [if_neg hp]; exact DenseTwoRootMap.empty_sound dcs
+
+/-- The address-restricted build is sound for the whole constraint list. -/
+theorem DenseTwoRootMap.buildForAddrs_sound (memShape : Nat → Option MemoryBusShape)
+    (bis : List (BusInteraction (DenseExpr p))) (dcs : List (DenseExpr p)) :
+    (DenseTwoRootMap.buildForAddrs memShape bis dcs).Sound dcs :=
+  (DenseTwoRootMap.build_sound _).mono (fun _ hc => List.mem_of_mem_filter hc)
 
 /-! ## Two-root decomposition soundness (value-level)
 
@@ -200,7 +214,7 @@ theorem denseTwoRootOf?_sound [Fact p.Prime] (c : DenseExpr p) (x : VarId)
         cases hl2 : denseLinearize f2 with
         | none => simp only [hl1, hl2] at h; exact absurd h (by simp)
         | some l2 =>
-          simp only [hl1, hl2] at h
+          simp only [hl1, hl2, denseTwoRootOfLins] at h
           split_ifs at h with hcond
           · obtain ⟨hk0, hcoeff, hterms⟩ := hcond
             simp only [Option.some.injEq, Prod.mk.injEq] at h

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
@@ -495,7 +495,7 @@ theorem denseCollectAllBuses_sound (d : DenseConstraintSystem p) (bs : BusSemant
     (denv : VarId → ZMod p) (hadm : d.admissible bs denv) (hsat : d.satisfies bs denv) :
     ∀ (busIds : List Nat),
     ∀ c ∈ denseCollectAllBuses d bs facts
-        (Thunk.mk fun _ => DenseTwoRootMap.build d.algebraicConstraints)
+        (Thunk.mk fun _ => DenseTwoRootMap.buildForAddrs facts.memShape d.busInteractions d.algebraicConstraints)
         (Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints) busIds,
       c.eval denv = 0 := by
   intro busIds
@@ -510,8 +510,8 @@ theorem denseCollectAllBuses_sound (d : DenseConstraintSystem p) (bs : BusSemant
       rw [hms, List.mem_append] at hc
       rcases hc with hc | hc
       · refine denseCollectForBus_sound d bs facts hp1 reg hcov
-          (DenseTwoRootMap.build d.algebraicConstraints)
-          (DenseTwoRootMap.build_sound d.algebraicConstraints) busId shape hms denv hadm hsat _ ?_ c
+          (DenseTwoRootMap.buildForAddrs facts.memShape d.busInteractions d.algebraicConstraints)
+          (DenseTwoRootMap.buildForAddrs_sound facts.memShape d.busInteractions d.algebraicConstraints) busId shape hms denv hadm hsat _ ?_ c
           hc
         intro cand hcand
         exact denseCandidateSplitsSweep_split
@@ -525,7 +525,7 @@ theorem denseCollectAllBuses_sound (d : DenseConstraintSystem p) (bs : BusSemant
 def denseBusUnifyNew (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     List (DenseExpr p) :=
   let T : Thunk (DenseTwoRootMap p) :=
-    Thunk.mk fun _ => DenseTwoRootMap.build d.algebraicConstraints
+    Thunk.mk fun _ => DenseTwoRootMap.buildForAddrs facts.memShape d.busInteractions d.algebraicConstraints
   let nw : Thunk (DenseNonzeroWits p) :=
     Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints
   let eqs := denseCollectAllBuses d bs facts T nw
@@ -576,7 +576,7 @@ theorem denseBusUnifyNew_sound (bs : BusSemantics p) (facts : BusFacts p bs) (re
     ∀ c ∈ denseBusUnifyNew bs facts d, c.eval denv = 0 := by
   intro c hc
   have hmem : c ∈ denseCollectAllBuses d bs facts
-      (Thunk.mk fun _ => DenseTwoRootMap.build d.algebraicConstraints)
+      (Thunk.mk fun _ => DenseTwoRootMap.buildForAddrs facts.memShape d.busInteractions d.algebraicConstraints)
       (Thunk.mk fun _ => DenseNonzeroWits.build d.algebraicConstraints)
       ((d.busInteractions.map (fun bi => bi.busId)).dedup) := List.mem_of_mem_filter hc
   exact denseCollectAllBuses_sound d bs facts hp1 reg hcov denv hadm hsat _ c hmem

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -150,7 +150,7 @@ keccak, so anything superlinear is fatal there.
 - gdb samples (keccak, mid-run): `findConsumer` (busUnify), `reencodeLoop`, `foldLoopDirect`
   (domainFold's unindexed path), `collectForBus` — matching the analysis below.
 
-### Where the time goes at SHA scale (2026-07-26, PRs #205–#210 + entries 142–143)
+### Where the time goes at SHA scale (2026-07-26, PRs #205–#210 + entries 142–144)
 
 sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):
 **989 s (main-of-2026-07-24) → 550 s** across #205 (registry array-copy, encode 80.5 → 0.8 s),
@@ -158,14 +158,17 @@ sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48
 #208 (pointwiseDupDrop slot-0 index + hoisted singles, flagFold 85 → 15.6 s), #209 (rootPairUnify
 per-variable bound indexes, 49.6 → 33.7 s), #210 (busPairCancel segment scans, 107 → 89.5 s), then
 **524 → 445 s** with entry 142 (reencode's two per-candidate whole-system scans, 184 → 97 s) and
-**445 → 404 s** with entry 143 (busPairCancel's per-query domain scans, 90 → 50 s).
-Remaining per-pass: **reencode 98 s, busUnify 54 s, busPairCancel 50 s, gauss 36 s, domainBatch
+**445 → 404 s** with entry 143 (busPairCancel's per-query domain scans, 90 → 50 s) and
+**404 → 378 s** with entry 144 (two-root map: address-scoped build + factors linearized once).
+Remaining per-pass: **reencode 96 s, busUnify 40 s, busPairCancel 40 s, gauss 36 s, domainBatch
 20 s (parallel), bytePack 17 s, flagFold 15 s, normalize1 14 s, rootPairUnify 13 s, carryBranch
 13 s**; the tail below that is ~60 s over 25 passes. Cycles 0–2 are still ~78 % of the total.
 Whole-run perf: ~25 % `lean_dec_ref_cold` + ~17 % allocator + ~8 % `lean_apply_1` — the budget is
-still memory traffic, not arithmetic. `DenseTwoRootMap.build` (busUnify/busPairCancel certificate
-tables, via `denseLinearize`) is ~4 % of whole-run CPU on its own, and the `ZMod.commRing` rebuild
-chain (R9) another ~5 %.
+still memory traffic, not arithmetic; the `ZMod.commRing` rebuild chain (R9) is ~5 %.
+**reencode is again the top pass (96 s)** and its cost is now diffuse: `denseLookupIx` +
+`denseAssignments` (the survivor enumeration) ~1.6 % of CPU, `DenseExpr.vars`/`hashedDedup` ~2 %
+(per-target `c.vars.eraseDups` gates and the per-accept `denseBuildPruned`), `denseGroupRewrite` +
+`denseDegPreReject` ~1.7 %.
 
 **Measurement note:** the profiler's per-pass wall times and `perf`'s CPU shares are not the same
 denominator — domainBatch is parallel, so it burns ~25 % of CPU for 4 % of wall. For a serial pass,
@@ -347,6 +350,11 @@ between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldO
 to a single per-address-key `pending` bit, maintainable across one sweep — but the pass's
 tombstone-and-restart structure (drops invalidate prefix state: removing a consumed receive
 un-shields earlier messages) forces a recompute-on-drop scheme, bounded by #drops × O(B).
+
+**R9a (done, entry 144).** `DenseTwoRootMap.addVars` re-linearized a product's factors per
+variable; `addVarsFast` + `@[csimp] addVars_eq_fast` hoists them. The `@[csimp]` twin is the
+zero-proof-churn way to swap an implementation — prefer it over threading a fast path through the
+proofs. Same shape may still apply to `denseDeepEnumDoms`/`denseRootsIn`-style per-variable loops.
 
 **R9. Stop rebuilding `ZMod.commRing` per helper call**  ·  *horizontal, medium value / medium
 effort*. Any helper doing `ZMod` arithmetic without a threaded `DenseZModOps` re-materializes the

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4870,3 +4870,36 @@ busPairCancel 8.5 → 7.3 s, redundantByteDrop 172 → 61 ms.
 
 **Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak, wasm-eth
 apc_036 and the 168k-var OpenVM sha256 case).**
+
+### 144. Runtime: two-root certificate map — address-scoped build, factors linearized once
+
+`DenseTwoRootMap.build` (the address-disequality certificate table busUnify and busPairCancel
+consult) was ~4.9 % of whole-run CPU on sha256_big, rebuilt per pass invocation over the **whole**
+constraint list. Two independent fixes:
+
+1. **Scope the build to what can be queried.** Only variables sitting at an address-slot position
+   of some declared memory shape are ever looked up: `denseAddrTwoRootNeq` reads
+   `S.payload[slot]`/`m.payload[slot]` for `slot ∈ shape.addressFields`, and `densePtrReductions`
+   keys on the queried form's own variables. `DenseTwoRootMap.buildForAddrs` therefore indexes only
+   the constraints mentioning such a variable (`denseAddrSlotVars` collects them across every
+   interaction — the candidate's shape decides the slots, so an interaction on any bus can be read
+   at another bus's address positions). Entries for queried variables are unchanged: an entry for
+   `v` is only inserted by a constraint mentioning `v` (`addVars` folds over `c.vars`), and such a
+   constraint mentions an address variable, so it survives the filter. Soundness needed one lemma,
+   `DenseTwoRootMap.Sound.mono` — `Sound` only asserts *some* witnessing constraint in the list.
+2. **Linearize a product's factors once per constraint, not once per variable.**
+   `denseTwoRootOf? c v` re-ran `denseLinearize` on both factors for every variable of `c`.
+   `addVarsFast` hoists the two linearizations out of the per-variable loop and is wired in as the
+   compiled twin (`@[csimp] addVars_eq_fast`), so every proof still sees `addVars`. This was the
+   larger half of the win.
+
+sha256_big (`profile`, quiet 48-core box, on top of #212): busUnify **54.1 → 40.2 s (−26 %)**,
+busPairCancel **50.1 → 39.6 s (−21 %)**, total **404.4 → 377.6 s (−6.6 %)**. The address scoping
+alone was 404.4 → 398.2 s: much less than its 4.9 % CPU share suggested, because sha256's
+bridge-bus address slots mention variables that appear in a large share of the constraints — the
+filter keeps more than expected. wasm-eth apc_036 `opt-export`: 39 → 33 s.
+
+Cumulative for entries 142–144: sha256_big **523.9 → 377.6 s (−28 %)**.
+
+**Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak, wasm-eth
+apc_036 and the 168k-var OpenVM sha256 case).**


### PR DESCRIPTION
`DenseTwoRootMap.build` — the address-disequality certificate table `busUnify` and `busPairCancel`
consult — was ~4.9 % of whole-run CPU on the 168k-variable sha256 APC, rebuilt per pass invocation
over the **whole** constraint list. Two independent fixes, both output-preserving:

## What changed

- **Scope the build to what can be queried.** Only variables at an address-slot position of some
  declared memory shape are ever looked up: `denseAddrTwoRootNeq` reads
  `S.payload[slot]`/`m.payload[slot]` for `slot ∈ shape.addressFields`, and `densePtrReductions`
  keys on the queried form's own variables. `DenseTwoRootMap.buildForAddrs` indexes only the
  constraints mentioning such a variable (`denseAddrSlotVars` collects them across every
  interaction — the *candidate's* shape decides the slots, so an interaction on any bus can be read
  at another bus's address positions). Every reachable entry is unchanged: an entry for `v` is only
  inserted by a constraint mentioning `v` (`addVars` folds over `c.vars`), and such a constraint
  mentions an address variable, so it survives the filter. Soundness needed one lemma —
  `DenseTwoRootMap.Sound.mono`, since `Sound` only asserts *some* witnessing constraint in the list.
- **Linearize a product's factors once per constraint.** `denseTwoRootOf? c v` re-ran
  `denseLinearize` on both factors for every variable of `c`. `addVarsFast` hoists the two
  linearizations out of the per-variable loop and is wired in as the compiled twin
  (`@[csimp] addVars_eq_fast`), so every proof still sees `addVars`. This was the larger half.

## Impact

sha256_big (146k constraints / 71k interactions / 168k vars, `profile`, quiet 48-core box):

| | main (47c71eb) | this PR |
|---|---|---|
| busUnify | 54.1 s | **40.2 s** (−26 %) |
| busPairCancel | 50.1 s | **39.6 s** (−21 %) |
| total | 404.4 s | **377.6 s** (−6.6 %) |

Cumulative with #211 and #212 on the same box: **523.9 → 377.6 s (−28 %)**. wasm-eth apc_036
`opt-export`: 39 → 33 s.

Note on sizing: the address scoping *alone* was only 404.4 → 398.2 s, well under its 4.9 % CPU
share — sha256's bridge-bus address slots mention variables that appear in a large share of the
constraints, so the filter keeps more than expected. The hoisting supplied the rest.

## Validation

- `lake build` (warning-free), `Scripts/check-proof-integrity.sh` (three standard axioms, no unused
  theorems)
- byte-identical `opt-export` vs. main on openvm-eth apc_044 / apc_067, keccak apc_001, wasm-eth
  apc_036 and OpenVM sha256 apc_001 (the 168k-var case)
- `agent-docs/log.md` entry 144; `agent-docs/ideas.md` runtime section refreshed — reencode (96 s)
  is the top pass again, and its remaining cost is diffuse (survivor enumeration, per-target
  `c.vars.eraseDups` gates, per-accept index rebuilds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKR42FVxb2GLyEesKGgyvK