### PR TITLE
perf: sha256_big runtime −28% (reencode state on stable positions, busUnify sweep, bytePack resume)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -91,11 +91,11 @@ def denseCheckPair (shape : MemoryBusShape) (T : DenseTwoRootMap p) (nw : DenseN
 
 /-! ## The pass -/
 
-/-- One `(pre, S, mid, R, post)` split candidate. -/
+/-- One `(S, mid, R)` split candidate; the surrounding `pre`/`post` context exists only in the
+    proofs (`denseSweepGo_split`), so the sweep never materializes it. -/
 abbrev DenseSplitCand (p : ℕ) :=
-  List (BusInteraction (DenseExpr p)) × BusInteraction (DenseExpr p)
-    × List (BusInteraction (DenseExpr p)) × BusInteraction (DenseExpr p)
-    × List (BusInteraction (DenseExpr p))
+  BusInteraction (DenseExpr p) × List (BusInteraction (DenseExpr p))
+    × BusInteraction (DenseExpr p)
 
 /-! ## The consumer sweep
 
@@ -147,32 +147,31 @@ def DenseAddrKey.allConst (k : DenseAddrKey p) : Bool :=
     | .const _ => true
     | _ => false
 
-/-- An open send window: the send `S`, its split context, and its position `i`. -/
+/-- An open send window: the send `S`, its stored suffix, and its position `i`. -/
 structure DenseOpenRec (p : ℕ) where
-  revPre : List (BusInteraction (DenseExpr p))
   S : BusInteraction (DenseExpr p)
   restAfter : List (BusInteraction (DenseExpr p))
   i : Nat
 
 /-- Assemble the split candidate for a consumed window, tagged with its send position; `mid` is
     recovered positionally from the send's stored suffix (`take (j−i−1)`). -/
-def denseEmitCand (w : DenseOpenRec p) (j : Nat) (R : BusInteraction (DenseExpr p))
-    (post : List (BusInteraction (DenseExpr p))) : Option (Nat × DenseSplitCand p) :=
+def denseEmitCand (w : DenseOpenRec p) (j : Nat) (R : BusInteraction (DenseExpr p)) :
+    Option (Nat × DenseSplitCand p) :=
   if w.i < j then
-    some (w.i, (w.revPre.reverse, w.S, w.restAfter.take (j - w.i - 1), R, post))
+    some (w.i, (w.S, w.restAfter.take (j - w.i - 1), R))
   else none
 
 /-- The sweep: one pass over the interaction list. `acc` collects `(sendPosition, candidate)` pairs,
     order restored by the caller's sort. -/
 def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p)) :
-    (revSeen rest : List (BusInteraction (DenseExpr p))) → (j : Nat) →
+    (rest : List (BusInteraction (DenseExpr p))) → (j : Nat) →
     (constOpen : Std.HashMap (DenseAddrKey p) (DenseOpenRec p)) →
     (symOpen : List (DenseOpenRec p)) →
     (acc : List (Nat × DenseSplitCand p)) →
     List (Nat × DenseSplitCand p)
-  | _, [], _, _, _, acc => acc
-  | revSeen, m :: rest', j, constOpen, symOpen, acc =>
+  | [], _, _, _, acc => acc
+  | m :: rest', j, constOpen, symOpen, acc =>
     let mKey? := denseAddrKey? shape m
     let mAllConst := match mKey? with
       | some k => k.allConst
@@ -188,7 +187,7 @@ def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
             match denseStepTest ops shape T nw w.S m with
             | .consumer =>
               (constOpen.erase k,
-               match denseEmitCand w j m rest' with
+               match denseEmitCand w j m with
                | some c => c :: acc
                | none => acc)
             | .excluded => (constOpen, acc)
@@ -201,7 +200,7 @@ def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
             match denseStepTest ops shape T nw kw.2.S m with
             | .consumer =>
               (kw.1 :: ds,
-               match denseEmitCand kw.2 j m rest' with
+               match denseEmitCand kw.2 j m with
                | some c => c :: a
                | none => a)
             | .excluded => (ds, a)
@@ -214,7 +213,7 @@ def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
         match denseStepTest ops shape T nw w.S m with
         | .consumer =>
           (so,
-           match denseEmitCand w j m rest' with
+           match denseEmitCand w j m with
            | some c => c :: a
            | none => a)
         | .excluded => (w :: so, a)
@@ -225,7 +224,7 @@ def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
       if decide (denseMultConst m = some (denseSetNewMult ops shape)) then
         match mKey? with
         | some k =>
-          let w : DenseOpenRec p := ⟨revSeen, m, rest', j⟩
+          let w : DenseOpenRec p := ⟨m, rest', j⟩
           if k.allConst then
             match constOpen[k]? with
             | some old => (constOpen.insert k w, old :: symOpen)
@@ -233,14 +232,14 @@ def denseSweepGo (ops : DenseZModOps p) (shape : MemoryBusShape)
           else (constOpen, w :: symOpen)
         | none => (constOpen, symOpen)
       else (constOpen, symOpen)
-    denseSweepGo ops shape T nw (m :: revSeen) rest' (j + 1) constOpen symOpen acc
+    denseSweepGo ops shape T nw rest' (j + 1) constOpen symOpen acc
 
 /-- All consumer candidates of one bus, in send-position order. -/
 def denseCandidateSplitsSweep (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p))
     (nw : Thunk (DenseNonzeroWits p)) (L : List (BusInteraction (DenseExpr p))) :
     List (DenseSplitCand p) :=
   let ops : DenseZModOps p := denseZModOps
