### PR TITLE
perf: sparse same-key region scans for busPairCancel (58→32 s on the 168k-var sha256 case) + prepared certificates, bucketed domains, one-walk reencode freshness

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
@@ -1,0 +1,215 @@
+import ApcOptimizer.Implementation.OptimizerPasses.BusUnify
+
+set_option autoImplicit false
+
+/-! # Prepared address-disequality certificates
+
+The disequality certificates (`AddrDiseq.lean`) re-derive the same per-interaction data — the
+address slot's constant value, linear form, and two-root reductions — once per *compared pair*,
+which made the region scans of `busPairCancel` and the mid re-verification of `busUnify`'s
+`denseCheckPair` quadratic in interaction count. `DenseAddrPre` prepares that data once per
+interaction (each field a memoizing `Thunk`, so untouched certificate arms stay unpaid); the `*P`
+twins below read the prepared records, and their `*_eq` lemmas let call sites rewrite scan
+hypotheses back to the original certificate forms. -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+/-- Prepared per-address-slot data: the raw slot expression plus its lazily-computed constant
+    value, linear form, and two-root reductions. -/
+structure DenseSlotPre (p : ℕ) where
+  expr : DenseExpr p
+  cval : Thunk (Option (ZMod p))
+  lin : Thunk (Option (DenseLinExpr p))
+  reds : Thunk (List (DenseLinExpr p × DenseLinExpr p))
+
+def denseSlotPrep (T : DenseTwoRootMap p) (e : DenseExpr p) : DenseSlotPre p :=
+  ⟨e, Thunk.mk fun _ => e.constValue?, Thunk.mk fun _ => denseLinearize e,
+   Thunk.mk fun _ => densePtrReductions T e⟩
+
+/-- Prepared per-interaction address data relative to one memory-bus shape: the bus id, the
+    multiplicity constant, and the prepared slot record at each of the shape's address fields. -/
+structure DenseAddrPre (p : ℕ) where
+  busId : Nat
+  mult : Thunk (Option (ZMod p))
+  slots : List (Option (DenseSlotPre p))
+
+def denseAddrPrep (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (bi : BusInteraction (DenseExpr p)) : DenseAddrPre p :=
+  ⟨bi.busId, Thunk.mk fun _ => denseMultConst bi,
+   shape.addressFields.map (fun slot => (bi.payload[slot]?).map (denseSlotPrep T))⟩
+
+/-- The zipped prepared slot lists are the pairwise map over the shape's address fields. -/
+theorem denseAddrPrep_slots_zip (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (S m : BusInteraction (DenseExpr p)) :
+    ((denseAddrPrep shape T S).slots).zip ((denseAddrPrep shape T m).slots)
+      = shape.addressFields.map (fun slot =>
+          ((S.payload[slot]?).map (denseSlotPrep T), (m.payload[slot]?).map (denseSlotPrep T))) := by
+  simp [denseAddrPrep, List.zip_map']
+
+/-! ## The prepared certificate twins -/
+
+def denseAddrConstsNeqP (a b : DenseAddrPre p) : Bool :=
+  (a.slots.zip b.slots).any (fun s =>
+    match s with
+    | (some sa, some sb) =>
+        (match sa.cval.get, sb.cval.get with
+         | some c, some c' => decide (c ≠ c')
+         | _, _ => false)
+    | _ => false)
+
+theorem denseAddrConstsNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (S m : BusInteraction (DenseExpr p)) :
+    denseAddrConstsNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = denseAddrConstsNeq shape S m := by
+  unfold denseAddrConstsNeqP denseAddrConstsNeq
+  rw [denseAddrPrep_slots_zip, List.any_map]
+  refine congrArg _ (funext fun slot => ?_)
+  simp only [Function.comp_apply]
+  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+
+def denseAddrConstsEqP (a b : DenseAddrPre p) : Bool :=
+  (a.slots.zip b.slots).all (fun s =>
+    match s with
+    | (some sa, some sb) =>
+        decide (sa.expr = sb.expr) ||
+        (match sa.cval.get, sb.cval.get with
+         | some c, some c' => c = c'
+         | _, _ => false)
+    | _ => false)
+
+theorem denseAddrConstsEqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (S m : BusInteraction (DenseExpr p)) :
+    denseAddrConstsEqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = denseAddrConstsEq shape S m := by
+  unfold denseAddrConstsEqP denseAddrConstsEq
+  rw [denseAddrPrep_slots_zip, List.all_map]
+  refine congrArg _ (funext fun slot => ?_)
+  simp only [Function.comp_apply]
+  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+
+def denseAddrAffineNeqP (a b : DenseAddrPre p) : Bool :=
+  (a.slots.zip b.slots).any (fun s =>
+    match s with
+    | (some sa, some sb) =>
+        (match sa.lin.get, sb.lin.get with
+         | some L, some L' => denseConstDiffNZ L L'
+         | _, _ => false)
+    | _ => false)
+
+theorem denseAddrAffineNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (S m : BusInteraction (DenseExpr p)) :
+    denseAddrAffineNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = denseAddrAffineNeq shape S m := by
+  unfold denseAddrAffineNeqP denseAddrAffineNeq
+  rw [denseAddrPrep_slots_zip, List.any_map]
+  refine congrArg _ (funext fun slot => ?_)
+  simp only [Function.comp_apply]
+  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+
+def denseAddrTwoRootNeqP (a b : DenseAddrPre p) : Bool :=
+  (a.slots.zip b.slots).any (fun s =>
+    match s with
+    | (some sa, some sb) =>
+        sa.reds.get.any (fun red => sb.reds.get.any (fun red' =>
+          denseConstDiffNZ red.1 red'.1 && denseConstDiffNZ red.1 red'.2 &&
+          denseConstDiffNZ red.2 red'.1 && denseConstDiffNZ red.2 red'.2))
+    | _ => false)
+
+theorem denseAddrTwoRootNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (S m : BusInteraction (DenseExpr p)) :
+    denseAddrTwoRootNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = denseAddrTwoRootNeq shape T S m := by
+  unfold denseAddrTwoRootNeqP denseAddrTwoRootNeq
+  rw [denseAddrPrep_slots_zip, List.any_map]
+  refine congrArg _ (funext fun slot => ?_)
+  simp only [Function.comp_apply]
+  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+
+/-- `denseDiffSumOver` over prepared slot pairs (same fold, linearizations read from the prep). -/
+def denseDiffSumP : List (Option (DenseSlotPre p) × Option (DenseSlotPre p)) →
+    Option (DenseLinExpr p)
+  | [] => some ⟨0, []⟩
+  | s :: fs =>
+    match denseDiffSumP fs with
+    | none => none
+    | some acc =>
+      match s with
+      | (some sa, some sb) =>
+        match sa.lin.get, sb.lin.get with
+        | some lS, some lM => some ((lM.add (lS.scale (-1))).add acc)
+        | _, _ => none
+      | _ => none
+
+theorem denseDiffSumP_eq (T : DenseTwoRootMap p) (S m : BusInteraction (DenseExpr p)) :
+    ∀ fs : List Nat,
+      denseDiffSumP (fs.map (fun slot =>
+          ((S.payload[slot]?).map (denseSlotPrep T), (m.payload[slot]?).map (denseSlotPrep T))))
+        = denseDiffSumOver S m fs := by
+  intro fs
+  induction fs with
+  | nil => rfl
+  | cons f fs ih =>
+      rw [List.map_cons, denseDiffSumP, ih, denseDiffSumOver]
+      cases denseDiffSumOver S m fs
+      · rfl
+      · cases S.payload[f]? <;> cases m.payload[f]? <;> rfl
+
+def denseAddrNonzeroNeqP (nw : DenseNonzeroWits p) (a b : DenseAddrPre p) : Bool :=
+  (a.slots.zip b.slots).sublists.any (fun sub =>
+    match denseDiffSumP sub with
+    | some D => nw.wits.any (fun g =>
+        denseIsZeroLin (D.add (g.scale (-1))) || denseIsZeroLin (D.add g))
+    | none => false)
+
+theorem denseAddrNonzeroNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (nw : DenseNonzeroWits p) (S m : BusInteraction (DenseExpr p)) :
+    denseAddrNonzeroNeqP nw (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = denseAddrNonzeroNeq shape nw S m := by
+  unfold denseAddrNonzeroNeqP denseAddrNonzeroNeq
+  rw [denseAddrPrep_slots_zip, List.sublists_map, List.any_map]
+  refine congrArg _ (funext fun fs => ?_)
+  simp only [Function.comp_apply]
+  rw [denseDiffSumP_eq]
+  rfl
+
+/-! ## `busUnify`'s verifier on prepared records
+
+`denseCheckPair` re-verifies each candidate's whole mid region; the compiled twin prepares the
+candidate side once and each mid message once, so a mid message costs one preparation instead of
+one certificate derivation per arm. -/
+
+/-- `denseCheckPair`'s per-mid-message exclusion disjunction, on prepared records. -/
+def denseMidExcludedP (nw : DenseNonzeroWits p) (preS prem : DenseAddrPre p) : Bool :=
+  denseAddrConstsNeqP preS prem || denseAddrAffineNeqP preS prem
+    || denseAddrTwoRootNeqP preS prem || denseAddrNonzeroNeqP nw preS prem
+    || decide (prem.mult.get = some 0)
+
+theorem denseMidExcludedP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (nw : DenseNonzeroWits p) (S m : BusInteraction (DenseExpr p)) :
+    denseMidExcludedP nw (denseAddrPrep shape T S) (denseAddrPrep shape T m)
+      = (denseAddrConstsNeq shape S m || denseAddrAffineNeq shape S m
+        || denseAddrTwoRootNeq shape T S m || denseAddrNonzeroNeq shape nw S m
+        || decide (denseMultConst m = some 0)) := by
+  unfold denseMidExcludedP
+  rw [denseAddrConstsNeqP_eq, denseAddrAffineNeqP_eq, denseAddrTwoRootNeqP_eq,
+    denseAddrNonzeroNeqP_eq]
+  rfl
+
+def denseCheckPairFast (shape : MemoryBusShape) (T : DenseTwoRootMap p) (nw : DenseNonzeroWits p)
+    (S : BusInteraction (DenseExpr p))
+    (mid : List (BusInteraction (DenseExpr p))) (R : BusInteraction (DenseExpr p)) : Bool :=
+  decide (denseMultConst S = some shape.setNewMult) &&
+    decide (denseMultConst R = some (-shape.setNewMult)) &&
+  denseAddrConstsEq shape S R &&
+  (let preS := denseAddrPrep shape T S
+   mid.all (fun m => denseMidExcludedP nw preS (denseAddrPrep shape T m)))
+
+@[csimp] theorem denseCheckPair_eq_fast : @denseCheckPair = @denseCheckPairFast := by
+  funext q shape T nw S mid R
+  unfold denseCheckPair denseCheckPairFast
+  congr 1
+  exact (congrArg mid.all (funext fun m => denseMidExcludedP_eq shape T nw S m)).symm
+
+end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
@@ -48,84 +48,147 @@ theorem denseAddrPrep_slots_zip (shape : MemoryBusShape) (T : DenseTwoRootMap p)
           ((S.payload[slot]?).map (denseSlotPrep T), (m.payload[slot]?).map (denseSlotPrep T))) := by
   simp [denseAddrPrep, List.zip_map']
 
-/-! ## The prepared certificate twins -/
+/-! ## The prepared certificate twins
+
+The hot three (`ConstsNeq`/`ConstsEq`/`AffineNeq`/`TwoRootNeq`) recurse over the two slot lists
+directly — a mid-scan runs them once per compared pair, so a `zip` there allocates on every
+test. -/
+
+def denseConstsNeqSlots : List (Option (DenseSlotPre p)) → List (Option (DenseSlotPre p)) → Bool
+  | some sa :: as, some sb :: bs =>
+      (match sa.cval.get, sb.cval.get with
+       | some c, some c' => decide (c ≠ c')
+       | _, _ => false) || denseConstsNeqSlots as bs
+  | _ :: as, _ :: bs => denseConstsNeqSlots as bs
+  | _, _ => false
 
 def denseAddrConstsNeqP (a b : DenseAddrPre p) : Bool :=
-  (a.slots.zip b.slots).any (fun s =>
-    match s with
-    | (some sa, some sb) =>
-        (match sa.cval.get, sb.cval.get with
-         | some c, some c' => decide (c ≠ c')
-         | _, _ => false)
-    | _ => false)
+  denseConstsNeqSlots a.slots b.slots
+
+theorem denseConstsNeqSlots_eq (T : DenseTwoRootMap p) (S m : BusInteraction (DenseExpr p)) :
+    ∀ fields : List Nat,
+      denseConstsNeqSlots (fields.map (fun slot => (S.payload[slot]?).map (denseSlotPrep T)))
+          (fields.map (fun slot => (m.payload[slot]?).map (denseSlotPrep T)))
+        = fields.any (fun slot =>
+            match S.payload[slot]?, m.payload[slot]? with
+            | some e, some e' =>
+              (match e.constValue?, e'.constValue? with
+               | some c, some c' => decide (c ≠ c')
+               | _, _ => false)
+            | _, _ => false)
+  | [] => rfl
+  | slot :: rest => by
+      simp only [List.map_cons, List.any_cons]
+      rw [← denseConstsNeqSlots_eq T S m rest]
+      cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
 
 theorem denseAddrConstsNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
     denseAddrConstsNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
-      = denseAddrConstsNeq shape S m := by
-  unfold denseAddrConstsNeqP denseAddrConstsNeq
-  rw [denseAddrPrep_slots_zip, List.any_map]
-  refine congrArg _ (funext fun slot => ?_)
-  simp only [Function.comp_apply]
-  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+      = denseAddrConstsNeq shape S m :=
+  denseConstsNeqSlots_eq T S m shape.addressFields
+
+def denseConstsEqSlots : List (Option (DenseSlotPre p)) → List (Option (DenseSlotPre p)) → Bool
+  | some sa :: as, some sb :: bs =>
+      (decide (sa.expr = sb.expr) ||
+       (match sa.cval.get, sb.cval.get with
+        | some c, some c' => c = c'
+        | _, _ => false)) && denseConstsEqSlots as bs
+  | _ :: as, _ :: bs => false && denseConstsEqSlots as bs
+  | _, _ => true
 
 def denseAddrConstsEqP (a b : DenseAddrPre p) : Bool :=
