### PR TITLE
perf: de-quadratify the shared expression walks (sha256 0.95×, gauss 0.75×, effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -1,4 +1,5 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Normalize
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 import ApcOptimizer.MemoryBus
 
 set_option autoImplicit false
@@ -159,6 +160,28 @@ def densePtrReductions (T : DenseTwoRootMap p) (E : DenseExpr p) :
       match T.map[v]? with
       | some (k, A, δ) => some (densePtrBranchesOf k A δ (L.coeff v) (L.others v))
       | none => none)
+
+/-- Runtime `densePtrReductions`: the two-root variables are deduplicated through the hash-bucketed
+    twin. The list is a linear form's variable list, and the pass queries this per compared message
+    pair, so the `List.eraseDups` quadratic showed up directly in `busPairCancel`. -/
+def densePtrReductionsFast (T : DenseTwoRootMap p) (E : DenseExpr p) :
+    List (DenseLinExpr p × DenseLinExpr p) :=
+  match denseLinearize E with
+  | none => []
+  | some L =>
+    (HashedDedup.hashedEraseDups (hash ·) (L.terms.map Prod.fst)).filterMap (fun v =>
+      match T.map[v]? with
+      | some (k, A, δ) => some (densePtrBranchesOf k A δ (L.coeff v) (L.others v))
+      | none => none)
+
+@[csimp] theorem densePtrReductions_eq_fast :
+    @densePtrReductions = @densePtrReductionsFast := by
+  funext q T E
+  show densePtrReductions T E = _
+  unfold densePtrReductions densePtrReductionsFast
+  cases denseLinearize E with
+  | none => rfl
+  | some L => dsimp only; rw [HashedDedup.hashedEraseDups_eq]
 
 /-! ## Nonzero-constant differences -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -50,6 +50,19 @@ prefix at every node — `O(terms²)`. `denseLinearizeAcc` builds the same list 
 (right subtree first), which costs one cons per term. Only `add` needs the accumulator; a `mul`
 that linearizes has a term-free side, so it scales rather than concatenates. -/
 
+/-- `l.map (fun t => (t.1, k * t.2)) ++ acc` in one pass, so the scaling `mul` branch below does
+    not build an intermediate list only to copy it onto the accumulator. -/
+def denseScaleAppend (k : ZMod p) :
+    List (VarId × ZMod p) → List (VarId × ZMod p) → List (VarId × ZMod p)
+  | [], acc => acc
+  | t :: ts, acc => (t.1, k * t.2) :: denseScaleAppend k ts acc
+
+theorem denseScaleAppend_eq (k : ZMod p) (l acc : List (VarId × ZMod p)) :
+    denseScaleAppend k l acc = l.map (fun t => (t.1, k * t.2)) ++ acc := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons t ts ih => simp [denseScaleAppend, ih]
+
 def denseLinearizeAcc : DenseExpr p → List (VarId × ZMod p) →
     Option (ZMod p × List (VarId × ZMod p))
   | .const n, acc => some (n, acc)
@@ -64,8 +77,8 @@ def denseLinearizeAcc : DenseExpr p → List (VarId × ZMod p) →
   | .mul a b, acc =>
       match denseLinearizeAcc a [], denseLinearizeAcc b [] with
       | some (ca, ta), some (cb, tb) =>
-          if ta.isEmpty then some (ca * cb, tb.map (fun t => (t.1, ca * t.2)) ++ acc)
-          else if tb.isEmpty then some (cb * ca, ta.map (fun t => (t.1, cb * t.2)) ++ acc)
+          if ta.isEmpty then some (ca * cb, denseScaleAppend ca tb acc)
+          else if tb.isEmpty then some (cb * ca, denseScaleAppend cb ta acc)
           else none
       | _, _ => none
 
