### PR TITLE
perf: measure and reduce superlinear scaling

### DIFF
--- a/.github/workflows/scaling_bench.yml
+++ b/.github/workflows/scaling_bench.yml
@@ -1,0 +1,105 @@
+name: Scaling Bench
+
+# Benchmark how the optimizer's runtime *scales* with circuit size, per pass
+# (`Benchmarks/scaling_bench.py`): a ladder of `k` disjoint copies of one APC, from which the
+# log-log slope of time-vs-`k` gives each pass's exponent (1.00 = linear). This is the companion to
+# `Runtime Bench`, which measures wall time on fixed inputs and so cannot tell a pass that is
+# expensive from a pass that is superlinear.
+#
+# By default the target is also compared against `main`, benched on the same runner in the same job.
+# Exponents are more robust than absolute times, but both sides still belong on one runner.
+#
+# On-demand only (it runs the whole ladder, twice when comparing). Dispatch it from the Actions UI
+# or with, e.g.:
+#
+#   gh workflow run "Scaling Bench" -f pr=82        # bench PR #82 vs main, sticky-comment there
+#   gh workflow run "Scaling Bench" -f pr=82 -f baseline=   # no comparison, target only
+#   gh workflow run "Scaling Bench"                 # bench the dispatched branch vs main
+#   gh workflow run "Scaling Bench" -f rungs=1,2,4 -f repeat=3   # cheaper ladder, best of 3
+#
+# Results always go to the job summary; with `pr` set they are also posted as a sticky comment.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number: bench its head and post/update a sticky comment there (empty = bench the dispatched branch, job summary only)"
+        required: false
+        default: ""
+      baseline:
+        description: "ref to compare against, benched on the same runner (empty = no comparison)"
+        required: false
+        default: "main"
+      source:
+        description: "APC to replicate (path from the repo root)"
+        required: false
+        default: "Benchmarks/OpenVM/openvm-eth/apc_005_pc0x32ab5c.json.gz"
+      rungs:
+        description: "comma-separated copy counts for the ladder"
+        required: false
+        default: "1,2,3,4,6,8"
+      repeat:
+        description: "runs per rung; the fastest is kept"
+        required: false
+        default: "1"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    runs-on: warp-ubuntu-2404-x64-32x
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr) || github.ref }}
+      - uses: leanprover/lean-action@v1
+      - name: Bench target
+        run: |
+          echo "BENCH_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "TARGET_REF=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          # The baseline checkout below replaces the working tree, so keep this version of the
+          # bench script (and its results) outside it.
+          cp Benchmarks/scaling_bench.py "$RUNNER_TEMP/scaling_bench.py"
+          REPEAT='${{ inputs.repeat }}'
+          python3 Benchmarks/scaling_bench.py --no-build \
+            --source '${{ inputs.source }}' --rungs '${{ inputs.rungs }}' \
+            --json "$RUNNER_TEMP/target.json" --md bench.md \
+            --repeat "${REPEAT:-1}"
+      - name: Bench baseline
+        if: inputs.baseline != ''
+        run: |
+          git fetch --depth 1 origin '${{ inputs.baseline }}'
+          if [ "$(git rev-parse FETCH_HEAD)" = "$(git rev-parse HEAD)" ]; then
+            echo "baseline is the benched commit itself; skipping comparison"
+            exit 0
+          fi
+          echo "BASE_SHA=$(git rev-parse --short FETCH_HEAD)" >> "$GITHUB_ENV"
+          git checkout --force FETCH_HEAD
+          lake exe cache get || true
+          lake build
+          REPEAT='${{ inputs.repeat }}'
+          python3 "$RUNNER_TEMP/scaling_bench.py" --no-build --repo "$GITHUB_WORKSPACE" \
+            --source '${{ inputs.source }}' --rungs '${{ inputs.rungs }}' \
+            --json "$RUNNER_TEMP/baseline.json" \
+            --repeat "${REPEAT:-1}"
+          python3 "$RUNNER_TEMP/scaling_bench.py" \
+            --compare "$RUNNER_TEMP/baseline.json" "$RUNNER_TEMP/target.json" --md bench.md
+          # Restore the target checkout: the report step below runs a local action, which must
+          # exist in the working tree (the baseline may predate it).
+          git checkout --force "$TARGET_REF"
+      - name: Report
+        uses: ./.github/actions/report-bench
+        with:
+          md-file: bench.md
+          marker: "<!-- scaling-bench -->"
+          pr: ${{ inputs.pr }}
+          note: >-
+            Exponents from a CI runner
+            (${{ env.BASE_SHA && format('target `{0}` vs baseline `{1}`', env.BENCH_SHA, env.BASE_SHA)
+                 || format('`{0}`', env.BENCH_SHA) }});
+            1.00 = linear in circuit size. Read the exponents over the absolute times, and check the
+            iteration column is flat before trusting a rung.
+          token: ${{ github.token }}

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -91,7 +91,10 @@ def denseCheckPair (shape : MemoryBusShape) (T : DenseTwoRootMap p) (nw : DenseN
 
 /-! ## The pass -/
 
-/-- One `(pre, S, mid, R, post)` split candidate. -/
+/-- One `(revPre, S, mid, R, post)` split candidate. The prefix is stored **reversed** — the sweep
+    already has it that way, and only the proofs read it (as `revPre.reverse`, see `SplitEqC` in
+    `Proofs/BusUnify.lean`), so reversing it here would copy the whole prefix per candidate for
+    nothing. -/
 abbrev DenseSplitCand (p : ℕ) :=
   List (BusInteraction (DenseExpr p)) × BusInteraction (DenseExpr p)
     × List (BusInteraction (DenseExpr p)) × BusInteraction (DenseExpr p)
@@ -155,11 +158,12 @@ structure DenseOpenRec (p : ℕ) where
   i : Nat
 
 /-- Assemble the split candidate for a consumed window, tagged with its send position; `mid` is
-    recovered positionally from the send's stored suffix (`take (j−i−1)`). -/
+    recovered positionally from the send's stored suffix (`take (j−i−1)`). The prefix is passed
+    through still reversed (see `DenseSplitCand`). -/
 def denseEmitCand (w : DenseOpenRec p) (j : Nat) (R : BusInteraction (DenseExpr p))
     (post : List (BusInteraction (DenseExpr p))) : Option (Nat × DenseSplitCand p) :=
   if w.i < j then
-    some (w.i, (w.revPre.reverse, w.S, w.restAfter.take (j - w.i - 1), R, post))
+    some (w.i, (w.revPre, w.S, w.restAfter.take (j - w.i - 1), R, post))
   else none
 
 /-- The sweep: one pass over the interaction list. `acc` collects `(sendPosition, candidate)` pairs,

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -88,6 +88,36 @@ def DenseExpr.vars : DenseExpr p → List VarId
   | .add a b => a.vars ++ b.vars
   | .mul a b => a.vars ++ b.vars
 
+/-! ### `vars` with an accumulator (runtime `@[csimp]` replacement)
+
+`DenseExpr.vars` appends the child lists, so the left subtree's result is copied again at every
+enclosing node: quadratic in the depth of a left-associated chain, which is exactly the shape affine
+reconstruction produces (`((a + b) + c) + d`). `varsAcc` traverses the right subtree into the
+accumulator first, so it allocates only the final list, and `vars_eq_fast` installs it for every
+call site. Every proof keeps using `vars`; the list order is identical. -/
+
+/-- `vars` into an accumulator: `e.varsAcc acc = e.vars ++ acc` (`varsAcc_eq`). -/
+def DenseExpr.varsAcc : DenseExpr p → List VarId → List VarId
+  | .const _, acc => acc
+  | .var i, acc => i :: acc
+  | .add a b, acc => a.varsAcc (b.varsAcc acc)
+  | .mul a b, acc => a.varsAcc (b.varsAcc acc)
+
+def DenseExpr.varsFast (e : DenseExpr p) : List VarId := e.varsAcc []
+
+theorem DenseExpr.varsAcc_eq (e : DenseExpr p) : ∀ acc, e.varsAcc acc = e.vars ++ acc := by
+  induction e with
+  | const n => intro acc; rfl
+  | var i => intro acc; rfl
+  | add a b iha ihb =>
+      intro acc; rw [DenseExpr.varsAcc, ihb, iha, DenseExpr.vars, List.append_assoc]
+  | mul a b iha ihb =>
+      intro acc; rw [DenseExpr.varsAcc, ihb, iha, DenseExpr.vars, List.append_assoc]
+
+@[csimp] theorem DenseExpr.vars_eq_fast : @DenseExpr.vars = @DenseExpr.varsFast := by
+  funext q e
+  rw [DenseExpr.varsFast, DenseExpr.varsAcc_eq, List.append_nil]
+
 /-- All `VarId`s of a dense bus interaction (multiplicity then payload). -/
 def denseBIVars (bi : BusInteraction (DenseExpr p)) : List VarId :=
   bi.multiplicity.vars ++ bi.payload.flatMap DenseExpr.vars

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
@@ -168,7 +168,7 @@ theorem denseCheckPair_sound (d : DenseConstraintSystem p) (bs : BusSemantics p)
 threads them across `insert`/`erase`/`getElem?`/`toList`. -/
 
 private abbrev SplitEqC (L : List (BusInteraction (DenseExpr p))) (cand : DenseSplitCand p) : Prop :=
-  L = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2
+  L = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2
 
 private def OpenWF (L : List (BusInteraction (DenseExpr p))) (w : DenseOpenRec p) : Prop :=
   w.revPre.length = w.i ∧ L = w.revPre.reverse ++ w.S :: w.restAfter
@@ -368,7 +368,7 @@ theorem denseSweepGo_split {ops : DenseZModOps p} {shape : MemoryBusShape}
 theorem denseCandidateSplitsSweep_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap p)}
     {nw : Thunk (DenseNonzeroWits p)} (L : List (BusInteraction (DenseExpr p)))
     (cand : DenseSplitCand p) (hcand : cand ∈ denseCandidateSplitsSweep shape T nw L) :