-  (a.slots.zip b.slots).all (fun s =>
-    match s with
-    | (some sa, some sb) =>
-        decide (sa.expr = sb.expr) ||
-        (match sa.cval.get, sb.cval.get with
-         | some c, some c' => c = c'
-         | _, _ => false)
-    | _ => false)
+  denseConstsEqSlots a.slots b.slots
+
+theorem denseConstsEqSlots_eq (T : DenseTwoRootMap p) (S m : BusInteraction (DenseExpr p)) :
+    ∀ fields : List Nat,
+      denseConstsEqSlots (fields.map (fun slot => (S.payload[slot]?).map (denseSlotPrep T)))
+          (fields.map (fun slot => (m.payload[slot]?).map (denseSlotPrep T)))
+        = fields.all (fun slot =>
+            match S.payload[slot]?, m.payload[slot]? with
+            | some e, some e' =>
+              decide (e = e') ||
+              (match e.constValue?, e'.constValue? with
+               | some c, some c' => c = c'
+               | _, _ => false)
+            | _, _ => false)
+  | [] => rfl
+  | slot :: rest => by
+      simp only [List.map_cons, List.all_cons]
+      rw [← denseConstsEqSlots_eq T S m rest]
+      cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
 
 theorem denseAddrConstsEqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
     denseAddrConstsEqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
-      = denseAddrConstsEq shape S m := by
-  unfold denseAddrConstsEqP denseAddrConstsEq
-  rw [denseAddrPrep_slots_zip, List.all_map]
-  refine congrArg _ (funext fun slot => ?_)
-  simp only [Function.comp_apply]
-  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+      = denseAddrConstsEq shape S m :=
+  denseConstsEqSlots_eq T S m shape.addressFields
+
+def denseAffineNeqSlots : List (Option (DenseSlotPre p)) → List (Option (DenseSlotPre p)) → Bool
+  | some sa :: as, some sb :: bs =>
+      (match sa.lin.get, sb.lin.get with
+       | some L, some L' => denseConstDiffNZ L L'
+       | _, _ => false) || denseAffineNeqSlots as bs
+  | _ :: as, _ :: bs => denseAffineNeqSlots as bs
+  | _, _ => false
 
 def denseAddrAffineNeqP (a b : DenseAddrPre p) : Bool :=
-  (a.slots.zip b.slots).any (fun s =>
-    match s with
-    | (some sa, some sb) =>
-        (match sa.lin.get, sb.lin.get with
-         | some L, some L' => denseConstDiffNZ L L'
-         | _, _ => false)
-    | _ => false)
+  denseAffineNeqSlots a.slots b.slots
+
+theorem denseAffineNeqSlots_eq (T : DenseTwoRootMap p) (S m : BusInteraction (DenseExpr p)) :
+    ∀ fields : List Nat,
+      denseAffineNeqSlots (fields.map (fun slot => (S.payload[slot]?).map (denseSlotPrep T)))
+          (fields.map (fun slot => (m.payload[slot]?).map (denseSlotPrep T)))
+        = fields.any (fun slot =>
+            match S.payload[slot]?, m.payload[slot]? with
+            | some e, some e' =>
+              (match denseLinearize e, denseLinearize e' with
+               | some L, some L' => denseConstDiffNZ L L'
+               | _, _ => false)
+            | _, _ => false)
+  | [] => rfl
+  | slot :: rest => by
+      simp only [List.map_cons, List.any_cons]
+      rw [← denseAffineNeqSlots_eq T S m rest]
+      cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
 
 theorem denseAddrAffineNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
     denseAddrAffineNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
-      = denseAddrAffineNeq shape S m := by
-  unfold denseAddrAffineNeqP denseAddrAffineNeq
-  rw [denseAddrPrep_slots_zip, List.any_map]
-  refine congrArg _ (funext fun slot => ?_)
-  simp only [Function.comp_apply]
-  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+      = denseAddrAffineNeq shape S m :=
+  denseAffineNeqSlots_eq T S m shape.addressFields
+
+def denseTwoRootNeqSlots : List (Option (DenseSlotPre p)) → List (Option (DenseSlotPre p)) → Bool
+  | some sa :: as, some sb :: bs =>
+      sa.reds.get.any (fun red => sb.reds.get.any (fun red' =>
+        denseConstDiffNZ red.1 red'.1 && denseConstDiffNZ red.1 red'.2 &&
+        denseConstDiffNZ red.2 red'.1 && denseConstDiffNZ red.2 red'.2))
+      || denseTwoRootNeqSlots as bs
+  | _ :: as, _ :: bs => denseTwoRootNeqSlots as bs
+  | _, _ => false
 
 def denseAddrTwoRootNeqP (a b : DenseAddrPre p) : Bool :=
-  (a.slots.zip b.slots).any (fun s =>
-    match s with
-    | (some sa, some sb) =>
-        sa.reds.get.any (fun red => sb.reds.get.any (fun red' =>
-          denseConstDiffNZ red.1 red'.1 && denseConstDiffNZ red.1 red'.2 &&
-          denseConstDiffNZ red.2 red'.1 && denseConstDiffNZ red.2 red'.2))
-    | _ => false)
+  denseTwoRootNeqSlots a.slots b.slots
+
+theorem denseTwoRootNeqSlots_eq (T : DenseTwoRootMap p) (S m : BusInteraction (DenseExpr p)) :
+    ∀ fields : List Nat,
+      denseTwoRootNeqSlots (fields.map (fun slot => (S.payload[slot]?).map (denseSlotPrep T)))
+          (fields.map (fun slot => (m.payload[slot]?).map (denseSlotPrep T)))
+        = fields.any (fun slot =>
+            match S.payload[slot]?, m.payload[slot]? with
+            | some e, some e' => denseExprTwoRootNeq T e e'
+            | _, _ => false)
+  | [] => rfl
+  | slot :: rest => by
+      simp only [List.map_cons, List.any_cons]
+      rw [← denseTwoRootNeqSlots_eq T S m rest]
+      cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
 
 theorem denseAddrTwoRootNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
     denseAddrTwoRootNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
-      = denseAddrTwoRootNeq shape T S m := by
-  unfold denseAddrTwoRootNeqP denseAddrTwoRootNeq
-  rw [denseAddrPrep_slots_zip, List.any_map]
-  refine congrArg _ (funext fun slot => ?_)
-  simp only [Function.comp_apply]
-  cases S.payload[slot]? <;> cases m.payload[slot]? <;> rfl
+      = denseAddrTwoRootNeq shape T S m :=
+  denseTwoRootNeqSlots_eq T S m shape.addressFields
 
 /-- `denseDiffSumOver` over prepared slot pairs (same fold, linearizations read from the prep). -/
 def denseDiffSumP : List (Option (DenseSlotPre p) × Option (DenseSlotPre p)) →

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -182,12 +182,14 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
+    (preT : Thunk (Array (DenseAddrPre p)))
+    (hpreT : preT.get = arr.map (denseAddrPrep shape T.get.tworoot))
     (i : Nat) : Option (DenseDropResult cs0 bs arr alive checksOld) :=
   if hi : i < arr.size then
     let S := arr[i]
     let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
       shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive
-      checksOld hsz idx (i + 1)
+      checksOld hsz idx preT hpreT (i + 1)
     if haliveS : alive[i]?.getD false = true then
     if decide (S.busId = busId) &&
         decide (denseMultConst S = some (denseSetNewMult ops shape)) then
@@ -204,15 +206,36 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
             by_contra hc
             rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hR; simp at hR
           have hSget : arr[i]? = some S := Array.getElem?_eq_getElem hi
-          if hmidB : denseLiveAllSeg arr alive (denseMidRefuted ops shape T busId S)
-              (i + 1) (j - i - 1) = true then
-          if hshieldA : (denseShieldScanSeg ops shape T busId S arr alive 0 i).2 = true then
+          match hps : preT.get[i]? with
+          | none => next ()
+          | some preS =>
+          have hpreS : preS = denseAddrPrep shape T.get.tworoot S := by
+            rw [hpreT, Array.getElem?_map, hSget] at hps
+            exact (Option.some.inj hps).symm
+          if hmidB : denseLiveAllSegP preT.get alive
+              (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true then
+          if hshieldA : (denseShieldScanSegP
+              (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+              (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+              preT.get alive 0 i).2 = true then
           have hmid : ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
               denseMidRefuted ops shape T busId S m0 = true := by
-            rw [denseLiveAllSeg_eq] at hmidB
-            exact fun m0 hm0 => List.all_eq_true.mp hmidB m0 hm0
+            rw [hpreT, denseLiveAllSegP_eq, denseLiveAllSeg_eq] at hmidB
+            intro m0 hm0
+            have h := List.all_eq_true.mp hmidB m0 hm0
+            rw [hpreS] at h
+            rwa [denseMidRefutedP_eq] at h
           have hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
-            rw [denseShieldScanSeg_eq] at hshieldA
+            rw [hpreT, denseShieldScanSegP_eq] at hshieldA
+            have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
+                  (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
+                = densePreRefuted ops shape T busId S :=
+              funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
+            have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
+                  (denseAddrPrep shape T.get.tworoot m))
+                = denseProvRecv ops shape busId S :=
+              funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
+            rw [hP, hQ, denseShieldScanW_eq] at hshieldA
             exact hshieldA
           match hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) with
           | none => next ()
@@ -256,7 +279,8 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
   termination_by arr.size - i
 
 /-- Search declared buses from list index `curIdx` for a droppable pair, honouring the resume
-    hint. -/
+    hint. Each bus carries its prepared certificate array (`hpre` ties it to
+    `denseAddrPrep` over the bus's shape), shared across every scan and resume. -/
 def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (hp1 : (1 : ZMod p) ≠ 0) (deep : Bool) (hdeep : deep = true → p.Prime)
     (aggressive : Bool) (ops : DenseZModOps p)
@@ -273,26 +297,30 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
     (bcBus? : Option (Nat × ByteXorSpec p)) (resumeIdx resumePos : Nat) :
-    Nat → List Nat → Option (DenseDropResult cs0 bs arr alive checksOld)
-  | _, [] => none
-  | curIdx, busId :: rest =>
+    Nat → (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)))) →
+    (∀ busId t, (busId, t) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
+      t.get = arr.map (denseAddrPrep shape T.get.tworoot)) →
+    Option (DenseDropResult cs0 bs arr alive checksOld)
+  | _, [], _ => none
+  | curIdx, (busId, preT) :: rest, hpre =>
     if curIdx < resumeIdx then
       denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
         hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
+        (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
             T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive checksOld
-            hsz idx startPos with
+            hsz idx preT (hpre busId preT (List.mem_cons_self ..) shape hshape) startPos with
         | some dr => some { dr with dropIdx := curIdx }
         | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
             domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-            (curIdx + 1) rest
+            (curIdx + 1) rest (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
       | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
           domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-          (curIdx + 1) rest
+          (curIdx + 1) rest (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
 
 /-! The materialized final system plus (erased) correctness and coverage proofs that
 `denseCancelLoop` returns. -/
@@ -316,10 +344,13 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
-    (bcBus? : Option (Nat × ByteXorSpec p)) (busIds : List Nat)
+    (bcBus? : Option (Nat × ByteXorSpec p))
+    (preBuses : List (Nat × Thunk (Array (DenseAddrPre p))))
     (fidx bidx : Std.HashMap VarId (List Nat))
     (arr : Array (BusInteraction (DenseExpr p)))
     (idx : Std.HashMap UInt64 (List Nat))
+    (hpre : ∀ busId t, (busId, t) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
+      t.get = arr.map (denseAddrPrep shape T.get.tworoot))
     (alive : Array Bool) (checksOld : List (BusInteraction (DenseExpr p)))
     (hsz : alive.size = arr.size) (resumeIdx resumePos : Nat)
     (hcur : ∀ (isInput : VarId → Bool) (reg : VarRegistry), cs0.CoveredBy reg →
@@ -328,7 +359,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       (denseMkCs cs0 arr alive checksOld).CoveredBy reg) :
     DenseCancelBundle cs0 bs :=
   match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT
-      candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 busIds with
+      candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 preBuses hpre with
   | none =>
     { out := { cs0 with
         busInteractions := denseLiveArr arr alive hsz 0 arr.size (by omega) ++ checksOld }
@@ -346,7 +377,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
     denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
-      hcands bcBus? busIds fidx bidx arr idx dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos
+      hcands bcBus? preBuses fidx bidx arr idx hpre dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos
       (fun isInput reg hcs0 => (hcur isInput reg hcs0).andThen (dr.step isInput reg (hsyscov reg hcs0)))
       (fun reg hcs0 => dr.covNew reg (hsyscov reg hcs0))
   termination_by denseLiveCount arr alive
@@ -400,6 +431,25 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     let bcBus? := busIds.findSome? (fun k => match facts.byteXorSpec k with
       | some spec => if spec.bound = 256 then some (k, spec) else none
       | none => none)
+    -- One prepared certificate array per declared bus, shared across every region scan and
+    -- resume of this invocation (the thunk is forced only when a matched pair reaches a scan).
+    let preBuses : List (Nat × Thunk (Array (DenseAddrPre p))) :=
+      busIds.filterMap (fun busId => (facts.memShape busId).map (fun shape =>
+        (busId, Thunk.mk (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)))))
+    have hpreBuses : ∀ busId t, (busId, t) ∈ preBuses → ∀ shape,
+        facts.memShape busId = some shape →
+        t.get = arr.map (denseAddrPrep shape T.get.tworoot) := by
+      intro busId t hmem shape hshape
+      obtain ⟨b, _hb, hsome⟩ := List.mem_filterMap.mp hmem
+      cases hms : facts.memShape b with
+      | none => rw [hms] at hsome; simp at hsome
+      | some sh =>
+          rw [hms, Option.map_some] at hsome
+          obtain ⟨hb, ht⟩ := Prod.mk.injEq .. ▸ Option.some.inj hsome
+          subst hb
+          rw [hshape] at hms
+          rw [← ht, ← Option.some.inj hms]
+          rfl
     have hcur0 : ∀ (isInput : VarId → Bool) (reg : VarRegistry), d.CoveredBy reg →
         DensePassCorrect isInput d (denseMkCs d arr alive []) [] bs :=
       fun isInput _ _ => by
@@ -408,8 +458,8 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
         (denseMkCs d arr alive []).CoveredBy reg :=
       fun _ hcs0 => by rw [denseMkCs_all d arr rfl alive halltrue]; exact hcs0
     let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive ops
-      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? busIds fidx bidx arr idx alive [] hsz 0 0
-      hcur0 hsyscov0
+      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? preBuses fidx bidx arr idx hpreBuses
+      alive [] hsz 0 0 hcur0 hsyscov0
     { reg' := reg
       out := bundle.out
       derivs := []

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.BusPairCancelCheck
 import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelWits
+import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelKeyIdx
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.BusPairCancelIndex
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.AddrDiseq
 
@@ -184,12 +185,14 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (idx : Std.HashMap UInt64 (List Nat))
     (preT : Thunk (Array (DenseAddrPre p)))
     (hpreT : preT.get = arr.map (denseAddrPrep shape T.get.tworoot))
+    (kT : Thunk (DenseKeyIdx p))
+    (hkT : kT.get = denseKeyIdxBuild shape busId arr)
     (i : Nat) : Option (DenseDropResult cs0 bs arr alive checksOld) :=
   if hi : i < arr.size then
     let S := arr[i]
     let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
       shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive
-      checksOld hsz idx preT hpreT (i + 1)
+      checksOld hsz idx preT hpreT kT hkT (i + 1)
     if haliveS : alive[i]?.getD false = true then
     if decide (S.busId = busId) &&
         decide (denseMultConst S = some (denseSetNewMult ops shape)) then
@@ -212,31 +215,15 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           have hpreS : preS = denseAddrPrep shape T.get.tworoot S := by
             rw [hpreT, Array.getElem?_map, hSget] at hps
             exact (Option.some.inj hps).symm
-          if hmidB : denseLiveAllSegP preT.get alive
-              (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true then
-          if hshieldA : (denseShieldScanSegP
-              (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-              (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-              preT.get alive 0 i).2 = true then
+          if hRT : (denseRegionTests ops shape T busId arr alive preT.get hpreT kT.get hkT
+              S preS hpreS i j hij).val = true then
           have hmid : ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
-              denseMidRefuted ops shape T busId S m0 = true := by
-            rw [hpreT, denseLiveAllSegP_eq, denseLiveAllSeg_eq] at hmidB
-            intro m0 hm0
-            have h := List.all_eq_true.mp hmidB m0 hm0
-            rw [hpreS] at h
-            rwa [denseMidRefutedP_eq] at h
-          have hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
-            rw [hpreT, denseShieldScanSegP_eq] at hshieldA
-            have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
-                  (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
-                = densePreRefuted ops shape T busId S :=
-              funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
-            have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
-                  (denseAddrPrep shape T.get.tworoot m))
-                = denseProvRecv ops shape busId S :=
-              funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
-            rw [hP, hQ, denseShieldScanW_eq] at hshieldA
-            exact hshieldA
+              denseMidRefuted ops shape T busId S m0 = true :=
+            ((denseRegionTests ops shape T busId arr alive preT.get hpreT kT.get hkT
+              S preS hpreS i j hij).property hRT).1
+          have hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true :=
+            ((denseRegionTests ops shape T busId arr alive preT.get hpreT kT.get hkT
+              S preS hpreS i j hij).property hRT).2
           match hslots : facts.recvByteSlots busId (R.payload.map DenseExpr.constValue?) with
           | none => next ()
           | some (slots, bound) =>
@@ -270,7 +257,6 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
             else next ()
           else next ()
           else next ()
-          else next ()
         | none => next ()
       | none => next ()
     else next ()
@@ -297,30 +283,32 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
     (bcBus? : Option (Nat × ByteXorSpec p)) (resumeIdx resumePos : Nat) :
-    Nat → (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)))) →
-    (∀ busId t, (busId, t) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
-      t.get = arr.map (denseAddrPrep shape T.get.tworoot)) →
+    Nat → (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p))) →
+    (∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
+      t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+      kt.get = denseKeyIdxBuild shape busId arr) →
     Option (DenseDropResult cs0 bs arr alive checksOld)
   | _, [], _ => none
-  | curIdx, (busId, preT) :: rest, hpre =>
+  | curIdx, (busId, preT, kT) :: rest, hpre =>
     if curIdx < resumeIdx then
       denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
         hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
-        (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
+        (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
             T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive checksOld
-            hsz idx preT (hpre busId preT (List.mem_cons_self ..) shape hshape) startPos with
+            hsz idx preT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).1
+            kT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).2 startPos with
         | some dr => some { dr with dropIdx := curIdx }
         | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
             domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-            (curIdx + 1) rest (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
+            (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
       | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
           domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-          (curIdx + 1) rest (fun b t hbt => hpre b t (List.mem_cons_of_mem _ hbt))
+          (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
 
 /-! The materialized final system plus (erased) correctness and coverage proofs that
 `denseCancelLoop` returns. -/
@@ -345,12 +333,14 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
-    (preBuses : List (Nat × Thunk (Array (DenseAddrPre p))))
+    (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)))
     (fidx bidx : Std.HashMap VarId (List Nat))
     (arr : Array (BusInteraction (DenseExpr p)))
     (idx : Std.HashMap UInt64 (List Nat))
-    (hpre : ∀ busId t, (busId, t) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
-      t.get = arr.map (denseAddrPrep shape T.get.tworoot))
+    (hpre : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
+      facts.memShape busId = some shape →
+      t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+      kt.get = denseKeyIdxBuild shape busId arr)
     (alive : Array Bool) (checksOld : List (BusInteraction (DenseExpr p)))
     (hsz : alive.size = arr.size) (resumeIdx resumePos : Nat)
     (hcur : ∀ (isInput : VarId → Bool) (reg : VarRegistry), cs0.CoveredBy reg →
@@ -433,23 +423,26 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
       | none => none)
     -- One prepared certificate array per declared bus, shared across every region scan and
     -- resume of this invocation (the thunk is forced only when a matched pair reaches a scan).
-    let preBuses : List (Nat × Thunk (Array (DenseAddrPre p))) :=
+    let preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)) :=
       busIds.filterMap (fun busId => (facts.memShape busId).map (fun shape =>
-        (busId, Thunk.mk (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)))))
-    have hpreBuses : ∀ busId t, (busId, t) ∈ preBuses → ∀ shape,
+        (busId, Thunk.mk (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)),
+         Thunk.mk (fun _ => denseKeyIdxBuild shape busId arr))))
+    have hpreBuses : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
         facts.memShape busId = some shape →
-        t.get = arr.map (denseAddrPrep shape T.get.tworoot) := by
-      intro busId t hmem shape hshape
+        t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+        kt.get = denseKeyIdxBuild shape busId arr := by
+      intro busId t kt hmem shape hshape
       obtain ⟨b, _hb, hsome⟩ := List.mem_filterMap.mp hmem
       cases hms : facts.memShape b with
       | none => rw [hms] at hsome; simp at hsome
       | some sh =>
           rw [hms, Option.map_some] at hsome
-          obtain ⟨hb, ht⟩ := Prod.mk.injEq .. ▸ Option.some.inj hsome
+          injection Option.some.inj hsome with hb hrest
+          injection hrest with ht hkt
           subst hb
           rw [hshape] at hms
-          rw [← ht, ← Option.some.inj hms]
-          rfl
+          obtain rfl := Option.some.inj hms
+          exact ⟨by rw [← ht]; rfl, by rw [← hkt]; rfl⟩
     have hcur0 : ∀ (isInput : VarId → Bool) (reg : VarRegistry), d.CoveredBy reg →
         DensePassCorrect isInput d (denseMkCs d arr alive []) [] bs :=
       fun isInput _ _ => by

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelIndex
 import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelLive
+import ApcOptimizer.Implementation.OptimizerPasses.AddrDiseqPre
 
 set_option autoImplicit false
 
@@ -115,6 +116,103 @@ theorem denseShieldScanSeg_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
           | none =>
               rw [denseLiveSeg, halive, harr, if_pos rfl]
               simp