-  ((denseSweepGo ops shape T nw [] L 0 ∅ [] []).mergeSort
+  ((denseSweepGo ops shape T nw L 0 ∅ [] []).mergeSort
     (fun a b => decide (a.1 ≤ b.1))).map (·.2)
 
 /-- Collect the entailed equalities for one bus: for each candidate, `denseCheckPair` and, when it
@@ -249,7 +248,7 @@ def denseCollectForBus (shape : MemoryBusShape) (T : Thunk (DenseTwoRootMap p))
     (nw : Thunk (DenseNonzeroWits p)) :
     List (DenseSplitCand p) → List (DenseExpr p)
   | [] => []
-  | (_pre, S, mid, R, _post) :: rest =>
+  | (S, mid, R) :: rest =>
     let acc := denseCollectForBus shape T nw rest
     if denseCheckPair shape T.get nw.get S mid R = true then
       denseMemEqConstraints shape S R ++ acc

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
@@ -168,51 +168,52 @@ theorem denseCheckPair_sound (d : DenseConstraintSystem p) (bs : BusSemantics p)
 threads them across `insert`/`erase`/`getElem?`/`toList`. -/
 
 private abbrev SplitEqC (L : List (BusInteraction (DenseExpr p))) (cand : DenseSplitCand p) : Prop :=
-  L = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2
+  ∃ pre post, L = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post
 
 private def OpenWF (L : List (BusInteraction (DenseExpr p))) (w : DenseOpenRec p) : Prop :=
-  w.revPre.length = w.i ∧ L = w.revPre.reverse ++ w.S :: w.restAfter
+  ∃ pre, pre.length = w.i ∧ L = pre ++ w.S :: w.restAfter
 
 theorem dense_split_of_positions
-    {L revPre restAfter revSeen post : List (BusInteraction (DenseExpr p))}
+    {L pre restAfter seen post : List (BusInteraction (DenseExpr p))}
     {S R : BusInteraction (DenseExpr p)} {i j : Nat}
-    (hi : revPre.length = i) (hsplit : L = revPre.reverse ++ S :: restAfter)
-    (hj : revSeen.length = j) (hnow : L = revSeen.reverse ++ R :: post) (hlt : i < j) :
-    L = revPre.reverse ++ S :: restAfter.take (j - i - 1) ++ R :: post := by
+    (hi : pre.length = i) (hsplit : L = pre ++ S :: restAfter)
+    (hj : seen.length = j) (hnow : L = seen ++ R :: post) (hlt : i < j) :
+    L = pre ++ S :: restAfter.take (j - i - 1) ++ R :: post := by
   have hRA : restAfter = L.drop (i + 1) := by
-    have h1 : L = (revPre.reverse ++ [S]) ++ restAfter := by rw [hsplit]; simp
+    have h1 : L = (pre ++ [S]) ++ restAfter := by rw [hsplit]; simp
     rw [h1, List.drop_left' (by simp [hi])]
   have hRp : R :: post = L.drop j := by rw [hnow, List.drop_left' (by simp [hj])]
   have hdrop : restAfter.drop (j - i - 1) = R :: post := by
     rw [hRA, List.drop_drop, hRp]; congr 1; omega
-  have hn : L = revPre.reverse ++ S :: (restAfter.take (j - i - 1) ++ R :: post) := by
+  have hn : L = pre ++ S :: (restAfter.take (j - i - 1) ++ R :: post) := by
     rw [← hdrop, List.take_append_drop]; exact hsplit
   simpa [List.append_assoc] using hn
 
 private theorem denseEmitCand_split {L : List (BusInteraction (DenseExpr p))} (w : DenseOpenRec p)
     (hwf : OpenWF L w)
-    {revSeen : List (BusInteraction (DenseExpr p))} (j : Nat) (hj : revSeen.length = j)
+    {seen : List (BusInteraction (DenseExpr p))} (j : Nat) (hj : seen.length = j)
     (R : BusInteraction (DenseExpr p)) (post : List (BusInteraction (DenseExpr p)))
-    (hnow : L = revSeen.reverse ++ R :: post)
-    {ic : Nat × DenseSplitCand p} (h : denseEmitCand w j R post = some ic) :
+    (hnow : L = seen ++ R :: post)
+    {ic : Nat × DenseSplitCand p} (h : denseEmitCand w j R = some ic) :
     SplitEqC L ic.2 := by
   unfold denseEmitCand at h
   by_cases hlt : w.i < j
   · rw [if_pos hlt] at h
     simp only [Option.some.injEq] at h
     subst h
-    exact dense_split_of_positions hwf.1 hwf.2 hj hnow hlt
+    obtain ⟨pre, hi, hsplit⟩ := hwf
+    exact ⟨pre, post, dense_split_of_positions hi hsplit hj hnow hlt⟩
   · rw [if_neg hlt] at h; exact absurd h (by simp)
 
 private theorem denseEmitCand_cons_split {L : List (BusInteraction (DenseExpr p))}
     (w : DenseOpenRec p) (hwf : OpenWF L w)
-    {revSeen : List (BusInteraction (DenseExpr p))} (j : Nat) (hj : revSeen.length = j)
+    {seen : List (BusInteraction (DenseExpr p))} (j : Nat) (hj : seen.length = j)
     (R : BusInteraction (DenseExpr p)) (post : List (BusInteraction (DenseExpr p)))
-    (hnow : L = revSeen.reverse ++ R :: post)
+    (hnow : L = seen ++ R :: post)
     (acc : List (Nat × DenseSplitCand p)) (hacc : ∀ ic ∈ acc, SplitEqC L ic.2) :
-    ∀ ic ∈ (match denseEmitCand w j R post with | some c => c :: acc | none => acc),
+    ∀ ic ∈ (match denseEmitCand w j R with | some c => c :: acc | none => acc),
       SplitEqC L ic.2 := by
-  cases hem : denseEmitCand w j R post with
+  cases hem : denseEmitCand w j R with
   | none => intro ic hic; exact hacc ic hic
   | some c =>
     intro ic hic
@@ -259,23 +260,24 @@ private theorem eraseFold_ow {L : List (BusInteraction (DenseExpr p))}
 theorem denseSweepGo_split {ops : DenseZModOps p} {shape : MemoryBusShape}
     {T : Thunk (DenseTwoRootMap p)}
     {nw : Thunk (DenseNonzeroWits p)} (L : List (BusInteraction (DenseExpr p)))
-    (revSeen rest : List (BusInteraction (DenseExpr p))) (j : Nat)
+    (rest : List (BusInteraction (DenseExpr p))) (j : Nat)
     (constOpen : Std.HashMap (DenseAddrKey p) (DenseOpenRec p))
     (symOpen : List (DenseOpenRec p)) (acc : List (Nat × DenseSplitCand p))
-    (hsplit : L = revSeen.reverse ++ rest) (hj : revSeen.length = j)
+    (hseen : ∃ seen : List (BusInteraction (DenseExpr p)), seen.length = j ∧ L = seen ++ rest)
     (hcO : ∀ (k : DenseAddrKey p) (w : DenseOpenRec p), constOpen[k]? = some w → OpenWF L w)
     (hsO : ∀ w ∈ symOpen, OpenWF L w)
     (hacc : ∀ ic ∈ acc, SplitEqC L ic.2) :
-    ∀ ic ∈ denseSweepGo ops shape T nw revSeen rest j constOpen symOpen acc, SplitEqC L ic.2 := by
-  revert hsplit hj hcO hsO hacc
-  fun_induction denseSweepGo ops shape T nw revSeen rest j constOpen symOpen acc with
-  | case1 revSeen j constOpen symOpen acc =>
-    intro hsplit hj hcO hsO hacc ic hic
+    ∀ ic ∈ denseSweepGo ops shape T nw rest j constOpen symOpen acc, SplitEqC L ic.2 := by
+  revert hseen hcO hsO hacc
+  fun_induction denseSweepGo ops shape T nw rest j constOpen symOpen acc with
+  | case1 j constOpen symOpen acc =>
+    intro hseen hcO hsO hacc ic hic
     exact hacc ic hic
-  | case2 revSeen m rest' j constOpen symOpen acc mKey mAllC constOpen_1 acc_1 hP1 so a hP2 constOpen_2 symOpen_1 hP3 ih =>
-    intro hsplit hj hcO hsO hacc
+  | case2 m rest' j constOpen symOpen acc mKey mAllC constOpen_1 acc_1 hP1 so a hP2 constOpen_2 symOpen_1 hP3 ih =>
+    intro hseen hcO hsO hacc
     clear_value mAllC mKey
-    have hnow : L = revSeen.reverse ++ m :: rest' := hsplit
+    obtain ⟨seen, hj, hsplit⟩ := hseen
+    have hnow : L = seen ++ m :: rest' := hsplit
     have hP1inv : (∀ (k : DenseAddrKey p) (w : DenseOpenRec p), constOpen_1[k]? = some w → OpenWF L w)
         ∧ (∀ ic ∈ acc_1, SplitEqC L ic.2) := by
       split at hP1
@@ -338,7 +340,7 @@ theorem denseSweepGo_split {ops : DenseZModOps p} {shape : MemoryBusShape}
           | blocker => exact ⟨hso2, ha2⟩
         exact ⟨hfr.1, hfr.2⟩
     obtain ⟨hso3, hacc2⟩ := hP2inv
-    have hwNew : OpenWF L (⟨revSeen, m, rest', j⟩ : DenseOpenRec p) := ⟨hj, hnow⟩
+    have hwNew : OpenWF L (⟨m, rest', j⟩ : DenseOpenRec p) := ⟨seen, hj, hnow⟩
     have hP3inv : (∀ (k : DenseAddrKey p) (w : DenseOpenRec p), constOpen_2[k]? = some w → OpenWF L w)
         ∧ (∀ w ∈ symOpen_1, OpenWF L w) := by
       split at hP3
@@ -359,22 +361,22 @@ theorem denseSweepGo_split {ops : DenseZModOps p} {shape : MemoryBusShape}
       · simp only [Prod.mk.injEq] at hP3; obtain ⟨rfl, rfl⟩ := hP3
         exact ⟨hcO1, hso3⟩
     intro ic hic
-    exact ih (by rw [List.reverse_cons, List.append_assoc]; exact hsplit)
-             (by rw [List.length_cons, hj])
+    exact ih ⟨seen ++ [m], by simp [hj], by simpa [List.append_assoc] using hsplit⟩
              hP3inv.1 hP3inv.2 hacc2 ic hic
 
 
-/-- Wrapper: every candidate the sweep enumerator returns recomposes the swept list. -/
+/-- Wrapper: every candidate the sweep enumerator returns recomposes the swept list (the `pre` and
+    `post` context lists exist only here — the sweep does not materialize them). -/
 theorem denseCandidateSplitsSweep_split {shape : MemoryBusShape} {T : Thunk (DenseTwoRootMap p)}
     {nw : Thunk (DenseNonzeroWits p)} (L : List (BusInteraction (DenseExpr p)))
     (cand : DenseSplitCand p) (hcand : cand ∈ denseCandidateSplitsSweep shape T nw L) :
-    L = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 := by
+    ∃ pre post, L = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post := by
   unfold denseCandidateSplitsSweep at hcand
   rw [List.mem_map] at hcand
   obtain ⟨ic, hic, rfl⟩ := hcand
   rw [List.mem_mergeSort] at hic
-  exact denseSweepGo_split L [] L 0 ∅ [] []
-    (by simp) rfl
+  exact denseSweepGo_split L L 0 ∅ [] []
+    ⟨[], rfl, by simp⟩
     (by intro k w h; rw [Std.HashMap.getElem?_empty] at h; exact absurd h (by simp))
     (by intro w hw; simp at hw)
     (by intro ic hic; simp at hic) ic hic
@@ -398,19 +400,19 @@ theorem denseCollectForBus_vars (d : DenseConstraintSystem p)
     (T : Thunk (DenseTwoRootMap p)) (nw : Thunk (DenseNonzeroWits p)) (shape : MemoryBusShape)
     (busId : Nat) :
     ∀ (cands : List (DenseSplitCand p)),
-    (∀ cand ∈ cands, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
+    (∀ cand ∈ cands, ∃ pre post, d.busInteractions.filter (fun bi => bi.busId = busId)
+        = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post) →
     ∀ c ∈ denseCollectForBus shape T nw cands, ∀ z ∈ c.vars, z ∈ d.occ := by
   intro cands
   induction cands with
   | nil => intro _ c hc; simp [denseCollectForBus] at hc
   | cons cand rest ih =>
     intro hsplitc c hc z hz
-    obtain ⟨pre, S, mid, R, post⟩ := cand
-    have hsplit : d.busInteractions.filter (fun bi => bi.busId = busId)
-        = pre ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
-    have hrest : ∀ cand ∈ rest, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
+    obtain ⟨S, mid, R⟩ := cand
+    obtain ⟨pre, post, hsplit⟩ := hsplitc (S, mid, R) (List.mem_cons_self ..)
+    have hrest : ∀ cand ∈ rest, ∃ pre post,
+        d.busInteractions.filter (fun bi => bi.busId = busId)
+          = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post :=
       fun cand h => hsplitc cand (List.mem_cons_of_mem _ h)
     have hSmem : S ∈ d.busInteractions := by
       have h : S ∈ d.busInteractions.filter (fun bi => bi.busId = busId) := by
@@ -464,8 +466,8 @@ theorem denseCollectForBus_sound (d : DenseConstraintSystem p) (bs : BusSemantic
     (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
     (denv : VarId → ZMod p) (hadm : d.admissible bs denv) (hsat : d.satisfies bs denv) :
     ∀ (cands : List (DenseSplitCand p)),
-    (∀ cand ∈ cands, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2) →
+    (∀ cand ∈ cands, ∃ pre post, d.busInteractions.filter (fun bi => bi.busId = busId)
+        = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post) →
     ∀ c ∈ denseCollectForBus shape (Thunk.pure T)
         (Thunk.pure (DenseNonzeroWits.build d.algebraicConstraints)) cands,
       c.eval denv = 0 := by
@@ -474,11 +476,11 @@ theorem denseCollectForBus_sound (d : DenseConstraintSystem p) (bs : BusSemantic
   | nil => intro _ c hc; simp [denseCollectForBus] at hc
   | cons cand rest ih =>
     intro hsplitc c hc
-    obtain ⟨pre, S, mid, R, post⟩ := cand
-    have hsplit : d.busInteractions.filter (fun bi => bi.busId = busId)
-        = pre ++ S :: mid ++ R :: post := hsplitc (pre, S, mid, R, post) (List.mem_cons_self ..)
-    have hrest : ∀ cand ∈ rest, d.busInteractions.filter (fun bi => bi.busId = busId)
-        = cand.1 ++ cand.2.1 :: cand.2.2.1 ++ cand.2.2.2.1 :: cand.2.2.2.2 :=
+    obtain ⟨S, mid, R⟩ := cand
+    obtain ⟨pre, post, hsplit⟩ := hsplitc (S, mid, R) (List.mem_cons_self ..)
+    have hrest : ∀ cand ∈ rest, ∃ pre post,
+        d.busInteractions.filter (fun bi => bi.busId = busId)
+          = pre ++ cand.1 :: cand.2.1 ++ cand.2.2 :: post :=
       fun cand h => hsplitc cand (List.mem_cons_of_mem _ h)
     rw [denseCollectForBus] at hc
     split_ifs at hc with hchk

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
@@ -510,13 +510,15 @@ theorem denseBytePackStep_correct (isInput : VarId → Bool) (bs : BusSemantics 
     (busId : Nat) (spec : ByteXorSpec p) (pre : List (BusInteraction (DenseExpr p)))
     (eA : DenseExpr p) (mid : List (BusInteraction (DenseExpr p))) (eB : DenseExpr p)
     (post : List (BusInteraction (DenseExpr p)))
-    (hfg : denseFindGo bs facts [] d.busInteractions = some (busId, spec, pre, eA, mid, eB, post)) :
+    (revPre bis : List (BusInteraction (DenseExpr p)))
+    (hbis : revPre.reverse ++ bis = d.busInteractions)
+    (hfg : denseFindGo bs facts revPre bis = some (busId, spec, pre, eA, mid, eB, post)) :
     DensePassCorrect isInput d
       { d with busInteractions := pre ++ denseMkBytePair spec busId eA eB :: mid ++ post } [] bs := by
   obtain ⟨a, b, hsplit0, hsaEq, hsbEq, hab, hspec, hbound⟩ :=
-    denseFindGo_split bs facts [] d.busInteractions busId spec pre eA mid eB post hfg
+    denseFindGo_split bs facts revPre bis busId spec pre eA mid eB post hfg
   have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by
-    rw [← hsplit0, List.reverse_nil, List.nil_append]
+    rw [← hbis]; exact hsplit0
   have hsa := denseSvCheck?_sound bs facts a eA hsaEq
   have hsbd := denseSvCheck?_sound bs facts b eB hsbEq
   have hstC : bs.isStateful (denseMkBytePair spec busId eA eB).busId = false := by
@@ -548,13 +550,15 @@ theorem denseBytePackStep_covered (reg : VarRegistry) (bs : BusSemantics p) (fac
     (busId : Nat) (spec : ByteXorSpec p) (pre : List (BusInteraction (DenseExpr p)))
     (eA : DenseExpr p) (mid : List (BusInteraction (DenseExpr p))) (eB : DenseExpr p)
     (post : List (BusInteraction (DenseExpr p)))
-    (hfg : denseFindGo bs facts [] d.busInteractions = some (busId, spec, pre, eA, mid, eB, post)) :
+    (revPre bis : List (BusInteraction (DenseExpr p)))
+    (hbis : revPre.reverse ++ bis = d.busInteractions)
+    (hfg : denseFindGo bs facts revPre bis = some (busId, spec, pre, eA, mid, eB, post)) :
     ({ d with busInteractions := pre ++ denseMkBytePair spec busId eA eB :: mid ++ post } :
       DenseConstraintSystem p).CoveredBy reg := by
   obtain ⟨a, b, hsplit0, hsaEq, hsbEq, _hab, _hspec, _hbound⟩ :=
-    denseFindGo_split bs facts [] d.busInteractions busId spec pre eA mid eB post hfg
+    denseFindGo_split bs facts revPre bis busId spec pre eA mid eB post hfg
   have hsplit : d.busInteractions = pre ++ a :: mid ++ b :: post := by
-    rw [← hsplit0, List.reverse_nil, List.nil_append]
+    rw [← hbis]; exact hsplit0
   have hsa := denseSvCheck?_sound bs facts a eA hsaEq
   have hsbd := denseSvCheck?_sound bs facts b eB hsbEq
   obtain ⟨hcac, hcbi⟩ := hcov
@@ -579,23 +583,29 @@ theorem denseBytePackStep_covered (reg : VarRegistry) (bs : BusSemantics p) (fac
 /-! ## The dense `bytePack` pass: drain packs through `DenseNativeStep.drain` -/
 
 /-- One drain step: on a `denseFindGo` hit, a non-extending certified pack step; otherwise `none`.
-    Fuel = interaction-list length, a safe bound since each pack drops that count by one. -/
+    Fuel = interaction-list length, a safe bound since each pack drops that count by one.
+    The threaded `Nat` resumes the scan just past the previous pack: a position before it can
+    never fire later — an interaction's shape is fixed, a pack only removes single-value checks
+    (the inserted pair is not one), so a rejected first element stays rejected. -/
 def denseBytePackStep (bs : BusSemantics p) (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) :
-    Unit → (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg →
-      Option (Unit × DenseNativeStep p bs reg d) :=
-  fun _ reg d hcov =>
-    match hfg : denseFindGo bs facts [] d.busInteractions with
+    Nat → (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg →
+      Option (Nat × DenseNativeStep p bs reg d) :=
+  fun k reg d hcov =>
+    match hfg : denseFindGo bs facts (d.busInteractions.take k).reverse
+        (d.busInteractions.drop k) with
     | none => none
     | some (busId, spec, pre, eA, mid, eB, post) =>
-      some ((), DenseNativeStep.ofSame bs
-        (denseBytePackStep_covered reg bs facts d hcov busId spec pre eA mid eB post hfg)
-        (denseBytePackStep_correct reg.isInput bs facts hp1 d busId spec pre eA mid eB post hfg))
+      some (pre.length + 1, DenseNativeStep.ofSame bs
+        (denseBytePackStep_covered reg bs facts d hcov busId spec pre eA mid eB post
+          (d.busInteractions.take k).reverse (d.busInteractions.drop k) (by simp) hfg)
+        (denseBytePackStep_correct reg.isInput bs facts hp1 d busId spec pre eA mid eB post
+          (d.busInteractions.take k).reverse (d.busInteractions.drop k) (by simp) hfg))
 
 /-- The dense single-value byte-check packing pass (see `denseFindGo`, `ByteCheckPack.lean`). -/
 def denseByteCheckPackPass : DenseVerifiedPassW p :=
   DenseVerifiedPassW.ofDenseStep (fun reg bs facts d hcov =>
     if hp1 : (1 : ZMod p) ≠ 0 then
-      (DenseNativeStep.drain bs (denseBytePackStep bs facts hp1) d.busInteractions.length ()
+      (DenseNativeStep.drain bs (denseBytePackStep bs facts hp1) d.busInteractions.length 0
         reg d hcov).2
     else DenseNativeStep.refl bs hcov)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1240,6 +1240,84 @@ theorem stepIdentityPost (reg reg' : VarRegistry) (d : DenseConstraintSystem p)
   ⟨hext, hii, csCoveredBy_mono hext hcov, (by intro x hx; simp at hx), hvs,
    DensePassCorrect.refl reg'.isInput d bs⟩
 
+/-- `stepIdentityPost` for the cached step, which does not carry the variable-set invariant
+    (its `varSet` over-approximates the live variables; see `DenseReencodeCacheState`). -/
+theorem stepIdentityPostC (reg reg' : VarRegistry) (d : DenseConstraintSystem p)
+    (bs : BusSemantics p)
+    (hext : reg.Extends reg') (hii : ∀ i, reg'.isInput i = reg.isInput i)
+    (hcov : d.CoveredBy reg) :
+    reg.Extends reg' ∧ (∀ i, reg'.isInput i = reg.isInput i) ∧ d.CoveredBy reg'
+    ∧ DenseDerivations.CoveredBy reg' ([] : DenseDerivations p)
+    ∧ DensePassCorrect reg'.isInput d d ([] : DenseDerivations p) bs :=
+  ⟨hext, hii, csCoveredBy_mono hext hcov, (by intro x hx; simp at hx),
+   DensePassCorrect.refl reg'.isInput d bs⟩
+
+/-! ## Group variables occur in `d`, straight from the certificate
+
+The cached step's `varSet` gate no longer witnesses `xs ⊆ d.occ` (the set is over-approximating),
+so the accept case derives it from the certificate itself: `denseCheckReencode`'s domain lookup
+returns, for every group variable, a covered constraint of `d` mentioning it. -/
+
+private theorem DenseExpr.mentions_mem_vars {i : VarId} :
+    ∀ {e : DenseExpr p}, e.mentions i = true → i ∈ e.vars := by
+  intro e
+  induction e with
+  | const n => intro h; simp [DenseExpr.mentions] at h
+  | var j =>
+      intro h
+      simp only [DenseExpr.mentions, beq_iff_eq] at h
+      simp [DenseExpr.vars, h]
+  | add a b iha ihb =>
+      intro h
+      rcases Bool.or_eq_true .. |>.mp h with h | h
+      · exact List.mem_append_left _ (iha h)
+      · exact List.mem_append_right _ (ihb h)
+  | mul a b iha ihb =>
+      intro h
+      rcases Bool.or_eq_true .. |>.mp h with h | h
+      · exact List.mem_append_left _ (iha h)
+      · exact List.mem_append_right _ (ihb h)
+
+private theorem denseFindDomainAlg_mentions {i : VarId} :
+    ∀ {all : List (DenseExpr p)} {dm : List (ZMod p)},
+      denseFindDomainAlg all i = some dm → ∃ c ∈ all, c.mentions i = true
+  | [], dm, h => by simp [denseFindDomainAlg] at h
+  | c :: rest, dm, h => by
+      rw [denseFindDomainAlg] at h
+      by_cases hm : c.mentions i = true
+      · exact ⟨c, List.mem_cons_self .., hm⟩
+      · rw [if_neg (by simpa using hm)] at h
+        obtain ⟨c', hc', hm'⟩ := denseFindDomainAlg_mentions h
+        exact ⟨c', List.mem_cons_of_mem _ hc', hm'⟩
+
+private theorem denseGroupDoms_mentions {es : List (DenseExpr p)} :
+    ∀ {xs : List VarId} {doms : List (VarId × List (ZMod p))},
+      denseGroupDoms es xs = some doms → ∀ x ∈ xs, ∃ c ∈ es, c.mentions x = true
+  | [], _, _, x, hx => absurd hx (by simp)
+  | i :: rest, doms, h, x, hx => by
+      rw [denseGroupDoms] at h
+      cases hd : denseFindDomainAlg es i with
+      | none => rw [hd] at h; exact absurd h (by simp)
+      | some dm =>
+          cases hr : denseGroupDoms es rest with
+          | none => rw [hd, hr] at h; exact absurd h (by simp)
+          | some ds =>
+              rcases List.mem_cons.1 hx with rfl | hmem
+              · exact denseFindDomainAlg_mentions hd
+              · exact denseGroupDoms_mentions hr x hmem
+
+theorem denseCheckReencode_xsOcc (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) (hchk : denseCheckReencode d xs bits hm = true) :
+    ∀ x ∈ xs, x ∈ d.occ := by
+  intro x hx
+  unfold denseCheckReencode at hchk
+  cases hdoms : denseGroupDoms (denseCoveredCsOf d xs) xs with
+  | none => rw [hdoms] at hchk; exact absurd hchk (by simp)
+  | some doms =>
+      obtain ⟨c, hc, hmn⟩ := denseGroupDoms_mentions hdoms x hx
+      exact DenseConstraintSystem.mem_occ_of_constraint (List.mem_of_mem_filter hc)
+        (DenseExpr.mentions_mem_vars hmn)
+
 theorem denseCheckReencode_polyVars (d : DenseConstraintSystem p) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) (hchk : denseCheckReencode d xs bits hm = true) :
     ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs hm)).vars, v ∈ bits := by
@@ -1354,26 +1432,20 @@ theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Boo
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId) (freshBase : String)
-    (bs : BusSemantics p)
-    (hcov : d.CoveredBy reg) (hvs : ∀ x, state.varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
-    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state use xs freshBase).1.isInput i
+    (xs : List VarId) (freshBase : String) (bs : BusSemantics p) (hcov : d.CoveredBy reg) :
+    reg.Extends (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput i
         = reg.isInput i)
-    ∧ (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
+    ∧ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.CoveredBy
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
     ∧ DenseDerivations.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.1
-    ∧ (∀ x,
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.2.varSet.contains x
-          = true →
-        x ∈ (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1.occ)
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1
     ∧ DensePassCorrect
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).1.isInput d
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.1
-        (denseReencodeStepCached b useIdx reg d state use xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStepCached b useIdx reg d state use xs freshBase
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput d
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1
+        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStepCached b useIdx reg d state xs freshBase
   case case4 =>
     rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
     have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
@@ -1385,8 +1457,7 @@ theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx
     have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
       rw [hbii x]
       exact List.all_eq_true.mp hgate x hx
-    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := fun x hx =>
-      hvs x (List.all_eq_true.mp hA x hx)
+    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := denseCheckReencode_xsOcc d xs bits hm hD
     have hxsB : ∀ x ∈ xs, x ∉ bits := fun x hx =>
       of_decide_eq_true (List.all_eq_true.mp hB x hx)
     have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
@@ -1397,21 +1468,18 @@ theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx
       rfl
     have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
       hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
-    refine ⟨hbext, hbii, ?_, ?_, ?_, ?_⟩
+    refine ⟨hbext, hbii, ?_, ?_, ?_⟩
     · exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov)
         hbval hpolyVars
     · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
-    · intro x hx
-      rw [Std.HashSet.contains_ofList] at hx
-      exact List.contains_iff_mem.mp hx
     · exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB
         hbnInput hD
   all_goals first
-    | exact stepIdentityPost reg reg d state.varSet bs (VarRegistry.Extends.refl reg)
-        (fun _ => rfl) hcov hvs
-    | exact stepIdentityPost reg _ d state.varSet bs
+    | exact stepIdentityPostC reg reg d bs (VarRegistry.Extends.refl reg)
+        (fun _ => rfl) hcov
+    | exact stepIdentityPostC reg _ d bs
         (denseBuildReencodeCached_ext_of_eq (by assumption))
-        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov hvs
+        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov
 
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
@@ -1471,45 +1539,44 @@ set_option maxHeartbeats 1000000 in
 theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
     (bs : BusSemantics p) :
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
-      (state : DenseReencodeCacheState p) (use : Thunk (DenseReencodeUseIdx p)) (nc nb : Nat),
-      d.CoveredBy reg → (∀ x, state.varSet.contains x = true → x ∈ d.occ) →
-      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
-      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1.isInput i
+      (state : DenseReencodeCacheState p) (nc nb : Nat),
+      d.CoveredBy reg →
+      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
+      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1.isInput i
           = reg.isInput i)
-      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.1.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
+      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.1.CoveredBy
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
       ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.2
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.2
       ∧ DensePassCorrect
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).1.isInput d
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.1
-          (denseReencodeLoopCached b useIdx targets idx reg d state use nc nb).2.2 bs := by
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1.isInput d
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.1
+          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
-      intro idx reg d state use nc nb hcov hvs
+      intro idx reg d state nc nb hcov
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
         ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
         (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput d bs⟩
   | cons xs rest ih =>
-      intro idx reg d state use nc nb hcov hvs
+      intro idx reg d state nc nb hcov
       simp only [denseReencodeLoopCached]
-      rcases hstep : denseReencodeStepCached b useIdx reg d state use xs s!"rnc{nc}_{nb}_{idx}"
+      rcases hstep : denseReencodeStepCached b useIdx reg d state xs s!"rnc{nc}_{nb}_{idx}"
           with ⟨reg1, d1, derivs1, state1⟩
-      have hsp := denseReencodeStepCached_correct b useIdx reg d state use xs
-          s!"rnc{nc}_{nb}_{idx}" bs hcov hvs
+      have hsp := denseReencodeStepCached_correct b useIdx reg d state xs
+          s!"rnc{nc}_{nb}_{idx}" bs hcov
       simp only [hstep] at hsp
-      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
+      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
       rcases hrec : denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
-          (denseReencodeUseNext derivs1 d1 use)
           (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
           with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 state1 (denseReencodeUseNext derivs1 d1 use)
+      have hih := ih (idx + 1) reg1 d1 state1
           (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
-          hs_cov hs_vs
+          hs_cov
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1540,13 +1607,16 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
     · rw [if_pos hcache]
       obtain ⟨he, _, hc, hd, hcorr⟩ :=
         denseReencodeLoopCached_correct b useIdx bs targets 0 reg d
-          ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
-           d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩
-          (Thunk.mk (fun _ => denseBuildUseIdx d))
+          { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
+            arrCs := d.algebraicConstraints.toArray
+            rootCache := ∅
+            varSet := Std.HashSet.ofList d.occ
+            useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
+            useBis := denseCovBuild denseBIVars d.busInteractions
+            arrBis := d.busInteractions.toArray
+            foldCs := d.algebraicConstraints.zipIdx.foldl
+              (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
           d.algebraicConstraints.length d.busInteractions.length hcov
-          (fun x hx => by
-            rw [Std.HashSet.contains_ofList] at hx
-            exact List.contains_iff_mem.mp hx)
       exact ⟨he, hc, hd, hcorr⟩
     · rw [if_neg hcache]
       obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -502,21 +502,22 @@ def denseUsePositions (idx : DenseCovIndex) (xs : List VarId) : List Nat :=
 /-- Degree pre-gate (untrusted): rewrite only the items sharing a variable with the group and fire
     when a rewritten item already exceeds the bound. Only the indexed candidate positions are
     visited — the buckets are complete, so every item outside them is variable-disjoint from `xs`
-    and cannot fire. -/
-def denseDegPreReject (b : DegreeBound) (use : Thunk (DenseReencodeUseIdx p))
+    and cannot fire. Stale bucket entries (the cached loop's indexes are grow-only) are harmless:
+    each position's current content is re-tested. -/
+def denseDegPreRejectIdx (b : DegreeBound) (csIdxUse biIdxUse : DenseCovIndex)
+    (arrBis : Array (BusInteraction (DenseExpr p)))
     (arrCs : Array (DenseExpr p)) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
   let σ := denseGroupSubst xs hm
   let patts := denseAssignments (denseBitBox bits)
-  let use := use.get
-  (denseUsePositions use.csIdx xs).any (fun i =>
+  (denseUsePositions csIdxUse xs).any (fun i =>
     match arrCs[i]? with
     | some c =>
       c.sharesVarIn xs && !denseCoveredBy xs c &&
         decide (b.identities < (denseGroupRewrite xs bits σ patts c).degree)
     | none => false) ||
-  (denseUsePositions use.biIdx xs).any (fun i =>
-    match use.arrBis[i]? with
+  (denseUsePositions biIdxUse xs).any (fun i =>
+    match arrBis[i]? with
     | some bi =>
       (bi.multiplicity.sharesVarIn xs &&
         decide (b.busInteractions < (denseGroupRewrite xs bits σ patts bi.multiplicity).degree)) ||
@@ -524,6 +525,11 @@ def denseDegPreReject (b : DegreeBound) (use : Thunk (DenseReencodeUseIdx p))
         e.sharesVarIn xs &&
           decide (b.busInteractions < (denseGroupRewrite xs bits σ patts e).degree))
     | none => false)
+
+def denseDegPreReject (b : DegreeBound) (use : Thunk (DenseReencodeUseIdx p))
+    (arrCs : Array (DenseExpr p)) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+  denseDegPreRejectIdx b use.get.csIdx use.get.biIdx use.get.arrBis arrCs xs bits hm
 
 /-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
     gates in order, minting fresh bits and rewriting `d` only on full acceptance. -/
@@ -566,15 +572,75 @@ def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
     else (reg1, d, [], csIdx, arrCs, varSet)
   else (reg, d, [], csIdx, arrCs, varSet)
 
+/-- The cached loop's candidate-state, kept on stable positions across accepts: dropped
+    constraints become `.const 0` tombstones (variable-free, so every index query skips them),
+    the bucket indexes are grow-only, and `denseReencodeStateUpdate` touches only the positions
+    an accept can change — nothing here is rebuilt per accepted group. `varSet` only ever gains
+    the fresh bits, so it over-approximates the live variables; a group whose variable was
+    eliminated by an earlier accept passes that gate and is then rejected by the certificate
+    (no covered constraint mentions the variable), the same outcome the exact set produces. -/
 structure DenseReencodeCacheState (p : ℕ) where
   csIdx : DenseCovIndex
   arrCs : Array (DenseExpr p)
   rootCache : DenseReencodeRootCache p
   varSet : Std.HashSet VarId
+  useCs : DenseCovIndex
+  useBis : DenseCovIndex
+  arrBis : Array (BusInteraction (DenseExpr p))
+  foldCs : Std.HashSet Nat
+
+/-- Apply an accepted rewrite to the threaded state in place, mirroring `denseReencodeOut` on the
+    stable-position arrays: only positions holding a group variable (bucket candidates) or a
+    variable-free composite node (`foldCs`) can change. The root cache keeps every untouched
+    position (it memoizes a pure function of the position's content). -/
+def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeCacheState p :=
+  let σfn := denseGroupSubst xs hm
+  let patts := denseAssignments (denseBitBox bits)
+  let bucketAdd : DenseCovIndex → List VarId → Nat → DenseCovIndex := fun idx vs i =>
+    ⟨vs.foldl (fun m v => m.insert v (i :: m.getD v [])) idx.buckets, idx.varless⟩
+  let posC := (denseCandidates state.useCs xs).foldl (·.insert ·) state.foldCs
+  let st := posC.fold (fun st i =>
+    if h : i < st.arrCs.size then
+      let c := st.arrCs[i]
+      if denseCoveredBy xs c then
+        { st with arrCs := st.arrCs.set i (.const 0), rootCache := st.rootCache.erase i,
+                  foldCs := st.foldCs.erase i }
+      else if c.sharesVarIn xs || c.hasConstFoldableNode then
+        let c' := denseGroupRewrite xs bits σfn patts c
+        let vs := HashedDedup.hashedDedup (hash ·) c'.vars
+        { st with
+          arrCs := st.arrCs.set i c'
+          rootCache := st.rootCache.erase i
+          csIdx := if vs.length ≤ 8 then bucketAdd st.csIdx vs i else st.csIdx
+          useCs := bucketAdd st.useCs vs i
+          foldCs := if c'.hasConstFoldableNode then st.foldCs.insert i else st.foldCs.erase i }
+      else st
+    else st) state
+  let st := bits.foldl (fun st b =>
+    let i := st.arrCs.size
+    { st with arrCs := st.arrCs.push (denseBoolConstraint b),
+              csIdx := bucketAdd st.csIdx [b] i,
+              useCs := bucketAdd st.useCs [b] i }) st
+  let posB := (denseCandidates state.useBis xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)
+  let st := posB.fold (fun st i =>
+    if h : i < st.arrBis.size then
+      let bi := st.arrBis[i]
+      if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
+          || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
+        let bi' : BusInteraction (DenseExpr p) :=
+          { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
+                    payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
+        { st with arrBis := st.arrBis.set i bi',
+                  useBis := bucketAdd st.useBis
+                    (HashedDedup.hashedDedup (hash ·) (denseBIVars bi')) i }
+      else st
+    else st) st
+  { st with varSet := bits.foldl (·.insert ·) st.varSet }
 
 def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId) (freshBase : String) :
+    (xs : List VarId) (freshBase : String) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseReencodeCacheState p :=
   if xs.all (fun x => reg.isInput x) then
   if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
@@ -586,7 +652,8 @@ def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
   | (reg1, none, rootCache) => (reg1, d, [], { state with rootCache })
   | (reg1, some (bits, hm), rootCache) =>
     let state := { state with rootCache }
-    if denseDegPreReject b use state.arrCs xs bits hm then (reg1, d, [], state)
+    if denseDegPreRejectIdx b state.useCs state.useBis state.arrBis state.arrCs xs bits hm then
+      (reg1, d, [], state)
     else
     if xs.all (fun x => state.varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
@@ -596,8 +663,7 @@ def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
       if ro.withinDegreeB b then
         (reg1, ro,
          bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
-         ⟨(if useIdx then denseBuildPruned DenseExpr.vars 8 ro.algebraicConstraints else ⟨∅, []⟩),
-          ro.algebraicConstraints.toArray, ∅, Std.HashSet.ofList ro.occ⟩)
+         denseReencodeStateUpdate state xs bits hm)
       else (reg1, d, [], state)
     else (reg1, d, [], state)
     else (reg1, d, [], state)
@@ -636,16 +702,15 @@ def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
 
 def denseReencodeLoopCached (b : DegreeBound) (useIdx : Bool) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
-      DenseReencodeCacheState p → Thunk (DenseReencodeUseIdx p) → Nat → Nat →
+      DenseReencodeCacheState p → Nat → Nat →
       VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _, _, _, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, state, use, nc, nb =>
+  | [], _, reg, d, _, _, _ => (reg, d, [])
+  | xs :: rest, idx, reg, d, state, nc, nb =>
     let (reg1, d1, derivs1, state1) :=
-      denseReencodeStepCached b useIdx reg d state use xs s!"rnc{nc}_{nb}_{idx}"
+      denseReencodeStepCached b useIdx reg d state xs s!"rnc{nc}_{nb}_{idx}"
     let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
     let (reg2, d2, derivs2) :=
-      denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
-        (denseReencodeUseNext derivs1 d1 use) nc1 nb1
+      denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1 nc1 nb1
     (reg2, d2, derivs1 ++ derivs2)
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
@@ -678,9 +743,15 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
     let useIdx := 8192 ≤ d.algebraicConstraints.length
     if useIdx ∧ useRootCache then
       denseReencodeLoopCached b useIdx targets 0 reg d
-        ⟨denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints,
-         d.algebraicConstraints.toArray, ∅, Std.HashSet.ofList d.occ⟩
-        (Thunk.mk (fun _ => denseBuildUseIdx d))
+        { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
+          arrCs := d.algebraicConstraints.toArray
+          rootCache := ∅
+          varSet := Std.HashSet.ofList d.occ
+          useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
+          useBis := denseCovBuild denseBIVars d.busInteractions
+          arrBis := d.busInteractions.toArray
+          foldCs := d.algebraicConstraints.zipIdx.foldl
+            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
         d.algebraicConstraints.length d.busInteractions.length
     else
       denseReencodeLoop b useIdx targets 0 reg d

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -200,6 +200,127 @@ def DenseExpr.sharesVarIn (xs : List VarId) : DenseExpr p → Bool
   | .add a b => a.sharesVarIn xs || b.sharesVarIn xs
   | .mul a b => a.sharesVarIn xs || b.sharesVarIn xs
 
+/-! ### Compiled twin of the system rewrite
+
+`denseGroupRewrite` is the identity on an item that shares no variable with the group and has no
+variable-free composite node (`denseGroupRewrite_eq_self`), so the compiled `denseReencodeOut`
+guards every item with a read-only gate and rebuilds only the few that can change — the plain
+definition rebuilds every expression of the system per accepted group. Installed with `@[csimp]`
+below, so callers compile to the gated form while the proofs keep the plain `denseReencodeOut`. -/
+
+theorem DenseExpr.varsInF_eq_false {xs : List VarId} {e : DenseExpr p}
+    (hv : e.hasVar = true) (hs : e.sharesVarIn xs = false) : e.varsInF xs = false := by
+  induction e with
+  | const n => simp [DenseExpr.hasVar] at hv
+  | var y =>
+      simp only [DenseExpr.sharesVarIn] at hs
+      simp [DenseExpr.varsInF, hs]
+  | add a b iha ihb =>
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.sharesVarIn, Bool.or_eq_false_iff] at hs
+      rcases hv with hv | hv
+      · simp [DenseExpr.varsInF, iha hv hs.1]
+      · simp [DenseExpr.varsInF, ihb hv hs.2]
+  | mul a b iha ihb =>
+      simp only [DenseExpr.hasVar, Bool.or_eq_true] at hv
+      simp only [DenseExpr.sharesVarIn, Bool.or_eq_false_iff] at hs
+      rcases hv with hv | hv
+      · simp [DenseExpr.varsInF, iha hv hs.1]
+      · simp [DenseExpr.varsInF, ihb hv hs.2]
+
+theorem denseGroupRewrite_eq_self {xs bits : List VarId} {σfn : VarId → Option (DenseExpr p)}
+    {patts : List (List (VarId × ZMod p))} {e : DenseExpr p}
+    (hs : e.sharesVarIn xs = false) (hf : e.hasConstFoldableNode = false) :
+    denseGroupRewrite xs bits σfn patts e = e := by
+  induction e with
+  | const n => rfl
+  | var y =>
+      simp only [DenseExpr.sharesVarIn] at hs
+      simp [denseGroupRewrite, hs]
+  | add a b iha ihb =>
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff, Bool.not_eq_false'] at hf
+      obtain ⟨⟨hv, hfa⟩, hfb⟩ := hf
+      simp only [DenseExpr.sharesVarIn, Bool.or_eq_false_iff] at hs
+      rw [denseGroupRewrite, if_neg (by
+        rw [DenseExpr.varsInF_eq_false hv
+          (by simp [DenseExpr.sharesVarIn, hs.1, hs.2])]; simp)]
+      rw [iha hs.1 hfa, ihb hs.2 hfb]
+  | mul a b iha ihb =>
+      simp only [DenseExpr.hasConstFoldableNode, Bool.or_eq_false_iff, Bool.not_eq_false'] at hf
+      obtain ⟨⟨hv, hfa⟩, hfb⟩ := hf
+      simp only [DenseExpr.sharesVarIn, Bool.or_eq_false_iff] at hs
+      rw [denseGroupRewrite, if_neg (by
+        rw [DenseExpr.varsInF_eq_false hv
+          (by simp [DenseExpr.sharesVarIn, hs.1, hs.2])]; simp)]
+      rw [iha hs.1 hfa, ihb hs.2 hfb]
+
+/-- `denseGroupRewrite` behind the read-only gate. -/
+def denseGroupRewriteGate (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) : DenseExpr p :=
+  if e.sharesVarIn xs || e.hasConstFoldableNode then denseGroupRewrite xs bits σfn patts e else e
+
+theorem denseGroupRewriteGate_eq (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    denseGroupRewriteGate xs bits σfn patts = denseGroupRewrite xs bits σfn patts := by
+  funext e
+  unfold denseGroupRewriteGate
+  split
+  · rfl
+  · next h =>
+      rw [Bool.or_eq_true, not_or, Bool.not_eq_true, Bool.not_eq_true] at h
+      exact (denseGroupRewrite_eq_self h.1 h.2).symm
+
+/-- Per-interaction gate: an interaction none of whose expressions can change is kept as-is. -/
+def denseBIRewriteGate (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
+    BusInteraction (DenseExpr p) :=
+  if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
+      || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
+    { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
+              payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
+  else bi
+
+theorem denseBIRewriteGate_eq (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    denseBIRewriteGate xs bits σfn patts
+      = fun bi => { bi with
+          multiplicity := denseGroupRewrite xs bits σfn patts bi.multiplicity,
+          payload := bi.payload.map (denseGroupRewrite xs bits σfn patts) } := by
+  funext bi
+  unfold denseBIRewriteGate
+  split
+  · rw [denseGroupRewriteGate_eq]
+  · next h =>
+      rw [Bool.or_eq_true, not_or, Bool.or_eq_true, not_or,
+        Bool.not_eq_true, Bool.not_eq_true, List.any_eq_true] at h
+      obtain ⟨⟨hm, hf⟩, hp⟩ := h
+      have hpl : bi.payload.map (denseGroupRewrite xs bits σfn patts) = bi.payload := by
+        have hcg : bi.payload.map (denseGroupRewrite xs bits σfn patts) = bi.payload.map id :=
+          List.map_congr_left (fun e he => by
+            have he' : ¬(e.sharesVarIn xs = true ∨ e.hasConstFoldableNode = true) := fun hor =>
+              hp ⟨e, he, by rw [Bool.or_eq_true]; exact hor⟩
+            rw [not_or, Bool.not_eq_true, Bool.not_eq_true] at he'
+            exact denseGroupRewrite_eq_self he'.1 he'.2)
+        rw [hcg, List.map_id]
+      rw [denseGroupRewrite_eq_self hm hf, hpl]
+
+/-- The gated twin of `denseReencodeOut`, with the substitution and pattern list hoisted out of the
+    per-interaction closures. -/
+def denseReencodeOutFast (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : DenseConstraintSystem p :=
+  let σfn := denseGroupSubst xs hm
+  let patts := denseAssignments (denseBitBox bits)
+  { algebraicConstraints :=
+      ((d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).map
+        (denseGroupRewriteGate xs bits σfn patts)) ++ bits.map denseBoolConstraint,
+    busInteractions := d.busInteractions.map (denseBIRewriteGate xs bits σfn patts) }
+
+@[csimp]
+theorem denseReencodeOut_eq_fast : @denseReencodeOut = @denseReencodeOutFast := by
+  funext p d xs bits hm
+  simp only [denseReencodeOut, denseReencodeOutFast, denseBIRewriteGate_eq,
+    denseGroupRewriteGate_eq]
+
 /-! ## The build/step/loop/pass layer -/
 
 inductive DenseReencodeRootPlan (p : ℕ)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -127,6 +127,34 @@ def denseGroupSurvivorsE (es : List (DenseExpr p)) (doms : List (VarId × List (
     (denseAssignments doms).filter
       (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = 0)))
 
+/-- `filter P l` if it keeps at most `cap` elements, `none` as soon as a `cap + 1`-st hit shows
+    up — the tail is not scanned. -/
+def denseFilterCap {α : Type} (P : α → Bool) : Nat → List α → Option (List α)
+  | _, [] => some []
+  | cap, x :: rest =>
+    if P x then
+      match cap with
+      | 0 => none
+      | cap + 1 =>
+        match denseFilterCap P cap rest with
+        | some l => some (x :: l)
+        | none => none
+    else denseFilterCap P cap rest
+
+/-- `denseGroupSurvivorsE`, stopping as soon as more than `cap` survivors exist. The build uses
+    `cap = 2 ^ (xs.length − 1)`: any larger survivor count makes `Nat.clog 2` reach the group
+    size and the `k < xs.length` gate reject, so the outcome is the full enumeration's. -/
+def denseGroupSurvivorsECap (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p)))
+    (cap : Nat) : Option (List (List (VarId × ZMod p))) :=
+  match denseCompileEs (doms.map Prod.fst) es with
+  | some ces =>
+    denseFilterCap
+      (denseSurvZeroCW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul ces)
+      cap (denseAssignments doms)
+  | none =>
+    denseFilterCap (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = 0)))
+      cap (denseAssignments doms)
+
 /-! ## The checked re-encoding certificate -/
 
 /-- All checked side conditions for one re-encoding step. The freshness conjunct is deliberately
@@ -434,7 +462,9 @@ def denseBuildReencode (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovInde
         -- single-var-only covered set (one per variable): survivors = box; unencodable
         (reg, none)
       else
-      let survs := denseGroupSurvivorsE es doms
+      match denseGroupSurvivorsECap es doms (2 ^ (xs.length - 1)) with
+      | none => (reg, none)
+      | some survs =>
       if 2 ≤ survs.length then
         let k := Nat.clog 2 survs.length
         if k < xs.length then
@@ -467,7 +497,9 @@ def denseBuildReencodeCached (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseC
           && xs.length ≤ Nat.clog 2 boxSize then
         (reg, none, cache)
       else
-      let survs := denseGroupSurvivorsE es doms
+      match denseGroupSurvivorsECap es doms (2 ^ (xs.length - 1)) with
+      | none => (reg, none, cache)
+      | some survs =>
       if 2 ≤ survs.length then
         let k := Nat.clog 2 survs.length
         if k < xs.length then

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -4991,3 +4991,51 @@ accept; and a *sequential* A/B of the two binaries showed a 2–6 % "win" that i
 entirely — run-ordering bias on this box is larger than the effect being measured. Always interleave.
 
 **Worked locally: yes** (byte-identical `opt-export` on 8 of 9 fixtures; `apc_020` size-identical).
+
+### 146. Runtime: sha256_big −28% — reencode stable-position state, busUnify ghost context, bytePack resume
+
+Targeted the runtime gap against powdr on the 168k-var sha256 case (timing comparison of
+2026-07-26: 511.9 s Lean vs 113.6 s Rust). A gdb stack-sampling harness over a live `profile` run
+(357 samples, shares matching the profiler's per-pass totals) pinned the superlinear costs; five
+output-preserving commits, in profile order:
+
+1. **busUnify: the sweep stops materializing `pre`/`post`.** `denseEmitCand` reversed the whole
+   seen-prefix per consumed window (~7 % of the run in samples) though `denseCollectForBus` only
+   reads `(S, mid, R)`. The context lists now exist only in the proofs — `OpenWF` and `SplitEqC`
+   quantify them existentially. busUnify **78.3 → 35.0 s (−55 %)**.
+2. **reencode: `@[csimp]` gated system rewrite.** `denseReencodeOut` rebuilt every expression per
+   accepted group; `denseGroupRewrite` is the identity on items sharing no group variable and
+   carrying no variable-free composite node (`denseGroupRewrite_eq_self`), so the compiled twin
+   rebuilds only items passing that read-only gate, and hoists the substitution closure and
+   pattern list out of the per-interaction lambdas (they re-enumerated `denseAssignments
+   (denseBitBox bits)` twice per interaction).
+3. **reencode: candidate state on stable positions.** The cached step rebuilt csIdx
+   (`denseBuildPruned`), the degree pre-gate indexes (two `denseCovBuild`s + `toArray`), the
+   variable set (`HashSet.ofList ro.occ` — every occurrence!), the root cache (cleared) and the
+   constraint array per accept — O(accepts × system) deep walks, the dominant reencode cost.
+   `DenseReencodeCacheState` now owns all of it on stable positions: `.const 0` tombstones for
+   dropped constraints (variable-free ⇒ inert to every index query), grow-only buckets, in-place
+   updates of exactly the touched positions (`denseReencodeStateUpdate`), tracked
+   variable-free-composite positions (`foldCs`) so the fold-in-passing behavior of the reference
+   map is mirrored. `varSet` only gains bits, so it over-approximates live variables — the
+   affected groups are instead rejected by the certificate (no covered constraint mentions an
+   eliminated variable), and the accept case's `xs ⊆ d.occ` is now derived from the certificate
+   (`denseCheckReencode_xsOcc`) rather than a threaded varSet invariant, which *simplified* the
+   loop proofs. Together with 2: reencode **152.0 → 62.1 s (−59 %)**.
+4. **bytePack: resume past the previous pack.** Each drain step re-ran `denseFindGo` from
+   position 0 (O(packs × interactions), a `denseSvCheck?` decode per visited item). The drain
+   state (was `Unit`) now carries the resume position — a position before the last pack can never
+   fire later, since shapes are fixed and packing only removes single-value checks. The step
+   theorems take the scan split `revPre.reverse ++ bis = d.busInteractions` instead of a scan
+   pinned at the head. bytePack **28.6 → 3.6 s**, bytePackLate **13.7 → 1.0 s**.
+5. **reencode: survivor enumeration capped at `2^(|xs|−1)`** — past that `Nat.clog 2` reaches the
+   group size and the `k < xs.length` gate rejects anyway, so barely-constrained groups stop
+   after a handful of box points. Small on sha (the enumeration share was ~2 %).
+
+sha256_big (`profile`, this 4-core box): **586.9 → 421.7 s (−28.2 %)**, cycle 0 256.8 → 144.2 s.
+Every cycle's `(vars, bus, constraints)` triple and the final circuit
+(11906 / 12464 / 3194) are identical to main, and keccak's `run` output (2021 / 186 / 1748) is
+unchanged after every commit. Remaining top passes: busPairCancel 67 s, gauss 51 s, domainBatch
+37 s.
+
+**Worked locally: yes (identical outputs; PR #220 for the CI matrix).**


### PR DESCRIPTION
Targets the runtime gap against powdr on the sha256 stress case (the [timing comparison](https://raw.githubusercontent.com/powdr-labs/powdr/apc-optimizer-timing-comparison/apc-timing/apc_optimizer_timing_2026_07_26.json) has the 168k-var case at 511.9s Lean vs 113.6s Rust, 4.5×). Stack-sampling a full `profile` run showed the superlinear costs concentrated in per-accept whole-system rebuilds (reencode), per-candidate prefix reversal (busUnify), and per-pack rescans (bytePack).

Five perf commits, each output-preserving (argument in the commit message; all opt-outputs below identical to main):

1. **busUnify** — the sweep emitted `(pre, S, mid, R, post)` per consumed window, reversing the whole seen prefix each time, but only `(S, mid, R)` is ever read. `pre`/`post` now exist only in the proofs (existentials in `OpenWF`/`SplitEqC`).
2. **reencode** — `@[csimp]` twin of `denseReencodeOut` that rebuilds only items sharing a group variable or carrying a variable-free composite node (`denseGroupRewrite` is provably the identity elsewhere), and hoists the substitution/pattern closures out of the per-interaction lambdas.
3. **reencode** — the cached loop's candidate state (pruned covered index, degree pre-gate indexes, constraint array, root cache, variable set) is no longer rebuilt per accepted group: stable positions with `.const 0` tombstones, grow-only buckets, in-place updates of just the touched positions (`denseReencodeStateUpdate`). The accept case's `xs ⊆ d.occ` now comes from the certificate (`denseCheckReencode_xsOcc`) instead of the varSet invariant.
4. **bytePack** — the drain resumes past the previous pack instead of rescanning from position 0 (a rejected first element can never fire later).
5. **reencode** — survivor enumeration stops past `2^(|xs|−1)` survivors, where the `k < xs.length` gate rejects anyway.

### Local numbers (4-core box, `profile Benchmarks/OpenVM/sha256/apc_001_pcsha256.json.gz`)

| | main | PR (all 5) | Δ |
|---|---|---|---|
| total | 586.9 s | 421.7 s | **−28.2%** |
| reencode | 152.0 s | 62.1 s | −59% |
| busUnify | 78.3 s | 35.0 s | −55% |
| bytePack + bytePackLate | 42.3 s | 4.7 s | −89% |
| cycle 0 | 256.8 s | 144.2 s | −44% |

Per-cycle sizes and the final circuit (11906 vars / 12464 bus / 3194 constraints) are identical to main throughout; keccak (`run`) output is identical (2021 / 186 / 1748) after every commit. Log entry 146 has the full story.

Draft until the CI benchmark confirms the sha256 runtime row and the effectiveness matrix is clean. Remaining top passes on sha after this PR: busPairCancel 67s, gauss 51s, domainBatch 37s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157cSJhkKKWif5Sji6JTb4e