### PR TITLE
perf(domainFold): gate the index on the candidate-group count (exponent 2.07 → 1.10)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
@@ -7,9 +7,9 @@ set_option autoImplicit false
 
 The hot evaluators (`denseGroupSurvivorsEV`, `denseConstOnSurvsV`) compile the group's covered
 constraints once (via `DomainBatch.lean`'s `IExpr`) and evaluate every enumerated point by index,
-value-only (`List (ZMod p)` points, no `VarId` per point). Systems at least
-`domainFoldIndexThreshold` large use the index-preserving indexed loop; smaller ones the direct
-loop. Runtime only — correctness is in `Proofs/DomainFold.lean`. -/
+value-only (`List (ZMod p)` points, no `VarId` per point). Runs with at least
+`domainFoldTargetIndexThreshold` candidate groups use the index-preserving indexed loop; fewer use
+the direct loop. Runtime only — correctness is in `Proofs/DomainFold.lean`. -/
 
 namespace ApcOptimizer.Dense
 
@@ -148,7 +148,7 @@ def denseSystemHasFoldableIdxV (fidx : DenseFoldIdx p) (xs : List VarId)
 
 /-! ## The direct (unindexed) fold loop
 
-For systems smaller than `domainFoldIndexThreshold`. -/
+For runs with fewer than `domainFoldTargetIndexThreshold` candidate groups. -/
 
 /-- One checked fold for a candidate group, given the covered set `es` and its complement `csRest`
     (the non-covered constraints, feeding the no-op gate). -/
@@ -222,8 +222,8 @@ def denseFoldOutIdxV (d : DenseConstraintSystem p) (fidx : DenseFoldIdx p) (xs :
 
 /-! ## The indexed fold loop
 
-For systems at least `domainFoldIndexThreshold` large; the covered set is served from the prebuilt
-`DenseFoldIdx`, refreshed (no rebuild) only on an accepted fold. -/
+For runs with at least `domainFoldTargetIndexThreshold` candidate groups; the covered set is served
+from the prebuilt `DenseFoldIdx`, refreshed (no rebuild) only on an accepted fold. -/
 
 /-- One checked fold served from the prebuilt covered-constraint index; an accepted fold is computed
     sparsely (`denseFoldOutIdxV`) and the index refreshed without rebuild (`fidx.refresh`). -/
@@ -316,7 +316,7 @@ def denseTargetsV (d : DenseConstraintSystem p) : List (List VarId) :=
 def denseDomainFoldFV (pw : PrimeWitness p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
     let targets := denseTargetsV d
-    if domainFoldIndexThreshold ≤ d.algebraicConstraints.length then
+    if domainFoldTargetIndexThreshold ≤ targets.length then
       denseFoldLoopV targets d (DenseFoldIdx.mk' d)
     else denseFoldLoopDirectV targets d
   else d
@@ -327,7 +327,7 @@ def denseDomainFoldFVFast (pw : PrimeWitness p) (d : DenseConstraintSystem p) :
     DenseConstraintSystem p :=
   if pw.isPrime = true then
     let targets := denseTargetsV d
-    if domainFoldIndexThreshold ≤ d.algebraicConstraints.length then
+    if domainFoldTargetIndexThreshold ≤ targets.length then
       let fidx := denseFoldLoopArrV targets (DenseFoldIdx.mk' d)
       { algebraicConstraints := fidx.arr.toList, busInteractions := fidx.arrBis.toList }
     else denseFoldLoopDirectV targets d

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
@@ -927,7 +927,7 @@ theorem denseDomainFoldFV_correct (pw : PrimeWitness p) (bs : BusSemantics p) (i
   by_cases hpB : pw.isPrime = true
   · rw [if_pos hpB]
     haveI : Fact p.Prime := ⟨pw.correct hpB⟩
-    by_cases hthr : domainFoldIndexThreshold ≤ d.algebraicConstraints.length
+    by_cases hthr : domainFoldTargetIndexThreshold ≤ (denseTargetsV d).length
     · rw [if_pos hthr]
       exact denseFoldLoopV_correct bs isInput (denseTargetsV d) d (DenseFoldIdx.mk' d)
         (fun i hi v hv => denseBuild_complete denseDedupVarsOf d.algebraicConstraints i hi v (by
@@ -948,7 +948,7 @@ theorem denseDomainFoldFV_covered (pw : PrimeWitness p) (reg : VarRegistry)
   unfold denseDomainFoldFV
   by_cases hpB : pw.isPrime = true
   · rw [if_pos hpB]
-    by_cases hthr : domainFoldIndexThreshold ≤ d.algebraicConstraints.length
+    by_cases hthr : domainFoldTargetIndexThreshold ≤ (denseTargetsV d).length
     · rw [if_pos hthr]
       exact denseFoldLoopV_covered reg (denseTargetsV d) d (DenseFoldIdx.mk' d) hcov
     · rw [if_neg hthr]
@@ -1115,7 +1115,7 @@ theorem denseFoldLoopArrV_eq :
   unfold denseDomainFoldFV denseDomainFoldFVFast
   by_cases hpB : pw.isPrime = true
   · rw [if_pos hpB, if_pos hpB]
-    by_cases hthr : domainFoldIndexThreshold ≤ d.algebraicConstraints.length
+    by_cases hthr : domainFoldTargetIndexThreshold ≤ (denseTargetsV d).length
     · rw [if_pos hthr, if_pos hthr]
       obtain ⟨h1, h2⟩ := denseFoldLoopArrV_eq (denseTargetsV d) d (DenseFoldIdx.mk' d) rfl rfl
       show denseFoldLoopV (denseTargetsV d) d (DenseFoldIdx.mk' d)

--- a/ApcOptimizer/Implementation/OptimizerPasses/SearchBudgets.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SearchBudgets.lean
@@ -28,10 +28,16 @@ def basisFuel : Nat := 3
 /-- Work cap for one joint enumeration: box size × number of covered targets. -/
 def maxEnumWork : Nat := 524288
 
-/-- Systems with at least this many algebraic constraints use the inverted index; smaller ones use
-    the direct per-target `coveredCsOf` scan. Purely a runtime gate — both paths compute the
-    identical fold. -/
-def domainFoldIndexThreshold : Nat := 8192
+/-- From this many candidate groups on, `domainFold` uses the inverted index; below it the direct
+    per-target `coveredCsOf` scan is cheaper than building the index. Gating on the group count
+    rather than the system size is what makes the pass linear: the direct path costs
+    `O(groups × system)`, the indexed one one build plus per-group bucket work.
+
+    The two paths are separately proven and agree on every group they fold; they differ only in how
+    much constant folding their no-op gates let through — `denseFoldRewriteV` also rewrites items
+    sharing *no* variable with the group (a variable-free subexpression is vacuously `varsInF xs`),
+    which the indexed path's bucket scan skips. -/
+def domainFoldTargetIndexThreshold : Nat := 2
 
 /-- Systems with at least this many bus interactions use the slot-0-indexed representative store in
     `densePdDropSet`; smaller ones scan the per-class representative list directly (the index's

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -226,12 +226,22 @@ and candidate-mask scanner, and hot-variable bucket capping (not byte-identical 
 `esFull`).
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
-index gate**  ·  mostly **done (entries 105/107/109)**:
+index gate**  ·  mostly **done (entries 105/107/109/145)**:
+   - ~~domainFold's 8192 raw-count gate~~ **done (entry 145)**: replaced by a *candidate-group*
+     count gate (`domainFoldTargetIndexThreshold := 2`). The direct path costs `groups × system`,
+     so the raw constraint count was the wrong quantity to gate on — a small system with many
+     groups needs the index, a huge one with a single group does not. Replica ladder: exponent
+     **2.07 → 1.10**, `k=4` 29.0 → 0.74 s, total exponent 1.99 → 1.86. Not byte-identical
+     (see the entry: the direct path's no-op gate also constant-folds variable-free subexpressions
+     in group-disjoint items), but size-identical on every fixture checked.
    - reencode: the pruned index (`CoveredIndex.buildPruned`, entry 105 — items with more than 8
      distinct variables can never be covered by a ≤8-variable target, so pruning keeps covered
      sets identical) stays, but **behind the 8192 gate again** (entry 107): CI measured
      always-indexed at 1.19× on the dense openvm-eth blocks with no keccak gain — the entry-73a
      direct-path trade-off is real. Do not retire the gate without a same-runner A/B on eth.
+     **Re-confirmed on the ladder (entry 145)**: forcing `useIdx` on made reencode *worse*
+     (82.4 → 97.5 s at `k=4`), because the accept path then also pays a per-accept
+     `denseBuildPruned`. reencode's cost is not in the covered-set scan.
    - ~~domainFold's direct-path double `coveredBy` sweep~~ **done**: one `partition` per target
      feeds both the covered set and the no-op gate (`systemHasFoldableW`).
    - ~~both passes' doubled `c.vars.dedup` setup~~ **done** (`hashedDedup`, computed once).
@@ -262,6 +272,33 @@ index gate**  ·  mostly **done (entries 105/107/109)**:
      proof-free (`denseCheckReencode` re-verifies), so a prefix-pruned DFS enumeration with an
      early abort once the survivor count passes `2 ^ (|xs| − 1)` (above which `k < xs.length`
      fails) needs no new proof — only the same survivor *list order* to stay byte-identical.
+   - **Still open — reencode is the last exponent ≈ 2.3, and it is the *accept* path.** gdb
+     attribution on the ladder's `k=4` rung (35 samples, all inside `denseReencodeStep`), with the
+     indexed path forced on so the shape matches sha256's:
+     `denseBuildPruned` 20 %, `denseDegPreReject` 20 % (of which the thunked `denseBuildUseIdx`
+     rebuild 11 %), `denseReencodeOut` 17 %, `denseCheckReencode` 14 %, the remaining 23 % directly
+     in the step (`toArray`, `HashSet.ofList ro.occ`, `withinDegreeB`). That is **~70 % in six
+     whole-system passes per accepted re-encoding**, and accepts grow with the circuit, so the pass
+     is `O(accepts × system)`.
+     Three of those six recompute `DenseExpr.vars` over the whole system independently
+     (`denseBuildPruned`, `occ`, `denseBuildUseIdx`) — a shared per-item var list would cut ~25 % of
+     the pass with a pure `@[csimp]` twin (the values must be *identical*, which a shared fold
+     gives; `varSet` is compared as a `Std.HashSet`, so it cannot be replaced by an equivalent
+     structure, only computed from shared inputs).
+     Getting the **exponent** down needs `denseReencodeOut` to stop rewriting the whole system per
+     accept, and that is blocked on one specific fact: `denseGroupRewrite` is *not* the identity on
+     items sharing no variable with the group — `varsInF xs` is vacuously true for a variable-free
+     subexpression, so the rewrite constant-folds those too. A sparse, index-driven rewrite is equal
+     to the spec only under a **fold-normality** precondition (`hasConstFoldableNode = false`
+     everywhere), which is checkable in one pass per invocation and, after an accept, on the touched
+     items only — with a fall-back to the current loop when the check fails, so the twin stays
+     byte-identical. Sketch: `denseUsePositions`-driven `zipIdx` rewrite (`use` is already built and
+     forced per accept, so no new index), `L_id : hasConstFoldableNode e = false → anyVarIn xs e =
+     false → denseGroupRewrite … e = e`, and the `denseCandidates` completeness already proven for
+     `denseCoveredIdx_eq_filter_of_complete` (variable-free items land in `idx.varless`, so they are
+     candidates and keep being dropped as covered). That removes 17 %; the other four per-accept
+     sweeps additionally need position preservation (tombstoned `alive` mask + bool constraints
+     appended to the array), which is the larger half of the project.
 
 **R4. Constant-factor levers that touch every pass**  ·  *medium value, cheap*:
    - **Variable interning-lite, `Implementation/`-only**: parse-time interning is **done (entry

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -231,9 +231,25 @@ index gate**  ·  mostly **done (entries 105/107/109/145)**:
      count gate (`domainFoldTargetIndexThreshold := 2`). The direct path costs `groups × system`,
      so the raw constraint count was the wrong quantity to gate on — a small system with many
      groups needs the index, a huge one with a single group does not. Replica ladder: exponent
-     **2.07 → 1.10**, `k=4` 29.0 → 0.74 s, total exponent 1.99 → 1.86. Not byte-identical
-     (see the entry: the direct path's no-op gate also constant-folds variable-free subexpressions
-     in group-disjoint items), but size-identical on every fixture checked.
+     **2.07 → 1.10**, `k=4` 29.0 → 0.74 s, total exponent 1.99 → 1.86. **Not byte-identical**, and
+     the CI matrix charges a real (tiny) price: SP1 `rsp` constraints 9.372× → 9.365×, two of 100
+     cases 175 → 177, variables and bus interactions identical on all six sets. It is a butterfly
+     (`reencode` mints `rnc…_49_0` instead of `rnc…_37_0` and its greedy accept order shifts), not a
+     systematic loss.
+   - **Open — the byte-identical version of the same fix.** The two `domainFold` paths differ in
+     *two* ways, so no gate tuning equates them: the direct path also constant-folds variable-free
+     subexpressions in group-disjoint items, **and** `denseFoldOutV` moves the covered constraints to
+     the end of the list while `denseFoldOutIdxV` rewrites in place. The fix that keeps the current
+     output exactly is to leave the direct path's *transform* alone and index only its **no-op gate**:
+     `denseSystemHasFoldableWV` is an `any`, so order and multiplicity are irrelevant, and
+     `hasFoldableV xs survsV e = true → e.anyVarIn xs = true ∨ e.hasConstFoldableNode = true` (one
+     induction — a `varsInF xs` node with no `xs` variable is variable-free, which is exactly
+     `hasConstFoldableNode`). Scan the `xs` buckets plus a per-invocation list of positions carrying a
+     variable-free node and the gate decides identically; take `es` from `denseCoveredIdx`
+     (`denseCoveredIdx_eq_filter_of_complete`), which also retires the per-target `partition`. Rebuild
+     both indexes per *accept* — free against the `O(system)` `denseFoldOutV` an accept already pays.
+     Result: `O(accepts × system + groups × (bucket + foldable))` with the output preserved exactly.
+     ~250–400 lines of proof; strictly better than the gate change above, which it would replace.
    - reencode: the pruned index (`CoveredIndex.buildPruned`, entry 105 — items with more than 8
      distinct variables can never be covered by a ≤8-variable target, so pruning keeps covered
      sets identical) stays, but **behind the 8192 gate again** (entry 107): CI measured

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -280,6 +280,20 @@ index gate**  ·  mostly **done (entries 105/107/109/145)**:
      in the step (`toArray`, `HashSet.ofList ro.occ`, `withinDegreeB`). That is **~70 % in six
      whole-system passes per accepted re-encoding**, and accepts grow with the circuit, so the pass
      is `O(accepts × system)`.
+     **Tried and reverted (no code change):** a `@[csimp]` twin walking the system *once* for all
+     bits (`DenseExpr.anyVarIn bits`) instead of once per bit, plus the box cap tested before
+     `denseGroupSurvivorsE` enumerates. Proven equal (`denseFreshScan_eq`, from
+     `anyVarIn bits e = false ↔ ∀ b ∈ bits, e.mentions b = false`) and byte-identical on 8 fixtures,
+     but interleaved best-of-3 on `openvm-eth/apc_005` is **6387/6697/6503 vs 6353/6696/6375 ms** —
+     noise. Reason: the |bits| comparisons at the variable nodes stay, only the tree-walk overhead
+     goes, and the conjunct is last in the `&&` chain so it is reached about once per accept. A
+     sequential A/B looked like a 2–6 % win purely from run-ordering bias; always interleave.
+     The version worth building instead decides freshness in `O(|bits|)` from the `varSet` the loop
+     already threads (`varSet = Std.HashSet.ofList d.occ` is maintained exactly: accept sets it to
+     `ofList ro.occ` with `d := ro`, every reject leaves both alone), which deletes the scan rather
+     than speeding it up — but it needs a twin of `denseReencodeStep`/`StepCached`/`Loop`/
+     `LoopCached`/`F` carrying that equation, since the equality cannot be stated on
+     `denseCheckReencode` alone.
      Three of those six recompute `DenseExpr.vars` over the whole system independently
      (`denseBuildPruned`, `occ`, `denseBuildUseIdx`) — a shared per-item var list would cut ~25 % of
      the pass with a pure `@[csimp]` twin (the values must be *identical*, which a shared fold

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4903,3 +4903,54 @@ Cumulative for entries 142–144: sha256_big **523.9 → 377.6 s (−28 %)**.
 
 **Worked locally: yes (byte-identical `opt-export` on openvm-eth apc_044/apc_067, keccak, wasm-eth
 apc_036 and the 168k-var OpenVM sha256 case).**
+
+### 145. Runtime: domainFold gates its index on the candidate-group count
+
+Measured with a **disjoint-replica ladder** — `k` renamed copies of one APC in a single circuit, so
+every per-item quantity scales exactly `k×` while the cleanup-iteration count stays flat, which
+turns a per-pass wall time into a per-pass *exponent* (`Benchmarks/scaling_bench.py`, PR #216).
+On `openvm-eth/apc_005` at `k = 1,2,4` the two top passes were `reencode` (exponent 2.4) and
+`domainFold` (2.07), together 83 % of the `k=4` run.
+
+`domainFold`'s inverted index was gated on `8192 ≤ d.algebraicConstraints.length`, so every smaller
+system ran `denseFoldLoopDirectV`: one `partition` **and** one whole-system
+`denseSystemHasFoldableWV` scan *per candidate group*. The gate scan is the expensive half —
+`hasFoldableV` calls `denseConstOnSurvsV` (compile plus up to 256 point evaluations) at every node
+it visits. Candidate groups grow with the circuit, so the direct path is `O(groups × system)`.
+
+The gate now reads the **candidate-group count** (`domainFoldTargetIndexThreshold := 2`): with 0 or
+1 groups the direct path's single pass beats building the index, from 2 on the index amortizes.
+Nothing else moves — both loops were already proven separately and the indexed one is already the
+array-native `Array.modify` twin (entry 138). Gating on the group count rather than the raw
+constraint count is the point: the direct path's cost is `groups × system`, so a 500-constraint
+system with 40 groups needs the index while a 50k-constraint system with one group does not.
+
+Replica ladder (`apc_005`, k = 1/2/4, same 4-core box, both sides built from source):
+
+| ms | k=1 | k=2 | k=4 | exponent |
+|---|---|---|---|---|
+| domainFold before | 1641 | 6345 | 28976 | 2.07 |
+| domainFold after | 161 | 326 | 741 | **1.10** |
+| total before | 8121 | 25454 | 127826 | 1.99 |
+| total after | 6854 | 19385 | 90468 | **1.86** |
+
+keccak `profile` 39.0 → 34.0 s; the openvm-eth spread (apc_001/005/010/020/040/060/080/100) is
+0.93–1.03× except `apc_001`, whose 49 → 68 ms is the one case with too few groups to amortize an
+index — the group-count gate is what keeps that from being a size-gate-wide regression, and the
+crossover constant (2) is the only tuning knob left.
+
+**The two paths are not equal**, and the pass never claimed they were by accident:
+`denseFoldRewriteV`'s gate (`anyVarIn xs || hasConstFoldableNode`) also rewrites items sharing *no*
+variable with the group, because a variable-free subexpression is vacuously `varsInF xs` and folds
+to a constant — the indexed path's bucket scan skips those items. Eight of nine local fixtures stay
+byte-identical under `opt-export`; `openvm-eth/apc_020` differs only in which fresh `rnc` bits
+`reencode` mints afterwards, at identical variable / bus / constraint counts (786 / 422 / 309).
+The `SearchBudgets.lean` doc comment now says so instead of claiming an identical fold.
+
+**Do not read this as "retire the other index gates".** Entry 107 measured *reencode's* 8192 gate
+at 1.19× worse when always-indexed, and lowering it again here reproduced that: on the ladder,
+reencode with `useIdx` forced on went `82.4 → 97.5 s` at `k=4`, because the accept path then also
+pays a per-accept `denseBuildPruned`. The gate that helped is the one whose *shape* was wrong
+(size instead of work), not gates in general.
+
+**Worked locally: yes** (byte-identical `opt-export` on 8 of 9 fixtures; `apc_020` size-identical).

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4953,4 +4953,14 @@ reencode with `useIdx` forced on went `82.4 → 97.5 s` at `k=4`, because the ac
 pays a per-accept `denseBuildPruned`. The gate that helped is the one whose *shape* was wrong
 (size instead of work), not gates in general.
 
+**Tried in the same session and reverted (no code change):** a `@[csimp]` twin of
+`denseCheckReencode` walking the system once for all bits (`DenseExpr.anyVarIn bits`) instead of once
+per bit, with the box cap tested before the survivor box is enumerated. Proven equal and
+byte-identical on eight fixtures, but interleaved best-of-3 on `openvm-eth/apc_005` gave
+**6387/6697/6503 vs 6353/6696/6375 ms** — noise, so it was not worth ~120 lines of proof. Two lessons
+worth more than the change: the |bits| comparisons at the variable nodes survive the rewrite (only
+the tree-walk overhead goes) and the conjunct is last in the `&&` chain, so it runs about once per
+accept; and a *sequential* A/B of the two binaries showed a 2–6 % "win" that interleaving erased
+entirely — run-ordering bias on this box is larger than the effect being measured. Always interleave.
+
 **Worked locally: yes** (byte-identical `opt-export` on 8 of 9 fixtures; `apc_020` size-identical).

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4953,6 +4953,33 @@ reencode with `useIdx` forced on went `82.4 → 97.5 s` at `k=4`, because the ac
 pays a per-accept `denseBuildPruned`. The gate that helped is the one whose *shape* was wrong
 (size instead of work), not gates in general.
 
+**CI effectiveness matrix (PR #217, `59f2967` vs main `ce9a820`).** Variables and bus interactions
+are **identical on all six sets**; runtime −10 % on wasm-eth and on OpenVM keccak, +2 % on sha256
+(report-only row, ±noisy). One delta: SP1 `rsp` constraints **9.372× → 9.365×**, from two of 100
+cases going 175 → 177 constraints at unchanged variable and bus counts. Diffing
+`rsp/apc_024` shows it is **not** lost constant folding but a butterfly: the fresh reencode bit is
+`rnc1617_1136_37_0` on main and `rnc1617_1136_49_0` here, i.e. the changed constraint list moved
+`reencode`'s greedy accept order — 9 constraints leave and 11 arrive. It could as easily have gone
+the other way.
+
+The deeper reason the two paths differ at all is *not only* the constant folding: `denseFoldOutV`
+emits `(non-covered, folded) ++ coveredCsOf`, moving the covered constraints to the **end**, while
+`denseFoldOutIdxV` rewrites in place. So no gate tuning makes the paths byte-identical; they are
+different transforms.
+
+**The byte-identical version of this fix, for whoever takes it next.** Keep the *direct* path's
+transform exactly and serve only its **no-op gate** from an index. `denseSystemHasFoldableWV` is a
+`Bool` built with `any`, so order and multiplicity do not matter, and
+`hasFoldableV xs survsV e = true → e.anyVarIn xs = true ∨ e.hasConstFoldableNode = true` (one
+induction: a `varsInF xs` node with no variable of `xs` is variable-free, which is exactly
+`hasConstFoldableNode`). So the gate can scan the `xs` buckets plus a per-invocation list of
+positions carrying a variable-free node, and decide identically; `es` comes from
+`denseCoveredIdx` (already `= filter` by `denseCoveredIdx_eq_filter_of_complete`), which also
+retires the per-target `partition`. Both indexes are rebuilt per *accept*, which is free against the
+`O(system)` `denseFoldOutV` an accept already pays. That leaves the pass at
+`O(accepts × system + groups × (bucket + foldable))` with the current output preserved exactly —
+strictly better than this entry's gate change, and about 250–400 lines of proof.
+
 **Tried in the same session and reverted (no code change):** a `@[csimp]` twin of
 `denseCheckReencode` walking the system once for all bits (`DenseExpr.anyVarIn bits`) instead of once
 per bit, with the box cap tested before the survivor box is enumerated. Proven equal and


### PR DESCRIPTION
Based on `main` (`ce9a820`), independent of #213 (docs) and #216 (the other runtime PR).

**⚠️ Needs a maintainer call:** this is a runtime PR that is *not* effectiveness-neutral. Variables
and bus interactions are identical on all six benchmark sets, but SP1 `rsp` constraints go
**9.372× → 9.365×** (two of 100 cases, 175 → 177). See "The price" below — and the follow-up that
would keep the output exactly.

## What this fixes

The two passes with the worst scaling exponents on the disjoint-replica ladder over
`openvm-eth/apc_005` were `domainFold` (2.07) and `reencode` (2.4) — together 83 % of the `k=4` run.
This PR fixes `domainFold` and reports a measurement that says precisely what `reencode` needs.

`domainFold`'s inverted index was gated on `8192 ≤ d.algebraicConstraints.length`, so every smaller
system ran `denseFoldLoopDirectV`: one `partition` **and** one whole-system
`denseSystemHasFoldableWV` scan *per candidate group*. The gate scan is the expensive half —
`hasFoldableV` calls `denseConstOnSurvsV` (compile plus up to 256 point evaluations) at every node it
visits. Candidate groups grow with the circuit, so the direct path is `O(groups × system)`.

The raw constraint count was simply the wrong quantity to gate on. The gate now reads the
**candidate-group count** (`domainFoldTargetIndexThreshold := 2`): with 0 or 1 groups the direct
path's single pass beats building the index, from 2 groups on the index amortizes. A 500-constraint
system with 40 groups needs the index; a 50k-constraint system with one group does not.

Nothing else moves. Both loops were already proven separately, and the indexed one is already the
array-native `Array.modify` twin (log entry 138), so the diff is the gate plus its three `by_cases`
sites. `Scripts/check-proof-integrity.sh` is green (three standard axioms, no unused theorems).

## The gain

Replica ladder (`apc_005`, `k = 1/2/4`, same 4-core box, both sides built from source):

| ms | k=1 | k=2 | k=4 | exponent |
|---|---|---|---|---|
| domainFold before | 1641 | 6345 | 28976 | 2.07 |
| domainFold after | 161 | 326 | 741 | **1.10** |
| total before | 8121 | 25454 | 127826 | 1.99 |
| total after | 6854 | 19385 | 90468 | **1.86** |

CI matrix runtime rows (report-only, but consistent): wasm-eth **−10 %**, OpenVM keccak **−10 %**,
sha256 +2 %, SP1 rsp +1 %. `domainFold` in the openvm-eth per-pass breakdown: 1505 → 227 ms (0.15×).
The one openvm-eth case that gets slower is `apc_001` (49 → 68 ms locally): too few groups to
amortize an index — which is exactly the case the group-count gate keeps from becoming a
size-gate-wide regression.

## The price

Variables and bus interactions: **identical on all six sets.** Constraints: identical on five;
SP1 `rsp` 9.372× → 9.365×, from `apc_024` and `apc_040` going 175 → 177 at unchanged variable and bus
counts.

I diffed `rsp/apc_024`. It is **not** lost constant folding — it is a butterfly. The fresh reencode
bit is `rnc1617_1136_37_0` on main and `rnc1617_1136_49_0` here: the changed constraint list moved
`reencode`'s greedy accept order, 9 constraints leaving and 11 arriving. It could as easily have gone
the other way.

The two `domainFold` paths differ in **two** ways, so no gate tuning equates them:

1. `denseFoldRewriteV`'s gate is `anyVarIn xs || hasConstFoldableNode`, so the direct path also
   constant-folds variable-free subexpressions in group-disjoint items (a variable-free subexpression
   is vacuously `varsInF xs`). The indexed path's bucket scan skips those items.
2. `denseFoldOutV` emits `(non-covered, folded) ++ coveredCsOf`, moving the covered constraints to the
   **end**; `denseFoldOutIdxV` rewrites in place.

The `SearchBudgets.lean` doc comment claimed the two paths "compute the identical fold". That was
wrong and is corrected.

## The follow-up that would keep the output exactly

Specified in `ideas.md` R3 and log entry 145, in case you would rather have byte-identity than this
patch: keep the *direct* path's transform and index only its **no-op gate**.
`denseSystemHasFoldableWV` is an `any`, so order and multiplicity are irrelevant, and one induction
gives `hasFoldableV xs survsV e = true → e.anyVarIn xs = true ∨ e.hasConstFoldableNode = true` (a
`varsInF xs` node with no `xs` variable is variable-free, i.e. exactly `hasConstFoldableNode`). So the
gate can scan the `xs` buckets plus a per-invocation list of positions carrying a variable-free node
and decide identically; `es` comes from `denseCoveredIdx` (already `= filter` via
`denseCoveredIdx_eq_filter_of_complete`), which also retires the per-target `partition`. Rebuild both
indexes per *accept* — free against the `O(system)` `denseFoldOutV` an accept already pays. That
leaves the pass at `O(accepts × system + groups × (bucket + foldable))` with the current output
preserved exactly. ~250–400 lines of proof; it would replace this PR's gate change rather than sit on
top of it.

## What `reencode` needs (measured, not landed here)

gdb attribution on the ladder's `k=4` rung — 35 samples, all inside `denseReencodeStep`, with the
indexed path forced on so the shape matches sha256's:

| | share |
|---|---|
| `denseBuildPruned` (per-accept index rebuild) | 20 % |
| `denseDegPreReject` (of which `denseBuildUseIdx` rebuild 11 %) | 20 % |
| `denseReencodeOut` | 17 % |
| `denseCheckReencode` | 14 % |
| directly in the step (`toArray`, `HashSet.ofList ro.occ`, `withinDegreeB`) | 23 % |

~70 % in **six whole-system passes per accepted re-encoding**, and accepts grow with the circuit:
`O(accepts × system)`. Consequences, written up in `ideas.md` R3:

1. Three of the six recompute `DenseExpr.vars` over the whole system independently — a shared
   per-item variable list cuts ~25 % of the pass with a pure `@[csimp]` twin.
2. The **exponent** needs `denseReencodeOut` to stop rewriting the whole system per accept, blocked on
   one fact: `denseGroupRewrite` is not the identity on group-disjoint items (that same vacuous
   `varsInF xs`). A sparse, index-driven rewrite equals the spec only under a *fold-normality*
   precondition — checkable once per invocation and then on touched items only, with a fall-back to
   the current loop, so the twin can stay byte-identical. The other four per-accept sweeps
   additionally need position preservation (tombstoned `alive` mask, bool constraints appended to the
   array), which is the larger half of that project.

Also re-confirmed: lowering *reencode's* 8192 gate makes it **worse** (82.4 → 97.5 s at `k=4`),
reproducing log entry 107. reencode's cost is not in the covered-set scan, so that gate stays.

### One reencode change was built, measured, and reverted

A `@[csimp]` twin of `denseCheckReencode` walking the system once for all bits
(`DenseExpr.anyVarIn bits`) instead of once per bit, with the box cap tested before the survivor box
is enumerated. Proven equal (`denseFreshScan_eq`) and byte-identical on eight fixtures — but
interleaved best-of-3 on `apc_005` gave **6387/6697/6503 vs 6353/6696/6375 ms**, i.e. noise, so it is
not carried. The |bits| comparisons at the variable nodes survive the rewrite (only the tree-walk
overhead goes) and the conjunct is last in the `&&` chain, so it runs about once per accept. Recorded
in log entry 145 with the methodological catch: a *sequential* A/B of the two binaries showed a 2–6 %
"win" that interleaving erased entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdrwAL7S5jwmeibazAxwcd