+
+/-- `denseShieldScan` with the two per-message tests abstracted. -/
+def denseShieldScanW {α : Type} (P Q : α → Bool) : List α → Bool × Bool
+  | [] => (false, true)
+  | m0 :: rest =>
+    let r := denseShieldScanW P Q rest
+    (r.1 || Q m0, r.2 && (P m0 || r.1))
+
+theorem denseShieldScanW_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S : BusInteraction (DenseExpr p)) :
+    ∀ l, denseShieldScanW (densePreRefuted ops shape T busId S)
+        (denseProvRecv ops shape busId S) l = denseShieldScan ops shape T busId S l := by
+  intro l
+  induction l with
+  | nil => rfl
+  | cons m0 rest ih => rw [denseShieldScanW, denseShieldScan, ih]
+
+/-- `denseShieldScanW` over a derived per-position array (prepared certificate records), reading
+    the prepared record at each live position. -/
+def denseShieldScanSegP {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool) :
+    (lo n : Nat) → Bool × Bool
+  | _, 0 => (false, true)
+  | lo, n + 1 =>
+    let r := denseShieldScanSegP P Q preArr alive (lo + 1) n
+    if alive[lo]?.getD false then
+      match preArr[lo]? with
+      | some m0 => (r.1 || Q m0, r.2 && (P m0 || r.1))
+      | none => r
+    else r
+
+theorem denseShieldScanSegP_eq {α : Type} (f : BusInteraction (DenseExpr p) → α)
+    (P Q : α → Bool) (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
+    ∀ (lo n : Nat),
+      denseShieldScanSegP P Q (arr.map f) alive lo n
+        = denseShieldScanW (fun m => P (f m)) (fun m => Q (f m))
+            (denseLiveSeg arr alive lo n) := by
+  intro lo n
+  induction n generalizing lo with
+  | zero => rfl
+  | succ n ih =>
+      rw [denseShieldScanSegP, ih (lo + 1), Array.getElem?_map]
+      cases halive : alive[lo]?.getD false with
+      | false => rw [denseLiveSeg_skip arr alive lo n halive, if_neg (by simp)]
+      | true =>
+          rw [if_pos rfl]
+          cases harr : arr[lo]? with
+          | some m0 =>
+              rw [denseLiveSeg_peel arr alive lo n m0 halive harr]
+              rfl
+          | none =>
+              rw [denseLiveSeg, halive, harr, if_pos rfl]
+              simp
+
+/-! ## The region tests on prepared records (`AddrDiseqPre.lean`) -/
+
+def denseMidRefutedP (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (busId : Nat)
+    (a b : DenseAddrPre p) : Bool :=
+  decide (b.busId ≠ busId) || decide (b.mult.get = some ops.zero) || denseAddrConstsNeqP a b
+    || denseAddrAffineNeqP a b || denseAddrTwoRootNeqP a b || denseAddrNonzeroNeqP nw a b
+
+theorem denseMidRefutedP_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p)) :
+    denseMidRefutedP ops T.get.nonzero busId (denseAddrPrep shape T.get.tworoot S)
+        (denseAddrPrep shape T.get.tworoot m)
+      = denseMidRefuted ops shape T busId S m := by
+  unfold denseMidRefutedP denseMidRefuted
+  rw [denseAddrConstsNeqP_eq, denseAddrAffineNeqP_eq, denseAddrTwoRootNeqP_eq,
+    denseAddrNonzeroNeqP_eq]
+  rfl
+
+def densePreRefutedP (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (busId : Nat)
+    (setMult : ZMod p) (a b : DenseAddrPre p) : Bool :=
+  denseMidRefutedP ops nw busId a b ||
+    (match b.mult.get with
+     | some c => decide (c ≠ setMult)
+     | none => false)
+
+theorem densePreRefutedP_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p)) :
+    densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape)
+        (denseAddrPrep shape T.get.tworoot S) (denseAddrPrep shape T.get.tworoot m)
+      = densePreRefuted ops shape T busId S m := by
+  unfold densePreRefutedP densePreRefuted
+  rw [denseMidRefutedP_eq]
+  rfl
+
+def denseProvRecvP (busId : Nat) (getPrevMult : ZMod p) (a b : DenseAddrPre p) : Bool :=
+  decide (b.busId = busId) && denseAddrConstsEqP a b && decide (b.mult.get = some getPrevMult)
+
+theorem denseProvRecvP_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : DenseTwoRootMap p) (busId : Nat) (S m : BusInteraction (DenseExpr p)) :
+    denseProvRecvP busId (denseGetPreviousMult ops shape) (denseAddrPrep shape T S)
+        (denseAddrPrep shape T m)
+      = denseProvRecv ops shape busId S m := by
+  unfold denseProvRecvP denseProvRecv
+  rw [denseAddrConstsEqP_eq]
+  rfl
 
 /-- Single-value byte check on `e`, emitted through `spec` (multiplicity `1`). -/
 def denseMkByteCheck (spec : ByteXorSpec p) (busId : Nat) (e : DenseExpr p) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -78,45 +78,6 @@ def denseShieldOk (ops : DenseZModOps p) (shape : MemoryBusShape)
     (S : BusInteraction (DenseExpr p)) (l : List (BusInteraction (DenseExpr p))) : Bool :=
   (denseShieldScan ops shape T busId S l).2
 