-    L = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 := by
+    L = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 := by
   unfold denseCandidateSplitsSweep at hcand
   rw [List.mem_map] at hcand
   obtain ⟨ic, hic, rfl⟩ := hcand
@@ -399,7 +399,7 @@ theorem denseCollectForBus_vars (d : DenseConstraintSystem p)
     (busId : Nat) :
     ∀ (cands : List (DenseSplitCand p)),
     (∀ cand ∈ cands, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
+        = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
     ∀ c ∈ denseCollectForBus shape T nw cands, ∀ z ∈ c.vars, z ∈ d.occ := by
   intro cands
   induction cands with
@@ -408,9 +408,9 @@ theorem denseCollectForBus_vars (d : DenseConstraintSystem p)
     intro hsplitc c hc z hz
     obtain ⟨pre, S, mid, R, post⟩ := cand
     have hsplit : d.busInteractions.filter (fun bi => bi.busId = busId)
-        = pre ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
+        = pre.reverse ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
     have hrest : ∀ cand ∈ rest, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
+        = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
       fun cand h => hsplitc cand (List.mem_cons_of_mem _ h)
     have hSmem : S ∈ d.busInteractions := by
       have h : S ∈ d.busInteractions.filter (fun bi => bi.busId = busId) := by
@@ -465,7 +465,7 @@ theorem denseCollectForBus_sound (d : DenseConstraintSystem p) (bs : BusSemantic
     (denv : VarId → ZMod p) (hadm : d.admissible bs denv) (hsat : d.satisfies bs denv) :
     ∀ (cands : List (DenseSplitCand p)),
     (∀ cand ∈ cands, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
+        = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
     ∀ c ∈ denseCollectForBus shape (Thunk.pure T)
         (Thunk.pure (DenseNonzeroWits.build d.algebraicConstraints)) cands,
       c.eval denv = 0 := by
@@ -476,16 +476,16 @@ theorem denseCollectForBus_sound (d : DenseConstraintSystem p) (bs : BusSemantic
     intro hsplitc c hc
     obtain ⟨pre, S, mid, R, post⟩ := cand
     have hsplit : d.busInteractions.filter (fun bi => bi.busId = busId)
-        = pre ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
+        = pre.reverse ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
     have hrest : ∀ cand ∈ rest, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
+        = cand.1.reverse ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
       fun cand h => hsplitc cand (List.mem_cons_of_mem _ h)
     rw [denseCollectForBus] at hc
     split_ifs at hc with hchk
     · rw [List.mem_append] at hc
       rcases hc with hc | hc
-      · exact denseCheckPair_sound d bs facts hp1 reg hcov T hT busId shape hshape pre S mid R post
-          hsplit hchk denv hadm hsat c hc
+      · exact denseCheckPair_sound d bs facts hp1 reg hcov T hT busId shape hshape pre.reverse S mid
+          R post hsplit hchk denv hadm hsat c hc
       · exact ih hrest c hc
     · exact ih hrest c hc
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
@@ -510,13 +510,14 @@ theorem denseBytePackStep_correct (isInput : VarId → Bool) (bs : BusSemantics 
     (busId : Nat) (spec : ByteXorSpec p) (pre : List (BusInteraction (DenseExpr p)))
     (eA : DenseExpr p) (mid : List (BusInteraction (DenseExpr p))) (eB : DenseExpr p)
     (post : List (BusInteraction (DenseExpr p)))
-    (hfg : denseFindGo bs facts [] d.busInteractions = some (busId, spec, pre, eA, mid, eB, post)) :
+    (revPre bis : List (BusInteraction (DenseExpr p)))
+    (hlist : revPre.reverse ++ bis = d.busInteractions)
+    (hfg : denseFindGo bs facts revPre bis = some (busId, spec, pre, eA, mid, eB, post)) :
     DensePassCorrect isInput d
       { d with busInteractions := pre ++ denseMkBytePair spec busId eA eB :: mid ++ post } [] bs := by
   obtain ⟨a, b, hsplit0, hsaEq, hsbEq, hab, hspec, hbound⟩ :=
-    denseFindGo_split bs facts [] d.busInteractions busId spec pre eA mid eB post hfg
-  have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by
-    rw [← hsplit0, List.reverse_nil, List.nil_append]
+    denseFindGo_split bs facts revPre bis busId spec pre eA mid eB post hfg
+  have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by rw [← hlist, hsplit0]
   have hsa := denseSvCheck?_sound bs facts a eA hsaEq
   have hsbd := denseSvCheck?_sound bs facts b eB hsbEq
   have hstC : bs.isStateful (denseMkBytePair spec busId eA eB).busId = false := by
@@ -548,13 +549,14 @@ theorem denseBytePackStep_covered (reg : VarRegistry) (bs : BusSemantics p) (fac
     (busId : Nat) (spec : ByteXorSpec p) (pre : List (BusInteraction (DenseExpr p)))
     (eA : DenseExpr p) (mid : List (BusInteraction (DenseExpr p))) (eB : DenseExpr p)
     (post : List (BusInteraction (DenseExpr p)))
-    (hfg : denseFindGo bs facts [] d.busInteractions = some (busId, spec, pre, eA, mid, eB, post)) :
+    (revPre bis : List (BusInteraction (DenseExpr p)))
+    (hlist : revPre.reverse ++ bis = d.busInteractions)
+    (hfg : denseFindGo bs facts revPre bis = some (busId, spec, pre, eA, mid, eB, post)) :
     ({ d with busInteractions := pre ++ denseMkBytePair spec busId eA eB :: mid ++ post } :
       DenseConstraintSystem p).CoveredBy reg := by
   obtain ⟨a, b, hsplit0, hsaEq, hsbEq, _hab, _hspec, _hbound⟩ :=
-    denseFindGo_split bs facts [] d.busInteractions busId spec pre eA mid eB post hfg
-  have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by
-    rw [← hsplit0, List.reverse_nil, List.nil_append]
+    denseFindGo_split bs facts revPre bis busId spec pre eA mid eB post hfg
+  have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by rw [← hlist, hsplit0]
   have hsa := denseSvCheck?_sound bs facts a eA hsaEq
   have hsbd := denseSvCheck?_sound bs facts b eB hsbEq
   obtain ⟨hcac, hcbi⟩ := hcov
@@ -578,24 +580,35 @@ theorem denseBytePackStep_covered (reg : VarRegistry) (bs : BusSemantics p) (fac
 
 /-! ## The dense `bytePack` pass: drain packs through `DenseNativeStep.drain` -/
 
-/-- One drain step: on a `denseFindGo` hit, a non-extending certified pack step; otherwise `none`.
-    Fuel = interaction-list length, a safe bound since each pack drops that count by one. -/
+/-- One drain step, resuming at position `n`: the first `n` interactions are handed to
+    `denseFindGo` as its already-scanned prefix rather than re-examined. Sound to skip them, and
+    output-preserving: the step emits `pre ++ pairCheck :: mid ++ post`, `pre` is unchanged and holds
+    no *packable* single-value check (`denseFindGo` walked past each one either because it is not a
+    recognised check or because it had no partner, and a pack only removes single-value checks), and
+    the emitted `.pair` check is not one either (`denseSvCheck?` fires only for single-operand
+    shapes). So resuming at `|pre| + 1` sees the same candidates in the same order as restarting at
+    the head. Fuel = interaction-list length, a safe bound since each pack drops that count by one. -/
 def denseBytePackStep (bs : BusSemantics p) (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) :
-    Unit → (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg →
-      Option (Unit × DenseNativeStep p bs reg d) :=
-  fun _ reg d hcov =>
-    match hfg : denseFindGo bs facts [] d.busInteractions with
+    Nat → (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg →
+      Option (Nat × DenseNativeStep p bs reg d) :=
+  fun n reg d hcov =>
+    match hfg : denseFindGo bs facts (d.busInteractions.take n).reverse
+        (d.busInteractions.drop n) with
     | none => none
     | some (busId, spec, pre, eA, mid, eB, post) =>
-      some ((), DenseNativeStep.ofSame bs
-        (denseBytePackStep_covered reg bs facts d hcov busId spec pre eA mid eB post hfg)
-        (denseBytePackStep_correct reg.isInput bs facts hp1 d busId spec pre eA mid eB post hfg))
+      have hlist : ((d.busInteractions.take n).reverse).reverse ++ d.busInteractions.drop n
+          = d.busInteractions := by
+        rw [List.reverse_reverse]; exact List.take_append_drop n _
+      some (pre.length + 1, DenseNativeStep.ofSame bs
+        (denseBytePackStep_covered reg bs facts d hcov busId spec pre eA mid eB post _ _ hlist hfg)
+        (denseBytePackStep_correct reg.isInput bs facts hp1 d busId spec pre eA mid eB post _ _
+          hlist hfg))
 
 /-- The dense single-value byte-check packing pass (see `denseFindGo`, `ByteCheckPack.lean`). -/
 def denseByteCheckPackPass : DenseVerifiedPassW p :=
   DenseVerifiedPassW.ofDenseStep (fun reg bs facts d hcov =>
     if hp1 : (1 : ZMod p) ≠ 0 then
-      (DenseNativeStep.drain bs (denseBytePackStep bs facts hp1) d.busInteractions.length ()
+      (DenseNativeStep.drain bs (denseBytePackStep bs facts hp1) d.busInteractions.length 0
         reg d hcov).2
     else DenseNativeStep.refl bs hcov)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
@@ -802,7 +802,7 @@ private theorem denseVarBucketAdd_getD {α : Type} (a : α) (x : VarId) :
             · exact hxw rfl
             · exact hxs hmem)]
 
-private theorem denseVarBucket_lookup_eq {α : Type} (varsOf : α → List VarId) (x : VarId) :
+theorem denseVarBucket_lookup_eq {α : Type} (varsOf : α → List VarId) (x : VarId) :
     ∀ (items : List α),
       denseVarBucketLookup (denseVarBucket varsOf items) x
         = items.filter (fun a => decide (x ∈ varsOf a)) := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SubsumedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SubsumedCheck.lean
@@ -146,4 +146,89 @@ def denseSubsumedCheckDropPass : DenseVerifiedPassW p :=
 def denseSubsumedRangeDropPass : DenseVerifiedPassW p :=
   denseSubsumedDropPassOf denseSubsumedRangeCheck? denseSubsumedRangeCheck?_sound
 
+/-! ## The indexed bound lookup equals the scan (`@[csimp]` runtime replacement)
+
+`denseInteractionBound` needs a payload slot holding literally `.var x`, so an interaction that does
+not mention `x` can never yield a bound. Restricting the scan to the interactions that mention `x`
+therefore returns the identical first match, and `denseVarBucket` is exactly that restriction
+(`denseVarBucket_lookup_eq`). -/
+
+/-- `denseIsVarOf` only accepts the variable leaf itself. -/
+private theorem denseIsVarOf_mem {x : VarId} {e : DenseExpr p} (h : denseIsVarOf x e = true) :
+    x ∈ e.vars := by
+  cases e with
+  | var j =>
+      have : j = x := of_decide_eq_true (by simpa [denseIsVarOf] using h)
+      subst this; simp [DenseExpr.vars]
+  | const _ => exact absurd h (by simp [denseIsVarOf])
+  | add _ _ => exact absurd h (by simp [denseIsVarOf])
+  | mul _ _ => exact absurd h (by simp [denseIsVarOf])
+
+/-- A payload slot holding `.var x` puts `x` among the payload's variables. -/
+private theorem denseVarSlot_mem {x : VarId} :
+    ∀ (pl : List (DenseExpr p)) {s : Nat}, denseVarSlot x pl = some s →
+      x ∈ pl.flatMap DenseExpr.vars := by
+  intro pl
+  induction pl with
+  | nil => intro s h; exact absurd h (by simp [denseVarSlot])
+  | cons e rest ih =>
+    intro s h
+    rw [denseVarSlot] at h
+    simp only [List.flatMap_cons, List.mem_append]
+    by_cases he : denseIsVarOf x e
+    · exact Or.inl (denseIsVarOf_mem he)
+    · rw [if_neg (by simpa using he)] at h
+      obtain ⟨s', hs', -⟩ := Option.map_eq_some_iff.1 h
+      exact Or.inr (ih hs')
+
+/-- No bound from an interaction that does not mention the variable. -/
+private theorem denseInteractionBound_of_not_mem (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (x : VarId) (h : x ∉ denseBIVars bi) :
+    denseInteractionBound bs facts bi x = none := by
+  unfold denseInteractionBound
+  split
+  · rfl
+  · split
+    · rfl
+    · split
+      · rfl
+      · rename_i slot hs
+        exact absurd (by
+          simp only [denseBIVars, List.mem_append]
+          exact Or.inr (denseVarSlot_mem bi.payload hs)) h
+
+/-- Restricting the scan to the interactions mentioning `x` leaves the first bound unchanged. -/
+private theorem denseFindVarBound_filter (bs : BusSemantics p) (facts : BusFacts p bs)
+    (x : VarId) :
+    ∀ (l : List (BusInteraction (DenseExpr p))),
+      denseFindVarBound bs facts (l.filter (fun bi => decide (x ∈ denseBIVars bi))) x
+        = denseFindVarBound bs facts l x := by
+  intro l
+  induction l with
+  | nil => rfl
+  | cons bi rest ih =>
+    by_cases hmem : x ∈ denseBIVars bi
+    · rw [List.filter_cons_of_pos (by simpa using hmem), denseFindVarBound, denseFindVarBound]
+      cases denseInteractionBound bs facts bi x with
+      | some b => rfl
+      | none => exact ih
+    · rw [List.filter_cons_of_neg (by simpa using hmem), ih, denseFindVarBound,
+        denseInteractionBound_of_not_mem bs facts bi x hmem]
+
+@[csimp] theorem denseSubsumedDropF_eq_fast :
+    @denseSubsumedDropF = @denseSubsumedDropFFast := by
+  funext q bs facts f d
+  show d.filterBus (denseSubsumedDropKeep bs facts f (denseSubsumedDropBase f d))
+      = d.filterBus (denseSubsumedDropKeepIdx bs facts f
+          (denseVarBucketLookup (denseVarBucket denseBIVars (denseSubsumedDropBase f d))))
+  congr 1
+  funext bi
+  unfold denseSubsumedDropKeep denseSubsumedDropKeepIdx
+  cases hfb : f bi with
+  | none => rfl
+  | some xB =>
+      obtain ⟨x, B⟩ := xB
+      dsimp only
+      rw [denseVarBucket_lookup_eq denseBIVars x, denseFindVarBound_filter bs facts x]
+
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
@@ -67,4 +67,33 @@ def denseSubsumedDropF (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   d.filterBus (denseSubsumedDropKeep bs facts f (denseSubsumedDropBase f d))
 
+/-! ## Indexed bound lookups (runtime twin)
+
+`denseSubsumedDropKeep` walks the whole `base` list for every recognised check, so the pass is
+`O(checks × interactions)`. A bound can only come from an interaction that mentions the variable
+(`denseInteractionBound` needs a payload slot holding literally `.var x`), so serving the query from
+a per-variable index returns the identical first match — `denseSubsumedDropF_eq_fast`
+(`Proofs/SubsumedCheck.lean`) proves it and installs the twin via `@[csimp]`. -/
+
+/-- `denseSubsumedDropKeep` with the justification base served from a per-variable index. -/
+def denseSubsumedDropKeepIdx (bs : BusSemantics p) (facts : BusFacts p bs)
+    (f : BusInteraction (DenseExpr p) → Option (VarId × Nat))
+    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
+  match f bi with
+  | some (x, B) =>
+    match denseFindVarBound bs facts (witsOf x) x with
+    | some b' => !decide (b' ≤ B)
+    | none => true
+  | none => true
+
+/-- `denseSubsumedDropF` with one index build per invocation. The index is passed as a value with
+    the lookup applied at the use site; a partial application stored elsewhere would rebuild it per
+    query (`agent-docs/log.md` entries 106, 143). -/
+def denseSubsumedDropFFast (bs : BusSemantics p) (facts : BusFacts p bs)
+    (f : BusInteraction (DenseExpr p) → Option (VarId × Nat))
+    (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  let witsIdx := denseVarBucket denseBIVars (denseSubsumedDropBase f d)
+  d.filterBus (denseSubsumedDropKeepIdx bs facts f (denseVarBucketLookup witsIdx))
+
 end ApcOptimizer.Dense

--- a/Benchmarks/scaling_bench.py
+++ b/Benchmarks/scaling_bench.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Measure how the optimizer's runtime *scales* with circuit size, per pass.
+
+`runtime_bench.py` measures wall time on fixed inputs. This measures the growth rate, which is a
+different question: the optimizer can get uniformly faster while staying quadratic. To separate
+"this pass is expensive" from "this pass is superlinear", we need inputs of the same *shape* at
+several sizes.
+
+The ladder is built by replication: rung `k` is `k` copies of one real APC with disjoint variables
+(copy `c` renames every `<name>@<id>` to `<name>@<id + c*stride>`). Two properties make this the
+right instrument:
+
+  * A linear optimizer takes exactly `k x` the single-copy time, so the log-log slope of
+    time-vs-`k` *is* the exponent -- no curve fitting against a guessed model.
+  * The copies share nothing, so each copy's fixpoint runs exactly as it does alone. The cleanup
+    iteration count therefore stays flat across rungs (it is reported; if it drifts, the rung is
+    not comparable), which is what isolates per-pass cost from "bigger circuits need more rounds".
+
+    Benchmarks/scaling_bench.py                        # default source APC, rungs 1,2,3,4,6,8
+    Benchmarks/scaling_bench.py --rungs 1,2,4          # cheaper ladder
+    Benchmarks/scaling_bench.py --source Benchmarks/OpenVM/keccak/apc_001_pckeccak.json.gz
+    Benchmarks/scaling_bench.py --md scaling.md        # also write a markdown summary
+    Benchmarks/scaling_bench.py --json out.json        # also dump raw results (for --compare)
+
+To compare two runs (e.g. a PR head against main, both on the same machine -- exponents are more
+robust than absolute times, but still measure both sides on one runner):
+
+    Benchmarks/scaling_bench.py --compare base.json target.json --md scaling.md
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]  # Benchmarks -> repo root
+VM_DIR = {"openvm": "OpenVM", "sp1": "SP1"}
+DEFAULT_SOURCE = "Benchmarks/OpenVM/openvm-eth/apc_005_pc0x32ab5c.json.gz"
+DEFAULT_RUNGS = [1, 2, 3, 4, 6, 8]
+
+# `apc-optimizer profile` output, shared with runtime_bench.py.
+PROFILE_HEAD_RE = re.compile(r": (\d+) cleanup iterations, (\d+) ms total")
+PROFILE_PASS_RE = re.compile(r"^\s+(\w+): (\d+) ms$", re.M)
+
+# Times below this are dominated by noise and are excluded from the fit.
+FIT_FLOOR_MS = 20
+
+
+def parse_profile(out):
+    m = PROFILE_HEAD_RE.search(out)
+    if not m:
+        return None
+    passes = {name: int(ms) for name, ms in PROFILE_PASS_RE.findall(out)}
+    return int(m.group(2)), int(m.group(1)), passes
+
+
+def fmt_ms(ms):
+    return f"{ms / 1000:.1f} s" if ms >= 10_000 else f"{ms} ms"
+
+
+def fmt_exp(e):
+    return "—" if e is None else f"{e:.2f}"
+
+
+# --- input generation ------------------------------------------------------------------------
+
+VAR_RE = re.compile(r"^(.*)@(\d+)$")
+
+
+def shift_expr(e, off):
+    """Rename every variable in a powdr expression tree, offsetting its `@<id>` by `off`.
+
+    Mirrors `JsonParser.parseJsonExpr` positionally: a number is a constant, a string is a
+    variable, a 3-element array is `[lhs, op, rhs]`, a 2-element array is `[op, operand]`.
+    Operators are matched by position, never by value, so a variable named like an operator
+    cannot be misread.
+    """
+    if isinstance(e, str):
+        m = VAR_RE.match(e)
+        if m is None:
+            raise ValueError(
+                f"variable {e!r} has no `@<id>` suffix, so copies could not be made disjoint")
+        return f"{m.group(1)}@{int(m.group(2)) + off}"
+    if isinstance(e, list):
+        if len(e) == 3:
+            return [shift_expr(e[0], off), e[1], shift_expr(e[2], off)]
+        if len(e) == 2:
+            return [e[0], shift_expr(e[1], off)]
+        raise ValueError(f"expected a 2- or 3-element expression array, got {len(e)} elements")
+    return e  # a JSON number: a constant
+
+
+def max_var_id(machine):
+    """The largest `@<id>` in the machine, so replicas can be offset past it."""
+    top = -1
+
+    def walk(e):
+        nonlocal top
+        if isinstance(e, str):
+            m = VAR_RE.match(e)
+            if m is not None:
+                top = max(top, int(m.group(2)))
+        elif isinstance(e, list):
+            for x in (e[0], e[2]) if len(e) == 3 else e[1:]:
+                walk(x)
+
+    for c in machine["constraints"]:
+        walk(c)
+    for bi in machine["bus_interactions"]:
+        walk(bi["mult"])
+        for a in bi["args"]:
+            walk(a)
+    return top
+
+
+def load_source(path):
+    opener = gzip.open if path.name.endswith(".gz") else open
+    with opener(path, "rt") as f:
+        return json.load(f)
+
+
+def build_rung(src, k, stride, out_path):
+    """Write `k` disjoint copies of `src`'s machine to `out_path` (gzipped JSON).
+
+    Only the keys `JsonParser.lean` reads are emitted: `machine.constraints`,
+    `machine.bus_interactions`, `bus_map`, and `next_free_id`.
+    """
+    machine = src["machine"]
+    constraints, interactions = [], []
+    for c in range(k):
+        off = c * stride
+        constraints += [shift_expr(x, off) for x in machine["constraints"]]
+        interactions += [{"id": bi["id"],
+                          "mult": shift_expr(bi["mult"], off),
+                          "args": [shift_expr(a, off) for a in bi["args"]]}
+                         for bi in machine["bus_interactions"]]
+    out = {"machine": {"constraints": constraints,
+                       "bus_interactions": interactions,
+                       "derived_columns": []},
+           "bus_map": src["bus_map"],
+           "next_free_id": k * stride}
+    with gzip.open(out_path, "wt") as f:
+        json.dump(out, f)
+    return len(constraints), len(interactions)
+
+
+# --- fitting ---------------------------------------------------------------------------------
+
+def fit_exponent(rungs, values):
+    """Least-squares log-log slope of `values` against `rungs`.
+
+    `None` when fewer than three rungs clear `FIT_FLOOR_MS` -- a slope through two noisy points is
+    not worth printing.
+    """
+    pts = [(k, v) for k, v in zip(rungs, values) if v >= FIT_FLOOR_MS]
+    if len(pts) < 3:
+        return None
+    xs = [math.log(k) for k, _ in pts]
+    ys = [math.log(v) for _, v in pts]
+    mx, my = sum(xs) / len(xs), sum(ys) / len(ys)
+    sxx = sum((x - mx) ** 2 for x in xs)
+    if sxx == 0:
+        return None
+    return sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / sxx
+
+
+def vs_linear(rungs, values):
+    """How much worse than linear the largest rung is, relative to the smallest usable one."""
+    pts = [(k, v) for k, v in zip(rungs, values) if v >= FIT_FLOOR_MS]
+    if len(pts) < 2:
+        return None
+    (k0, v0), (k1, v1) = pts[0], pts[-1]
+    return (v1 / v0) / (k1 / k0)
+
+
+# --- benchmarking ----------------------------------------------------------------------------
+
+def bench(args):
+    repo = args.repo.resolve()
+    source = args.source if args.source.is_absolute() else repo / args.source
+    if not source.exists():
+        sys.exit(f"error: source APC {source} not found")
+
+    binary = args.binary.resolve() if args.binary is not None else None
+    os.chdir(repo)
+    if binary is None:
+        if not args.no_build:
+            print("building apc-optimizer...", file=sys.stderr)
+            subprocess.run(["lake", "build"], check=True)
+        binary = repo / ".lake" / "build" / "bin" / "apc-optimizer"
+    if not binary.exists():
+        sys.exit(f"error: {binary} missing (build first, or pass --binary/--no-build correctly)")
+    # The VM token is optional and defaults to openvm; omit it there so the command stays
+    # compatible with binaries that predate the token (e.g. a latest-main baseline).
+    vm_tok = [] if args.vm == "openvm" else [args.vm]
+
+    src = load_source(source)
+    stride = max_var_id(src["machine"]) + 1
+    if stride <= 0:
+        sys.exit(f"error: no `@<id>` variables in {source}; cannot build disjoint copies")
+
+    total_ms, iters, sizes = {}, {}, {}
+    pass_ms = {}  # pass name -> {rung -> ms}
+    with tempfile.TemporaryDirectory(prefix="apc-scaling-") as tmp:
+        for k in args.rungs:
+            rung = Path(tmp) / f"rung{k:02d}.json.gz"
+            ncs, nbis = build_rung(src, k, stride, rung)
+            best = None
+            for _ in range(args.repeat):
+                out = subprocess.run([str(binary), "profile", *vm_tok, str(rung)],
+                                     capture_output=True, text=True, check=True).stdout
+                parsed = parse_profile(out)
+                if parsed is None:
+                    sys.exit(f"could not parse profile output for rung {k}:\n{out}")
+                if best is None or parsed[0] < best[0]:
+                    best = parsed
+            total, its, passes = best
+            total_ms[k], iters[k], sizes[k] = total, its, [ncs, nbis]
+            for name, ms in passes.items():
+                pass_ms.setdefault(name, {})[k] = ms
+            print(f"[k={k}] {ncs} constraints, {nbis} interactions: "
+                  f"{fmt_ms(total)}, {its} iterations", file=sys.stderr)
+            rung.unlink()
+
+    return {"source": str(source.relative_to(repo)) if source.is_relative_to(repo) else str(source),
+            "rungs": list(args.rungs), "repeat": args.repeat, "stride": stride,
+            "sizes": sizes, "total_ms": total_ms, "iters": iters, "pass_ms": pass_ms}
+
+
+# --- reporting -------------------------------------------------------------------------------
+
+def _rungs(data):
+    """Rung keys as ints; JSON round-trips dict keys to strings."""
+    return [int(k) for k in data["rungs"]]
+
+
+def _series(m, rungs):
+    return [m.get(str(k), m.get(k, 0)) for k in rungs]
+
+
+def emit_md(data):
+    rungs = _rungs(data)
+    totals = _series(data["total_ms"], rungs)
+    its = _series(data["iters"], rungs)
+
+    lines = [f"### Runtime scaling — {data['source']}, {len(rungs)} rungs of disjoint replicas"
+             + (f", best of {data['repeat']}" if data["repeat"] > 1 else ""), ""]
+    lines.append("Rung `k` is `k` disjoint copies of the source APC, so a linear optimizer would "
+                 "take exactly `k ×` the `k=1` time; the exponent is the log-log slope. "
+                 "Iterations must stay flat for the rungs to be comparable.")
+    lines.append("")
+    lines.append("| k | constraints | interactions | total | vs. linear | iterations |")
+    lines.append("|---|---|---|---|---|---|")
+    base = totals[0] if totals else 0
+    for k, t, it in zip(rungs, totals, its):
+        ncs, nbis = _series(data["sizes"], [k])[0]
+        rel = f"{(t / base) / (k / rungs[0]):.1f}×" if base else "—"
+        lines.append(f"| {k} | {ncs} | {nbis} | {fmt_ms(t)} | {rel} | {it} |")
+    lines.append("")
+    lines.append(f"**Total exponent: {fmt_exp(fit_exponent(rungs, totals))}** "
+                 f"(1.00 = linear).")
+    lines.append("")
+    lines.append("| pass | " + " | ".join(f"k={k}" for k in rungs) + " | exponent | vs. linear |")
+    lines.append("|---" * (len(rungs) + 3) + "|")
+    for name in sorted(data["pass_ms"], key=lambda n: -_series(data["pass_ms"][n], rungs)[-1]):
+        series = _series(data["pass_ms"][name], rungs)
+        if series[-1] < FIT_FLOOR_MS:
+            continue
+        rel = vs_linear(rungs, series)
+        lines.append(f"| {name} | " + " | ".join(str(v) for v in series)
+                     + f" | {fmt_exp(fit_exponent(rungs, series))} "
+                     + f"| {'—' if rel is None else f'{rel:.1f}×'} |")
+    lines.append("")
+    lines.append(f"Passes under {FIT_FLOOR_MS} ms at the largest rung are omitted; an exponent "
+                 f"needs three rungs above that floor.")
+    return "\n".join(lines) + "\n"
+
+
+def emit_compare_md(base, target):
+    rungs = [k for k in _rungs(target) if k in _rungs(base)]
+    if not rungs:
+        return "No rungs in common between the two runs.\n"
+    t_tot, b_tot = _series(target["total_ms"], rungs), _series(base["total_ms"], rungs)
+
+    lines = [f"### Runtime scaling — {target['source']}, target vs baseline (same runner)", ""]
+    lines.append("Exponent 1.00 = linear in circuit size. Δ = target / baseline; below 1× means "
+                 "the target is faster.")
+    lines.append("")
+    lines.append("| | target | baseline |")
+    lines.append("|---|---|---|")
+    lines.append(f"| total exponent | **{fmt_exp(fit_exponent(rungs, t_tot))}** "
+                 f"| {fmt_exp(fit_exponent(rungs, b_tot))} |")
+    lines.append(f"| largest rung (k={rungs[-1]}) | {fmt_ms(t_tot[-1])} | {fmt_ms(b_tot[-1])} |")
+    lines.append("")
+    lines.append("| pass | target exp | baseline exp | target k=%d | baseline k=%d | Δ |"
+                 % (rungs[-1], rungs[-1]))
+    lines.append("|---|---|---|---|---|---|")
+    names = set(base["pass_ms"]) | set(target["pass_ms"])
+    for name in sorted(names, key=lambda n: -_series(target["pass_ms"].get(n, {}), rungs)[-1]):
+        t = _series(target["pass_ms"].get(name, {}), rungs)
+        b = _series(base["pass_ms"].get(name, {}), rungs)
+        if max(t[-1], b[-1]) < FIT_FLOOR_MS:
+            continue
+        delta = "∞" if t[-1] and not b[-1] else ("—" if not t[-1] else f"{t[-1] / b[-1]:.2f}×")
+        lines.append(f"| {name} | {fmt_exp(fit_exponent(rungs, t))} "
+                     f"| {fmt_exp(fit_exponent(rungs, b))} | {t[-1]} | {b[-1]} | {delta} |")
+    t_it, b_it = _series(target["iters"], rungs), _series(base["iters"], rungs)
+    if t_it != b_it:
+        lines.append("")
+        lines.append(f"⚠ cleanup iterations differ: target {t_it} vs baseline {b_it} — the two "
+                     f"sides did different amounts of work, so read the exponents with care.")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--source", type=Path, default=Path(DEFAULT_SOURCE), metavar="APC.json[.gz]",
+                    help=f"APC to replicate (default: {DEFAULT_SOURCE})")
+    ap.add_argument("--rungs", default=",".join(map(str, DEFAULT_RUNGS)),
+                    help=f"comma-separated copy counts (default: {','.join(map(str, DEFAULT_RUNGS))})")
+    ap.add_argument("--vm", choices=sorted(VM_DIR), default="openvm",
+                    help="VM whose fact-aware optimizer to use (default: openvm)")
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="runs per rung; the fastest is kept (default: 1)")
+    ap.add_argument("--no-build", action="store_true",
+                    help="skip `lake build` (the binary must already exist)")
+    ap.add_argument("--binary", type=Path, default=None, metavar="EXE",
+                    help="bench this apc-optimizer executable instead of building the repo's; "
+                         "implies no build")
+    ap.add_argument("--repo", type=Path, default=REPO, metavar="DIR",
+                    help="repository to build and bench (default: the one holding this script; "
+                         "lets a saved copy of the script bench another checkout, e.g. a baseline)")
+    ap.add_argument("--md", type=Path, default=None, metavar="OUT.md",
+                    help="also write a markdown summary (for CI job summaries / PR comments)")
+    ap.add_argument("--json", type=Path, default=None, metavar="OUT.json",
+                    help="also dump the raw per-rung/per-pass results (input for --compare)")
+    ap.add_argument("--compare", nargs=2, default=None, metavar=("BASE.json", "TARGET.json"),
+                    help="don't bench; render a comparison of two --json dumps instead")
+    args = ap.parse_args()
+
+    if args.compare is not None:
+        base, target = (json.loads(Path(p).read_text()) for p in args.compare)
+        md = emit_compare_md(base, target)
+        print(md, end="")
+        if args.md is not None:
+            args.md.write_text(md)
+        return
+
+    try:
+        args.rungs = sorted({int(x) for x in args.rungs.split(",") if x.strip()})
+    except ValueError:
+        sys.exit(f"error: --rungs must be a comma-separated list of integers, got {args.rungs!r}")
+    if not args.rungs or args.rungs[0] < 1:
+        sys.exit("error: --rungs must contain positive integers")
+
+    data = bench(args)
+    md = emit_md(data)
+    print(md, end="")
+    if args.md is not None:
+        args.md.write_text(md)
+    if args.json is not None:
+        args.json.write_text(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ workflow (`gh workflow run "Runtime Bench" -f pr=<N>`) benches the full set from
 Benchmarks/runtime_bench.py            # all openvm-eth cases, serial (stable timings)
 Benchmarks/runtime_bench.py --n 20 --repeat 3   # top 20, best-of-3 per case
 ```
+
+To bench how runtime *scales* with circuit size — which the above cannot show, since a pass can get
+uniformly faster while staying quadratic — use `scaling_bench.py`. It replicates one APC `k` times
+with disjoint variables, so a linear optimizer would take exactly `k ×` the single-copy time and the
+log-log slope of time-vs-`k` is each pass's exponent (`1.00` = linear). The copies share nothing, so
+the cleanup iteration count stays flat across rungs, which is what isolates per-pass cost from
+"bigger circuits need more fixpoint rounds". The on-demand `Scaling Bench` workflow
+(`gh workflow run "Scaling Bench" -f pr=<N>`) compares a PR head against `main` on one runner:
+
+```bash
+Benchmarks/scaling_bench.py                    # default APC, rungs 1,2,3,4,6,8
+Benchmarks/scaling_bench.py --rungs 1,2,4 --repeat 3   # cheaper ladder, best-of-3 per rung
+```

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -128,6 +128,42 @@ claimed to help at SHA scale — entries 142–144 cut 524 → 378 s without mov
 count flat (it is reported; a drifting rung is not comparable), which is what separates per-pass cost
 from "bigger circuits need more rounds".
 
+### The exponent is owned by `reencode` and `domainFold` (measured, entry 145)
+
+First ladder run, `openvm-eth/apc_005`, rungs 1–4 (4652 → 18608 constraints), this container, main at
+`ce9a820`. Iterations flat at 5–6, so every number below is per-pass cost, not extra rounds.
+**Total exponent 1.95.**
+
+| pass | k=1 | k=4 | growth for 4× size | exponent |
+|---|---|---|---|---|
+| `reencode` | 2746 ms | 78.3 s | **28.5×** | **2.36** |
+| `domainFold` | 1659 ms | 28.0 s | **16.9×** | **2.07** |
+| `busPairCancel` | 156 ms | 1608 ms | 10.3× | 1.68 |
+| `flagUnify` | 107 ms | 899 ms | 8.4× | 1.54 |
+| `flagFold` | 439 ms | 3213 ms | 7.3× | 1.44 |
+| `gauss` | 565 ms | 2650 ms | 4.7× | 1.13 |
+| everything else | — | — | 4.2–5.5× | 1.05–1.2 |
+
+`reencode` + `domainFold` are **83 % of the k=4 run**. Everything else is at or near the
+allocation floor. So: *stop tuning the small passes; the exponent lives in the candidate-group
+family.*
+
+**Why they are quadratic here, specifically.** Under disjoint replication a variable's index bucket
+does *not* grow — the copies share nothing — so every per-variable lookup (`denseCoveredIdx`,
+`denseUsePositions`, `denseDegPreReject` since entry 142) is constant per target and contributes
+only linearly. What grows is the **per-accept whole-system work**, and the number of accepts scales
+with `k`: `denseReencodeOut` rewrites the entire system, and then the accept rebuilds
+`denseBuildPruned` + `arrCs.toArray` + `HashSet.ofList ro.occ` + `denseBuildUseIdx`, each O(system).
+O(accepts) × O(system) = O(k²). This is exactly the shape entry 109 removed from `domainFold`
+(order-preserving in-place rewrite, `FoldIdx.refresh` with no rebuild, sparse `foldOutIdx`), and R3
+already names `reencode` as the next candidate — it needs the position remap or a
+pruned-completeness argument because its rewrite *adds* bit columns and drops covered constraints.
+That is now the highest-value runtime work in the tree, ahead of everything else in R1–R12.
+
+`domainFold` still measuring 2.07 after #206 says its own per-accept path retains an O(system) term —
+re-check `denseFoldOutArrV`'s `Array.modify` chain for a copy when the array is still shared, and
+`DenseFoldIdx.mk'`/`refresh`.
+
 Rewritten 2026-07-18 from a fresh profiling session (per-pass `profile`, per-cycle timing, gdb
 stack sampling, and a size-scaling sweep — all on this container, serial). **Runtime is
 end-to-end quadratic in circuit size** (openvm-eth sweep: input 2.3k → 8.8k items costs

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -400,12 +400,25 @@ congruence); and `denseLiveSeg_congr` for the `alive → aliveNew` transport. Cl
 change and on `emitted`. Modelled at 62× (mixed keys) to 186× (32 keys). A wrong entry costs time,
 never soundness — the O(|addressFields|) slot check is the guard, falling back to `w = 0`.
 
-Two independent wins found alongside: (i) with `addressFields = []`, `denseAddrNonzeroNeq` degenerates
-to a witness scan *independent of both `S` and `m`*, yet is re-evaluated per prefix message with
-`DenseLinExpr.scale`/`norm` allocations — hoist it (pure refactor, and the bridge is 8006 of
-sha256's 71k interactions); (ii) the off-bus fold identity also licenses scanning only the bus's own
-positions, modelled at 3.45× on the memory bus — but that one is *trusted*, so it needs a
-completeness proof for the per-bus position index.
+Two independent wins found alongside.
+
+**(i) `denseAddrNonzeroNeq` on the execution bridge — likely the largest single constant factor left
+in this pass.** `addressFields = []` there (`OpenVmSemantics.lean`), and `[].sublists = [[]]`, so the
+`any` runs exactly once with `T = []`; `denseDiffSumOver S m [] = some ⟨0, []⟩`, so the body reduces
+to `nw.wits.any (fun g => denseIsZeroLin (0 − g) || denseIsZeroLin (0 + g))` — **independent of both
+`S` and `m`**, i.e. a constant for the whole invocation. But it is re-evaluated for *every* prefix
+message of *every* candidate, and each witness costs two `DenseLinExpr` `add`/`scale` allocations.
+`nw.wits` is `constraints.flatMap denseReciprocalWits?`, so on sha256_big (146k constraints) that
+inner scan can be thousands of allocations per message. The bridge is 8006 of sha256's 71k
+interactions and `addressFields = []` makes every message same-address, so this is on the hot path
+for the whole bridge sweep. Fix: carry the `T = []` value once per invocation (a `Bool` alongside the
+witness list) rather than recomputing it. Note it cannot simply be replaced by `false`: a
+syntactically-zero witness would make it `true`, which `DenseNonzeroWits.Sound` only rules out for
+satisfiable systems — so hoist the computation, do not assume its result.
+
+**(ii)** The off-bus fold identity also licenses scanning only the bus's own positions, modelled at
+3.45× on the memory bus — but that one is *trusted*, so it needs a completeness proof for the per-bus
+position index.
 
 **R9a (done, entry 144).** `DenseTwoRootMap.addVars` re-linearized a product's factors per
 variable; `addVarsFast` + `@[csimp] addVars_eq_fast` hoists them. The `@[csimp]` twin is the

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -120,6 +120,14 @@ touching these files anyway):
 
 ## Runtime
 
+**Measure the exponent, not just the time.** `Benchmarks/scaling_bench.py` (entry 145) runs a ladder
+of `k` disjoint replicas of one APC and reports each pass's log-log slope; the `Scaling Bench`
+workflow does it for a PR head against a baseline on one runner. Use it before and after any change
+claimed to help at SHA scale — entries 142–144 cut 524 → 378 s without moving a single exponent, and
+`runtime_bench.py` cannot tell those two kinds of win apart. The ladder holds the cleanup iteration
+count flat (it is reported; a drifting rung is not comparable), which is what separates per-pass cost
+from "bigger circuits need more rounds".
+
 Rewritten 2026-07-18 from a fresh profiling session (per-pass `profile`, per-cycle timing, gdb
 stack sampling, and a size-scaling sweep — all on this container, serial). **Runtime is
 end-to-end quadratic in circuit size** (openvm-eth sweep: input 2.3k → 8.8k items costs
@@ -213,6 +221,19 @@ these need no new proof.
    - ~~`flagFold` triple `eraseDups` in `btPre`~~ **done (entry 104)**. `singleVarCs`/`btCert`
      still recompute per-constraint `eraseDups`, but only on gate-passing constraints (proofs
      unfold them — rework only if they show up in profiles).
+   - ~~`bytePack`/`bytePackLate` restart their pack scan at the list head per packed pair~~ **done
+     (entry 145)**: `DenseNativeStep.drain`'s generic state carries a resume position (it was sitting
+     at `Unit`). keccak bytePack 596 → 188 ms, bytePackLate 70 → 10 ms. **`tupleRange` has the same
+     shape and is worse** — `denseDrainTuplePacks` re-scans from the head *for every candidate tuple
+     bus* on every drain iteration, Θ(drops × buses × system) — but its drain is hand-rolled
+     (`DensePassCorrect.trans`), so the cursor has to be threaded through that loop instead. 5.7 s on
+     sha256_big.
+   - ~~`subsumedRange`/`subsumedCheck` scan the whole justification base per recognised check~~
+     **done (entry 145)**: exponent 2.24 → per-variable `denseVarBucket`, `@[csimp]` twin, no proof
+     shape change. A bound can only come from an interaction mentioning the variable.
+   - ~~`busUnify` copies the whole prefix per emitted candidate (`denseEmitCand`'s
+     `revPre.reverse`)~~ **done (entry 145)**: the field is never read at runtime, so the candidate
+     stores the reversed prefix and `SplitEqC` states `cand.1.reverse ++ …`.
 
 **R2. domainBatch setup and enumeration**  ·  **mostly done (entries 104, 128–131)**. Entry 129
 skips the Cartesian scan when every active filter is already discharged by
@@ -264,6 +285,11 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      fails) needs no new proof — only the same survivor *list order* to stay byte-identical.
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
+   - ~~`DenseExpr.vars` is `++`-built~~ **done (entry 145)**: the left subtree's list was rebuilt at
+     every enclosing node, quadratic on the left-associated chains affine reconstruction produces.
+     `varsAcc` + `@[csimp] vars_eq_fast`, byte-identical by the theorem, −3% on openvm-eth and keccak.
+     Worth checking the other `++`-built traversals (`denseBIVars`, `DenseExpr.uniqueVars`) for the
+     same shape.
    - **Variable interning-lite, `Implementation/`-only**: parse-time interning is **done (entry
      106)**. The `powdrId?`-first `Hashable Variable` swap was **tried and reverted (entry
      116)**: hash values leak into `Std.HashMap`/`HashSet` iteration orders, and *some* consumer
@@ -346,10 +372,40 @@ lemmas) — is **done (#210)**: sha256_big busPairCancel 107 → 89.5 s, and ent
 justification's domain scans out (89.5 → 50 s). The remaining 50 s is the O(live²) certificate work
 itself — `denseShieldScanSeg` is ~4 % of whole-run CPU: `shieldOk` still evaluates
 `densePreRefuted` over the whole live prefix per candidate send, and `midRefuted` over the
-between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldOk` left-folds
-to a single per-address-key `pending` bit, maintainable across one sweep — but the pass's
-tombstone-and-restart structure (drops invalidate prefix state: removing a consumed receive
-un-shields earlier messages) forces a recompute-on-drop scheme, bounded by #drops × O(B).
+between-region. **Design (b) is now specified, and one tempting alternative is a measured dead end
+(entry 145).**
+
+*Not this:* starting the scan at the last live provable same-address receive `q` instead of at 0. The
+supporting algebra is real — `ok(l)` = "every non-`densePreRefuted` message has a `denseProvRecv`
+strictly to its right", so a provable receive in a suffix makes the head irrelevant — but the win is
+not. Simulating `denseFindCancelGoIdx`'s scan order (resume-at-`dropPos`, both positions tombstoned)
+against the real exports gives Σ(i−q)/Σi = **1.00** on the execution bridge with real positions and
+1.00–1.01× under realistic memory-key models: the pass drops the send *and* its matching receive, so
+the last surviving same-key receive collapses back to the *first* access of that key. (The "gap = 1
+at p100" figure measures the *between*-region `j − i − 1`, a send to its own partner — not the
+distance back to the previous *surviving* receive.) And the hint lookup reintroduces Θ(N): with
+`addressFields = []` every bridge message hashes to one `denseAddrHash` bucket, and "last entry
+`< i`" on a `List` is O(bucket).
+
+*This:* a **monotone per-key watermark**, which the drop protocol does not invalidate. The scan
+frontier only moves forward (a drop tombstones `iP = i` and `jP > i`, and `denseFindCancel` only skips
+forward), and off-bus tombstones are *fold identities* of `denseShieldScan` (`m.busId ≠ busId` ⇒
+`densePreRefuted = true`, `denseProvRecv = false`), so a bus-b watermark survives drops on other
+buses. Thread a per-key map `K → (w, S₀)` carrying, as a `Subtype` invariant,
+`denseShieldOk … S₀ (denseLiveSeg arr alive 0 w) = true`; at a candidate compare address slots in
+O(|addressFields|) and scan only `[w, i)`. Lemmas needed: `hasRecv` distributes over `++`;
+`ok(l₁) = true → ok(l₁ ++ l₂) = ok(l₂)`; the off-bus fold identity; address-slot congruence for the
+five certificates (each reads only `shape.addressFields`, so this is unfolding plus `List.any/all`
+congruence); and `denseLiveSeg_congr` for the `alive → aliveNew` transport. Clear the map on bus
+change and on `emitted`. Modelled at 62× (mixed keys) to 186× (32 keys). A wrong entry costs time,
+never soundness — the O(|addressFields|) slot check is the guard, falling back to `w = 0`.
+
+Two independent wins found alongside: (i) with `addressFields = []`, `denseAddrNonzeroNeq` degenerates
+to a witness scan *independent of both `S` and `m`*, yet is re-evaluated per prefix message with
+`DenseLinExpr.scale`/`norm` allocations — hoist it (pure refactor, and the bridge is 8006 of
+sha256's 71k interactions); (ii) the off-bus fold identity also licenses scanning only the bus's own
+positions, modelled at 3.45× on the memory bus — but that one is *trusted*, so it needs a
+completeness proof for the per-bus position index.
 
 **R9a (done, entry 144).** `DenseTwoRootMap.addVars` re-linearized a product's factors per
 variable; `addVarsFast` + `@[csimp] addVars_eq_fast` hoists them. The `@[csimp]` twin is the
@@ -403,6 +459,10 @@ worth a prototype on one index first.
 - **Eager per-sweep variable→bound witness maps in busPairCancel**: ~30× the work of the
   early-exit query-time scan on eth (entry 90). Query-time scans + per-variable *position*
   indexes are the pattern.
+- **Truncating `busPairCancel`'s shield scan at the last same-address receive** (entry 145): measured
+  Σ(i−q)/Σi = 1.00 on the execution bridge with real positions, 1.00–1.01× on modelled memory keys —
+  the pass drops the matching receive, so `q` collapses to each key's first access. The hint lookup
+  also reintroduces Θ(N) on a one-bucket `denseAddrHash`. See R8 for the watermark that does work.
 - **Feeding whole regions into per-query justification arms**: 63 s/case for −3 interactions
   (entry 102). Use a position index or nothing.
 - CI notes (updated 2026-07-24): the effectiveness-matrix runtime row swung **+51 % → +15 % on

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4903,3 +4903,70 @@ Cumulative for entries 142–144: sha256_big **523.9 → 377.6 s (−28 %)**.
 
 **Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak, wasm-eth
 apc_036 and the 168k-var OpenVM sha256 case).**
+
+### 145. Runtime: a scaling instrument, and four exponent fixes it justifies
+
+`runtime_bench.py` measures wall time on fixed inputs, which cannot distinguish "this pass is
+expensive" from "this pass is superlinear" — the optimizer can get uniformly faster while staying
+quadratic, which is exactly what entries 142–144 did (524 → 378 s on sha256_big with no exponent
+changed). So this entry starts with the missing instrument.
+
+**`Benchmarks/scaling_bench.py`** builds a ladder by replication: rung `k` is `k` copies of one real
+APC with disjoint variables (copy `c` renames `<name>@<id>` to `<name>@<id + c·stride>`). Two
+properties make it the right measurement: a linear optimizer takes exactly `k ×` the single-copy
+time, so the log-log slope of time-vs-`k` *is* the exponent with no model to fit; and the copies
+share nothing, so each copy's fixpoint runs as it does alone and the cleanup iteration count stays
+flat across rungs — which is what separates per-pass cost from "bigger circuits need more rounds".
+The count is reported, so a rung that drifts is visibly not comparable. Generation emits only the
+keys `JsonParser` reads and renames variables positionally, mirroring `parseJsonExpr`, so an operator
+can never be misread as a variable. `.github/workflows/scaling_bench.yml` runs it for a PR head
+against a baseline on one runner and posts the exponent table as a sticky comment.
+
+Four fixes, each byte-identical and independently benched:
+
+1. **`DenseExpr.vars` accumulator twin.** `vars` appended its children's lists, so the left subtree
+   was copied again at every enclosing node — quadratic in the depth of a left-associated chain,
+   which is exactly what affine reconstruction produces. It is called per constraint per cycle by
+   nearly every dense pass. `varsAcc` proves `e.varsAcc acc = e.vars ++ acc` and `@[csimp]
+   vars_eq_fast` installs it everywhere; the list order is identical, so output is byte-identical
+   *by the theorem*. openvm-eth apc_044/067 −3%, keccak −3%, wasm-eth apc_036 neutral.
+2. **`busUnify` keeps the split candidate's prefix reversed.** `denseEmitCand` materialized
+   `w.revPre.reverse` per emitted candidate — a fresh copy of the whole prefix of the bus's
+   interaction list. Nothing reads it at runtime (`denseCollectForBus` binds it as `_pre`,
+   `denseCheckPair` takes only `S mid R`); it exists so the positional split can be *stated*, and
+   proofs are erased. `SplitEqC` now says `cand.1.reverse ++ …` and the two consumers instantiate at
+   `pre.reverse`. `dense_split_of_positions` already produced the reversed form, so
+   `denseEmitCand_split` was unchanged.
+3. **`subsumedRange`/`subsumedCheck` serve bound queries from a per-variable index.**
+   `denseSubsumedDropKeep` walked the whole justification base per recognised check —
+   O(checks × interactions), exponent 2.24 on the ladder, the cleanest quadratic left in the tree. A
+   bound can only come from an interaction mentioning the variable (`denseInteractionBound` needs
+   `denseVarSlot` to find a slot holding literally `.var x`), so `denseVarBucket` returns the
+   identical first match. `@[csimp]` twin, so `denseSubsumedDropF_correct`'s whole-list hypothesis is
+   untouched. `denseVarBucket_lookup_eq` (entry 140's exactness lemma) loses its `private`.
+4. **`bytePack` resumes the pack scan instead of restarting at the head.** `denseBytePackStep` called
+   `denseFindGo` with an empty prefix every drain iteration, re-examining every earlier interaction
+   with `denseSvCheck?`: Θ(packs × interactions). `DenseNativeStep.drain`'s state parameter is
+   generic and was sitting at `Unit`. Skipping is output-preserving because `pre` holds no *packable*
+   single-value check (each was walked past either as unrecognised or as partnerless, and a pack only
+   removes single-value checks, so a partnerless check stays partnerless) and the emitted `.pair`
+   check is not one either. Both step lemmas generalise from the `[] / d.busInteractions` instance to
+   an arbitrary scanned prefix plus `revPre.reverse ++ bis = d.busInteractions`; each used that
+   hypothesis only to derive the split. **keccak: bytePack 596 → 188 ms (−68%), bytePackLate
+   70 → 10 ms (−86%).**
+
+**Measured dead end — `busPairCancel` shield truncation.** The obvious reading of R8 is to start
+`denseShieldScanSeg` at the last live provable same-address receive `q` instead of at 0, justified by
+two short list lemmas (a provable receive in a suffix makes the head irrelevant). The lemmas are
+real, but the win is not: simulating `denseFindCancelGoIdx`'s scan order against the real exports
+gives Σ(i−q)/Σi = **1.00** on the execution bridge with real positions and 1.00–1.01× under
+realistic memory-key models. The pass drops the send *and* its matching receive, so the last
+surviving same-key receive collapses back to the *first* access of that key and the window stays
+≈ `i`. The "gap = 1 at p100" statistic that suggested otherwise measures the *between*-region
+`j − i − 1` (a send to its own partner), not the distance back to the previous *surviving* receive.
+Worse, the hint lookup reintroduces Θ(N): with `addressFields = []` every bridge message hashes to
+one `denseAddrHash` bucket and "last entry `< i`" on a `List` is O(bucket). See R8 for the design
+that does work (a monotone per-key watermark).
+
+**Worked: yes** — `lake build` warning-free, `Scripts/check-proof-integrity.sh` green, and
+byte-identical `opt-export` on openvm-eth apc_044, keccak and wasm-eth apc_036 for every commit.


### PR DESCRIPTION
## Why

The Lean optimizer's wall time grows as ~N^1.5–1.8 in circuit size while powdr's Rust optimizer is ~N^1.0 (analysis in #213). #211/#212/#215 took the 168k-variable sha256 case 524 → 378 s, but **none of them changed an exponent** — they cut constants, and `runtime_bench.py` cannot tell those two kinds of win apart. So this PR builds the instrument that can, then uses it.

## Headline

`Scaling Bench`, `openvm-eth/apc_005`, rungs 1–4, one runner, cleanup iterations flat at 5–6:

| | this branch | main |
|---|---|---|
| **total exponent** | **1.87** | 1.95 |
| k=4 wall time | 120.7 s | 128.2 s |

Per-pass exponents that moved:

| pass | branch exp | main exp | Δ at k=4 |
|---|---|---|---|
| `busUnify` | **0.96** | 1.38 | 0.68× |
| `bytePack` | 1.22 | 1.42 | 0.65× |
| `disconnected` | 1.12 | 1.28 | 0.75× |
| `encode` | 1.08 | 1.39 | 0.86× |
| `gauss` | 1.00 | 1.13 | 0.96× |
| `subsumedRange` | 1.96 | 2.00 | 0.90× |

`busUnify` is no longer superlinear at all. Nearly every other pass is 5–15 % faster from the `DenseExpr.vars` twin.

## What's in it

**`Benchmarks/scaling_bench.py`** — the missing instrument. Rung `k` is `k` copies of one real APC with disjoint variables, so a linear optimizer takes exactly `k ×` the single-copy time and the log-log slope of time-vs-`k` *is* the exponent, with no model to fit. The copies share nothing, so each copy's fixpoint runs as it does alone and the cleanup iteration count stays flat — that is what separates per-pass cost from "bigger circuits need more rounds"; the count is reported, so a drifting rung is visibly not comparable. Generation emits only the keys `JsonParser` reads and renames variables positionally, mirroring `parseJsonExpr`.

**`.github/workflows/scaling_bench.yml`** — on-demand `Scaling Bench`, same two-checkout shape as `Runtime Bench`, sticky comment via the existing `report-bench` action.

**`perf(dense)`: accumulator twin for `DenseExpr.vars`** — `vars` appended its children's lists, so the left subtree was copied again at every enclosing node: quadratic in the depth of a left-associated chain, which is what affine reconstruction produces. Called per constraint per cycle by nearly every dense pass. `@[csimp] vars_eq_fast` installs the accumulator everywhere; list order identical, so output is byte-identical **by the theorem**.

**`perf(busUnify)`: keep the split candidate's prefix reversed** — `denseEmitCand` copied the whole prefix per emitted candidate. Nothing reads it at runtime (`denseCollectForBus` binds it `_pre`; `denseCheckPair` takes only `S mid R`); it exists so the positional split can be *stated*, and proofs are erased. `SplitEqC` now says `cand.1.reverse ++ …`.

**`perf(subsumedRange)`: per-variable bound index** — `denseSubsumedDropKeep` walked the whole justification base per recognised check. A bound can only come from an interaction mentioning the variable (`denseInteractionBound` needs a slot holding literally `.var x`), so `denseVarBucket` returns the identical first match. `@[csimp]` twin, soundness lemma untouched.

**`perf(bytePack)`: resume the pack scan instead of restarting at the head** — `denseFindGo` was called with an empty prefix every drain iteration, re-examining every earlier interaction with `denseSvCheck?`. `DenseNativeStep.drain`'s state parameter is generic and was sitting at `Unit`. Skipping is output-preserving: `pre` holds no *packable* single-value check (each was walked past as unrecognised or partnerless, and a pack only removes single-value checks) and the emitted `.pair` check is not one either. **keccak: bytePack 596 → 188 ms, bytePackLate 70 → 10 ms.**

## Verification

- `lake build` clean with no warnings and `Scripts/check-proof-integrity.sh` green on every commit.
- **The CI effectiveness matrix reports per-case circuit sizes identical to main on all six benchmark sets** (openvm-eth, wasm-eth, keccak, sha256, sp1/rsp, sp1/keccak) — stronger than the four spot-checked `opt-export` diffs, which are also byte-identical.
- Serial `Runtime Bench` (openvm-eth, 100 cases): total 0.99×, with `busUnify` 0.96×, `bytePack` 0.93×, `dedup` 0.90×, `disconnected` 0.91×, `subsumedCheck` 0.76× — small consistent wins across the board.
- The audited surface and `Basic.lean` are untouched; the Lean diff is 193 lines across 7 files, all under `Implementation/OptimizerPasses/`.

## What the instrument found, which is the most useful output here

**`reencode` (exponent 2.36) and `domainFold` (2.07) own the exponent — together 83 % of the k=4 run.** Every other pass now sits at 1.0–1.25, at or near the allocation floor. This PR does not fix those two, and the numbers say that is where all remaining runtime value is.

The ladder also isolates *why*: under disjoint replication a variable's index bucket does not grow, so per-variable lookups contribute only linearly. What grows is the **per-accept whole-system work** — `denseReencodeOut` rewrites the entire system, then the accept rebuilds `denseBuildPruned` + `arrCs.toArray` + `HashSet.ofList ro.occ` + `denseBuildUseIdx`, each O(system) — and the number of accepts scales with `k`. O(accepts) × O(system) = O(k²). That is exactly the shape entry 109 removed from `domainFold`, and `ideas.md` R3 already names `reencode` as the next candidate. `domainFold` still measuring 2.07 after #206 says its own per-accept path retains an O(system) term too.

Recorded in `ideas.md` as the top runtime priority, ahead of everything in R1–R12.

## One measured dead end, so it is not retried

R8's natural reading — start the shield scan at the last live provable same-address receive instead of at 0 — was simulated against the real exports and buys **nothing**: Σ(i−q)/Σi = 1.00 on the execution bridge with real positions, 1.00–1.01× under realistic memory-key models. The pass drops the send *and* its matching receive, so the last surviving same-key receive collapses back to each key's first access. (The "gap = 1 at p100" figure that suggested otherwise measures the *between*-region `j − i − 1`.) The hint lookup also reintroduces Θ(N) on a one-bucket `denseAddrHash`. R8 is re-scoped to the design that does work — a monotone per-key watermark, which the drop protocol provably does not invalidate — with the lemmas it needs enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdrwAL7S5jwmeibazAxwcd