### PR TITLE
perf(reencode): accept path skips items the rewrite provably cannot change

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1245,6 +1245,154 @@ theorem denseCheckReencode_polyVars (d : DenseConstraintSystem p) (xs bits : Lis
     ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs hm)).vars, v ∈ bits := by
   grind [denseCheckReencode, List.contains_iff_mem]
 
+/-- `denseBuildPruned` recomputed the item's variable list for the prune test and then again inside
+    `denseBuildStep`; the compiled body shares one. -/
+@[csimp] theorem denseBuildPruned_eq_fast : @denseBuildPruned = @denseBuildPrunedFast := by
+  funext α varsOf maxVars items
+  rw [denseBuildPruned, denseBuildPrunedFast]
+  refine congrArg (fun f => items.zipIdx.foldr f (⟨∅, []⟩ : DenseCovIndex)) ?_
+  funext ai idx
+  rfl
+
+/-! ### The sparse accept path equals `denseReencodeOut` on a fold-normal system -/
+
+/-- An expression with a variable, none of them in `xs`, is not wholly inside `xs`. -/
+theorem denseVarsInF_false_of_disjoint (xs : List VarId) :
+    ∀ (e : DenseExpr p), e.hasVar = true → e.anyVarIn xs = false → e.varsInF xs = false := by
+  intro e
+  induction e with
+  | const n => intro h; simp [DenseExpr.hasVar] at h
+  | var y => intro _ h; simpa [DenseExpr.varsInF] using h
+  | add e₁ e₂ ih₁ ih₂ =>
+      intro hv hd
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hd
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.varsInF, Bool.and_eq_false_iff]
+      rcases hv with hv | hv
+      · exact Or.inl (ih₁ hv hd.1)
+      · exact Or.inr (ih₂ hv hd.2)
+  | mul e₁ e₂ ih₁ ih₂ =>
+      intro hv hd
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hd
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.varsInF, Bool.and_eq_false_iff]
+      rcases hv with hv | hv
+      · exact Or.inl (ih₁ hv hd.1)
+      · exact Or.inr (ih₂ hv hd.2)
+
+/-- Nothing sharing no variable with the group is covered by it. -/
+theorem denseCoveredBy_false_of_disjoint (xs : List VarId) (e : DenseExpr p)
+    (hd : e.anyVarIn xs = false) : denseCoveredBy xs e = false := by
+  simp only [denseCoveredBy, Bool.and_eq_false_iff]
+  cases hv : e.hasVar with
+  | false => exact Or.inl rfl
+  | true => exact Or.inr (denseVarsInF_false_of_disjoint xs e hv hd)
+
+/-- **The identity the sparse rewrite rests on.** `denseGroupRewrite` leaves an expression alone
+    when it shares no variable with the group *and* has no variable-free node left to fold — the
+    second condition is needed because `varsInF xs` holds vacuously on a variable-free node, which
+    would otherwise be replaced by its constant value. -/
+theorem denseGroupRewrite_id_of_disjoint (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) :
+    ∀ (e : DenseExpr p), e.anyVarIn xs = false → e.hasConstFoldableNode = false →
+      denseGroupRewrite xs bits σfn patts e = e := by
+  intro e
+  induction e with
+  | const n => intro _ _; rfl
+  | var y =>
+      intro hd _
+      simp only [DenseExpr.anyVarIn] at hd
+      rw [denseGroupRewrite, if_neg (by simp [hd])]
+  | add e₁ e₂ ih₁ ih₂ =>
+      intro hd hf
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hd
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff, Bool.not_eq_false'] at hf
+      obtain ⟨⟨hv, hf₁⟩, hf₂⟩ := hf
+      rw [denseGroupRewrite,
+        if_neg (by simp [denseVarsInF_false_of_disjoint xs _ hv (by
+          simp [DenseExpr.anyVarIn, hd.1, hd.2])]),
+        ih₁ hd.1 hf₁, ih₂ hd.2 hf₂]
+  | mul e₁ e₂ ih₁ ih₂ =>
+      intro hd hf
+      simp only [DenseExpr.anyVarIn, Bool.or_eq_false_iff] at hd
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff, Bool.not_eq_false'] at hf
+      obtain ⟨⟨hv, hf₁⟩, hf₂⟩ := hf
+      rw [denseGroupRewrite,
+        if_neg (by simp [denseVarsInF_false_of_disjoint xs _ hv (by
+          simp [DenseExpr.anyVarIn, hd.1, hd.2])]),
+        ih₁ hd.1 hf₁, ih₂ hd.2 hf₂]
+
+/-- The sparse accept path equals the dense one for *any* rewrite and keep-test that fix the items
+    the test rejects. Stated over abstract `rwf`/`keepCs`/`keepBis` so the instantiation below is a
+    direct application: with the concrete terms in place the unifier has to look inside
+    `denseGroupRewrite`, which does not elaborate in reasonable time. -/
+theorem denseSparseOut_eq (d : DenseConstraintSystem p) (xs : List VarId)
+    (rwf : DenseExpr p → DenseExpr p) (extra : List (DenseExpr p))
+    (keepCs : DenseExpr p → Bool) (keepBis : BusInteraction (DenseExpr p) → Bool)
+    (hcs : ∀ c ∈ d.algebraicConstraints, keepCs c = false →
+      denseCoveredBy xs c = false ∧ rwf c = c)
+    (hbis : ∀ bi ∈ d.busInteractions, keepBis bi = false →
+      rwf bi.multiplicity = bi.multiplicity ∧ ∀ e ∈ bi.payload, rwf e = e) :
+    ({ algebraicConstraints :=
+          (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).map rwf ++ extra,
+       busInteractions := d.busInteractions.map (fun bi =>
+         { bi with multiplicity := rwf bi.multiplicity, payload := bi.payload.map rwf }) } :
+        DenseConstraintSystem p)
+      = { algebraicConstraints :=
+            d.algebraicConstraints.filterMap (fun c =>
+              if keepCs c then
+                (if !denseCoveredBy xs c then some (rwf c) else none)
+              else some c) ++ extra,
+          busInteractions := d.busInteractions.map (fun bi =>
+            if keepBis bi then
+              { bi with multiplicity := rwf bi.multiplicity, payload := bi.payload.map rwf }
+            else bi) } := by
+  have h1 : (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).map rwf
+      = d.algebraicConstraints.filterMap (fun c =>
+          if keepCs c then (if !denseCoveredBy xs c then some (rwf c) else none) else some c) := by
+    rw [← filterMap_if_some (fun c => !denseCoveredBy xs c) rwf d.algebraicConstraints]
+    refine filterMap_congr' d.algebraicConstraints ?_
+    intro c hc
+    by_cases hk : keepCs c = true
+    · rw [if_pos hk]
+    · rw [if_neg hk]
+      obtain ⟨hcov, hfix⟩ := hcs c hc (by simpa using hk)
+      rw [if_pos (show (!denseCoveredBy xs c) = true by simp [hcov]), hfix]
+  have h2 : d.busInteractions.map (fun bi =>
+        { bi with multiplicity := rwf bi.multiplicity, payload := bi.payload.map rwf })
+      = d.busInteractions.map (fun bi =>
+          if keepBis bi then
+            { bi with multiplicity := rwf bi.multiplicity, payload := bi.payload.map rwf }
+          else bi) := by
+    refine List.map_congr_left ?_
+    intro bi hbi
+    by_cases hk : keepBis bi = true
+    · rw [if_pos hk]
+    · rw [if_neg hk]
+      obtain ⟨hmult, hpay⟩ := hbis bi hbi (by simpa using hk)
+      exact denseMapExpr_eq_self hmult hpay
+  rw [h1, h2]
+
+/-- **The sparse accept path is the accept path**, with no side condition: an item the skip test
+    rejects shares no variable with the group *and* has no variable-free node left, so it is neither
+    covered (`denseCoveredBy_false_of_disjoint`) nor changed by the rewrite
+    (`denseGroupRewrite_id_of_disjoint`). -/
+@[csimp] theorem denseReencodeOut_eq_sparse : @denseReencodeOut = @denseReencodeOutSparse := by
+  funext q d xs bits hm
+  rw [denseReencodeOut, denseReencodeOutSparse]
+  refine denseSparseOut_eq d xs _ _ (denseReencodeTouchesCs xs) (denseReencodeTouchesBi xs) ?_ ?_
+  · intro c _ hskip
+    simp only [denseReencodeTouchesCs, Bool.or_eq_false_iff] at hskip
+    exact ⟨denseCoveredBy_false_of_disjoint xs c hskip.1,
+      denseGroupRewrite_id_of_disjoint xs bits _ _ _ hskip.1 hskip.2⟩
+  · intro bi _ hskip
+    simp only [denseReencodeTouchesBi, denseBiAnyVarIn, Bool.or_eq_false_iff,
+      List.any_eq_false] at hskip
+    obtain ⟨⟨⟨hdm, hdp⟩, hnm⟩, hnp⟩ := hskip
+    exact ⟨denseGroupRewrite_id_of_disjoint xs bits _ _ _ hdm hnm,
+      fun e he => denseGroupRewrite_id_of_disjoint xs bits _ _ _
+        (by simpa using hdp e he) (by simpa using hnp e he)⟩
+
 theorem denseBuildReencode_ext_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
     {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)} {xs : List VarId} {freshBase : String}
     {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -285,6 +285,22 @@ def denseBuildPruned {α : Type} (varsOf : α → List VarId) (maxVars : Nat) (i
       denseBuildStep varsOf ai idx
     else idx) ⟨∅, []⟩
 
+/-- `denseBuildStep` with the item's variable list already in hand. -/
+def denseBuildStepWith (vs : List VarId) (i : Nat) (idx : DenseCovIndex) : DenseCovIndex :=
+  match vs with
+  | [] => ⟨idx.buckets, i :: idx.varless⟩
+  | vs => ⟨vs.foldl (fun m v => m.insert v (i :: m.getD v [])) idx.buckets, idx.varless⟩
+
+/-- `denseBuildPruned`'s compiled body: the item's variable list is computed once and shared between
+    the prune test and the bucket insert, instead of once for each (`denseBuildPruned_eq_fast`). -/
+def denseBuildPrunedFast {α : Type} (varsOf : α → List VarId) (maxVars : Nat) (items : List α) :
+    DenseCovIndex :=
+  items.zipIdx.foldr (fun ai idx =>
+    let vs := varsOf ai.1
+    if (HashedDedup.hashedEraseDups (hash ·) vs).length ≤ maxVars then
+      denseBuildStepWith vs ai.2 idx
+    else idx) ⟨∅, []⟩
+
 /-- Register the `k` fresh bit variables `freshBase ++ "_0", …, freshBase ++ "_(k-1)"` into `reg`,
     in order. -/
 def denseRegisterBits (reg : VarRegistry) (freshBase : String) (k : Nat) :
@@ -377,6 +393,47 @@ def denseBuildUseIdx (d : DenseConstraintSystem p) : DenseReencodeUseIdx p :=
     occurrence, and the gate below rewrites every position it visits). -/
 def denseUsePositions (idx : DenseCovIndex) (xs : List VarId) : List Nat :=
   ((denseCandidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
+
+/-! ## The sparse accept path
+
+`denseReencodeOut` rewrites *every* item, and it cannot simply skip the ones sharing no variable with
+the group: `varsInF xs` holds vacuously on a variable-free node, so `denseGroupRewrite` replaces such
+a node by its constant even in an item the group does not touch. Adding that second condition to the
+skip test makes the rewrite provably an identity on everything skipped
+(`denseGroupRewrite_id_of_disjoint`), so the sparse form needs no side condition at all — it trades
+one allocating traversal per item for one read-only one. -/
+
+/-- Does this interaction mention a variable of `xs` (multiplicity or payload)? -/
+def denseBiAnyVarIn (xs : List VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  bi.multiplicity.anyVarIn xs || bi.payload.any (fun e => e.anyVarIn xs)
+
+/-- Can the group rewrite change this constraint at all? -/
+def denseReencodeTouchesCs (xs : List VarId) (c : DenseExpr p) : Bool :=
+  c.anyVarIn xs || c.hasConstFoldableNode
+
+/-- Can the group rewrite change this interaction at all? -/
+def denseReencodeTouchesBi (xs : List VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  denseBiAnyVarIn xs bi || bi.multiplicity.hasConstFoldableNode ||
+    bi.payload.any (fun e => e.hasConstFoldableNode)
+
+/-- `denseReencodeOut`'s compiled body: items the rewrite provably cannot change are passed through
+    without being rebuilt (`denseReencodeOut_eq_sparse`). -/
+def denseReencodeOutSparse (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : DenseConstraintSystem p :=
+  let σ := denseGroupSubst xs hm
+  let patts := denseAssignments (denseBitBox bits)
+  { algebraicConstraints :=
+      d.algebraicConstraints.filterMap (fun c =>
+        if denseReencodeTouchesCs xs c then
+          (if !denseCoveredBy xs c then some (denseGroupRewrite xs bits σ patts c) else none)
+        else some c)
+        ++ bits.map denseBoolConstraint,
+    busInteractions := d.busInteractions.map (fun bi =>
+      if denseReencodeTouchesBi xs bi then
+        { bi with
+          multiplicity := denseGroupRewrite xs bits σ patts bi.multiplicity,
+          payload := bi.payload.map (denseGroupRewrite xs bits σ patts) }
+      else bi) }
 
 /-- Degree pre-gate (untrusted): rewrite only the items sharing a variable with the group and fire
     when a rewritten item already exceeds the bound. Only the indexed candidate positions are

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -127,6 +127,30 @@ end-to-end quadratic in circuit size** (openvm-eth sweep: input 2.3k → 8.8k it
 keccak (28.6k constraints / 13.3k interactions / 27.5k vars) takes **252 s**; openvm SHA is ~8×
 keccak, so anything superlinear is fatal there.
 
+### The target, and why it is reachable (vs powdr's Rust optimizer, 2026-07-26)
+
+powdr's timing comparison (`apc-timing/apc_optimizer_timing.json` on its
+`apc-optimizer-timing-comparison` branch: 20 115 APCs, both optimizers on one machine) puts median
+µs **per input variable** at 1248 → 679 for Rust as circuits grow from <500 to 64k–300k variables,
+against 923 → 4083 for this optimizer: **Rust is flat, we grow 4.4×**. Below ~8k variables we are
+1.3–2.6× *faster* than Rust, and summed over all 20 115 APCs we are still 32 % faster; the whole
+problem is the large tail, where one call costs minutes. At ~170k variables (this repo's `sha256`
+case) Rust is ~6× faster.
+
+The structural reason, from reading
+`powdr_autoprecompiles::memory_optimizer::redundant_memory_interactions_indices`: it is a **single
+left-to-right sweep** carrying a `HashMap<Address, MemoryContent>` of live sends, and one sweep's
+drops are applied in one batch — nothing is re-verified against the region between a send and its
+receive, and `IndexedConstraintSystem` makes per-variable lookups O(1) by construction. We *have*
+that sweep (`denseSweepGo` mirrors it), but then re-verify every candidate it proposes, because that
+is the form a machine-checked certificate takes. So the gap is not a port defect: **Θ(system) work
+per candidate, with Θ(N) candidates.** Closing it means proving the sweep's invariant *implies* the
+per-pair conditions instead of re-deriving each pair from the raw list (R8/R10) — or, where the gate
+is untrusted, just indexing it, which needs no proof at all beyond keeping the index complete across
+accepts. The disjoint-replica ladder (`Benchmarks/scaling_bench.py`) is the instrument that tells
+those two cases apart: it holds the fixpoint round count constant while scaling size, so a per-pass
+*exponent* becomes visible.
+
 ### Where the time goes (measured)
 
 - keccak per-pass (254 s profile): domainFold 48 s, domainBatch 48 s, reencode 42 s,

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4991,3 +4991,62 @@ accept; and a *sequential* A/B of the two binaries showed a 2–6 % "win" that i
 entirely — run-ordering bias on this box is larger than the effect being measured. Always interleave.
 
 **Worked locally: yes** (byte-identical `opt-export` on 8 of 9 fixtures; `apc_020` size-identical).
+
+### 146. Runtime: reencode's accept path skips items the rewrite cannot change
+
+`denseReencodeOut` — the system an accepted re-encoding produces — maps `denseGroupRewrite` over
+**every** constraint and interaction, allocating a fresh node per node. gdb attribution on the
+replica ladder's `k=4` rung (35 samples, all inside `denseReencodeStep`) charged the rewrite 17 % of
+the pass, inside a per-accept total of ~70 %.
+
+It cannot simply skip items sharing no variable with the group, and that is the whole subtlety:
+`varsInF xs` holds **vacuously** on a variable-free node, so `denseGroupRewrite` replaces such a node
+by its constant even in an item the group does not touch. Adding that as a second condition —
+`denseReencodeTouchesCs`/`denseReencodeTouchesBi` = *shares a variable with the group* **or** *still
+has a variable-free node* — makes the rewrite provably the identity on everything skipped. So the
+sparse form needs no side condition and no fall-back: `@[csimp] denseReencodeOut_eq_sparse` is an
+unconditional equality, and the output is byte-identical by construction. Per item it trades one
+allocating traversal for one read-only one.
+
+Proof chain: `denseVarsInF_false_of_disjoint` (a variable outside the group defeats `varsInF`) →
+`denseCoveredBy_false_of_disjoint` and `denseGroupRewrite_id_of_disjoint` → `denseSparseOut_eq` →
+the `@[csimp]`. State the list-level step over an **abstract** rewrite/keep pair, as
+`denseSparseOut_eq` does: with the concrete `denseGroupRewrite …` terms in place the unifier looks
+inside them and the theorem does not elaborate even at 1M heartbeats. The same commit shares
+`denseBuildPruned`'s per-item variable list between the prune test and the bucket insert, which it
+computed twice (`denseBuildPruned_eq_fast`).
+
+**Measured — and the honest answer is "below this box's resolution".** All interleaved against a
+binary built from the same `main`, on one 4-core container:
+
+| fixture | rounds (main → this) | ratio |
+|---|---|---|
+| ladder `apc_005` ×4 | 84.2→86.2, 83.4→78.8, 80.8→84.0 s | 1.02 / 0.95 / 1.04 |
+| keccak | 33.4→32.7, 34.5→33.9 s | **0.98 / 0.98** |
+| wasm-eth apc_036 | 41.9→41.3, 43.3→42.7 s | **0.99 / 0.99** |
+| sha256 | 618.6→600.1, 593.7→602.7 s | 0.97 / 1.02 |
+
+keccak and wasm-eth move ~1.5–2 % in the same direction in both rounds; the ladder and sha256 are
+noise, with ±13 % round-to-round on sha256's `reencode` row alone. The attribution predicts about
+this size and no more: the rewrite is 17 % of a pass that is ~28 % of sha256, so ~5 % of a run is the
+ceiling. **`Runtime Bench` on a quiet 32-core runner is the instrument that can resolve it; if it
+comes back flat, this should be dropped rather than carried.**
+
+**Two measurement traps paid for in this session, both worth remembering.** First, an intermediate
+version gated the skip on a separate whole-system `denseSystemFoldNormal` sweep; it measured as pure
+noise, because the added read-only sweep cost about what the sparse rewrite saved. Fusing the two
+tests into the per-item decision is what removed it — and it also removed the precondition, the
+fall-back branch and two lemmas. Second, the first numbers for this change looked like **0.71× on the
+total**, which was nonsense: the baseline binary predated entry 145, so the comparison was
+double-counting `domainFold`'s gate. Rebuild the baseline from the current `main` every time, and
+distrust any runtime win that is suspiciously close to the last one.
+
+**Not landed, and why.** The index-threaded version reuses the posting index the degree pre-gate
+already builds, so it skips the per-item test too. It needs the loop to thread
+`use.get = denseBuildUseIdx d` and hence "a rejecting step leaves `d` alone", which needs
+"an accepted candidate mints at least one bit" (`Nat.clog_pos`, plus a `List.range` foldl induction
+for `denseRegisterBits`'s length). All three were proved during this session and then dropped when
+the item-test design made them unnecessary; the traps in re-deriving them are recorded in
+`ideas.md` R3.
+
+**Worked locally: byte-identical by construction** (the `@[csimp]` equality is unconditional).


### PR DESCRIPTION
Based on `main` after #217. **Byte-identical by construction** — the `@[csimp]` equality is unconditional, so there is no effectiveness question here, only a runtime one, and my box cannot resolve it. Please read the measurement section before merging.

## The change

`denseReencodeOut` — the system an accepted re-encoding produces — maps `denseGroupRewrite` over
*every* constraint and interaction, allocating a fresh node per node, once per accepted group. gdb
attribution on the replica ladder's `k=4` rung (35 samples, all inside `denseReencodeStep`) charged
the rewrite 17 % of the pass, inside a per-accept total of ~70 %.

It cannot simply skip items sharing no variable with the group, and that is the whole subtlety:
`varsInF xs` holds **vacuously** on a variable-free node, so `denseGroupRewrite` replaces such a node
by its constant even in an item the group does not touch. Adding that as a second condition — *shares
a variable with the group* **or** *still has a variable-free node* — makes the rewrite provably the
identity on everything skipped. So the sparse form needs no side condition and no fall-back:
`denseReencodeOut_eq_sparse` is an unconditional equality. Per item it trades one allocating
traversal for one read-only one.

Chain: `denseVarsInF_false_of_disjoint` → `denseCoveredBy_false_of_disjoint` and
`denseGroupRewrite_id_of_disjoint` → `denseSparseOut_eq` → the `@[csimp]`. The list-level step is
stated over an *abstract* rewrite/keep pair on purpose: with the concrete `denseGroupRewrite …` terms
in place the unifier looks inside them and the theorem does not elaborate even at 1M heartbeats.

Also shares `denseBuildPruned`'s per-item variable list between the prune test and the bucket insert,
which it computed twice (`denseBuildPruned_eq_fast`).

`Scripts/check-proof-integrity.sh` green: three standard axioms, no unused theorems.

## Measurement — below this box's resolution

All interleaved against a binary built from the same `main`, one 4-core container:

| fixture | rounds (main → this) | ratio |
|---|---|---|
| ladder `apc_005` ×4 | 84.2→86.2, 83.4→78.8, 80.8→84.0 s | 1.02 / 0.95 / 1.04 |
| keccak | 33.4→32.7, 34.5→33.9 s | **0.98 / 0.98** |
| wasm-eth apc_036 | 41.9→41.3, 43.3→42.7 s | **0.99 / 0.99** |
| sha256 | 618.6→600.1, 593.7→602.7 s | 0.97 / 1.02 |

keccak and wasm-eth move ~1.5–2 % in the same direction in both rounds; the ladder and sha256 are
noise, ±13 % round-to-round on sha256's `reencode` row alone. The attribution predicts about this
size and no more — the rewrite is 17 % of a pass that is ~28 % of sha256, so ~5 % of a run is the
ceiling.

**So this needs `Runtime Bench` on a quiet 32-core runner to settle. If it comes back flat, drop this
rather than carry it** — I would rather record it as a measured non-win than ship 170 lines of proof
for nothing.

## Two traps paid for, both in log entry 146

- An intermediate version gated the skip on a separate whole-system `denseSystemFoldNormal` sweep and
  measured as **pure noise**: the added read-only sweep cost about what the sparse rewrite saved.
  Fusing the two tests into the per-item decision removed it — and with it the precondition, the
  fall-back branch and two lemmas.
- The first numbers for this looked like **0.71× on the total**. That was nonsense: the baseline
  binary predated #217, so the comparison double-counted `domainFold`'s gate. Rebuild the baseline
  from current `main` every time, and distrust a runtime win that lands suspiciously close to the
  previous one.

## Not landed

The index-threaded variant reuses the posting index the degree pre-gate already builds, so it skips
the per-item test too. It needs the loop to thread `use.get = denseBuildUseIdx d`, hence "a rejecting
step leaves `d` alone", hence "an accepted candidate mints at least one bit" (`Nat.clog_pos` plus a
`List.range` foldl induction for `denseRegisterBits`'s length). All three were proved during this
session and dropped when the item-test design made them unnecessary; `ideas.md` R3 records the
re-derivation traps (notably that `fun_cases` + positional `rename_i` does not reach the
`denseRegisterBits` equation, and that the implication must stay in the goal for `fun_cases` to
reduce it).

The four remaining per-accept whole-system sweeps (`denseBuildPruned`, `toArray`,
`HashSet.ofList ro.occ`, `withinDegreeB`) need position preservation, and `HashSet.ofList ro.occ` in
particular cannot be fixed by a `@[csimp]` twin at all — a csimp equality compares the `HashSet` as a
value, so an incrementally maintained set is equivalent but not equal. That one needs the loop's
state type to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdrwAL7S5jwmeibazAxwcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdrwAL7S5jwmeibazAxwcd)_