-/-- `denseShieldScan` over a live array segment, structurally mirrored — no intermediate list. -/
-def denseShieldScanSeg (ops : DenseZModOps p) (shape : MemoryBusShape)
-    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S : BusInteraction (DenseExpr p))
-    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
-    (lo n : Nat) → Bool × Bool
-  | _, 0 => (false, true)
-  | lo, n + 1 =>
-    let r := denseShieldScanSeg ops shape T busId S arr alive (lo + 1) n
-    if alive[lo]?.getD false then
-      match arr[lo]? with
-      | some m0 =>
-          (r.1 || denseProvRecv ops shape busId S m0,
-            r.2 && (densePreRefuted ops shape T busId S m0 || r.1))
-      | none => r
-    else r
-
-theorem denseShieldScanSeg_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
-    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S : BusInteraction (DenseExpr p))
-    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
-    ∀ (lo n : Nat),
-      denseShieldScanSeg ops shape T busId S arr alive lo n
-        = denseShieldScan ops shape T busId S (denseLiveSeg arr alive lo n) := by
-  intro lo n
-  induction n generalizing lo with
-  | zero => rfl
-  | succ n ih =>
-      rw [denseShieldScanSeg, ih (lo + 1)]
-      cases halive : alive[lo]?.getD false with
-      | false => rw [denseLiveSeg_skip arr alive lo n halive, if_neg (by simp)]
-      | true =>
-          rw [if_pos rfl]
-          cases harr : arr[lo]? with
-          | some m0 =>
-              rw [denseLiveSeg_peel arr alive lo n m0 halive harr]
-              rfl
-          | none =>
-              rw [denseLiveSeg, halive, harr, if_pos rfl]
-              simp
-
 /-- `denseShieldScan` with the two per-message tests abstracted. -/
 def denseShieldScanW {α : Type} (P Q : α → Bool) : List α → Bool × Bool
   | [] => (false, true)

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
@@ -1,0 +1,777 @@
+import ApcOptimizer.Implementation.OptimizerPasses.BusPairCancelCheck
+
+set_option autoImplicit false
+
+/-! # Constant-address-key position index for `busPairCancel`'s region scans
+
+The mid/shield scans walked every position of their region per candidate pair — with tens of
+thousands of accepted drops each re-scanning an `O(prefix)` region, the scan *volume* dominated
+the pass. For a candidate whose address slots are all constants, a message can only fail the
+region tests if it is on the same bus and either shares the candidate's constant address key or
+has a non-constant key: every other position is refuted by the bus-id or constant-disequality arm
+and contributes the identity to the scan fold. `DenseKeyIdx` buckets each bus's positions by
+constant address key (plus a `sym` list for non-constant keys), so the sparse scans visit only
+the same-key and symbolic positions; the `*_eq` lemmas rewrite the sparse results back to the
+full-region scans via the skipped positions' refutation certificates. -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+/-! ## The constant address key -/
+
+/-- The all-constant address key of an interaction under a shape (`none` if any address slot is
+    missing or non-constant). -/
+def denseAddrKeyOf (shape : MemoryBusShape) (bi : BusInteraction (DenseExpr p)) :
+    Option (List (ZMod p)) :=
+  shape.addressFields.foldr (fun slot acc =>
+    match acc, (bi.payload[slot]?).bind DenseExpr.constValue? with
+    | some ks, some c => some (c :: ks)
+    | _, _ => none) (some [])
+
+/-- Over an arbitrary field list: two constant keys that differ force a slot whose constants
+    differ, so the constant-disequality test fires. -/
+theorem denseKeyFold_ne_any (S m : BusInteraction (DenseExpr p)) :
+    ∀ (fields : List Nat) (kS km : List (ZMod p)),
+      fields.foldr (fun slot acc =>
+        match acc, (S.payload[slot]?).bind DenseExpr.constValue? with
+        | some ks, some c => some (c :: ks)
+        | _, _ => none) (some []) = some kS →
+      fields.foldr (fun slot acc =>
+        match acc, (m.payload[slot]?).bind DenseExpr.constValue? with
+        | some ks, some c => some (c :: ks)
+        | _, _ => none) (some []) = some km →
+      kS ≠ km →
+      fields.any (fun slot =>
+        match S.payload[slot]?, m.payload[slot]? with
+        | some e, some e' =>
+          (match e.constValue?, e'.constValue? with
+           | some c, some c' => decide (c ≠ c')
+           | _, _ => false)
+        | _, _ => false) = true := by
+  intro fields
+  induction fields with
+  | nil =>
+      intro kS km hS hm hne
+      simp only [List.foldr_nil, Option.some.injEq] at hS hm
+      exact absurd (hS.symm.trans hm) hne
+  | cons slot rest ih =>
+      intro kS km hS hm hne
+      rw [List.foldr_cons] at hS hm
+      cases hSr : (rest.foldr (fun slot acc =>
+          match acc, (S.payload[slot]?).bind DenseExpr.constValue? with
+          | some ks, some c => some (c :: ks)
+          | _, _ => none) (some []) : Option (List (ZMod p))) with
+      | none => rw [hSr] at hS; exact absurd hS (by simp)
+      | some ksr =>
+        cases hSc : (S.payload[slot]?).bind DenseExpr.constValue? with
+        | none => rw [hSr, hSc] at hS; exact absurd hS (by simp)
+        | some cS =>
+          rw [hSr, hSc] at hS
+          cases hmr : (rest.foldr (fun slot acc =>
+              match acc, (m.payload[slot]?).bind DenseExpr.constValue? with
+              | some ks, some c => some (c :: ks)
+              | _, _ => none) (some []) : Option (List (ZMod p))) with
+          | none => rw [hmr] at hm; exact absurd hm (by simp)
+          | some kmr =>
+            cases hmc : (m.payload[slot]?).bind DenseExpr.constValue? with
+            | none => rw [hmr, hmc] at hm; exact absurd hm (by simp)
+            | some cm =>
+              rw [hmr, hmc] at hm
+              simp only [Option.some.injEq] at hS hm
+              rw [List.any_cons]
+              by_cases hc : cS = cm
+              · -- the head slot agrees, so the tails must differ
+                have htne : ksr ≠ kmr := fun h => hne (by rw [← hS, ← hm, hc, h])
+                rw [ih ksr kmr hSr hmr htne, Bool.or_true]
+              · -- the head slot differs: its constants witness the disequality
+                obtain ⟨eS, heS, heSc⟩ := Option.bind_eq_some_iff.mp hSc
+                obtain ⟨em, hem, hemc⟩ := Option.bind_eq_some_iff.mp hmc
+                have hhead : (match S.payload[slot]?, m.payload[slot]? with
+                    | some e, some e' =>
+                      (match e.constValue?, e'.constValue? with
+                       | some c, some c' => decide (c ≠ c')
+                       | _, _ => false)
+                    | _, _ => false) = true := by
+                  simp only [heS, hem, heSc, hemc]
+                  exact decide_eq_true hc
+                rw [hhead, Bool.true_or]
+
+/-- Two constant keys that differ force a slot whose constants differ, so the constant
+    disequality certificate fires. -/
+theorem denseAddrKeyOf_ne_constsNeq (shape : MemoryBusShape)
+    (S m : BusInteraction (DenseExpr p)) (kS km : List (ZMod p))
+    (hS : denseAddrKeyOf shape S = some kS) (hm : denseAddrKeyOf shape m = some km)
+    (hne : kS ≠ km) : denseAddrConstsNeq shape S m = true :=
+  denseKeyFold_ne_any S m shape.addressFields kS km hS hm hne
+
+/-- Two constant keys that differ refute the constant address-equality test. -/
+theorem denseAddrKeyOf_ne_constsEq (shape : MemoryBusShape)
+    (S m : BusInteraction (DenseExpr p)) (kS km : List (ZMod p))
+    (hS : denseAddrKeyOf shape S = some kS) (hm : denseAddrKeyOf shape m = some km)
+    (hne : kS ≠ km) : denseAddrConstsEq shape S m = false := by
+  have hneq := denseAddrKeyOf_ne_constsNeq shape S m kS km hS hm hne
+  unfold denseAddrConstsNeq at hneq
+  unfold denseAddrConstsEq
+  rw [List.any_eq_true] at hneq
+  obtain ⟨slot, hslot, hval⟩ := hneq
+  rw [List.all_eq_false]
+  refine ⟨slot, hslot, ?_⟩
+  cases hpS : S.payload[slot]? with
+  | none => simp [hpS] at hval
+  | some e =>
+    cases hpm : m.payload[slot]? with
+    | none => simp [hpS, hpm] at hval
+    | some e' =>
+      simp only [hpS, hpm] at hval
+      cases hcS : e.constValue? with
+      | none => simp [hcS] at hval
+      | some c =>
+        cases hcm : e'.constValue? with
+        | none => simp [hcS, hcm] at hval
+        | some c' =>
+          simp only [hcS, hcm, decide_eq_true_eq] at hval
+          have hee : e ≠ e' := fun h => hval (by
+            rw [h] at hcS
+            exact Option.some.inj (hcS.symm.trans hcm))
+          intro hcontra
+          rw [Bool.or_eq_true] at hcontra
+          rcases hcontra with h1 | h2
+          · exact hee (of_decide_eq_true h1)
+          · simp only [hcS, hcm, decide_eq_true_eq] at h2
+            exact hval h2
+
+/-! ## Refutation of skipped positions -/
+
+/-- A cross-bus message is mid-refuted. -/
+theorem denseMidRefuted_of_crossBus (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p))
+    (h : m.busId ≠ busId) : denseMidRefuted ops shape T busId S m = true := by
+  unfold denseMidRefuted
+  rw [decide_eq_true h]
+  simp
+
+/-- A same-bus message with a different constant key is mid-refuted. -/
+theorem denseMidRefuted_of_keyNe (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p))
+    (kS km : List (ZMod p)) (hS : denseAddrKeyOf shape S = some kS)
+    (hm : denseAddrKeyOf shape m = some km) (hne : kS ≠ km) :
+    denseMidRefuted ops shape T busId S m = true := by
+  unfold denseMidRefuted
+  rw [denseAddrKeyOf_ne_constsNeq shape S m kS km hS hm hne]
+  simp
+
+/-- A cross-bus message is not a provable receive. -/
+theorem denseProvRecv_of_crossBus (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
+    (S m : BusInteraction (DenseExpr p)) (h : m.busId ≠ busId) :
+    denseProvRecv ops shape busId S m = false := by
+  unfold denseProvRecv
+  rw [decide_eq_false h]
+  simp
+
+/-- A same-bus message with a different constant key is not a provable receive. -/
+theorem denseProvRecv_of_keyNe (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
+    (S m : BusInteraction (DenseExpr p)) (kS km : List (ZMod p))
+    (hS : denseAddrKeyOf shape S = some kS) (hm : denseAddrKeyOf shape m = some km)
+    (hne : kS ≠ km) : denseProvRecv ops shape busId S m = false := by
+  unfold denseProvRecv
+  rw [denseAddrKeyOf_ne_constsEq shape S m kS km hS hm hne]
+  simp
+
+/-- Skipped positions are pre-refuted (the shield's `P` test): `densePreRefuted` contains
+    `denseMidRefuted` as its first disjunct. -/
+theorem densePreRefuted_of_midRefuted (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p))
+    (h : denseMidRefuted ops shape T busId S m = true) :
+    densePreRefuted ops shape T busId S m = true := by
+  unfold densePreRefuted
+  rw [h]
+  simp
+
+/-! ## The index -/
+
+def denseKeyHash (k : List (ZMod p)) : UInt64 :=
+  k.foldl (fun h c => mixHash h (hash c.val)) 7
+
+/-- Per-bus constant-key position index: `byKey` buckets the bus's all-constant-key positions by
+    key hash, `sym` lists its non-constant-key positions; both ascending. -/
+structure DenseKeyIdx (p : ℕ) where
+  byKey : Std.HashMap UInt64 (List Nat)
+  sym : List Nat
+
+/-- Insert one position (front of its bucket; the builder folds positions descending). -/
+def denseKeyIdxAdd (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (pos : Nat) (idx : DenseKeyIdx p) :
+    DenseKeyIdx p :=
+  match arr[pos]? with
+  | some m =>
+    if m.busId = busId then
+      match denseAddrKeyOf shape m with
+      | some k =>
+          let h := denseKeyHash k
+          { idx with byKey := idx.byKey.insert h (pos :: idx.byKey.getD h []) }
+      | none => { idx with sym := pos :: idx.sym }
+    else idx
+  | none => idx
+
+def denseKeyIdxBuild (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) : DenseKeyIdx p :=
+  (List.range arr.size).foldr (denseKeyIdxAdd shape busId arr) ⟨∅, []⟩
+
+/-- What the builder guarantees, all in one bundle: completeness (every same-bus position is in
+    its key's bucket, or in `sym` when its key is not constant), and strict ascending order of
+    every bucket and of `sym`. -/
+structure DenseKeyIdx.Sound (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (idx : DenseKeyIdx p) : Prop where
+  complete_key : ∀ pos m k, arr[pos]? = some m → m.busId = busId →
+    denseAddrKeyOf shape m = some k → pos ∈ idx.byKey.getD (denseKeyHash k) []
+  complete_sym : ∀ pos m, arr[pos]? = some m → m.busId = busId →
+    denseAddrKeyOf shape m = none → pos ∈ idx.sym
+  sorted_key : ∀ h, (idx.byKey.getD h []).Pairwise (· < ·)
+  sorted_sym : idx.sym.Pairwise (· < ·)
+  mem_key : ∀ h pos, pos ∈ idx.byKey.getD h [] → ∃ m k, arr[pos]? = some m ∧
+    m.busId = busId ∧ denseAddrKeyOf shape m = some k ∧ denseKeyHash k = h
+  mem_sym : ∀ pos, pos ∈ idx.sym → ∃ m, arr[pos]? = some m ∧ m.busId = busId ∧
+    denseAddrKeyOf shape m = none
+
+/-- The fold-step invariant: soundness for the positions processed so far, plus a lower bound
+    keeping every stored position strictly above the positions still to be processed. -/
+theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    ∀ (ps : List Nat), ps.Pairwise (· < ·) →
+      (let idx := ps.foldr (denseKeyIdxAdd shape busId arr) ⟨∅, []⟩
+       (∀ pos m k, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
+          denseAddrKeyOf shape m = some k → pos ∈ idx.byKey.getD (denseKeyHash k) []) ∧
+       (∀ pos m, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
+          denseAddrKeyOf shape m = none → pos ∈ idx.sym) ∧
+       (∀ h, (idx.byKey.getD h []).Pairwise (· < ·)) ∧
+       idx.sym.Pairwise (· < ·) ∧
+       (∀ h pos, pos ∈ idx.byKey.getD h [] → pos ∈ ps ∧ ∃ m k, arr[pos]? = some m ∧
+          m.busId = busId ∧ denseAddrKeyOf shape m = some k ∧ denseKeyHash k = h) ∧
+       (∀ pos, pos ∈ idx.sym → pos ∈ ps ∧ ∃ m, arr[pos]? = some m ∧ m.busId = busId ∧
+          denseAddrKeyOf shape m = none)) := by
+  intro ps hps
+  induction ps with
+  | nil =>
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+        simp [Std.HashMap.getD_empty]
+  | cons q rest ih =>
+      have hqlt : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hps).1 r hr
+      obtain ⟨ck, cs, sk, ss, mk, ms⟩ := ih (List.pairwise_cons.mp hps).2
+      simp only [List.foldr_cons]
+      set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, []⟩ : DenseKeyIdx p) with hidx
+      unfold denseKeyIdxAdd
+      cases hq : arr[q]? with
+      | none =>
+          dsimp only
+          refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_, sk, ss,
+            fun h pos hpos => ?_, fun pos hpos => ?_⟩
+          · rcases List.mem_cons.mp hpos with rfl | hpos
+            · rw [hq] at hm; exact absurd hm (by simp)
+            · exact ck pos m k hpos hm hb hk
+          · rcases List.mem_cons.mp hpos with rfl | hpos
+            · rw [hq] at hm; exact absurd hm (by simp)
+            · exact cs pos m hpos hm hb hk
+          · obtain ⟨hin, rest'⟩ := mk h pos hpos
+            exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+          · obtain ⟨hin, rest'⟩ := ms pos hpos
+            exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+      | some mq =>
+          dsimp only
+          by_cases hbq : mq.busId = busId
+          · rw [if_pos hbq]
+            cases hkq : denseAddrKeyOf shape mq with
+            | some kq =>
+                dsimp only
+                refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_,
+                  fun h => ?_, ss, fun h pos hpos => ?_, fun pos hpos => ?_⟩
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · rw [hq] at hm
+                    obtain rfl := Option.some.inj hm
+                    rw [hkq] at hk
+                    obtain rfl := Option.some.inj hk
+                    rw [Std.HashMap.getD_insert_self]
+                    exact List.mem_cons_self ..
+                  · have hmem := ck pos m k hpos hm hb hk
+                    by_cases hh : denseKeyHash kq = denseKeyHash k
+                    · rw [← hh, Std.HashMap.getD_insert_self]
+                      rw [← hh] at hmem
+                      exact List.mem_cons_of_mem _ hmem
+                    · rw [Std.HashMap.getD_insert,
+                        if_neg (fun hc => hh (beq_iff_eq.mp hc))]
+                      exact hmem
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · rw [hq] at hm
+                    obtain rfl := Option.some.inj hm
+                    rw [hkq] at hk
+                    exact absurd hk (by simp)
+                  · exact cs pos m hpos hm hb hk
+                · by_cases hh : h = denseKeyHash kq
+                  · subst hh
+                    rw [Std.HashMap.getD_insert_self]
+                    refine List.pairwise_cons.mpr ⟨fun r hr => ?_, sk _⟩
+                    exact hqlt r (mk _ r hr).1
+                  · rw [Std.HashMap.getD_insert,
+                      if_neg (fun hc => hh (beq_iff_eq.mp hc).symm)]
+                    exact sk h
+                · by_cases hh : h = denseKeyHash kq
+                  · subst hh
+                    rw [Std.HashMap.getD_insert_self] at hpos
+                    rcases List.mem_cons.mp hpos with rfl | hpos
+                    · exact ⟨List.mem_cons_self .., mq, kq, hq, hbq, hkq, rfl⟩
+                    · obtain ⟨hin, rest'⟩ := mk _ pos hpos
+                      exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+                  · rw [Std.HashMap.getD_insert,
+                      if_neg (fun hc => hh (beq_iff_eq.mp hc).symm)] at hpos
+                    obtain ⟨hin, rest'⟩ := mk h pos hpos
+                    exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+                · obtain ⟨hin, rest'⟩ := ms pos hpos
+                  exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+            | none =>
+                dsimp only
+                refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_,
+                  sk, ?_, fun h pos hpos => ?_, fun pos hpos => ?_⟩
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · rw [hq] at hm
+                    obtain rfl := Option.some.inj hm
+                    rw [hkq] at hk
+                    exact absurd hk (by simp)
+                  · exact ck pos m k hpos hm hb hk
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact List.mem_cons_self ..
+                  · exact List.mem_cons_of_mem _ (cs pos m hpos hm hb hk)
+                · refine List.pairwise_cons.mpr ⟨fun r hr => ?_, ss⟩
+                  exact hqlt r (ms r hr).1
+                · obtain ⟨hin, rest'⟩ := mk h pos hpos
+                  exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact ⟨List.mem_cons_self .., mq, hq, hbq, hkq⟩
+                  · obtain ⟨hin, rest'⟩ := ms pos hpos
+                    exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+          · rw [if_neg hbq]
+            refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_, sk, ss,
+              fun h pos hpos => ?_, fun pos hpos => ?_⟩
+            · rcases List.mem_cons.mp hpos with rfl | hpos
+              · rw [hq] at hm
+                obtain rfl := Option.some.inj hm
+                exact absurd hb hbq
+              · exact ck pos m k hpos hm hb hk
+            · rcases List.mem_cons.mp hpos with rfl | hpos
+              · rw [hq] at hm
+                obtain rfl := Option.some.inj hm
+                exact absurd hb hbq
+              · exact cs pos m hpos hm hb hk
+            · obtain ⟨hin, rest'⟩ := mk h pos hpos
+              exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+            · obtain ⟨hin, rest'⟩ := ms pos hpos
+              exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+
+theorem denseKeyIdxBuild_sound (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    (denseKeyIdxBuild shape busId arr).Sound shape busId arr := by
+  have hrange : (List.range arr.size).Pairwise (· < ·) := List.pairwise_lt_range
+  obtain ⟨ck, cs, sk, ss, mk, ms⟩ :=
+    denseKeyIdxBuild_sound_aux shape busId arr (List.range arr.size) hrange
+  have hin : ∀ pos m, arr[pos]? = some m → pos ∈ List.range arr.size := by
+    intro pos m hm
+    rw [List.mem_range]
+    by_contra hc
+    rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hm
+    exact absurd hm (by simp)
+  exact ⟨fun pos m k hm hb hk => ck pos m k (hin pos m hm) hm hb hk,
+    fun pos m hm hb hk => cs pos m (hin pos m hm) hm hb hk,
+    sk, ss,
+    fun h pos hpos => (mk h pos hpos).2,
+    fun pos hpos => (ms pos hpos).2⟩
+
+/-! ## Ascending merge -/
+
+def denseMergeAsc : List Nat → List Nat → List Nat
+  | [], ys => ys
+  | xs, [] => xs
+  | x :: xs, y :: ys =>
+    if x ≤ y then x :: denseMergeAsc xs (y :: ys) else y :: denseMergeAsc (x :: xs) ys
+  termination_by xs ys => xs.length + ys.length
+
+theorem denseMergeAsc_mem : ∀ (xs ys : List Nat) (q : Nat),
+    q ∈ denseMergeAsc xs ys ↔ q ∈ xs ∨ q ∈ ys
+  | [], ys, q => by simp [denseMergeAsc]
+  | x :: xs, [], q => by simp [denseMergeAsc]
+  | x :: xs, y :: ys, q => by
+      unfold denseMergeAsc
+      split
+      · simp only [List.mem_cons, denseMergeAsc_mem xs (y :: ys) q]
+        tauto
+      · simp only [List.mem_cons, denseMergeAsc_mem (x :: xs) ys q]
+        tauto
+  termination_by xs ys => xs.length + ys.length
+
+theorem denseMergeAsc_pairwise : ∀ (xs ys : List Nat),
+    xs.Pairwise (· < ·) → ys.Pairwise (· < ·) → (∀ x ∈ xs, x ∉ ys) →
+    (denseMergeAsc xs ys).Pairwise (· < ·)
+  | [], ys, _, hys, _ => by simpa [denseMergeAsc] using hys
+  | x :: xs, [], hxs, _, _ => by simpa [denseMergeAsc] using hxs
+  | x :: xs, y :: ys, hxs, hys, hdisj => by
+      unfold denseMergeAsc
+      obtain ⟨hxlt, hxs'⟩ := List.pairwise_cons.mp hxs
+      obtain ⟨hylt, hys'⟩ := List.pairwise_cons.mp hys
+      split
+      · rename_i hxy
+        refine List.pairwise_cons.mpr ⟨?_, ?_⟩
+        · intro q hq
+          rcases (denseMergeAsc_mem xs (y :: ys) q).mp hq with h | h
+          · exact hxlt q h
+          · rcases List.mem_cons.mp h with rfl | h
+            · exact Nat.lt_of_le_of_ne hxy (fun hc =>
+                hdisj x (List.mem_cons_self ..) (hc ▸ List.mem_cons_self ..))
+            · exact Nat.lt_of_le_of_lt hxy (hylt q h)
+        · exact denseMergeAsc_pairwise xs (y :: ys) hxs' hys
+            (fun z hz => hdisj z (List.mem_cons_of_mem _ hz))
+      · rename_i hxy
+        have hyx : y < x := Nat.lt_of_not_le hxy
+        refine List.pairwise_cons.mpr ⟨?_, ?_⟩
+        · intro q hq
+          rcases (denseMergeAsc_mem (x :: xs) ys q).mp hq with h | h
+          · rcases List.mem_cons.mp h with rfl | h
+            · exact hyx
+            · exact Nat.lt_trans hyx (hxlt q h)
+          · exact hylt q h
+        · exact denseMergeAsc_pairwise (x :: xs) ys hxs hys'
+            (fun z hz hzys => hdisj z hz (List.mem_cons_of_mem _ hzys))
+  termination_by xs ys => xs.length + ys.length
+
+/-! ## The sparse scans -/
+
+/-- `denseLiveAllSegP` restricted to a position list. -/
+def denseLiveAllSparse {α : Type} (preArr : Array α) (alive : Array Bool)
+    (P : α → Bool) : List Nat → Bool
+  | [] => true
+  | pos :: rest =>
+    (if alive[pos]?.getD false then (preArr[pos]?).elim true P else true)
+      && denseLiveAllSparse preArr alive P rest
+
+/-- `denseShieldScanSegP` restricted to a position list. -/
+def denseShieldScanSparse {α : Type} (P Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) : List Nat → Bool × Bool
+  | [] => (false, true)
+  | pos :: rest =>
+    let r := denseShieldScanSparse P Q preArr alive rest
+    if alive[pos]?.getD false then
+      match preArr[pos]? with
+      | some m0 => (r.1 || Q m0, r.2 && (P m0 || r.1))
+      | none => r
+    else r
+
+/-- A visited-position list that covers every non-refuted live position decides the full range
+    scan: skipped positions contribute the identity (`P` holds on them). -/
+theorem denseLiveAllSparse_eq {α : Type} (preArr : Array α) (alive : Array Bool)
+    (P : α → Bool) :
+    ∀ (n lo : Nat) (vs : List Nat), vs.Pairwise (· < ·) →
+      (∀ q ∈ vs, lo ≤ q ∧ q < lo + n) →
+      (∀ q, lo ≤ q → q < lo + n → q ∉ vs → ∀ m, preArr[q]? = some m →
+        alive[q]?.getD false = true → P m = true) →
+      denseLiveAllSparse preArr alive P vs = denseLiveAllSegP preArr alive P lo n := by
+  intro n
+  induction n with
+  | zero =>
+      intro lo vs _ hbound _
+      cases vs with
+      | nil => rfl
+      | cons q rest => exact absurd (hbound q (List.mem_cons_self ..)) (by omega)
+  | succ n ih =>
+      intro lo vs hsort hbound hskip
+      have hstepid : (lo ∉ vs) →
+          (if alive[lo]?.getD false then (preArr[lo]?).elim true P else true) = true := by
+        intro hnot
+        cases halive : alive[lo]?.getD false with
+        | false => simp
+        | true =>
+            rw [if_pos rfl]
+            cases hm : preArr[lo]? with
+            | none => rfl
+            | some m => exact hskip lo (Nat.le_refl _) (by omega) hnot m hm halive
+      cases vs with
+      | nil =>
+          rw [denseLiveAllSegP, ← ih (lo + 1) [] (by simp) (by simp)
+            (fun q hq1 hq2 _ => hskip q (by omega) (by omega) (by simp)),
+            hstepid (by simp)]
+          rfl
+      | cons q rest =>
+          by_cases hq : q = lo
+          · subst hq
+            rw [denseLiveAllSparse, denseLiveAllSegP]
+            have hrest : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hsort).1 r hr
+            rw [ih (q + 1) rest (List.pairwise_cons.mp hsort).2
+              (fun r hr => ⟨hrest r hr, by have := (hbound r (List.mem_cons_of_mem _ hr)).2; omega⟩)
+              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega)
+                (by
+                  intro hmem
+                  rcases List.mem_cons.mp hmem with rfl | hmem
+                  · omega
+                  · exact hnot hmem) m hm halive)]
+          · have hlonot : lo ∉ (q :: rest) := by
+              intro hmem
+              rcases List.mem_cons.mp hmem with rfl | hmem
+              · exact hq rfl
+              · have := (List.pairwise_cons.mp hsort).1 lo hmem
+                have := (hbound q (List.mem_cons_self ..)).1
+                omega
+            rw [denseLiveAllSegP, hstepid hlonot, Bool.true_and]
+            refine ih (lo + 1) (q :: rest) hsort (fun r hr => ?_)
+              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega) hnot m hm halive)
+            obtain ⟨h1, h2⟩ := hbound r hr
+            rcases List.mem_cons.mp hr with rfl | hmem
+            · refine ⟨by omega, by omega⟩
+            · have hq1 := (hbound q (List.mem_cons_self ..)).1
+              have := (List.pairwise_cons.mp hsort).1 r hmem
+              exact ⟨by omega, by omega⟩
+
+/-- Same for the shield scan: skipped positions have `P` true (pre-refuted) and `Q` false (not a
+    provable receive), which is the fold's identity step. -/
+theorem denseShieldScanSparse_eq {α : Type} (P Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) :
+    ∀ (n lo : Nat) (vs : List Nat), vs.Pairwise (· < ·) →
+      (∀ q ∈ vs, lo ≤ q ∧ q < lo + n) →
+      (∀ q, lo ≤ q → q < lo + n → q ∉ vs → ∀ m, preArr[q]? = some m →
+        alive[q]?.getD false = true → P m = true ∧ Q m = false) →
+      denseShieldScanSparse P Q preArr alive vs = denseShieldScanSegP P Q preArr alive lo n := by
+  intro n
+  induction n with
+  | zero =>
+      intro lo vs _ hbound _
+      cases vs with
+      | nil => rfl
+      | cons q rest => exact absurd (hbound q (List.mem_cons_self ..)) (by omega)
+  | succ n ih =>
+      intro lo vs hsort hbound hskip
+      have hstepid : (lo ∉ vs) → ∀ (r : Bool × Bool),
+          (if alive[lo]?.getD false then
+            match preArr[lo]? with
+            | some m0 => (r.1 || Q m0, r.2 && (P m0 || r.1))
+            | none => r
+          else r) = r := by
+        intro hnot r
+        cases halive : alive[lo]?.getD false with
+        | false => simp
+        | true =>
+            rw [if_pos rfl]
+            cases hm : preArr[lo]? with
+            | none => rfl
+            | some m =>
+                obtain ⟨hP, hQ⟩ := hskip lo (Nat.le_refl _) (by omega) hnot m hm halive
+                simp [hP, hQ]
+      cases vs with
+      | nil =>
+          rw [denseShieldScanSegP]
+          rw [← ih (lo + 1) [] (by simp) (by simp)
+            (fun q hq1 hq2 _ => hskip q (by omega) (by omega) (by simp))]
+          exact (hstepid (by simp) _).symm
+      | cons q rest =>
+          by_cases hq : q = lo
+          · subst hq
+            rw [denseShieldScanSparse, denseShieldScanSegP]
+            have hrest : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hsort).1 r hr
+            rw [ih (q + 1) rest (List.pairwise_cons.mp hsort).2
+              (fun r hr => ⟨hrest r hr, by have := (hbound r (List.mem_cons_of_mem _ hr)).2; omega⟩)
+              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega)
+                (by
+                  intro hmem
+                  rcases List.mem_cons.mp hmem with rfl | hmem
+                  · omega
+                  · exact hnot hmem) m hm halive)]
+            rfl
+          · have hlonot : lo ∉ (q :: rest) := by
+              intro hmem
+              rcases List.mem_cons.mp hmem with rfl | hmem
+              · exact hq rfl
+              · have := (List.pairwise_cons.mp hsort).1 lo hmem
+                have := (hbound q (List.mem_cons_self ..)).1
+                omega
+            rw [denseShieldScanSegP]
+            rw [← ih (lo + 1) (q :: rest) hsort (fun r hr => by
+                obtain ⟨h1, h2⟩ := hbound r hr
+                have hrne : r ≠ lo := fun hrl => hlonot (hrl ▸ hr)
+                exact ⟨by omega, by omega⟩)
+              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega) hnot m hm halive)]
+            exact (hstepid hlonot _).symm
+
+/-! ## The combined region test
+
+One decision for a candidate pair's mid and shield regions, sparse when the candidate's address
+key is constant, with the scan results already converted to the forms `denseMkDropResult`
+consumes. -/
+
+/-- Decide both region tests for the candidate `S` at `i` with matched receive at `j`. With a
+    constant candidate key the scans visit only the same-key bucket and the symbolic-key list;
+    every skipped position is refuted by the bus-id or constant-key arm. -/
+def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
+    (preArr : Array (DenseAddrPre p))
+    (hpre : preArr = arr.map (denseAddrPrep shape T.get.tworoot))
+    (kIdx : DenseKeyIdx p) (hkIdx : kIdx = denseKeyIdxBuild shape busId arr)
+    (S : BusInteraction (DenseExpr p)) (preS : DenseAddrPre p)
+    (hpreS : preS = denseAddrPrep shape T.get.tworoot S)
+    (i j : Nat) (hij : i < j) :
+    { b : Bool // b = true →
+      (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
+        denseMidRefuted ops shape T busId S m0 = true) ∧
+      denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true } :=
+  -- converting a full-region result to the consumed forms (shared by both paths)
+  have hmidOf : denseLiveAllSegP preArr alive
+      (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true →
+      ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
+        denseMidRefuted ops shape T busId S m0 = true := by
+    intro hmidB
+    rw [hpre, denseLiveAllSegP_eq, denseLiveAllSeg_eq] at hmidB
+    intro m0 hm0
+    have h := List.all_eq_true.mp hmidB m0 hm0
+    rw [hpreS] at h
+    rwa [denseMidRefutedP_eq] at h
+  have hshieldOf : (denseShieldScanSegP
+      (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+      (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+      preArr alive 0 i).2 = true →
+      denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
+    intro hshieldA
+    rw [hpre, denseShieldScanSegP_eq] at hshieldA
+    have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
+          (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
+        = densePreRefuted ops shape T busId S :=
+      funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
+    have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
+          (denseAddrPrep shape T.get.tworoot m))
+        = denseProvRecv ops shape busId S :=
+      funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
+    rw [hP, hQ, denseShieldScanW_eq] at hshieldA
+    exact hshieldA
+  match hkS : denseAddrKeyOf shape S with
+  | none =>
+      ⟨denseLiveAllSegP preArr alive
+            (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1)
+          && (denseShieldScanSegP
+            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+            preArr alive 0 i).2, by
+        intro hb
+        rw [Bool.and_eq_true] at hb
+        exact ⟨hmidOf hb.1, hshieldOf hb.2⟩⟩
+  | some kS =>
+      let bucket := kIdx.byKey.getD (denseKeyHash kS) []
+      let visMid := denseMergeAsc
+        (bucket.filter (fun q => decide (i + 1 ≤ q) && decide (q < j)))
+        (kIdx.sym.filter (fun q => decide (i + 1 ≤ q) && decide (q < j)))
+      let visShield := denseMergeAsc
+        (bucket.filter (fun q => decide (q < i)))
+        (kIdx.sym.filter (fun q => decide (q < i)))
+      have hsound := hkIdx ▸ denseKeyIdxBuild_sound shape busId arr
+      -- bucket/sym disjointness (a position's key cannot be both constant and not)
+      have hdisj : ∀ q, q ∈ bucket → q ∈ kIdx.sym → False := by
+        intro q hqb hqs
+        obtain ⟨m, k, hm, _, hk, _⟩ := hsound.mem_key _ q hqb
+        obtain ⟨m', hm', _, hk'⟩ := hsound.mem_sym q hqs
+        rw [hm] at hm'
+        obtain rfl := Option.some.inj hm'
+        rw [hk] at hk'
+        exact absurd hk' (by simp)
+      -- a skipped in-range position is refuted: cross-bus, or constant key ≠ kS
+      have hskipP : ∀ (inRange : Nat → Prop) (vs : List Nat),
+          (∀ q, q ∈ bucket → inRange q → q ∈ vs) →
+          (∀ q, q ∈ kIdx.sym → inRange q → q ∈ vs) →
+          ∀ q, inRange q → q ∉ vs → ∀ m, arr[q]? = some m →
+            denseMidRefuted ops shape T busId S m = true ∧
+            denseProvRecv ops shape busId S m = false := by
+        intro inRange vs hbk hsy q hqr hqnot m hm
+        by_cases hbus : m.busId = busId
+        · cases hkm : denseAddrKeyOf shape m with
+          | none =>
+              exact absurd (hsy q (hsound.complete_sym q m hm hbus hkm) hqr) hqnot
+          | some km =>
+              by_cases hkeq : km = kS
+              · subst hkeq
+                exact absurd (hbk q (hsound.complete_key q m km hm hbus hkm) hqr) hqnot
+              · refine ⟨denseMidRefuted_of_keyNe ops shape T busId S m kS km hkS hkm
+                  (fun h => hkeq (h.symm)) , ?_⟩
+                exact denseProvRecv_of_keyNe ops shape busId S m kS km hkS hkm
+                  (fun h => hkeq h.symm)
+        · exact ⟨denseMidRefuted_of_crossBus ops shape T busId S m hbus,
+            denseProvRecv_of_crossBus ops shape busId S m hbus⟩
+      ⟨denseLiveAllSparse preArr alive
+            (denseMidRefutedP ops T.get.nonzero busId preS) visMid
+          && (denseShieldScanSparse
+            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+            preArr alive visShield).2, by
+        intro hb
+        rw [Bool.and_eq_true] at hb
+        obtain ⟨hmidB, hshieldA⟩ := hb
+        have hbucketSorted : bucket.Pairwise (· < ·) := hsound.sorted_key _
+        have hsymSorted : kIdx.sym.Pairwise (· < ·) := hsound.sorted_sym
+        -- the mid region
+        have hmid : denseLiveAllSegP preArr alive
+            (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true := by
+          rw [← denseLiveAllSparse_eq preArr alive
+            (denseMidRefutedP ops T.get.nonzero busId preS) (j - i - 1) (i + 1) visMid
+            (denseMergeAsc_pairwise _ _ (hbucketSorted.filter _) (hsymSorted.filter _)
+              (fun x hx hx' => hdisj x (List.mem_of_mem_filter hx) (List.mem_of_mem_filter hx')))
+            (fun q hq => by
+              rcases (denseMergeAsc_mem _ _ q).mp hq with h | h <;>
+              · have := List.of_mem_filter h
+                simp only [Bool.and_eq_true, decide_eq_true_eq] at this
+                omega)
+            (fun q hq1 hq2 hqnot m hm halive => by
+              rw [hpre, Array.getElem?_map] at hm
+              cases harr : arr[q]? with
+              | none => rw [harr] at hm; exact absurd hm (by simp)
+              | some m0 =>
+                  rw [harr] at hm
+                  obtain rfl := Option.some.inj hm
+                  have href := (hskipP (fun q => i + 1 ≤ q ∧ q < j) visMid
+                    (fun q hqb hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inl
+                      (List.mem_filter.mpr ⟨hqb, by
+                        simp only [Bool.and_eq_true, decide_eq_true_eq]; omega⟩)))
+                    (fun q hqs hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inr
+                      (List.mem_filter.mpr ⟨hqs, by
+                        simp only [Bool.and_eq_true, decide_eq_true_eq]; omega⟩)))
+                    q ⟨hq1, by omega⟩ hqnot m0 harr).1
+                  rw [hpreS, denseMidRefutedP_eq]
+                  exact href)]
+          exact hmidB
+        -- the shield region
+        have hshield : (denseShieldScanSegP
+            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+            preArr alive 0 i).2 = true := by
+          rw [← denseShieldScanSparse_eq
+            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+            preArr alive i 0 visShield
+            (denseMergeAsc_pairwise _ _ (hbucketSorted.filter _) (hsymSorted.filter _)
+              (fun x hx hx' => hdisj x (List.mem_of_mem_filter hx) (List.mem_of_mem_filter hx')))
+            (fun q hq => by
+              rcases (denseMergeAsc_mem _ _ q).mp hq with h | h <;>
+              · have := List.of_mem_filter h
+                simp only [decide_eq_true_eq] at this
+                omega)
+            (fun q hq1 hq2 hqnot m hm halive => by
+              rw [hpre, Array.getElem?_map] at hm
+              cases harr : arr[q]? with
+              | none => rw [harr] at hm; exact absurd hm (by simp)
+              | some m0 =>
+                  rw [harr] at hm
+                  obtain rfl := Option.some.inj hm
+                  have href := hskipP (fun q => q < i) visShield
+                    (fun q hqb hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inl
+                      (List.mem_filter.mpr ⟨hqb, by simp only [decide_eq_true_eq]; omega⟩)))
+                    (fun q hqs hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inr
+                      (List.mem_filter.mpr ⟨hqs, by simp only [decide_eq_true_eq]; omega⟩)))
+                    q (by omega) hqnot m0 harr
+                  constructor
+                  · rw [hpreS, densePreRefutedP_eq]
+                    exact densePreRefuted_of_midRefuted ops shape T busId S m0 href.1
+                  · rw [hpreS, denseProvRecvP_eq]
+                    exact href.2)]
+          exact hshieldA
+        exact ⟨hmidOf hmid, hshieldOf hshield⟩⟩
+
+end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
@@ -220,6 +220,27 @@ theorem denseLiveAllSeg_eq (arr : Array (BusInteraction (DenseExpr p))) (alive :
       · simp
       · cases harr : arr[lo]? <;> simp [Option.elim]
 
+/-- `denseLiveAllSeg` over a derived per-position array (e.g. prepared certificate records), so a
+    per-element preparation is computed once per position instead of once per query. -/
+def denseLiveAllSegP {α : Type} (preArr : Array α) (alive : Array Bool)
+    (P : α → Bool) : (lo n : Nat) → Bool
+  | _, 0 => true
+  | lo, n + 1 =>
+    (if alive[lo]?.getD false then (preArr[lo]?).elim true P else true)
+      && denseLiveAllSegP preArr alive P (lo + 1) n
+
+theorem denseLiveAllSegP_eq {α : Type} (f : BusInteraction (DenseExpr p) → α)
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) (P : α → Bool) :
+    ∀ (lo n : Nat),
+      denseLiveAllSegP (arr.map f) alive P lo n
+        = denseLiveAllSeg arr alive (fun m => P (f m)) lo n := by
+  intro lo n
+  induction n generalizing lo with
+  | zero => rfl
+  | succ n ih =>
+      rw [denseLiveAllSegP, denseLiveAllSeg, ih (lo + 1), Array.getElem?_map]
+      cases arr[lo]? <;> rfl
+
 /-- The logical constraint system at a point in the loop: the original system with its interactions
     replaced by the live projection followed by the checks emitted so far. -/
 def denseMkCs (cs0 : DenseConstraintSystem p) (arr : Array (BusInteraction (DenseExpr p)))

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
@@ -78,10 +78,10 @@ def denseBoxTautoDropF (pw : PrimeWitness p) (_bs : BusSemantics p)
 
 /-- Joint-box agreement: every joint variable of `R`/`R'` has a proven finite domain, the box is
     small, and the two expressions agree at every box point. -/