@@ -93,9 +106,9 @@ theorem denseLinearizeAcc_eq (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
         | some lb =>
           simp only [Option.map_some, List.append_nil]
           by_cases h1 : la.terms.isEmpty
-          · simp [denseLinearize, ha, hb, h1, DenseLinExpr.scale]
+          · simp [denseLinearize, ha, hb, h1, DenseLinExpr.scale, denseScaleAppend_eq]
           · by_cases h2 : lb.terms.isEmpty
-            · simp [denseLinearize, ha, hb, h1, h2, DenseLinExpr.scale]
+            · simp [denseLinearize, ha, hb, h1, h2, DenseLinExpr.scale, denseScaleAppend_eq]
             · simp [denseLinearize, ha, hb, h1, h2]
 
 def denseLinearizeFast (e : DenseExpr p) : Option (DenseLinExpr p) :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -43,6 +43,70 @@ def denseLinearize : DenseExpr p → Option (DenseLinExpr p)
           else none
       | _, _ => none
 
+/-! ## Accumulator twin of `denseLinearize` (runtime `@[csimp]`)
+
+`DenseLinExpr.add` appends the left form's terms, so a left-associated affine chain recopies its
+prefix at every node — `O(terms²)`. `denseLinearizeAcc` builds the same list onto a suffix
+(right subtree first), which costs one cons per term. Only `add` needs the accumulator; a `mul`
+that linearizes has a term-free side, so it scales rather than concatenates. -/
+
+def denseLinearizeAcc : DenseExpr p → List (VarId × ZMod p) →
+    Option (ZMod p × List (VarId × ZMod p))
+  | .const n, acc => some (n, acc)
+  | .var i, acc => some (0, (i, 1) :: acc)
+  | .add a b, acc =>
+      match denseLinearizeAcc b acc with
+      | none => none
+      | some (cb, acc') =>
+        match denseLinearizeAcc a acc' with
+        | none => none
+        | some (ca, acc'') => some (ca + cb, acc'')
+  | .mul a b, acc =>
+      match denseLinearizeAcc a [], denseLinearizeAcc b [] with
+      | some (ca, ta), some (cb, tb) =>
+          if ta.isEmpty then some (ca * cb, tb.map (fun t => (t.1, ca * t.2)) ++ acc)
+          else if tb.isEmpty then some (cb * ca, ta.map (fun t => (t.1, cb * t.2)) ++ acc)
+          else none
+      | _, _ => none
+
+theorem denseLinearizeAcc_eq (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
+    denseLinearizeAcc e acc = (denseLinearize e).map (fun l => (l.const, l.terms ++ acc)) := by
+  induction e generalizing acc with
+  | const n => simp [denseLinearizeAcc, denseLinearize]
+  | var i => simp [denseLinearizeAcc, denseLinearize]
+  | add a b iha ihb =>
+      simp only [denseLinearizeAcc, ihb acc]
+      cases hb : denseLinearize b with
+      | none => simp [denseLinearize, hb]
+      | some lb =>
+        simp only [Option.map_some, iha (lb.terms ++ acc)]
+        cases ha : denseLinearize a with
+        | none => simp [denseLinearize, ha, hb]
+        | some la => simp [denseLinearize, ha, hb, DenseLinExpr.add, List.append_assoc]
+  | mul a b iha ihb =>
+      simp only [denseLinearizeAcc, iha [], ihb []]
+      cases ha : denseLinearize a with
+      | none => simp [denseLinearize, ha]
+      | some la =>
+        cases hb : denseLinearize b with
+        | none => simp [denseLinearize, ha, hb]
+        | some lb =>
+          simp only [Option.map_some, List.append_nil]
+          by_cases h1 : la.terms.isEmpty
+          · simp [denseLinearize, ha, hb, h1, DenseLinExpr.scale]
+          · by_cases h2 : lb.terms.isEmpty
+            · simp [denseLinearize, ha, hb, h1, h2, DenseLinExpr.scale]
+            · simp [denseLinearize, ha, hb, h1, h2]
+
+def denseLinearizeFast (e : DenseExpr p) : Option (DenseLinExpr p) :=
+  (denseLinearizeAcc e []).map (fun r => ⟨r.1, r.2⟩)
+
+@[csimp] theorem denseLinearize_eq_fast : @denseLinearize = @denseLinearizeFast := by
+  funext p e
+  show denseLinearize e = _
+  simp only [denseLinearizeFast, denseLinearizeAcc_eq, Option.map_map, List.append_nil]
+  cases denseLinearize e <;> rfl
+
 /-- Turn a dense linear form back into a dense expression. -/
 def DenseLinExpr.toExpr (l : DenseLinExpr p) : DenseExpr p :=
   l.terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) (.const l.const)

--- a/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
@@ -48,6 +48,25 @@ def denseNeverZeroB (B : Std.HashMap VarId Nat) (e : DenseExpr p) : Bool :=
     (1 :: n.const⁻¹ :: n.terms.map (fun t => t.2⁻¹)).any (fun k =>
       denseIntervalCert B ((n.scale k).norm))
 
+/-- Runtime `denseNeverZeroB`: the candidate list is built before `any` runs, so every term's
+    modular inverse is computed even when the first rescaling already certifies. Folding the map
+    into the `any` makes the inverses as lazy as the search. -/
+def denseNeverZeroBFast (B : Std.HashMap VarId Nat) (e : DenseExpr p) : Bool :=
+  match denseLinearize e with
+  | none => false
+  | some l =>
+    let n := l.norm
+    let test := fun k => denseIntervalCert B ((n.scale k).norm)
+    test 1 || test n.const⁻¹ || n.terms.any (fun t => test t.2⁻¹)
+
+@[csimp] theorem denseNeverZeroB_eq_fast : @denseNeverZeroB = @denseNeverZeroBFast := by
+  funext p B e
+  show denseNeverZeroB B e = _
+  unfold denseNeverZeroB denseNeverZeroBFast
+  cases denseLinearize e with
+  | none => rfl
+  | some l => simp [List.any_map, Function.comp_def, Bool.or_assoc]
+
 /-! ## Dense product-constraint resolution -/
 
 /-- Collapse a product `f·g` in a constraint to the surviving factor when the other factor is

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -88,6 +88,33 @@ def DenseExpr.vars : DenseExpr p → List VarId
   | .add a b => a.vars ++ b.vars
   | .mul a b => a.vars ++ b.vars
 
+/-! `vars` appends its children's lists, so every enclosing node recopies the left subtree's
+result — quadratic in the depth of the left-associated chains affine reconstruction produces, and
+one of the biggest allocation sources in the whole optimizer (`vars` is recomputed per item per
+pass). The accumulator twin below walks the right subtree into the suffix, allocating one cons per
+occurrence and preserving the left-to-right order exactly. -/
+
+def DenseExpr.varsAcc : DenseExpr p → List VarId → List VarId
+  | .const _, acc => acc
+  | .var i, acc => i :: acc
+  | .add a b, acc => a.varsAcc (b.varsAcc acc)
+  | .mul a b, acc => a.varsAcc (b.varsAcc acc)
+
+theorem DenseExpr.varsAcc_eq (e : DenseExpr p) (acc : List VarId) :
+    e.varsAcc acc = e.vars ++ acc := by
+  induction e generalizing acc with
+  | const n => rfl
+  | var i => rfl
+  | add a b iha ihb => simp [DenseExpr.varsAcc, DenseExpr.vars, iha, ihb]
+  | mul a b iha ihb => simp [DenseExpr.varsAcc, DenseExpr.vars, iha, ihb]
+
+def DenseExpr.varsFast (e : DenseExpr p) : List VarId := e.varsAcc []
+
+@[csimp] theorem DenseExpr.vars_eq_fast : @DenseExpr.vars = @DenseExpr.varsFast := by
+  funext p e
+  show e.vars = e.varsAcc []
+  rw [DenseExpr.varsAcc_eq, List.append_nil]
+
 /-- All `VarId`s of a dense bus interaction (multiplicity then payload). -/
 def denseBIVars (bi : BusInteraction (DenseExpr p)) : List VarId :=
   bi.multiplicity.vars ++ bi.payload.flatMap DenseExpr.vars

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -295,6 +295,101 @@ def denseSparseSubstF (σ : VarId → Option (DenseLinExpr p)) : DenseExpr p →
           let rb := denseSparseSubstF σ b
           denseReducedMul ra rb
 
+/-! ## Fused substitution walk (runtime `@[csimp]` replacement for `denseSparseSubstF`)
+
+`denseSparseSubstF` re-runs `denseLinearize` over the whole node at every node of the nonlinear
+spine, and substitutes into every affine node whose parent then re-substitutes the merged row —
+both quadratic in the size of a constraint. The fused walk carries each node's linear form up
+(`lin?`, provably `denseLinearize`) and leaves the substitution undeveloped (`lin`) while a parent
+can still absorb it. -/
+
+inductive DenseSubstRes (p : ℕ) where
+  | pre (r : DenseGaussReduced p) (l : DenseLinExpr p)
+  | lin (l : DenseLinExpr p)
+  | opq (r : DenseGaussReduced p)
+
+def DenseSubstRes.reduced (σ : VarId → Option (DenseLinExpr p)) :
+    DenseSubstRes p → DenseGaussReduced p
+  | .pre r _ => r
+  | .lin l => .affine (denseLinSubstF l σ)
+  | .opq r => r
+
+def DenseSubstRes.lin? : DenseSubstRes p → Option (DenseLinExpr p)
+  | .pre _ l => some l
+  | .lin l => some l
+  | .opq _ => none
+
+def denseSparseSubstFused (σ : VarId → Option (DenseLinExpr p)) :
+    DenseExpr p → DenseSubstRes p
+  | .const n => .pre (.affine ⟨n, []⟩) ⟨n, []⟩
+  | .var x =>
+      .pre (match σ x with | some row => .affine row | none => .affine ⟨0, [(x, 1)]⟩)
+        ⟨0, [(x, 1)]⟩
+  | .add a b =>
+      let ra := denseSparseSubstFused σ a
+      let rb := denseSparseSubstFused σ b
+      match ra.lin?, rb.lin? with
+      | some la, some lb => .lin (la.add lb)
+      | _, _ => .opq (denseReducedAdd (ra.reduced σ) (rb.reduced σ))
+  | .mul a b =>
+      let ra := denseSparseSubstFused σ a
+      let rb := denseSparseSubstFused σ b
+      match ra.lin?, rb.lin? with
+      | some la, some lb =>
+          if la.terms.isEmpty then .lin (lb.scale la.const)
+          else if lb.terms.isEmpty then .lin (la.scale lb.const)
+          else .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
+      | _, _ => .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
+
+def denseSparseSubstFFast (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
+    DenseGaussReduced p :=
+  (denseSparseSubstFused σ e).reduced σ
+
+theorem denseSparseSubstFused_lin (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
+    (denseSparseSubstFused σ e).lin? = denseLinearize e := by
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      rw [denseSparseSubstFused, denseLinearize]
+      rw [show (denseSparseSubstFused σ a).lin? = denseLinearize a from iha] at *
+      cases denseLinearize a <;> cases hb : (denseSparseSubstFused σ b).lin? <;>
+        rw [hb] at ihb <;> simp [DenseSubstRes.lin?, ← ihb]
+  | mul a b iha ihb =>
+      rw [denseSparseSubstFused, denseLinearize]
+      rw [show (denseSparseSubstFused σ a).lin? = denseLinearize a from iha] at *
+      cases denseLinearize a <;> cases hb : (denseSparseSubstFused σ b).lin? <;>
+        rw [hb] at ihb <;>
+        simp only [← ihb] <;> first | rfl | (split_ifs <;> rfl)
+
+theorem denseSparseSubstFused_reduced (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
+    (denseSparseSubstFused σ e).reduced σ = denseSparseSubstF σ e := by
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      rw [denseSparseSubstFused, denseSparseSubstF, denseLinearize,
+        denseSparseSubstFused_lin σ a, denseSparseSubstFused_lin σ b]
+      simp only [DenseSubstRes.reduced] at iha ihb ⊢
+      cases denseLinearize a <;> cases denseLinearize b <;>
+        first | rfl | rw [iha, ihb]
+  | mul a b iha ihb =>
+      rw [denseSparseSubstFused, denseSparseSubstF, denseLinearize,
+        denseSparseSubstFused_lin σ a, denseSparseSubstFused_lin σ b]
+      simp only [DenseSubstRes.reduced] at iha ihb ⊢
+      cases hla : denseLinearize a with
+      | none => rw [iha, ihb]
+      | some la =>
+        cases hlb : denseLinearize b with
+        | none => rw [iha, ihb]
+        | some lb =>
+          dsimp only
+          split_ifs <;> first | rfl | rw [iha, ihb]
+
+@[csimp] theorem denseSparseSubstF_eq_fast : @denseSparseSubstF = @denseSparseSubstFFast := by
+  funext p σ e
+  exact (denseSparseSubstFused_reduced σ e).symm
+
 def denseReducedSubst (r : DenseGaussReduced p) (x : VarId)
     (t : DenseLinExpr p) : DenseGaussReduced p :=
   match r with

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -528,6 +528,80 @@ theorem denseNormalizeFused_eq (e : DenseExpr p) :
 theorem denseNormalizeFused_fst (e : DenseExpr p) : (denseNormalizeFused e).1 = e.normalize := by
   rw [denseNormalizeFused_eq]
 
+/-! ## Deferred materialization (runtime `@[csimp]` replacement for `denseNormalizeFused`)
+
+`denseNormalizeFused` rebuilds `l.norm.toExpr` at *every* affine node, but a parent that is itself
+affine discards it and re-merges the linear form — so a `k`-term affine chain pays `k` merges and
+`k` tree builds over `1..k` terms, i.e. `O(k²)`. `denseNormalizeFusedFast` returns the linear form
+undeveloped (`DenseNormRes.lin`) and materializes only where a parent cannot absorb it. -/
+
+/-- A fused-walk result with the expression left undeveloped while it is still absorbable.
+    `var` is its own case because the walk returns a bare variable unchanged, not its normal form. -/
+inductive DenseNormRes (p : ℕ) where
+  | var (x : VarId)
+  | lin (l : DenseLinExpr p)
+  | opq (e : DenseExpr p)
+
+/-- The normalized expression of a deferred result — the `.1` of `denseNormalizeFused`. -/
+def DenseNormRes.expr : DenseNormRes p → DenseExpr p
+  | .var x => .var x
+  | .lin l => l.norm.toExpr
+  | .opq e => e
+
+/-- The linear form of a deferred result — the `.2` of `denseNormalizeFused`. -/
+def DenseNormRes.lin? : DenseNormRes p → Option (DenseLinExpr p)
+  | .var x => some ⟨0, [(x, 1)]⟩
+  | .lin l => some l
+  | .opq _ => none
+
+def denseNormalizeFusedFast : DenseExpr p → DenseNormRes p
+  | .const n => .lin ⟨n, []⟩
+  | .var x => .var x
+  | .add a b =>
+      let ra := denseNormalizeFusedFast a
+      let rb := denseNormalizeFusedFast b
+      match ra.lin?, rb.lin? with
+      | some la, some lb => .lin (la.add lb)
+      | _, _ => .opq (.add ra.expr rb.expr)
+  | .mul a b =>
+      let ra := denseNormalizeFusedFast a
+      let rb := denseNormalizeFusedFast b
+      match ra.lin?, rb.lin? with
+      | some la, some lb =>
+          if la.terms.isEmpty then .lin (lb.scale la.const)
+          else if lb.terms.isEmpty then .lin (la.scale lb.const)
+          else .opq (.mul ra.expr rb.expr)
+      | _, _ => .opq (.mul ra.expr rb.expr)
+
+def denseNormalizeFusedPair (e : DenseExpr p) : DenseExpr p × Option (DenseLinExpr p) :=
+  let r := denseNormalizeFusedFast e
+  (r.expr, r.lin?)
+
+/-- Runtime `DenseExpr.normalize`: the spec re-runs `denseLinearize` over the whole node at every
+    node it visits, which is quadratic; the fused walk visits each node once. -/
+def denseNormalizeFast (e : DenseExpr p) : DenseExpr p := (denseNormalizeFusedFast e).expr
+
+@[csimp] theorem denseNormalizeFused_eq_fast :
+    @denseNormalizeFused = @denseNormalizeFusedPair := by
+  funext p e
+  show denseNormalizeFused e = _
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      simp only [denseNormalizeFused, denseNormalizeFusedPair, denseNormalizeFusedFast, iha, ihb]
+      cases denseNormalizeFusedFast a <;> cases denseNormalizeFusedFast b <;> rfl
+  | mul a b iha ihb =>
+      simp only [denseNormalizeFused, denseNormalizeFusedPair, denseNormalizeFusedFast, iha, ihb]
+      cases denseNormalizeFusedFast a <;> cases denseNormalizeFusedFast b <;>
+        simp only [DenseNormRes.lin?] <;> first | rfl | (split_ifs <;> rfl)
+
+@[csimp] theorem DenseExpr_normalize_eq_fast : @DenseExpr.normalize = @denseNormalizeFast := by
+  funext p e
+  show DenseExpr.normalize e = _
+  rw [← denseNormalizeFused_fst, denseNormalizeFused_eq_fast]
+  rfl
+
 /-- The fused walk is eval-preserving (transported from `DenseExpr.normalize_eval`). -/
 theorem denseNormalizeFused_fst_eval (e : DenseExpr p) (denv : VarId → ZMod p) :
     ((denseNormalizeFused e).1).eval denv = e.eval denv := by

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5039,3 +5039,64 @@ unchanged after every commit. Remaining top passes: busPairCancel 67 s, gauss 51
 37 s.
 
 **Worked locally: yes (identical outputs; PR #220 for the CI matrix).**
+### 147. Runtime: de-quadratify the shared expression walks (sha256 0.93×)
+
+Five `@[csimp]` twins, each proven equal to the definition it replaces, so the output is
+byte-identical by theorem — the CI effectiveness matrix reports `+0.000×` on all three axes across
+all six benchmark sets.
+
+**Where the time is.** Stack-sampling a `run` of the 168k-variable sha256 case put ~47 % of the
+whole run in the allocator and `lean_dec_ref_cold`, with `DenseExpr.vars` at 9.7 % of innermost
+frames and `List.append` (`reverseAux`) at 6.9 % right behind it — the budget is memory traffic from
+list concatenation in walks that every pass shares, which is also the reason the gap to powdr grows
+with circuit size.
+
+- `DenseExpr.vars` appended its children's lists, so every enclosing node recopied the left subtree:
+  quadratic in the depth of the left-associated chains affine reconstruction produces, recomputed
+  per item per pass. Accumulator twin (`varsAcc`), same left-to-right order. Also proposed in
+  PR #173/#216.
+- `denseLinearize` had the same shape through `DenseLinExpr.add`. `denseLinearizeAcc` builds onto a
+  suffix; `denseScaleAppend` fuses the map and the append in the scaling `mul` branch. **That fusion
+  is load-bearing**: the first version wrote `l.map f ++ acc`, which is *worse* than the original
+  single map on the `c * x` shapes address slots have, and it showed up as a regression in
+  `busPairCancel`/`subsumedRange`/`rootPairUnify` — the passes that linearize address slots per
+  compared message pair.
+- `denseNormalizeFused` rebuilt `l.norm.toExpr` at every affine node although an affine parent
+  discards it and re-merges: `k` merges and `k` tree builds over `1..k` terms. `DenseNormRes` keeps
+  the linear form undeveloped and materializes only where a parent cannot absorb it. `.var` needs
+  its own constructor — the walk returns a bare variable unchanged, not its normal form.
+  `DenseExpr.normalize` is routed through the same walk.
+- `denseSparseSubstF` (Gauss) had both problems at once: `denseLinearize` over the whole node at
+  every node of the nonlinear spine, and a substitution into every affine node whose parent
+  re-substitutes the merged row. `denseSparseSubstFused` carries the linear form up and defers the
+  substitution. **gauss 0.73×**, the largest single win here.
+- `denseNeverZeroB` (carryBranch) built its rescaling-candidate list before `any` ran, computing
+  every term's extended-gcd inverse even when the first candidate certified.
+- `densePtrReductions` (addrDiseq) used `List.eraseDups` on a linear form's variable list, per
+  compared message pair; routed through the existing proven `HashedDedup.hashedEraseDups`.
+
+**Numbers** (CI `Runtime Bench`, sha256, quiet 32-core runner, target vs baseline on the same
+runner): total **350.4 → 324.6 s (0.93×)**; gauss 30.2 → 22.0 (0.73×), normalize1 12.4 → 9.2
+(0.74×), normalize2 8.6 → 6.8 (0.79×), domainFold 0.91×, disconnected 0.90×, zeroRegister 0.90×,
+reencode 0.97×. Effectiveness-matrix runtime rows: wasm-eth −9 %, OpenVM keccak −7 %, openvm-eth
+−4 %, sp1/rsp −5 %.
+
+**Measurement lesson, worth more than the change.** The first local reading of this work was
+**0.86×**, and it was wrong: the `main` baseline profile had been taken with a gdb stack sampler
+attached for most of its run, inflating it. Re-measuring `main` alone two hours later gave 649 s and
+then 815 s for the *same binary* — this container drifts ±25 % over hours, which is larger than the
+effect being measured. Two rules follow: never compare against a baseline captured under different
+instrumentation, and treat any local sha256 total as unusable — dispatch `Runtime Bench` with
+`-f benchmark=sha256`, which benches both sides on one runner, and read that.
+
+**Also learned:** a gdb sampler with no sleep between attaches does not merely slow the run, it
+*biases* it — allocation-heavy passes are perturbed far more than the rest, and reencode came out at
+74 % of samples against a profiler-measured 23 %. Sample with a ≥2 s gap and cross-check against
+`profile`.
+
+**Where sha256 stands after this** (same runner): reencode 112.5 s of 324.6 s (35 %), busPairCancel
+31.5, busUnify 29.9, gauss 22.0, domainBatch 19.3, bytePack 15.0. Reencode's `O(accepts × system)`
+per-accept rebuilds are the only remaining lever of that size, and PR #220 restructures exactly
+them; nothing here touches that code.
+
+**Worked: yes.**

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5075,11 +5075,16 @@ with circuit size.
 - `densePtrReductions` (addrDiseq) used `List.eraseDups` on a linear form's variable list, per
   compared message pair; routed through the existing proven `HashedDedup.hashedEraseDups`.
 
-**Numbers** (CI `Runtime Bench`, sha256, quiet 32-core runner, target vs baseline on the same
-runner): total **350.4 → 324.6 s (0.93×)**; gauss 30.2 → 22.0 (0.73×), normalize1 12.4 → 9.2
-(0.74×), normalize2 8.6 → 6.8 (0.79×), domainFold 0.91×, disconnected 0.90×, zeroRegister 0.90×,
-reencode 0.97×. Effectiveness-matrix runtime rows: wasm-eth −9 %, OpenVM keccak −7 %, openvm-eth
-−4 %, sp1/rsp −5 %.
+**Numbers** (CI `Runtime Bench`, sha256, quiet 32-core runner, both sides on the same runner).
+Against `main` after entry 146: total **253.2 → 240.3 s (0.95×)**; gauss 30.4 → 22.9 (0.75×),
+normalize1 12.1 → 9.3 (0.77×), normalize2 8.5 → 6.8 (0.80×), busPairCancelLate 0.83×,
+disconnected 0.91×, domainFold 0.92×, zeroRegister 0.93×, hintCollapse 0.93×, domainBatch 0.96×,
+reencode 1.02× (noise). Against `main` *before* entry 146 the same workflow measured
+350.4 → 324.6 s (0.93×) for an earlier head, so the two compose: 350.4 → 240.3 s.
+
+The effectiveness matrix's runtime row reported −17 % on sha256 for the same commit; that row is
+report-only and ran alongside five other sets. **Believe the serial `Runtime Bench` (0.95×), not
+the matrix row** — the same disagreement shows up on wasm-eth (−37 %) and sp1/rsp (−38 %).
 
 **Measurement lesson, worth more than the change.** The first local reading of this work was
 **0.86×**, and it was wrong: the `main` baseline profile had been taken with a gdb stack sampler
@@ -5094,9 +5099,14 @@ instrumentation, and treat any local sha256 total as unusable — dispatch `Runt
 74 % of samples against a profiler-measured 23 %. Sample with a ≥2 s gap and cross-check against
 `profile`.
 
-**Where sha256 stands after this** (same runner): reencode 112.5 s of 324.6 s (35 %), busPairCancel
-31.5, busUnify 29.9, gauss 22.0, domainBatch 19.3, bytePack 15.0. Reencode's `O(accepts × system)`
-per-accept rebuilds are the only remaining lever of that size, and PR #220 restructures exactly
-them; nothing here touches that code.
+**Where sha256 stands after this** (same runner, on top of entry 146): reencode 53.9 s of 240.3 s
+(22 %), busPairCancel 31.0, gauss 22.9, busUnify 19.9, domainBatch 18.9. The next lever of real
+size is `busPairCancel`'s address-disequality certificates: `denseAddrAffineNeq` /
+`denseAddrTwoRootNeq` / `denseAddrNonzeroNeq` recompute the whole *candidate* side (slot
+linearization, `densePtrReductions`, `denseDiffSumOver` over every address-field subset) once per
+compared message. Sampling puts ~42 % of the pass in that linear-form algebra. Hoisting a
+prepared-`S` record out of `denseLiveAllSeg`'s and `denseShieldScanSeg`'s inner loops makes it
+`O(candidates + messages)`; `denseShieldScanSeg` needs a closure-parameterized twin
+(`denseShieldScanSegW pre prov …`, one induction) so the caller can supply the prepared tests.
 
 **Worked: yes.**


### PR DESCRIPTION
Rebased on `main` after #220. Five `@[csimp]` runtime twins, each **proven equal to the definition it replaces**, so every optimizer output is byte-identical by theorem and the audited surface is untouched — the CI matrix confirms **+0.000× on all three axes across all six benchmark sets**.

## Numbers (CI `Runtime Bench`, sha256, quiet 32-core runner, both sides on the same runner)

Target `bb135ae` vs baseline `4959ef1`:

| | target | baseline | Δ |
|---|---|---|---|
| **sha256 total** | **240.3 s** | 253.2 s | **0.95×** |
| gauss | 22.9 s | 30.4 s | **0.75×** |
| normalize1 | 9.3 s | 12.1 s | **0.77×** |
| normalize2 | 6.8 s | 8.5 s | **0.80×** |
| busPairCancelLate | 0.40 s | 0.49 s | 0.83× |
| disconnected | 5.1 s | 5.6 s | 0.91× |
| domainFold | 6.4 s | 6.9 s | 0.92× |
| zeroRegister | 2.6 s | 2.8 s | 0.93× |
| hintCollapse | 4.0 s | 4.3 s | 0.93× |
| domainBatch | 18.9 s | 19.6 s | 0.96× |
| reencode | 53.9 s | 53.0 s | 1.02× |

Against `main` *before* #220 the same workflow measured 350.4 s → 324.6 s (0.93×) for an earlier head of this branch, so the two PRs compose: 350.4 s → 240.3 s combined.

## Where the time is, and what changed

Stack-sampling a `run` of `Benchmarks/OpenVM/sha256/apc_001_pcsha256.json.gz` puts **~47 % of the whole run in the allocator and `lean_dec_ref_cold`**, with `DenseExpr.vars` at 9.7 % of innermost frames and `List.append` (`reverseAux`) at another 6.9 % behind it. The budget is memory traffic from list concatenation in walks that every pass shares — which is also why the gap to powdr grows with circuit size. Five such walks concatenate or re-materialize per node:

- **`DenseExpr.vars`** appended its children's lists, recopying the left subtree at every enclosing node — quadratic in the depth of the left-associated chains affine reconstruction produces, recomputed per item per pass. The accumulator twin walks the right subtree into the suffix: one cons per occurrence, same left-to-right order. *(Also proposed in #173 / #216 — drop this commit if either lands first; the rest is new.)*
- **`denseLinearize`** had the same prefix-recopy shape through `DenseLinExpr.add`. `denseLinearizeAcc` builds onto a suffix, with `denseScaleAppend` fusing the map and the append in the scaling `mul` branch. **That fusion is load-bearing** — the first version wrote `l.map f ++ acc`, which is *worse* than the original single map on the `c * x` shapes address slots have, and it showed up as a regression in exactly the passes that linearize address slots per compared message pair.
- **`denseNormalizeFused`** rebuilt `l.norm.toExpr` at *every* affine node although an affine parent discards it and re-merges: a `k`-term chain paid `k` merges and `k` tree builds over `1..k` terms. The twin keeps the linear form undeveloped and materializes only where a parent cannot absorb it. `DenseExpr.normalize` — which re-ran `denseLinearize` over the whole node at every node it visited, and is called per constraint by Gauss and per payload-equality query by `busPairCancel`/`busUnify`/`bytePack` — is routed through the same walk.
- **`denseSparseSubstF`** (Gauss) had both problems at once: `denseLinearize` over the whole node at every node of the nonlinear spine, *and* a substitution into every affine node whose parent then re-substitutes the merged row. `denseSparseSubstFused` carries each node's linear form up (provably `denseLinearize`) and defers the substitution. This is the 0.75× on Gauss.
- **`denseNeverZeroB`** (carryBranch) built `(1 :: n.const⁻¹ :: n.terms.map (·.2⁻¹))` before running `any` over it, so every term's extended-gcd inverse was computed even when the first rescaling already certified.
- **`densePtrReductions`** (addrDiseq) deduplicated a linear form's variable list with `List.eraseDups`, per compared message pair; routed through the repo's existing proven `HashedDedup.hashedEraseDups`.

## Verification

- `lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` green (three standard axioms, no unused theorems).
- CI effectiveness matrix: per-case circuit sizes **identical to main on all six sets** (openvm-eth, wasm-eth, OpenVM keccak, sha256, sp1/rsp, sp1/keccak). Locally also byte-identical `opt-export` on openvm-eth apc_001/005/020/044, OpenVM keccak and SP1 rsp apc_001/024/030.
- Diff is 6 Lean files, all under `ApcOptimizer/Implementation/OptimizerPasses/`, plus log entry 147.

## Measurement note (recorded in the log entry too)

The first local reading of this work was 0.86×, and it was wrong: the `main` baseline profile had been captured with a gdb stack sampler attached for most of its run. Re-measuring `main` alone gave 649 s and then 815 s for the *same binary* two hours apart — that container drifts ±25 %, well above the effect size. Local sha256 totals are unusable; dispatch `Runtime Bench -f benchmark=sha256`, which benches both sides on one runner.

## Where sha256 stands after this

Same runner, after this PR: **reencode 53.9 s of 240.3 s (22 %)**, busPairCancel 31.0 s, gauss 22.9 s, busUnify 19.9 s, domainBatch 18.9 s. The next lever of real size is `busPairCancel`'s address-disequality certificates: `denseAddrAffineNeq` / `denseAddrTwoRootNeq` / `denseAddrNonzeroNeq` recompute all of the *candidate's* side (slot linearization, `densePtrReductions`, `denseDiffSumOver` over every address-field subset) once per compared message, so hoisting a prepared-`S` record out of `denseLiveAllSeg`'s and `denseShieldScanSeg`'s inner loops is `O(candidates × messages) → O(candidates + messages)` on that work. Sampling attributes ~42 % of the pass to that linear-form algebra.