-def denseBoxAgree (singles : List (DenseExpr p)) (R R' : DenseExpr p) : Bool :=
+def denseBoxAgree (domIdx : Std.HashMap VarId (List (DenseExpr p))) (R R' : DenseExpr p) : Bool :=
   let jv := (R.vars ++ R'.vars).eraseDups
   let doms := jv.filterMap (fun v =>
-    (denseFindDomainAlg singles v).map (fun d => (v, d)))
+    (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))
   decide (doms.map Prod.fst = jv) &&
   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
   (denseAssignments doms).all (fun pt =>
@@ -89,40 +89,40 @@ def denseBoxAgree (singles : List (DenseExpr p)) (R R' : DenseExpr p) : Bool :=
 
 /-- Slot-pair certificate: the two expressions are syntactically equal, or decompose over the same
     carrier with the same constant coefficient and offsets agreeing on the joint domain box. -/
-def denseSlotEqCert (singles : List (DenseExpr p)) (e e' : DenseExpr p) : Bool :=
+def denseSlotEqCert (domIdx : Std.HashMap VarId (List (DenseExpr p))) (e e' : DenseExpr p) : Bool :=
   e == e' ||
   e.vars.eraseDups.any (fun x =>
     e'.mentions x &&
     match e.splitAt x, e'.splitAt x with
-    | some (k, R), some (k2, R') => k2 == k && denseBoxAgree singles R R'
+    | some (k, R), some (k2, R') => k2 == k && denseBoxAgree domIdx R R'
     | _, _ => false)
 
 /-- Full-message certificate: same bus, same constant multiplicity, pointwise-equal payloads. -/
-def denseMsgEqCert (singles : List (DenseExpr p)) (bi bi' : BusInteraction (DenseExpr p)) : Bool :=
+def denseMsgEqCert (domIdx : Std.HashMap VarId (List (DenseExpr p))) (bi bi' : BusInteraction (DenseExpr p)) : Bool :=
   bi.busId == bi'.busId &&
   (match bi.multiplicity.constValue?, bi'.multiplicity.constValue? with
    | some m, some m' => m == m'
    | _, _ => false) &&
   bi.payload.length == bi'.payload.length &&
-  (bi.payload.zip bi'.payload).all (fun ee => denseSlotEqCert singles ee.1 ee.2)
+  (bi.payload.zip bi'.payload).all (fun ee => denseSlotEqCert domIdx ee.1 ee.2)
 
 /-- Is `bi` the first of its pointwise class (no earlier certified twin)? -/
-def densePdFirst (bs : BusSemantics p) (singles : List (DenseExpr p))
+def densePdFirst (bs : BusSemantics p) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p)) : Bool :=
   match bis.findIdx? (fun b => b == bi) with
   | none => true
-  | some i => (bis.take i).all (fun b => bs.isStateful b.busId || !(denseMsgEqCert singles b bi))
+  | some i => (bis.take i).all (fun b => bs.isStateful b.busId || !(denseMsgEqCert domIdx b bi))
 
 /-- Keep unless a *first-of-class* earlier stateless twin exists (depth-1 rule: the twin that
     justifies a drop is itself provably kept, so no chain induction is needed). -/
-def densePdKeep (bs : BusSemantics p) (singles : List (DenseExpr p))
+def densePdKeep (bs : BusSemantics p) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p)) : Bool :=
   bs.isStateful bi.busId ||
   (match bis.findIdx? (fun b => b == bi) with
    | none => true
    | some i =>
-     !((bis.take i).any (fun b => !bs.isStateful b.busId && denseMsgEqCert singles b bi
-         && densePdFirst bs singles bis b)))
+     !((bis.take i).any (fun b => !bs.isStateful b.busId && denseMsgEqCert domIdx b bi
+         && densePdFirst bs domIdx bis b)))
 
 /-! ### The fast duplicate analysis (dense)
 
@@ -160,7 +160,7 @@ structure DensePdEntry (p : ℕ) where
 
 /-- The value-keyed set of interactions the sweep decides to drop — the same set `densePdKeep`
     would drop (drops are value-based: `findIdx?` evaluates each duplicate at its first occurrence). -/
-def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
+def densePdDropSet (bs : BusSemantics p) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bis : List (BusInteraction (DenseExpr p))) :
     Std.HashMap UInt64 (List (BusInteraction (DenseExpr p))) := Id.run do
   -- Per coarse key (bus id, constant multiplicity, payload length), keep only the first-of-class
@@ -185,7 +185,7 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
           let (key, sigs) := densePdKeySigs bi m
           let entries := reps.getD key []
           if entries.any (fun e =>
-              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi) then
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert domIdx e.bi bi) then
             let vk := densePdValHash bi
             drops := drops.insert vk (bi :: (drops.getD vk []))
           else
@@ -206,10 +206,10 @@ def densePdDropSet (bs : BusSemantics p) (singles : List (DenseExpr p))
           match bi.payload with
           | [] =>
             (repsEmpty.getD key []).any (fun e =>
-              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi)
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert domIdx e.bi bi)
           | e0 :: _ =>
             let check := fun (e : DensePdEntry p) =>
-              densePdSigsCompatible e.sigs sigs && denseMsgEqCert singles e.bi bi
+              densePdSigsCompatible e.sigs sigs && denseMsgEqCert domIdx e.bi bi
             (repsByHash.getD (key, e0.bHash) []).any check ||
               (HashedDedup.hashedEraseDups (hash ·) e0.vars).any (fun v =>
                 (repsByVar.getD (key, v) []).any check)
@@ -256,15 +256,15 @@ theorem densePdVerdictKeep_false {p : ℕ} {P : BusInteraction (DenseExpr p) →
 def densePointwiseDupDropF (pw : PrimeWitness p) (bs : BusSemantics p)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let singles := denseSingleVarCs d.algebraicConstraints
-    let drops := densePdDropSet bs singles d.busInteractions
-    -- `singles` is reused in the re-verification below: spelling the filter out again inside the
-    -- `filterMap` closure would recompute the O(system) single-variable scan per proposed drop.
+    let domIdx := denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)
+    let drops := densePdDropSet bs domIdx d.busInteractions
+    -- `domIdx` is reused in the re-verification below, so the bucket index is built once, not
+    -- per proposed drop.
     let verdicts : Std.HashMap UInt64 (List { b : BusInteraction (DenseExpr p) //
-        densePdKeep bs singles d.busInteractions b = false }) :=
+        densePdKeep bs domIdx d.busInteractions b = false }) :=
       drops.fold (init := ∅) fun m h l =>
         m.insert h (l.eraseDups.filterMap (fun b =>
-          if hpd : densePdKeep bs singles d.busInteractions b = false
+          if hpd : densePdKeep bs domIdx d.busInteractions b = false
           then some ⟨b, hpd⟩ else none))
     d.filterBus (densePdVerdictKeep verdicts)
   else d

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -31,7 +31,7 @@ structure DenseFuData (p : ℕ) where
 /-- The pair-level half of the certificate: slot decompositions, fact bounds, no-wrap checks,
     domain cover, and the per-point offset bounds — computed once per matched pair. Reads
     `facts.slotBound` at runtime. -/
-def denseFuPairData? (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (DenseExpr p))
+def denseFuPairData? (bs : BusSemantics p) (facts : BusFacts p bs) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (biX biY : BusInteraction (DenseExpr p)) (x : VarId) : Option (DenseFuData p) :=
   match biX.multiplicity.constValue?, biY.multiplicity.constValue? with
   | some mx, some my =>
@@ -49,7 +49,7 @@ def denseFuPairData? (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List
                  m.val * (bY - 1) + (m.val - 1) < p then
                let jointVars := (RX.vars ++ RY.vars).eraseDups
                let doms := jointVars.filterMap (fun v =>
-                 (denseFindDomainAlg domCs v).map (fun d => (v, d)))
+                 (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))
                if doms.map Prod.fst = jointVars ∧
                    (doms.map (fun vd => vd.2.length)).prod ≤ 32 then
                  let pts0 := denseAssignments doms
@@ -79,9 +79,9 @@ def denseFuCheckWith (d : DenseFuData p) (vx vy : VarId) : Bool :=
 /-- Decidable certificate that `biX`, `biY` are scaled range checks of the same carrier `x` whose
     offset parts pin `vy` (in `biY`) to `vx` (in `biX`). Not called by `denseFuLoop`; provided for
     the prover's soundness lemmas. -/
-def denseFuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (DenseExpr p))
+def denseFuCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (biX biY : BusInteraction (DenseExpr p)) (x vx vy : VarId) : Bool :=
-  match denseFuPairData? bs facts domCs biX biY x with
+  match denseFuPairData? bs facts domIdx biX biY x with
   | some d => denseFuCheckWith d vx vy
   | none => false
 
@@ -136,7 +136,7 @@ def denseFuTargets (biX biY : BusInteraction (DenseExpr p)) (x : VarId) :
 
 /-- Scan the interactions: for each scaled-check candidate, find an earlier twin with the same key
     and adopt every flag pair the certificate confirms, accumulating into `DenseSolved`. -/
-def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (DenseExpr p)) :
+def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domIdx : Std.HashMap VarId (List (DenseExpr p))) :
     List (BusInteraction (DenseExpr p)) → Std.HashMap UInt64 (List (DenseFUSeen p)) →
       DenseSolved p → DenseSolved p
   | [], _, σ => σ
@@ -147,19 +147,19 @@ def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Den
           if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
         -- pair-level work once; per-target checks share it (definitionally `denseFuCheck`)
-        match denseFuPairData? bs facts domCs ex.1.bi c ex.2 with
+        match denseFuPairData? bs facts domIdx ex.1.bi c ex.2 with
         | none =>
-            denseFuLoop bs facts domCs rest
+            denseFuLoop bs facts domIdx rest
               (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
         | some d =>
         let pairs := (denseFuTargets ex.1.bi c ex.2).filterMap (fun t =>
           if denseFuCheckWith d t.2 t.1
           then some (t.1, DenseExpr.var t.2) else none)
-        denseFuLoop bs facts domCs rest
+        denseFuLoop bs facts domIdx rest
           (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p))))
           (σ.insertAll pairs)
     | none =>
-        denseFuLoop bs facts domCs rest
+        denseFuLoop bs facts domIdx rest
           (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
 
 /-- Flag unification across duplicate scaled range checks. When two checks decompose over the same
@@ -169,7 +169,7 @@ def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Den
 def denseFlagUnifyF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let σ := denseFuLoop bs facts d.algebraicConstraints d.busInteractions ∅ DenseSolved.empty
+    let σ := denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅ DenseSolved.empty
     if σ.map.isEmpty then d else d.substF σ.fn
   else d
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/FxSubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FxSubst.lean
@@ -39,17 +39,17 @@ def denseFxCheckWith (d : DenseFuData p) (E : DenseExpr p) (vy : VarId) : Bool :
   d.pts.all (fun ptb => !ptb.2 || decide (denseEnvOfFast ptb.1 vy = E.eval (denseEnvOfFast ptb.1)))
 
 /-- The full certificate, defined through the shared pair data `denseFuPairData?`. -/
-def denseFxCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (DenseExpr p))
+def denseFxCheck (bs : BusSemantics p) (facts : BusFacts p bs) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (biX biY : BusInteraction (DenseExpr p)) (x : VarId) (E : DenseExpr p)
     (vy : VarId) : Bool :=
-  match denseFuPairData? bs facts domCs biX biY x with
+  match denseFuPairData? bs facts domIdx biX biY x with
   | some d => denseFxCheckWith d E vy
   | none => false
 
 /-! ## The scan loop and the substitution pass (dense) -/
 
 /-- Scan for matched scaled-check pairs and adopt every certified interpolation `vy := E`. -/
-def denseFxLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (DenseExpr p)) :
+def denseFxLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domIdx : Std.HashMap VarId (List (DenseExpr p))) :
     List (BusInteraction (DenseExpr p)) → Std.HashMap UInt64 (List (DenseFUSeen p)) →
       DenseSolved p → DenseSolved p
   | [], _, σ => σ
@@ -60,19 +60,19 @@ def denseFxLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Den
           if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
         -- pair-level work once per match; per-target checks share it (see `denseFxCheck`)
-        match denseFuPairData? bs facts domCs ex.1.bi c ex.2 with
+        match denseFuPairData? bs facts domIdx ex.1.bi c ex.2 with
         | none =>
-            denseFxLoop bs facts domCs rest
+            denseFxLoop bs facts domIdx rest
               (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
         | some d =>
         let pairs := (d.ryVars.eraseDups.filter (fun v => !(v ∈ d.rxVars))).filterMap (fun vy =>
           if denseFxCheckWith d (denseBuildE d vy) vy
           then some (vy, denseBuildE d vy) else none)
-        denseFxLoop bs facts domCs rest
+        denseFxLoop bs facts domIdx rest
           (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p))))
           (σ.insertAll pairs)
     | none =>
-        denseFxLoop bs facts domCs rest
+        denseFxLoop bs facts domIdx rest
           (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
 
 /-- Entailed nonlinear substitution. When two bus interactions match up to a scaled range check,
@@ -82,7 +82,7 @@ def denseFxLoop (bs : BusSemantics p) (facts : BusFacts p bs) (domCs : List (Den
 def denseFxSubstF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let σ := denseFxLoop bs facts d.algebraicConstraints d.busInteractions ∅ DenseSolved.empty
+    let σ := denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅ DenseSolved.empty
     if σ.map.isEmpty then d else d.substF σ.fn
   else d
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
@@ -180,52 +180,52 @@ def denseBoxTautoDropPass (pw : PrimeWitness p) : DenseVerifiedPassW p :=
 
 /-- Joint-box agreement soundness: agreement at every box point gives agreement on every assignment
     zeroing the single-variable constraints. -/
-theorem denseBoxAgree_sound [Fact p.Prime] (singles : List (DenseExpr p)) (R R' : DenseExpr p)
-    (h : denseBoxAgree singles R R' = true) (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ singles, c.eval denv = 0) : R.eval denv = R'.eval denv := by
+theorem denseBoxAgree_sound [Fact p.Prime] (domIdx : Std.HashMap VarId (List (DenseExpr p))) (R R' : DenseExpr p)
+    (h : denseBoxAgree domIdx R R' = true) (denv : VarId → ZMod p)
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0) : R.eval denv = R'.eval denv := by
   unfold denseBoxAgree at h
   simp only [Bool.and_eq_true, decide_eq_true_eq] at h
   obtain ⟨⟨hcover, _hcap⟩, hall⟩ := h
   have hmemdoms : ∀ vd ∈ (R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-      (denseFindDomainAlg singles v).map (fun dm => (v, dm))), denv vd.1 ∈ vd.2 := by
+      (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm))), denv vd.1 ∈ vd.2 := by
     intro vd hvd
     obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-    cases hfd : denseFindDomainAlg singles v with
+    cases hfd : denseFindDomainAlg (denseVarBucketLookup domIdx v) v with
     | none => rw [hfd] at hvd'; simp at hvd'
     | some dm =>
         rw [hfd] at hvd'
         simp only [Option.map_some, Option.some.injEq] at hvd'
         obtain rfl := hvd'.symm
-        exact denseFindDomainAlg_sound denv singles v dm hfd hdom
+        exact denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx v) v dm hfd (hdom v)
   have hpt := mem_denseAssignments ((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-    (denseFindDomainAlg singles v).map (fun dm => (v, dm)))) denv hmemdoms
+    (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm)))) denv hmemdoms
   have hagree : ∀ v, v ∈ (R.vars ++ R'.vars).eraseDups →
       denseEnvOfFast (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-        (denseFindDomainAlg singles v).map (fun dm => (v, dm)))).map
+        (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm)))).map
           (fun vd => (vd.1, denv vd.1))) v = denv v := by
     intro v hv
     refine denseEnvOfFast_map _ denv v ?_
     rw [show (((R.vars ++ R'.vars).eraseDups.filterMap (fun v =>
-      (denseFindDomainAlg singles v).map (fun dm => (v, dm)))).map Prod.fst)
+      (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm)))).map Prod.fst)
       = (R.vars ++ R'.vars).eraseDups from hcover]
     exact hv
   have hRR := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
   have hRa : R.eval (denseEnvOfFast (((R.vars ++ R'.vars).eraseDups.filterMap
-      (fun v => (denseFindDomainAlg singles v).map (fun dm => (v, dm)))).map
+      (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm)))).map
         (fun vd => (vd.1, denv vd.1)))) = R.eval denv :=
     DenseExpr.eval_congr R _ denv (fun v hv =>
       hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
   have hRa' : R'.eval (denseEnvOfFast (((R.vars ++ R'.vars).eraseDups.filterMap
-      (fun v => (denseFindDomainAlg singles v).map (fun dm => (v, dm)))).map
+      (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun dm => (v, dm)))).map
         (fun vd => (vd.1, denv vd.1)))) = R'.eval denv :=
     DenseExpr.eval_congr R' _ denv (fun v hv =>
       hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
   rw [← hRa, ← hRa', hRR]
 
 /-- Slot-pair certificate soundness (`denseSlotEqCert`). -/
-theorem denseSlotEqCert_sound [Fact p.Prime] (singles : List (DenseExpr p)) (e e' : DenseExpr p)
-    (h : denseSlotEqCert singles e e' = true) (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ singles, c.eval denv = 0) : e.eval denv = e'.eval denv := by
+theorem denseSlotEqCert_sound [Fact p.Prime] (domIdx : Std.HashMap VarId (List (DenseExpr p))) (e e' : DenseExpr p)
+    (h : denseSlotEqCert domIdx e e' = true) (denv : VarId → ZMod p)
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0) : e.eval denv = e'.eval denv := by
   unfold denseSlotEqCert at h
   rw [Bool.or_eq_true] at h
   rcases h with heq | hany
@@ -245,13 +245,13 @@ theorem denseSlotEqCert_sound [Fact p.Prime] (singles : List (DenseExpr p)) (e e
             obtain ⟨hk2, hba⟩ := hx
             rw [DenseExpr.splitAt_eval x e k R hsX denv,
                 DenseExpr.splitAt_eval x e' k2 R' hsY denv, eq_of_beq hk2,
-                denseBoxAgree_sound singles R R' hba denv hdom]
+                denseBoxAgree_sound domIdx R R' hba denv hdom]
 
 /-- Full-message certificate soundness: the two interactions evaluate to the same message. -/
-theorem denseMsgEqCert_sound [Fact p.Prime] (singles : List (DenseExpr p))
-    (bi bi' : BusInteraction (DenseExpr p)) (h : denseMsgEqCert singles bi bi' = true)
+theorem denseMsgEqCert_sound [Fact p.Prime] (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (bi bi' : BusInteraction (DenseExpr p)) (h : denseMsgEqCert domIdx bi bi' = true)
     (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ singles, c.eval denv = 0) : denseBIEval bi denv = denseBIEval bi' denv := by
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0) : denseBIEval bi denv = denseBIEval bi' denv := by
   unfold denseMsgEqCert at h
   rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at h
   obtain ⟨⟨⟨hbus, hmult⟩, hlen⟩, hslots⟩ := h
@@ -279,15 +279,15 @@ theorem denseMsgEqCert_sound [Fact p.Prime] (singles : List (DenseExpr p))
       exact List.getElem_mem _
     have hcert := List.all_eq_true.mp hslots _ hz
     simp only [List.getElem_map]
-    exact denseSlotEqCert_sound singles _ _ hcert denv hdom
+    exact denseSlotEqCert_sound domIdx _ _ hcert denv hdom
   show denseBIEval bi denv = denseBIEval bi' denv
   unfold denseBIEval
   rw [eq_of_beq hbus, hmm, hpay]
 
 /-- A first-of-class interaction is always kept — the depth-1 justification for `densePdKeep`. -/
-theorem densePdFirst_keep (bs : BusSemantics p) (singles : List (DenseExpr p))
+theorem densePdFirst_keep (bs : BusSemantics p) (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (bis : List (BusInteraction (DenseExpr p))) (b : BusInteraction (DenseExpr p))
-    (h : densePdFirst bs singles bis b = true) : densePdKeep bs singles bis b = true := by
+    (h : densePdFirst bs domIdx bis b = true) : densePdKeep bs domIdx bis b = true := by
   unfold densePdKeep
   rw [Bool.or_eq_true]
   right
@@ -300,9 +300,9 @@ theorem densePdFirst_keep (bs : BusSemantics p) (singles : List (DenseExpr p))
       rw [Bool.not_eq_true']
       by_contra hany
       have hany' : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
-          && denseMsgEqCert singles b' b && densePdFirst bs singles bis b')) = true := by
+          && denseMsgEqCert domIdx b' b && densePdFirst bs domIdx bis b')) = true := by
         by_cases hh : ((bis.take i).any (fun b' => !bs.isStateful b'.busId
-            && denseMsgEqCert singles b' b && densePdFirst bs singles bis b')) = true
+            && denseMsgEqCert domIdx b' b && densePdFirst bs domIdx bis b')) = true
         · exact hh
         · exact absurd (by simpa using hh) hany
       obtain ⟨b'', hb''mem, hb''⟩ := List.any_eq_true.1 hany'
@@ -325,7 +325,7 @@ theorem DensePassCorrect.densePointwiseDupDrop [Fact p.Prime]
     (d : DenseConstraintSystem p) (bs : BusSemantics p) (isInput : VarId → Bool)
     (keep : BusInteraction (DenseExpr p) → Bool)
     (hkeep : ∀ bi ∈ d.busInteractions, keep bi = false →
-      densePdKeep bs (denseSingleVarCs d.algebraicConstraints) d.busInteractions bi = false) :
+      densePdKeep bs (denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)) d.busInteractions bi = false) :
     DensePassCorrect isInput d (d.filterBus keep) [] bs := by
   refine DensePassCorrect.denseFilterBusEntailed d bs isInput keep ?_ ?_
   · intro bi hbimem hkf
@@ -347,9 +347,9 @@ theorem DensePassCorrect.densePointwiseDupDrop [Fact p.Prime]
         rw [Bool.and_eq_true, Bool.and_eq_true] at hb
         obtain ⟨⟨hnst, hcert⟩, hfirst⟩ := hb
         have hbcs : b ∈ d.busInteractions := List.mem_of_mem_take hbmem
-        have hbkeep : densePdKeep bs (denseSingleVarCs d.algebraicConstraints)
+        have hbkeep : densePdKeep bs (denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints))
             d.busInteractions b = true :=
-          densePdFirst_keep bs (denseSingleVarCs d.algebraicConstraints) d.busInteractions b hfirst
+          densePdFirst_keep bs (denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)) d.busInteractions b hfirst
         have hbkept : keep b = true := by
           by_contra hkb
           have := hkeep b hbcs (by simpa using hkb)
@@ -357,11 +357,14 @@ theorem DensePassCorrect.densePointwiseDupDrop [Fact p.Prime]
           exact absurd hbkeep (by simp)
         have hbout : b ∈ (d.filterBus keep).busInteractions :=
           List.mem_filter.2 ⟨hbcs, hbkept⟩
-        have hdom : ∀ c ∈ denseSingleVarCs d.algebraicConstraints, c.eval denv = 0 := by
-          intro c hc
-          exact hsat.1 c (List.mem_of_mem_filter hc)
+        have hdom : ∀ v, ∀ c ∈ denseVarBucketLookup
+            (denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)) v,
+            c.eval denv = 0 := by
+          intro v c hc
+          exact hsat.1 c (List.mem_of_mem_filter
+            (denseVarBucket_mem DenseExpr.vars (denseSingleVarCs d.algebraicConstraints) v c hc))
         have heq : denseBIEval b denv = denseBIEval bi denv :=
-          denseMsgEqCert_sound (denseSingleVarCs d.algebraicConstraints) b bi hcert denv hdom
+          denseMsgEqCert_sound (denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)) b bi hcert denv hdom
         have hob := hsat.2 b hbout
         rw [heq] at hob
         exact hob hm

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.FlagUnify
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.RootPairUnify
+import ApcOptimizer.Implementation.OptimizerPasses.Proofs.BusPairCancelJustify
 
 set_option autoImplicit false
 
@@ -18,11 +19,11 @@ variable {p : ℕ}
 
 /-- A passed `denseFuCheck` forces `vx` into `biX`'s payload variables (for occurrence closure). -/
 theorem denseFuCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domCs : List (DenseExpr p)) (biX biY : BusInteraction (DenseExpr p))
-    (x vx vy : VarId) (h : denseFuCheck bs facts domCs biX biY x vx vy = true) :
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (biX biY : BusInteraction (DenseExpr p))
+    (x vx vy : VarId) (h : denseFuCheck bs facts domIdx biX biY x vx vy = true) :
     vx ∈ biX.payload.flatMap DenseExpr.vars := by
   unfold denseFuCheck at h
-  cases hd : denseFuPairData? bs facts domCs biX biY x with
+  cases hd : denseFuPairData? bs facts domIdx biX biY x with
   | none => rw [hd] at h; simp at h
   | some d =>
     rw [hd] at h
@@ -71,17 +72,17 @@ theorem denseFuCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
 /-- `denseFuCheck` entails `vy = vx` on satisfying assignments: two scaled range checks of the same
     carrier `x` whose offsets agree pointwise on their finite flag box pin the flags equal. -/
 theorem denseFuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domCs : List (DenseExpr p)) (biX biY : BusInteraction (DenseExpr p))
-    (x vx vy : VarId) (h : denseFuCheck bs facts domCs biX biY x vx vy = true)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (biX biY : BusInteraction (DenseExpr p))
+    (x vx vy : VarId) (h : denseFuCheck bs facts domIdx biX biY x vx vy = true)
     (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ domCs, c.eval denv = 0)
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0)
     (hobX : (denseBIEval biX denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval biX denv) = false)
     (hobY : (denseBIEval biY denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval biY denv) = false) :
     denv vy = denv vx := by
   unfold denseFuCheck at h
-  cases hd : denseFuPairData? bs facts domCs biX biY x with
+  cases hd : denseFuPairData? bs facts domIdx biX biY x with
   | none => rw [hd] at h; simp at h
   | some d =>
     rw [hd] at h
@@ -169,35 +170,35 @@ theorem denseFuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                       rw [mul_comm m k, hunit, one_mul] at h1
                       linear_combination -h1
                     have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                        (denseFindDomainAlg domCs v).map (fun d => (v, d))), denv vd.1 ∈ vd.2 := by
+                        (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d))), denv vd.1 ∈ vd.2 := by
                       intro vd hvd
                       obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-                      cases hfd : denseFindDomainAlg domCs v with
+                      cases hfd : denseFindDomainAlg (denseVarBucketLookup domIdx v) v with
                       | none => rw [hfd] at hvd'; simp at hvd'
                       | some dm =>
                         rw [hfd] at hvd'
                         simp only [Option.map_some, Option.some.injEq] at hvd'
                         obtain rfl := hvd'.symm
-                        exact denseFindDomainAlg_sound denv domCs v dm hfd hdom
+                        exact denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx v) v dm hfd (hdom v)
                     have hpt := mem_denseAssignments ((RX.vars ++ RY.vars).eraseDups.filterMap
-                      (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))) denv hmemdoms
+                      (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))) denv hmemdoms
                     have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
                         denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))) v = denv v := by
                       intro v hv
                       refine denseEnvOfFast_map _ denv v ?_
                       rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                        (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+                        (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map Prod.fst)
                         = (RX.vars ++ RY.vars).eraseDups from hcover]
                       exact hv
                     have hRXagree : RX.eval (denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap
-                        (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                           (fun vd => (vd.1, denv vd.1)))) = RX.eval denv :=
                       DenseExpr.eval_congr RX _ denv (fun v hv =>
                         hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
                     have hRYagree : RY.eval (denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap
-                        (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                           (fun vd => (vd.1, denv vd.1)))) = RY.eval denv :=
                       DenseExpr.eval_congr RY _ denv (fun v hv =>
                         hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
@@ -231,29 +232,29 @@ theorem denseFuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                       residue_uniq m.val (OX.eval denv).val (OY.eval denv).val _ _
                         (hvalX.symm.trans hvalY) hWXlt hWYlt
                     have hmempts : (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1)),
                         decide (((-m) * RX.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val
                           = ((-m) * RY.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val))
                         ∈ ((denseAssignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d))))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d))))).map
                             (fun pt => (pt, decide (((-m) * RX.eval (denseEnvOfFast pt)).val
                               = ((-m) * RY.eval (denseEnvOfFast pt)).val)))) :=
                       List.mem_map.2 ⟨_, hpt, rfl⟩
                     have horb := List.all_eq_true.mp hcw _ hmempts
                     have hb : decide (((-m) * RX.eval (denseEnvOfFast (((RX.vars
                         ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val
                         = ((-m) * RY.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val) = true :=
                       decide_eq_true (by rw [hRXagree, hRYagree]; exact hres)
                     simp only [hb, Bool.not_true, Bool.false_or, decide_eq_true_eq] at horb
@@ -331,9 +332,9 @@ theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
       (∀ denv, d.satisfies bs denv → ∀ i t, σ.fn i = some t → denv i = t.eval denv) →
       (∀ i t, σ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseFuLoop bs facts d.algebraicConstraints pending seen σ).fn i
+          (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) pending seen σ).fn i
             = some t → denv i = t.eval denv) ∧
-      (∀ i t, (denseFuLoop bs facts d.algebraicConstraints pending seen σ).fn i
+      (∀ i t, (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) pending seen σ).fn i
           = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
   intro pending
   induction pending with
@@ -361,7 +362,7 @@ theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
           exact ih _ σ hrest hseen' hσs hσv
       | some ex =>
           simp only []
-          cases hd0 : denseFuPairData? bs facts d.algebraicConstraints ex.1.bi c ex.2 with
+          cases hd0 : denseFuPairData? bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2 with
           | none =>
               simp only []
               exact ih _ σ hrest hseen' hσs hσv
@@ -386,11 +387,11 @@ theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
                     simp only [Option.some.injEq] at hpif
                     rw [← hpif]
                     show denv tt.1 = denv tt.2
-                    have hfc : denseFuCheck bs facts d.algebraicConstraints
+                    have hfc : denseFuCheck bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 tt.2 tt.1 = true := by
                       unfold denseFuCheck; rw [hd0]; exact hck
-                    exact denseFuCheck_sound bs facts d.algebraicConstraints ex.1.bi c ex.2
-                      tt.2 tt.1 hfc denv hsat.1 (hsat.2 ex.1.bi hexbi) (hsat.2 c hcmem)
+                    exact denseFuCheck_sound bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2
+                      tt.2 tt.1 hfc denv (fun v c' hc' => hsat.1 c' (denseVarBucket_mem DenseExpr.vars d.algebraicConstraints v c' hc')) (hsat.2 ex.1.bi hexbi) (hsat.2 c hcmem)
                   · rw [if_neg hck] at hpif
                     exact absurd hpif (by simp)
                 ·
@@ -406,12 +407,12 @@ theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
                     intro z hz
                     simp only [DenseExpr.vars, List.mem_singleton] at hz
                     subst hz
-                    have hfc : denseFuCheck bs facts d.algebraicConstraints
+                    have hfc : denseFuCheck bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 tt.2 tt.1 = true := by
                       unfold denseFuCheck; rw [hd0]; exact hck
                     exact DenseConstraintSystem.mem_occ_of_bi hexbi (by
                       simp only [denseBIVars, List.mem_append]
-                      exact Or.inr (denseFuCheck_vars bs facts d.algebraicConstraints
+                      exact Or.inr (denseFuCheck_vars bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 tt.2 tt.1 hfc))
                   · rw [if_neg hck] at hpif
                     exact absurd hpif (by simp)
@@ -425,9 +426,9 @@ theorem denseFlagUnifyF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : 
     (d : DenseConstraintSystem p) :
     denseFlagUnifyF pw bs facts d
       = (if pw.isPrime = true then
-          (if (denseFuLoop bs facts d.algebraicConstraints d.busInteractions ∅
+          (if (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
                 DenseSolved.empty).map.isEmpty then d
-           else d.substF (denseFuLoop bs facts d.algebraicConstraints d.busInteractions ∅
+           else d.substF (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
                 DenseSolved.empty).fn)
          else d) := rfl
 
@@ -435,9 +436,9 @@ theorem denseFlagUnifyF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : 
 theorem denseFlagUnify_loop_invariant [Fact p.Prime] (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseFuLoop bs facts d.algebraicConstraints d.busInteractions ∅
+        (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
           DenseSolved.empty).fn i = some t → denv i = t.eval denv) ∧
-    (∀ i t, (denseFuLoop bs facts d.algebraicConstraints d.busInteractions ∅
+    (∀ i t, (denseFuLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
         DenseSolved.empty).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
   refine denseFuLoop_sound bs facts d d.busInteractions ∅ DenseSolved.empty
     (fun _ h => h) ?_ ?_ ?_

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FxSubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FxSubst.lean
@@ -19,13 +19,13 @@ variable {p : ℕ}
     forces every variable of `E` into `biX`'s payload variables (needed for occurrence closure of
     the adopted `vy := E`). -/
 theorem denseFxCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domCs : List (DenseExpr p)) (biX biY : BusInteraction (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (biX biY : BusInteraction (DenseExpr p))
     (x : VarId) (E : DenseExpr p) (vy : VarId)
-    (h : denseFxCheck bs facts domCs biX biY x E vy = true) :
+    (h : denseFxCheck bs facts domIdx biX biY x E vy = true) :
     ∀ v ∈ E.vars, v ∈ biX.payload.flatMap DenseExpr.vars := by
   intro v hv
   unfold denseFxCheck at h
-  cases hd : denseFuPairData? bs facts domCs biX biY x with
+  cases hd : denseFuPairData? bs facts domIdx biX biY x with
   | none => rw [hd] at h; simp at h
   | some d =>
     rw [hd] at h
@@ -75,18 +75,18 @@ theorem denseFxCheck_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     Same pair-level residue argument as `flagUnify`'s `denseFuCheck_sound`, with the interpolation
     `E` as the certificate's target in place of the twin flag. -/
 theorem denseFxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domCs : List (DenseExpr p)) (biX biY : BusInteraction (DenseExpr p))
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) (biX biY : BusInteraction (DenseExpr p))
     (x : VarId) (E : DenseExpr p) (vy : VarId)
-    (h : denseFxCheck bs facts domCs biX biY x E vy = true)
+    (h : denseFxCheck bs facts domIdx biX biY x E vy = true)
     (denv : VarId → ZMod p)
-    (hdom : ∀ c ∈ domCs, c.eval denv = 0)
+    (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0)
     (hobX : (denseBIEval biX denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval biX denv) = false)
     (hobY : (denseBIEval biY denv).multiplicity ≠ 0 →
       bs.violatesConstraint (denseBIEval biY denv) = false) :
     denv vy = E.eval denv := by
   unfold denseFxCheck at h
-  cases hd : denseFuPairData? bs facts domCs biX biY x with
+  cases hd : denseFuPairData? bs facts domIdx biX biY x with
   | none => rw [hd] at h; simp at h
   | some d =>
     rw [hd] at h
@@ -177,35 +177,35 @@ theorem denseFxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                       linear_combination -h1
                     -- the environment restricted to the joint flag box is an enumerated point
                     have hmemdoms : ∀ vd ∈ (RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                        (denseFindDomainAlg domCs v).map (fun d => (v, d))), denv vd.1 ∈ vd.2 := by
+                        (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d))), denv vd.1 ∈ vd.2 := by
                       intro vd hvd
                       obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-                      cases hfd : denseFindDomainAlg domCs v with
+                      cases hfd : denseFindDomainAlg (denseVarBucketLookup domIdx v) v with
                       | none => rw [hfd] at hvd'; simp at hvd'
                       | some dm =>
                         rw [hfd] at hvd'
                         simp only [Option.map_some, Option.some.injEq] at hvd'
                         obtain rfl := hvd'.symm
-                        exact denseFindDomainAlg_sound denv domCs v dm hfd hdom
+                        exact denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx v) v dm hfd (hdom v)
                     have hpt := mem_denseAssignments ((RX.vars ++ RY.vars).eraseDups.filterMap
-                      (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))) denv hmemdoms
+                      (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))) denv hmemdoms
                     have hagree : ∀ v, v ∈ (RX.vars ++ RY.vars).eraseDups →
                         denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))) v = denv v := by
                       intro v hv
                       refine denseEnvOfFast_map _ denv v ?_
                       rw [show (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                        (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map Prod.fst)
+                        (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map Prod.fst)
                         = (RX.vars ++ RY.vars).eraseDups from hcover]
                       exact hv
                     have hRXagree : RX.eval (denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap
-                        (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                           (fun vd => (vd.1, denv vd.1)))) = RX.eval denv :=
                       DenseExpr.eval_congr RX _ denv (fun v hv =>
                         hagree v (List.mem_eraseDups.2 (List.mem_append_left _ hv)))
                     have hRYagree : RY.eval (denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap
-                        (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                           (fun vd => (vd.1, denv vd.1)))) = RY.eval denv :=
                       DenseExpr.eval_congr RY _ denv (fun v hv =>
                         hagree v (List.mem_eraseDups.2 (List.mem_append_right _ hv)))
@@ -242,35 +242,35 @@ theorem denseFxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                         (hvalX.symm.trans hvalY) hWXlt hWYlt
                     -- the target condition at the environment's point
                     have hmempts : (((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1)),
                         decide (((-m) * RX.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val
                           = ((-m) * RY.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val))
                         ∈ ((denseAssignments ((RX.vars ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d))))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d))))).map
                             (fun pt => (pt, decide (((-m) * RX.eval (denseEnvOfFast pt)).val
                               = ((-m) * RY.eval (denseEnvOfFast pt)).val)))) :=
                       List.mem_map.2 ⟨_, hpt, rfl⟩
                     have horb := List.all_eq_true.mp hcw _ hmempts
                     have hb : decide (((-m) * RX.eval (denseEnvOfFast (((RX.vars
                         ++ RY.vars).eraseDups.filterMap (fun v =>
-                          (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val
                         = ((-m) * RY.eval (denseEnvOfFast
                             (((RX.vars ++ RY.vars).eraseDups.filterMap
-                          (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                          (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                             (fun vd => (vd.1, denv vd.1))))).val) = true :=
                       decide_eq_true (by rw [hRXagree, hRYagree]; exact hres)
                     simp only [hb, Bool.not_true, Bool.false_or, decide_eq_true_eq] at horb
                     -- the built expression agrees on the box point (all its vars are joint flags)
                     have hEagree : E.eval (denseEnvOfFast (((RX.vars ++ RY.vars).eraseDups.filterMap
-                        (fun v => (denseFindDomainAlg domCs v).map (fun d => (v, d)))).map
+                        (fun v => (denseFindDomainAlg (denseVarBucketLookup domIdx v) v).map (fun d => (v, d)))).map
                           (fun vd => (vd.1, denv vd.1)))) = E.eval denv := by
                       refine DenseExpr.eval_congr E _ denv (fun v hv => ?_)
                       refine hagree v (List.mem_eraseDups.2 ?_)
@@ -294,9 +294,9 @@ theorem denseFxLoop_sound [Fact p.Prime] (bs : BusSemantics p)
       (∀ denv, d.satisfies bs denv → ∀ i t, σ.fn i = some t → denv i = t.eval denv) →
       (∀ i t, σ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseFxLoop bs facts d.algebraicConstraints pending seen σ).fn i
+          (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) pending seen σ).fn i
             = some t → denv i = t.eval denv) ∧
-      (∀ i t, (denseFxLoop bs facts d.algebraicConstraints pending seen σ).fn i
+      (∀ i t, (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) pending seen σ).fn i
           = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
   intro pending
   induction pending with
@@ -324,7 +324,7 @@ theorem denseFxLoop_sound [Fact p.Prime] (bs : BusSemantics p)
           exact ih _ σ hrest hseen' hσs hσv
       | some ex =>
           simp only []
-          cases hd0 : denseFuPairData? bs facts d.algebraicConstraints ex.1.bi c ex.2 with
+          cases hd0 : denseFuPairData? bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2 with
           | none =>
               simp only []
               exact ih _ σ hrest hseen' hσs hσv
@@ -350,11 +350,11 @@ theorem denseFxLoop_sound [Fact p.Prime] (bs : BusSemantics p)
                     simp only [Option.some.injEq] at hpif
                     rw [← hpif]
                     show denv vy = (denseBuildE d0 vy).eval denv
-                    have hfc : denseFxCheck bs facts d.algebraicConstraints
+                    have hfc : denseFxCheck bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 (denseBuildE d0 vy) vy = true := by
                       unfold denseFxCheck; rw [hd0]; exact hck
-                    exact denseFxCheck_sound bs facts d.algebraicConstraints ex.1.bi c ex.2
-                      (denseBuildE d0 vy) vy hfc denv hsat.1 (hsat.2 ex.1.bi hexbi) (hsat.2 c hcmem)
+                    exact denseFxCheck_sound bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2
+                      (denseBuildE d0 vy) vy hfc denv (fun v c' hc' => hsat.1 c' (denseVarBucket_mem DenseExpr.vars d.algebraicConstraints v c' hc')) (hsat.2 ex.1.bi hexbi) (hsat.2 c hcmem)
                   · rw [if_neg hck] at hpif
                     exact absurd hpif (by simp)
                 · -- (b) occurrence closure of the updated map
@@ -368,12 +368,12 @@ theorem denseFxLoop_sound [Fact p.Prime] (bs : BusSemantics p)
                     simp only [Option.some.injEq] at hpif
                     rw [← hpif]
                     intro z hz
-                    have hfc : denseFxCheck bs facts d.algebraicConstraints
+                    have hfc : denseFxCheck bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 (denseBuildE d0 vy) vy = true := by
                       unfold denseFxCheck; rw [hd0]; exact hck
                     exact DenseConstraintSystem.mem_occ_of_bi hexbi (by
                       simp only [denseBIVars, List.mem_append]
-                      exact Or.inr (denseFxCheck_vars bs facts d.algebraicConstraints
+                      exact Or.inr (denseFxCheck_vars bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints)
                         ex.1.bi c ex.2 (denseBuildE d0 vy) vy hfc z hz))
                   · rw [if_neg hck] at hpif
                     exact absurd hpif (by simp)
@@ -388,9 +388,9 @@ theorem denseFxSubstF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : Bu
     (d : DenseConstraintSystem p) :
     denseFxSubstF pw bs facts d
       = (if pw.isPrime = true then
-          (if (denseFxLoop bs facts d.algebraicConstraints d.busInteractions ∅
+          (if (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
                 DenseSolved.empty).map.isEmpty then d
-           else d.substF (denseFxLoop bs facts d.algebraicConstraints d.busInteractions ∅
+           else d.substF (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
                 DenseSolved.empty).fn)
          else d) := rfl
 
@@ -399,9 +399,9 @@ theorem denseFxSubstF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : Bu
 theorem denseFxSubst_loop_invariant [Fact p.Prime] (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseFxLoop bs facts d.algebraicConstraints d.busInteractions ∅
+        (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
           DenseSolved.empty).fn i = some t → denv i = t.eval denv) ∧
-    (∀ i t, (denseFxLoop bs facts d.algebraicConstraints d.busInteractions ∅
+    (∀ i t, (denseFxLoop bs facts (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
         DenseSolved.empty).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
   refine denseFxLoop_sound bs facts d d.busInteractions ∅ DenseSolved.empty
     (fun _ h => h) ?_ ?_ ?_

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1,5 +1,6 @@
 import ApcOptimizer.Implementation.OptimizerPasses.DomainBatch
 import ApcOptimizer.Implementation.OptimizerPasses.DomainFold
+import ApcOptimizer.Implementation.OptimizerPasses.AddrDiseq
 
 set_option autoImplicit false
 
@@ -188,6 +189,97 @@ def denseCheckReencode (d : DenseConstraintSystem p) (xs bits : List VarId)
       d.algebraicConstraints.all (fun c => !c.mentions b) &&
       d.busInteractions.all (fun bi =>
         !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b)))
+
+/-! ### Compiled twin of the certificate
+
+`denseCheckReencode` walks the whole system once per bit for the freshness conjunct and scans the
+covered set twice; the twin computes the covered set once and decides freshness in a single walk
+against the bit set. -/
+
+theorem DenseExpr.mentionsAny_ofList_false_iff (bits : List VarId) (e : DenseExpr p) :
+    e.mentionsAny (Std.HashSet.ofList bits) = false ↔ ∀ b ∈ bits, e.mentions b = false := by
+  induction e with
+  | const c => simp [DenseExpr.mentionsAny, DenseExpr.mentions]
+  | var y =>
+      simp only [DenseExpr.mentionsAny, DenseExpr.mentions, Std.HashSet.contains_ofList]
+      constructor
+      · intro h b hb
+        cases hyb : y == b with
+        | false => rfl
+        | true =>
+            rw [show y = b from eq_of_beq hyb] at h
+            rw [List.contains_eq_mem, decide_eq_false_iff_not] at h
+            exact absurd hb h
+      · intro h
+        rw [List.contains_eq_mem, decide_eq_false_iff_not]
+        intro hy
+        exact absurd (h y hy) (by simp)
+  | add a b iha ihb =>
+      simp only [DenseExpr.mentionsAny, DenseExpr.mentions, Bool.or_eq_false_iff, iha, ihb]
+      constructor
+      · rintro ⟨ha, hb⟩ x hx
+        exact ⟨ha x hx, hb x hx⟩
+      · exact fun h => ⟨fun x hx => (h x hx).1, fun x hx => (h x hx).2⟩
+  | mul a b iha ihb =>
+      simp only [DenseExpr.mentionsAny, DenseExpr.mentions, Bool.or_eq_false_iff, iha, ihb]
+      constructor
+      · rintro ⟨ha, hb⟩ x hx
+        exact ⟨ha x hx, hb x hx⟩
+      · exact fun h => ⟨fun x hx => (h x hx).1, fun x hx => (h x hx).2⟩
+
+theorem denseFreshFused_eq (d : DenseConstraintSystem p) (bits : List VarId) :
+    (d.algebraicConstraints.all (fun c => !c.mentionsAny (Std.HashSet.ofList bits)) &&
+      d.busInteractions.all (fun bi =>
+        !bi.multiplicity.mentionsAny (Std.HashSet.ofList bits) &&
+        bi.payload.all (fun e => !e.mentionsAny (Std.HashSet.ofList bits))))
+      = bits.all (fun b =>
+          d.algebraicConstraints.all (fun c => !c.mentions b) &&
+          d.busInteractions.all (fun bi =>
+            !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b))) := by
+  have hiff : ∀ {a b : Bool}, ((a = true) ↔ (b = true)) → a = b := by
+    intro a b h; cases a <;> cases b <;> simp_all
+  apply hiff
+  simp only [List.all_eq_true, Bool.and_eq_true, Bool.not_eq_true',
+    DenseExpr.mentionsAny_ofList_false_iff]
+  constructor
+  · rintro ⟨hcs, hbis⟩ b hb
+    exact ⟨fun c hc => hcs c hc b hb, fun bi hbi =>
+      ⟨(hbis bi hbi).1 b hb, fun e he => (hbis bi hbi).2 e he b hb⟩⟩
+  · intro h
+    exact ⟨fun c hc b hb => (h b hb).1 c hc, fun bi hbi =>
+      ⟨fun b hb => ((h b hb).2 bi hbi).1, fun e he b hb => ((h b hb).2 bi hbi).2 e he⟩⟩
+
+/-- `denseCheckReencode` with the covered set shared between the domain and soundness conjuncts
+    and the freshness conjunct decided in one system walk. -/
+def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+  let es := denseCoveredCsOf d xs
+  match denseGroupDoms es xs with
+  | none => false
+  | some doms =>
+    let survs := denseGroupSurvivorsE es doms
+    let patts := denseAssignments (denseBitBox bits)
+    decide ((doms.map (fun yd => yd.2.length)).prod ≤ 256) &&
+    decide (2 ≤ survs.length) &&
+    decide (bits.length < xs.length) &&
+    decide (bits.Nodup) &&
+    xs.all (fun x =>
+      ((DenseExpr.var x).substF (denseGroupSubst xs hm)).vars.all (fun v => bits.contains v)) &&
+    survs.all (fun s => patts.any (fun aβ =>
+      xs.all (fun x =>
+        decide (((DenseExpr.var x).substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ)
+          = denseEnvOfFast s x)))) &&
+    patts.all (fun aβ => es.all (fun c =>
+      decide ((c.substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ) = 0))) &&
+    (d.algebraicConstraints.all (fun c => !c.mentionsAny (Std.HashSet.ofList bits)) &&
+      d.busInteractions.all (fun bi =>
+        !bi.multiplicity.mentionsAny (Std.HashSet.ofList bits) &&
+        bi.payload.all (fun e => !e.mentionsAny (Std.HashSet.ofList bits))))
+
+@[csimp] theorem denseCheckReencode_eq_fast : @denseCheckReencode = @denseCheckReencodeFast := by
+  funext q d xs bits hm
+  unfold denseCheckReencode denseCheckReencodeFast
+  simp only [denseFreshFused_eq]
 
 /-! ## Derived-variable methods for the fresh bits
 

--- a/Main.lean
+++ b/Main.lean
@@ -288,11 +288,14 @@ def denseApplyTimed {p : ℕ} (pass : DenseVerifiedPassW p) (st : DenseProfState
     fixpoint below), threading the dense state and accumulating per-pass elapsed time. -/
 def denseRunCycleTimed {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
     (st : DenseProfState p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (acc : Std.HashMap String Nat) : IO (DenseProfState p × Std.HashMap String Nat) := do
+    (acc : Std.HashMap String Nat) (verbose : Bool := false) : IO (DenseProfState p × Std.HashMap String Nat) := do
   let mut s := st
   let mut a := acc
   for (name, pass) in passes do
     let (s', dt) ← denseApplyTimed pass s bs facts
+    if verbose && dt ≥ 100 then
+      IO.println s!"    {name}: {dt} ms -> {s'.2.1.varCount} vars, \
+        {s'.2.1.busInteractions.length} bus, {s'.2.1.algebraicConstraints.length} constraints"
     s := s'
     a := a.insert name (a.getD name 0 + dt)
   pure (s, a)
@@ -304,16 +307,17 @@ def denseRunCycleTimed {p : ℕ} (passes : List (String × DenseVerifiedPassW p)
     which strictly decreases at every recursive call — no fuel, no `partial`. -/
 def denseProfileLoop {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
     (st : DenseProfState p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (acc : Std.HashMap String Nat) (iter : Nat) (k : Nat ×ₗ Nat ×ₗ Nat) :
+    (acc : Std.HashMap String Nat) (iter : Nat) (k : Nat ×ₗ Nat ×ₗ Nat)
+    (verbose : Bool := false) :
     IO (DenseProfState p × Std.HashMap String Nat × Nat) := do
   let t0 ← IO.monoMsNow
-  let (st', acc') ← denseRunCycleTimed passes st bs facts acc
+  let (st', acc') ← denseRunCycleTimed passes st bs facts acc verbose
   let t1 ← IO.monoMsNow
   IO.println s!"  cycle {iter}: {st'.2.1.varCount} vars, {st'.2.1.busInteractions.length} bus, \
     {st'.2.1.algebraicConstraints.length} constraints ({t1 - t0} ms)"
   let k' := st'.2.1.sizeKey
   if h : k' < k then
-    denseProfileLoop passes st' bs facts acc' (iter + 1) k'
+    denseProfileLoop passes st' bs facts acc' (iter + 1) k' verbose
   else
     pure (st, acc', iter)
   termination_by k
@@ -329,7 +333,7 @@ def denseProfileLoop {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
     dense coda list once, decode once at output. Encode and decode are reported on their own lines and
     never charged to any pass. -/
 def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : ConstraintSystem p)
-    (bs : BusSemantics p) (facts : BusFacts p bs) : IO Unit := do
+    (bs : BusSemantics p) (facts : BusFacts p bs) (verbose : Bool := false) : IO Unit := do
   let t0 ← IO.monoMsNow
   -- Encode once at the pipeline entry (reported on its own line, never charged to a pass).
   let tEnc0 ← IO.monoMsNow
@@ -346,7 +350,7 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : ConstraintS
   -- Step the dense cleanup fixpoint (the SAME `cleanupPasses` list the optimizer runs), threading
   -- the registry / dense system / coverage from pass to pass and iteration to iteration.
   let (stF, acc, iters) ←
-    denseProfileLoop (cleanupPasses (p := p) b) st0 bs facts acc 0 st0.2.1.sizeKey
+    denseProfileLoop (cleanupPasses (p := p) b) st0 bs facts acc 0 st0.2.1.sizeKey verbose
   -- Coda (dense, run once).
   let (stF, acc) ← denseRunCycleTimed (codaPasses (p := p) b) stF bs facts acc
   -- Decode once at the pipeline output (reported on its own line).
@@ -363,16 +367,16 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : ConstraintS
     IO.println s!"  {name}: {ms} ms"
 
 /-- `profile [vm] <file>`: per-pass optimizer timing for the selected VM. -/
-def cmdProfile (vm fileName : String) : IO Unit := do
+def cmdProfile (vm fileName : String) (verbose : Bool := false) : IO Unit := do
   if isSp1 vm then
     let (cs, busMap) ← parseFileWith parseSp1 fileName
     profileRun ApcOptimizer.SP1.defaultDegreeBound fileName cs
       (ApcOptimizer.SP1.sp1BusSemantics ApcOptimizer.SP1.koalaBear busMap)
-      (ApcOptimizer.SP1.sp1Facts ApcOptimizer.SP1.koalaBear busMap)
+      (ApcOptimizer.SP1.sp1Facts ApcOptimizer.SP1.koalaBear busMap) verbose
   else
     let (cs, busMap) ← parseFileWith parseOpenVm fileName
     profileRun defaultDegreeBound fileName cs
-      (openVmBusSemantics babyBear busMap) (openVmFacts babyBear busMap)
+      (openVmBusSemantics babyBear busMap) (openVmFacts babyBear busMap) verbose
 
 def usage : String :=
   "usage: apc-optimizer run [vm] <file.json[.gz]>\n" ++
@@ -398,6 +402,7 @@ def main (args : List String) : IO Unit := do
   match rest with
   | ["run", fileName] => cmdRun vm fileName
   | ["profile", fileName] => cmdProfile vm fileName
+  | ["profile", "-v", fileName] => cmdProfile vm fileName (verbose := true)
   | ["report", unoptFile, optFile] => cmdReport vm unoptFile optFile
   | ["opt-export", inFile, outFile] => cmdOptExport vm inFile outFile
   | ["compare", unoptFile, optFile] => cmdCompare vm unoptFile optFile

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -513,3 +513,30 @@ worth a prototype on one index first.
 - **Runtime is a de-facto merge criterion**: build per-invocation indexes once; keep expensive
   arms out of hot per-query paths; put once-suffices passes in the coda.
 - **Check open PRs / recent `claude/*` branches for duplicates before implementing.**
+
+## Runtime ideas (2026-07-27 session, entry 148)
+
+- **Per-drop `alive` copies in busPairCancel**: with the region scans now sparse, the heavy-drop
+  cycle's residual includes `(alive.setIfInBounds iP false).setIfInBounds jP false` copying the
+  71k-entry array per drop (alive is shared by the scan closures). ~12k drops ≈ 1.7 GB of copies.
+  A persistent-friendly representation (e.g. a `Std.HashSet Nat` of tombstones consulted alongside
+  a stable array, or batching drops per findCancel sweep) could cut most of it.
+- **busUnify same-key mid verification**: `denseCheckPair` re-verifies each candidate's whole mid
+  window (`mid.all`). The same constant-key argument as entry 148 applies: mid messages with a
+  different constant key are refuted by the ConstsNeq arm. Needs the window's positions (the sweep
+  recovers mid positionally from the stored suffix), so it wants the sweep to carry position
+  ranges plus a `DenseKeyIdx`-style lookup; the sweep's `denseStepTest` per open symbolic window
+  is the other half.
+- **reencode cycle 0 (42–47 s to remove 128 vars)**: the remaining big certificate costs are the
+  per-candidate covered-set scans (`denseCoveredCsOf d xs`, a full pass over d per candidate —
+  the cached state's buckets could serve it with a threaded invariant) and the per-accept
+  full-system gated rewrite (`denseReencodeOutFast` — the state's `useCs` buckets + `foldCs` cover
+  exactly the positions the gate can fire on; needs a positions-driven twin with the state
+  invariant threaded, ~200-400 lines).
+- **domainBatch cycle 0 (26–28 s for 2.6k vars)**: gathers are bucket-served already; the cost is
+  hot-variable buckets × many candidate groups. Maybe gate groups on a cheap upper bound of the
+  gather size, or dedupe overlapping groups before gathering.
+- **flagFold cycle 0 (24 s, zero effect)**: NOT the domain lookups (bucketing them changed
+  nothing). Suspect `denseFuCandidates`' per-interaction `O.vars.eraseDups × splitAt` on large
+  first-slot payloads, or the per-matched-pair box evaluation in `denseFuPairData?`. Sample the
+  window before building anything.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5149,11 +5149,18 @@ the covered set once (was twice) and decides freshness in one system walk agains
 
 **Numbers** (this 4-core box, clean serial `profile` runs; per-pass dt totals, which exclude the
 `-v` printing overhead). Baseline main `f2d2c62`: busPairCancel 58.2, reencode 59.3, gauss 37.8,
-domainBatch 37.4, busUnify 33.5, flagFold 32.4, total 409.2 s. Final head: **busPairCancel 32.5
-(0.56×; the heavy-drop cycle 47.5→21.6 s)**, reencode 56.1, gauss 37.7, domainBatch 38.9,
-busUnify 33.7, flagFold 31.1. keccak `run` output identical (2021/186/1748) and every sha256
-cycle's `(vars, bus, constraints)` triple identical to main. CI Runtime Bench on PR #223
-(`-f benchmark=sha256`) dispatched for same-runner totals.
+domainBatch 37.4, busUnify 33.5, flagFold 32.4, total 409.2 s. Final head: **busPairCancel 30.9
+(0.53×; the heavy-drop cycle's dt 47.5→21.6 s)**, reencode 57.7, gauss 37.0, domainBatch 38.3,
+busUnify 33.3, flagFold 30.9. keccak `run` output identical (2021/186/1748) and every sha256
+cycle's `(vars, bus, constraints)` triple identical to main. The CI effectiveness matrix over all
+six sets reports **per-case circuit sizes identical** to main. CI Runtime Bench of the
+intermediate head `07ea18f` (prepared certificates + buckets + reencode twin, before the sparse
+scans): total 0.99× with reencode 0.87× and busPairCancel 1.08× — the prep-only regression is far
+smaller on the 32-core runner than on this box; the sparse-scan head's run in flight.
+
+A follow-up in the same session moved `pointwiseDupDrop`'s (flagFold part C) domain lookups to
+`denseVarBucket` buckets as well — output-identical, but **no measured sha256 effect** (flagFold
+31.1 → 30.9, noise): flagFold's cycle-0 cost is elsewhere (suspects in ideas.md).
 
 **Measurement lessons.** (1) A `-v` profile run is not comparable to a non-verbose one on totals
 or cycle times (the per-pass varCount printing adds ~8–10 s per big cycle); only per-pass dt

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5156,7 +5156,11 @@ cycle's `(vars, bus, constraints)` triple identical to main. The CI effectivenes
 six sets reports **per-case circuit sizes identical** to main. CI Runtime Bench of the
 intermediate head `07ea18f` (prepared certificates + buckets + reencode twin, before the sparse
 scans): total 0.99× with reencode 0.87× and busPairCancel 1.08× — the prep-only regression is far
-smaller on the 32-core runner than on this box; the sparse-scan head's run in flight.
+smaller on the 32-core runner than on this box. **CI Runtime Bench of the sparse-scan head
+(same runner, target vs main): total 244.4 → 221.0 s (0.90×); busPairCancel 31.2 → 16.8 s
+(0.54×), reencode 54.7 → 49.4 s (0.90×), everything else ≈ 1.00×.**
+Composed with entries 146–147, the big case stands at roughly 511.9 × 0.72 × 0.95 × 0.90 ≈ 315 s
+in the 2026-07-26 comparison's units vs powdr's 113.6 s — the 4.5× case gap is down to ~2.8×.
 
 A follow-up in the same session moved `pointwiseDupDrop`'s (flagFold part C) domain lookups to
 `denseVarBucket` buckets as well — output-identical, but **no measured sha256 effect** (flagFold

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5109,4 +5109,58 @@ prepared-`S` record out of `denseLiveAllSeg`'s and `denseShieldScanSeg`'s inner 
 `O(candidates + messages)`; `denseShieldScanSeg` needs a closure-parameterized twin
 (`denseShieldScanSegW pre prov …`, one induction) so the caller can supply the prepared tests.
 
-**Worked: yes.**
+**Worked: yes.**### 148. Runtime: sparse same-key region scans for busPairCancel (58 → 32 s on the 168k-var sha256 case)
+
+Targeting the >3x runtime gap vs powdr on the 168k-var sha256 case (timing comparison of
+2026-07-26: the sha256 set is 3.83x slower in Lean, 95 % of it this one case). A new `profile -v`
+mode (per-pass sizes and times inside each cleanup cycle) produced the pass×cycle matrix, and
+gdb sampling (`thread apply all` — the work happens on a worker thread, `bt` alone samples the
+main thread's join) attributed the hot windows.
+
+**The wrong first theory, kept for the record.** Entry 147 attributed ~42 % of busPairCancel to
+re-deriving certificate algebra per compared pair, so the first cut prepared per-interaction
+address data once (`DenseAddrPre`, AddrDiseqPre.lean: slot constants, linear forms, two-root
+reductions as memoizing thunks) and served the mid/shield scans from it. Measured cleanly, that
+REGRESSED busPairCancel (58.2 → 73.1 s zipped, 67.8 s after de-zipping the per-slot tests) while
+only the light cycles improved: the heavy-drop cycle's real cost is scan *volume*, not per-test
+algebra — ~12k accepted drops each re-scan an O(prefix) shield region ≈ 4×10⁸ steps, so any
+per-step constant dominates and extra indirection makes it worse. Sampling the cycle-1 window
+confirmed `denseShieldScanSegP`/`densePreRefutedP` on top.
+
+**The actual fix: sparse same-key scans (`BusPairCancelKeyIdx.lean`).** For a candidate whose
+address slots are all constants, a region message can only fail the region tests if it is on the
+same bus and either shares the candidate's constant key or has a symbolic key — every other
+position is refuted by the bus-id or constant-disequality arm and contributes the identity to the
+scan fold. `DenseKeyIdx` buckets each declared bus's positions by constant address key (ascending,
+`sym` for non-constant keys), built once per invocation on the stable array and threaded next to
+the prepared-certificate arrays. The sparse scans visit only the same-key bucket and `sym`
+filtered to the region; `denseRegionTests` packages the decision with the proof converting it
+back to the full-region forms `denseMkDropResult` consumes (builder completeness/ordering in
+`denseKeyIdxBuild_sound`, skipped-position refutations from `denseAddrKeyOf_ne_*`). Symbolic
+candidate keys fall back to the full scans. Region tests are now
+O(same-cell accesses + symbolic positions) per candidate instead of O(prefix).
+
+Also in this change set (each output-identical): busUnify's `denseCheckPair` verifier prepares
+the candidate side once per candidate and each mid message once (csimp twin); flagUnify/fxSubst
+domain lookups moved to `denseVarBucket` per-variable buckets (entry 143's pattern — hypothesis
+shape `∀ v, ∀ c ∈ lookup domIdx v, …` via `denseVarBucket_mem`); reencode's certificate computes
+the covered set once (was twice) and decides freshness in one system walk against the bit set
+(`mentionsAny`) instead of one walk per bit.
+
+**Numbers** (this 4-core box, clean serial `profile` runs; per-pass dt totals, which exclude the
+`-v` printing overhead). Baseline main `f2d2c62`: busPairCancel 58.2, reencode 59.3, gauss 37.8,
+domainBatch 37.4, busUnify 33.5, flagFold 32.4, total 409.2 s. Final head: **busPairCancel 32.5
+(0.56×; the heavy-drop cycle 47.5→21.6 s)**, reencode 56.1, gauss 37.7, domainBatch 38.9,
+busUnify 33.7, flagFold 31.1. keccak `run` output identical (2021/186/1748) and every sha256
+cycle's `(vars, bus, constraints)` triple identical to main. CI Runtime Bench on PR #223
+(`-f benchmark=sha256`) dispatched for same-runner totals.
+
+**Measurement lessons.** (1) A `-v` profile run is not comparable to a non-verbose one on totals
+or cycle times (the per-pass varCount printing adds ~8–10 s per big cycle); only per-pass dt
+totals compare. (2) Never run builds or other benchmarks concurrently with a measurement on this
+box — a keccak run plus two probe compiles inflated one busPairCancel reading by 15 s. (3) The
+remaining busPairCancel cost sits in the heavy-drop cycle's non-scan work: per-drop `alive` array
+copies (the array is shared by the scan closures, so `Array.set` copies 71k entries per drop),
+`denseCheckCancel`, and `denseFirstMatchAt`.
+
+**Worked: yes (busPairCancel 0.56×, output identity verified locally; PR #223).**


### PR DESCRIPTION
## Runtime on the SHA test case

The [2026-07-26 timing comparison](https://raw.githubusercontent.com/powdr-labs/powdr/apc-optimizer-timing-comparison/apc-timing/apc_optimizer_timing_2026_07_26.json) has the Lean optimizer 3.83× slower than powdr on the sha256 set — almost entirely the one 168915-var case (511.9 s vs 113.6 s at version `4349c88`, 95 % of the set's Lean time), while most other sets are at or below parity. This PR attacks that case's dominant superlinear cost.

**CI Runtime Bench, sha256, same runner (sticky comment below): total 244.4 → 221.0 s (0.90×), busPairCancel 31.2 → 16.8 s (0.54×), reencode 54.7 → 49.4 s (0.90×), everything else ≈ 1.00×.** Composed with the previous two runtime PRs, the big case's gap vs powdr in the timing comparison's units goes from 4.5× to ≈ 2.8×. Per-case circuit sizes are **identical to main on all six benchmark sets** (effectiveness matrix comment).

### Diagnosis

A new `profile -v` mode (per-pass sizes and times inside each cleanup cycle) produced the pass×cycle matrix; gdb stack sampling of the hot windows attributed the time. The headline was **not** what entry 147 predicted (per-pair certificate algebra): busPairCancel's heavy-drop cycle re-scans an O(prefix) shield region per accepted drop — ~12k drops ≈ 4×10⁸ scan steps — so scan **volume** dominates and any per-step constant is amplified. (An intermediate cut that only prepared the per-pair algebra measurably *regressed* the pass locally; numbers and the lesson are in log entry 148.)

### The fix: sparse same-key region scans (`BusPairCancelKeyIdx.lean`)

For a candidate send whose address slots are constants, a region message can only fail the mid/shield tests if it is on the same bus and either shares the candidate's constant address key or has a symbolic key — every other position is refuted by the bus-id or constant-disequality arm and contributes the identity to the scan fold. `DenseKeyIdx` buckets each declared bus's positions by constant address key once per invocation (ascending; `sym` holds symbolic-key positions). The sparse scans visit only the same-key bucket and `sym` filtered to the region, and `denseRegionTests` packages the decision together with the proof converting it back to the full-region forms the drop step consumes (builder completeness/ordering proven in `denseKeyIdxBuild_sound`; skipped positions' refutations from `denseAddrKeyOf_ne_*`). Symbolic candidate keys fall back to the full scans. Region tests go from O(prefix) to O(same-cell accesses + symbolic positions) per candidate.

Also included (each output-identical by construction):
- **Prepared address certificates** (`AddrDiseqPre.lean`): per-interaction slot constants / linear forms / two-root reductions as memoizing thunks, shared across all scans and drop resumes; busUnify's `denseCheckPair` verifier gets a `@[csimp]` twin preparing each side once.
- **flagUnify/fxSubst/pointwiseDupDrop domain lookups** from `denseVarBucket` per-variable buckets (entry 143's pattern) instead of scanning the whole constraint list per joint variable per matched pair.
- **reencode certificate `@[csimp]` twin**: covered set computed once (was twice); freshness decided in one system walk against the bit set instead of one walk per bit (reencode 0.90× on CI).
- `profile -v`: per-pass sizes and times inside each cleanup cycle.

### Verification

- Every sha256 cleanup cycle's `(vars, bus, constraints)` triple is identical to main cycle-by-cycle (final circuit 11906 / 12464 / 3194); keccak `run` counts unchanged (2021 / 186 / 1748).
- CI effectiveness matrix: per-case circuit sizes identical to main on openvm-eth, wasm-eth, keccak, sha256, sp1/rsp, sp1/keccak.
- `Scripts/check-proof-integrity.sh` passes (standard axioms only, no unused theorems).

The remaining runtime levers on this case (per-drop `alive` copies, reencode's cycle-0 covered-set scans and per-accept rewrite, domainBatch gathers, busUnify's mid verification) are documented with measurements in `agent-docs/ideas.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9JNXM6DfG3VBUsMmVynYh