### PR TITLE
perf: hoist the ZMod instance dictionary out of the affine-layer loops (gauss 1.5-2.4×, normalize 2.2-2.7×, pipeline 1.15-1.27×, effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -27,6 +27,50 @@ def DenseLinExpr.add (a b : DenseLinExpr p) : DenseLinExpr p :=
 def DenseLinExpr.scale (k : ZMod p) (a : DenseLinExpr p) : DenseLinExpr p :=
   ⟨k * a.const, a.terms.map (fun t => (t.1, k * t.2))⟩
 
+/-! ## Boxed runtime twins
+
+`p` is a runtime value, so every `ZMod p` operation Lean compiles inline re-derives the whole
+`CommRing (ZMod p)` instance chain — `ZMod.commRing` alone allocates nine closures. A `…With ops`
+twin takes a `DenseZModOps p` (`Encoding.lean`) instead, so a traversal costs one instance chain
+rather than one per element. Same pattern as `denseCoeffIdxWith` in `Gauss.lean`.
+
+A twin gets a `@[csimp]` only when it loops: building a `DenseZModOps p` costs about one instance
+chain itself, so for a function performing a single operation (`add`) the twin stays a plain helper
+for callers that already hold an `ops`. -/
+
+def DenseLinExpr.addWith (ops : DenseZModOps p) (a b : DenseLinExpr p) : DenseLinExpr p :=
+  ⟨ops.add a.const b.const, a.terms ++ b.terms⟩
+
+theorem DenseLinExpr.addWith_eq (ops : DenseZModOps p) (a b : DenseLinExpr p) :
+    a.addWith ops b = a.add b := by
+  simp only [DenseLinExpr.addWith, DenseLinExpr.add, ops.add_eq]
+
+def denseScaleTermsWith (ops : DenseZModOps p) (k : ZMod p) :
+    List (VarId × ZMod p) → List (VarId × ZMod p)
+  | [] => []
+  | t :: ts => (t.1, ops.mul k t.2) :: denseScaleTermsWith ops k ts
+
+theorem denseScaleTermsWith_eq (ops : DenseZModOps p) (k : ZMod p)
+    (l : List (VarId × ZMod p)) : denseScaleTermsWith ops k l = l.map (fun t => (t.1, k * t.2)) := by
+  induction l with
+  | nil => rfl
+  | cons t ts ih => simp only [denseScaleTermsWith, List.map_cons, ops.mul_eq, ih]
+
+def DenseLinExpr.scaleWith (ops : DenseZModOps p) (k : ZMod p) (a : DenseLinExpr p) :
+    DenseLinExpr p :=
+  ⟨ops.mul k a.const, denseScaleTermsWith ops k a.terms⟩
+
+def DenseLinExpr.scaleFast (k : ZMod p) (a : DenseLinExpr p) : DenseLinExpr p :=
+  DenseLinExpr.scaleWith denseZModOps k a
+
+theorem DenseLinExpr.scaleWith_eq (ops : DenseZModOps p) (k : ZMod p) (a : DenseLinExpr p) :
+    a.scaleWith ops k = a.scale k := by
+  simp only [DenseLinExpr.scaleWith, DenseLinExpr.scale, ops.mul_eq, denseScaleTermsWith_eq]
+
+@[csimp] theorem DenseLinExpr.scale_eq_fast : @DenseLinExpr.scale = @DenseLinExpr.scaleFast := by
+  funext p k a
+  exact (DenseLinExpr.scaleWith_eq denseZModOps k a).symm
+
 /-- Try to view a dense expression as a linear form (`none` on a variable×variable product). -/
 def denseLinearize : DenseExpr p → Option (DenseLinExpr p)
   | .const n => some ⟨n, []⟩
@@ -120,6 +164,78 @@ def denseLinearizeFast (e : DenseExpr p) : Option (DenseLinExpr p) :=
   simp only [denseLinearizeFast, denseLinearizeAcc_eq, Option.map_map, List.append_nil]
   cases denseLinearize e <;> rfl
 
+/-- Boxed twin of `denseScaleAppend`; see the `…With` note above. -/
+def denseScaleAppendWith (ops : DenseZModOps p) (k : ZMod p) :
+    List (VarId × ZMod p) → List (VarId × ZMod p) → List (VarId × ZMod p)
+  | [], acc => acc
+  | t :: ts, acc => (t.1, ops.mul k t.2) :: denseScaleAppendWith ops k ts acc
+
+theorem denseScaleAppendWith_eq (ops : DenseZModOps p) (k : ZMod p)
+    (l acc : List (VarId × ZMod p)) :
+    denseScaleAppendWith ops k l acc = denseScaleAppend k l acc := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons t ts ih => simp only [denseScaleAppendWith, denseScaleAppend, ops.mul_eq, ih]
+
+def denseScaleAppendFast (k : ZMod p) (l acc : List (VarId × ZMod p)) :
+    List (VarId × ZMod p) :=
+  denseScaleAppendWith denseZModOps k l acc
+
+@[csimp] theorem denseScaleAppend_eq_fast : @denseScaleAppend = @denseScaleAppendFast := by
+  funext p k l acc
+  exact (denseScaleAppendWith_eq denseZModOps k l acc).symm
+
+/-- Boxed twin of `denseLinearizeAcc`: the `var` leaf alone needs `0` and `1`, i.e. two instance
+    chains per variable occurrence in every expression the optimizer linearizes. -/
+def denseLinearizeAccWith (ops : DenseZModOps p) : DenseExpr p → List (VarId × ZMod p) →
+    Option (ZMod p × List (VarId × ZMod p))
+  | .const n, acc => some (n, acc)
+  | .var i, acc => some (ops.zero, (i, ops.one) :: acc)
+  | .add a b, acc =>
+      match denseLinearizeAccWith ops b acc with
+      | none => none
+      | some (cb, acc') =>
+        match denseLinearizeAccWith ops a acc' with
+        | none => none
+        | some (ca, acc'') => some (ops.add ca cb, acc'')
+  | .mul a b, acc =>
+      match denseLinearizeAccWith ops a [], denseLinearizeAccWith ops b [] with
+      | some (ca, ta), some (cb, tb) =>
+          if ta.isEmpty then some (ops.mul ca cb, denseScaleAppendWith ops ca tb acc)
+          else if tb.isEmpty then some (ops.mul cb ca, denseScaleAppendWith ops cb ta acc)
+          else none
+      | _, _ => none
+
+theorem denseLinearizeAccWith_eq (ops : DenseZModOps p) (e : DenseExpr p) :
+    ∀ acc, denseLinearizeAccWith ops e acc = denseLinearizeAcc e acc := by
+  induction e with
+  | const n => intro acc; rfl
+  | var i => intro acc; simp only [denseLinearizeAccWith, denseLinearizeAcc, ops.zero_eq, ops.one_eq]
+  | add a b iha ihb =>
+      intro acc
+      simp only [denseLinearizeAccWith, denseLinearizeAcc, ihb acc]
+      cases denseLinearizeAcc b acc with
+      | none => rfl
+      | some rb => simp only [iha rb.2]; cases denseLinearizeAcc a rb.2 <;> simp [ops.add_eq]
+  | mul a b iha ihb =>
+      intro acc
+      simp only [denseLinearizeAccWith, denseLinearizeAcc, iha [], ihb []]
+      cases denseLinearizeAcc a [] with
+      | none => rfl
+      | some ra =>
+        cases denseLinearizeAcc b [] with
+        | none => rfl
+        | some rb =>
+          simp only [ops.mul_eq, denseScaleAppendWith_eq]
+
+def denseLinearizeAccFast (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
+    Option (ZMod p × List (VarId × ZMod p)) :=
+  denseLinearizeAccWith denseZModOps e acc
+
+@[csimp] theorem denseLinearizeAcc_eq_fast : @denseLinearizeAcc = @denseLinearizeAccFast := by
+  funext p e acc
+  exact (denseLinearizeAccWith_eq denseZModOps e acc).symm
+
 /-- Turn a dense linear form back into a dense expression. -/
 def DenseLinExpr.toExpr (l : DenseLinExpr p) : DenseExpr p :=
   l.terms.foldl (fun acc t => .add acc (.mul (.const t.2) (.var t.1))) (.const l.const)
@@ -185,6 +301,31 @@ theorem denseLinearize_mem_vars (e : DenseExpr p) (l : DenseLinExpr p)
 /-- Total coefficient of `x` in a dense linear form. -/
 def DenseLinExpr.coeff (l : DenseLinExpr p) (x : VarId) : ZMod p :=
   ((l.terms.filter (fun t => t.1 = x)).map Prod.snd).sum
+
+/-- Boxed twin of `coeff`: one pass, no `filter`/`map` intermediates, one instance chain per call
+    instead of one per term (`List.sum` needs `+` and `0`). -/
+def denseCoeffSumWith (ops : DenseZModOps p) (x : VarId) : List (VarId × ZMod p) → ZMod p
+  | [] => ops.zero
+  | t :: ts =>
+      if t.1 = x then ops.add t.2 (denseCoeffSumWith ops x ts) else denseCoeffSumWith ops x ts
+
+theorem denseCoeffSumWith_eq (ops : DenseZModOps p) (x : VarId) (ts : List (VarId × ZMod p)) :
+    denseCoeffSumWith ops x ts = ((ts.filter (fun t => t.1 = x)).map Prod.snd).sum := by
+  induction ts with
+  | nil => simp [denseCoeffSumWith, ops.zero_eq]
+  | cons t rest ih =>
+      by_cases hx : t.1 = x
+      · rw [List.filter_cons_of_pos (by simpa using hx)]
+        simp only [denseCoeffSumWith, if_pos hx, ih, List.map_cons, List.sum_cons, ops.add_eq]
+      · rw [List.filter_cons_of_neg (by simpa using hx)]
+        simp only [denseCoeffSumWith, if_neg hx, ih]
+
+def DenseLinExpr.coeffFast (l : DenseLinExpr p) (x : VarId) : ZMod p :=
+  denseCoeffSumWith denseZModOps x l.terms
+
+@[csimp] theorem DenseLinExpr.coeff_eq_fast : @DenseLinExpr.coeff = @DenseLinExpr.coeffFast := by
+  funext p l x
+  exact (denseCoeffSumWith_eq denseZModOps x l.terms).symm
 
 /-- The dense linear form with all `x` terms removed. -/
 def DenseLinExpr.others (l : DenseLinExpr p) (x : VarId) : DenseLinExpr p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -231,6 +231,60 @@ def denseLinAdd (a b : DenseLinExpr p) : DenseLinExpr p :=
 def denseLinScale (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
   (l.scale k).norm
 
+/-- Boxed twin of `denseLinSubstF`, sharing one `DenseZModOps p` with the normal form it builds. -/
+def denseLinSubstFWith (ops : DenseZModOps p) (l : DenseLinExpr p)
+    (σ : VarId → Option (DenseLinExpr p)) : DenseLinExpr p :=
+  let const := l.terms.foldl (fun out yc =>
+    match σ yc.1 with
+    | some t => ops.add out (ops.mul yc.2 t.const)
+    | none => out) l.const
+  let terms := l.terms.flatMap (fun yc =>
+    match σ yc.1 with
+    | some t => denseScaleTermsWith ops yc.2 t.terms
+    | none => [yc])
+  (DenseLinExpr.mk const terms).normWith ops
+
+def denseLinSubstFFast (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p)) :
+    DenseLinExpr p :=
+  denseLinSubstFWith denseZModOps l σ
+
+theorem denseLinSubstFWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
+    (σ : VarId → Option (DenseLinExpr p)) : denseLinSubstFWith ops l σ = denseLinSubstF l σ := by
+  simp only [denseLinSubstFWith, denseLinSubstF, DenseLinExpr.normWith_eq, ops.add_eq, ops.mul_eq,
+    denseScaleTermsWith_eq]
+
+@[csimp] theorem denseLinSubstF_eq_fast : @denseLinSubstF = @denseLinSubstFFast := by
+  funext p l σ
+  exact (denseLinSubstFWith_eq denseZModOps l σ).symm
+
+def denseLinAddWith (ops : DenseZModOps p) (a b : DenseLinExpr p) : DenseLinExpr p :=
+  (a.addWith ops b).normWith ops
+
+def denseLinAddFast (a b : DenseLinExpr p) : DenseLinExpr p :=
+  denseLinAddWith denseZModOps a b
+
+theorem denseLinAddWith_eq (ops : DenseZModOps p) (a b : DenseLinExpr p) :
+    denseLinAddWith ops a b = denseLinAdd a b := by
+  simp only [denseLinAddWith, denseLinAdd, DenseLinExpr.addWith_eq, DenseLinExpr.normWith_eq]
+
+@[csimp] theorem denseLinAdd_eq_fast : @denseLinAdd = @denseLinAddFast := by
+  funext p a b
+  exact (denseLinAddWith_eq denseZModOps a b).symm
+
+def denseLinScaleWith (ops : DenseZModOps p) (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
+  (l.scaleWith ops k).normWith ops
+
+def denseLinScaleFast (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
+  denseLinScaleWith denseZModOps k l
+
+theorem denseLinScaleWith_eq (ops : DenseZModOps p) (k : ZMod p) (l : DenseLinExpr p) :
+    denseLinScaleWith ops k l = denseLinScale k l := by
+  simp only [denseLinScaleWith, denseLinScale, DenseLinExpr.scaleWith_eq, DenseLinExpr.normWith_eq]
+
+@[csimp] theorem denseLinScale_eq_fast : @denseLinScale = @denseLinScaleFast := by
+  funext p k l
+  exact (denseLinScaleWith_eq denseZModOps k l).symm
+
 def DenseLinExpr.mentions (l : DenseLinExpr p) (x : VarId) : Bool :=
   l.terms.any (fun yc => yc.1 = x)
 
@@ -341,6 +395,52 @@ def denseSparseSubstFused (σ : VarId → Option (DenseLinExpr p)) :
           else .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
       | _, _ => .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
 
+/-- Boxed twin of the fused walk. Its `var` leaf builds `⟨0, [(x, 1)]⟩`, so without a shared
+    `DenseZModOps p` every variable occurrence of every constraint costs two instance chains. -/
+def denseSparseSubstFusedWith (ops : DenseZModOps p) (σ : VarId → Option (DenseLinExpr p)) :
+    DenseExpr p → DenseSubstRes p
+  | .const n => .pre (.affine ⟨n, []⟩) ⟨n, []⟩
+  | .var x =>
+      .pre (match σ x with | some row => .affine row | none => .affine ⟨ops.zero, [(x, ops.one)]⟩)
+        ⟨ops.zero, [(x, ops.one)]⟩
+  | .add a b =>
+      let ra := denseSparseSubstFusedWith ops σ a
+      let rb := denseSparseSubstFusedWith ops σ b
+      match ra.lin?, rb.lin? with
+      | some la, some lb => .lin (la.addWith ops lb)
+      | _, _ => .opq (denseReducedAdd (ra.reduced σ) (rb.reduced σ))
+  | .mul a b =>
+      let ra := denseSparseSubstFusedWith ops σ a
+      let rb := denseSparseSubstFusedWith ops σ b
+      match ra.lin?, rb.lin? with
+      | some la, some lb =>
+          if la.terms.isEmpty then .lin (lb.scaleWith ops la.const)
+          else if lb.terms.isEmpty then .lin (la.scaleWith ops lb.const)
+          else .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
+      | _, _ => .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
+
+theorem denseSparseSubstFusedWith_eq (ops : DenseZModOps p) (σ : VarId → Option (DenseLinExpr p))
+    (e : DenseExpr p) : denseSparseSubstFusedWith ops σ e = denseSparseSubstFused σ e := by
+  induction e with
+  | const n => rfl
+  | var x =>
+      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, ops.zero_eq, ops.one_eq]
+  | add a b iha ihb =>
+      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, iha, ihb,
+        DenseLinExpr.addWith_eq]
+  | mul a b iha ihb =>
+      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, iha, ihb,
+        DenseLinExpr.scaleWith_eq]
+
+def denseSparseSubstFusedFast (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
+    DenseSubstRes p :=
+  denseSparseSubstFusedWith denseZModOps σ e
+
+@[csimp] theorem denseSparseSubstFused_eq_fast :
+    @denseSparseSubstFused = @denseSparseSubstFusedFast := by
+  funext p σ e
+  exact (denseSparseSubstFusedWith_eq denseZModOps σ e).symm
+
 def denseSparseSubstFFast (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
     DenseGaussReduced p :=
   (denseSparseSubstFused σ e).reduced σ
@@ -430,6 +530,29 @@ def denseSparseSolveAt (l : DenseLinExpr p) (x : VarId) :
   else if l.coeff x * (l.coeff x)⁻¹ = 1 then
     some (x, denseLinScale (-(l.coeff x)⁻¹) (l.others x))
   else none
+
+/-- Boxed twin of `denseSparseSolveAt`, binding the pivot coefficient once. -/
+def denseSparseSolveAtWith (ops : DenseZModOps p) (l : DenseLinExpr p) (x : VarId) :
+    Option (VarId × DenseLinExpr p) :=
+  let c := denseCoeffSumWith ops x l.terms
+  if c = ops.one then some (x, denseLinScaleWith ops ops.negOne (l.others x))
+  else if c = ops.negOne then some (x, l.others x)
+  else if ops.mul c c⁻¹ = ops.one then
+    some (x, denseLinScaleWith ops (ops.mul ops.negOne c⁻¹) (l.others x))
+  else none
+
+def denseSparseSolveAtFast (l : DenseLinExpr p) (x : VarId) : Option (VarId × DenseLinExpr p) :=
+  denseSparseSolveAtWith denseZModOps l x
+
+theorem denseSparseSolveAtWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p) (x : VarId) :
+    denseSparseSolveAtWith ops l x = denseSparseSolveAt l x := by
+  simp only [denseSparseSolveAtWith, denseSparseSolveAt, DenseLinExpr.coeff,
+    denseCoeffSumWith_eq, denseLinScaleWith_eq, ops.one_eq, ops.negOne_eq, ops.mul_eq,
+    ← neg_eq_neg_one_mul]
+
+@[csimp] theorem denseSparseSolveAt_eq_fast : @denseSparseSolveAt = @denseSparseSolveAtFast := by
+  funext p l x
+  exact (denseSparseSolveAtWith_eq denseZModOps l x).symm
 
 def denseSparseBest (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
     (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
@@ -521,6 +644,43 @@ def denseMarkowitzPivots (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
           ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
         (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
       out.1.reverse
+
+/-- Boxed twin of `denseMarkowitzPivots`. The body re-inlines `densePivotDescs` rather than calling
+    it, so that function's `@[csimp]` does not reach the two descriptor scans here. -/
+def denseMarkowitzPivotsWith (ops : DenseZModOps p) (r : DenseGaussReduced p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
+  match r with
+  | .nonlinear _ => []
+  | .affine l =>
+      let idx := denseCoeffIdxWith ops l.terms ∅
+      let vars := l.terms.map Prod.fst
+      let descs := vars.filterMap (densePm1DescWith ops idx l.terms.length occ prot) ++
+        vars.filterMap (denseUnitDescWith ops idx l.terms.length occ prot)
+      let out := descs.foldl (fun (out, seen) (x, _) =>
+        if seen.contains x then (out, seen)
+        else
+          let cv := (idx[x]?).getD (ops.zero, 0)
+          ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
+        (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
+      out.1.reverse
+
+def denseMarkowitzPivotsFast (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
+    (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
+  denseMarkowitzPivotsWith denseZModOps r occ prot
+
+theorem denseMarkowitzPivotsWith_eq (ops : DenseZModOps p) (r : DenseGaussReduced p)
+    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
+    denseMarkowitzPivotsWith ops r occ prot = denseMarkowitzPivots r occ prot := by
+  cases r with
+  | nonlinear _ => rfl
+  | affine l =>
+      simp only [denseMarkowitzPivotsWith, denseMarkowitzPivots, denseCoeffIdx,
+        denseCoeffIdxWith_eq, densePm1DescWith_eq, denseUnitDescWith_eq, ops.zero_eq]
+
+@[csimp] theorem denseMarkowitzPivots_eq_fast :
+    @denseMarkowitzPivots = @denseMarkowitzPivotsFast := by
+  funext p r occ prot
+  exact (denseMarkowitzPivotsWith_eq denseZModOps r occ prot).symm
 
 def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
     (prot : Std.HashSet VarId) (generation : Nat := 0) : DenseMarkowitzRow p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -222,29 +222,98 @@ theorem denseRecon (acc : List (VarId × ZMod p)) (order : Array VarId)
     funext (fun v => by rw [hm v])]
   exact denseReconAssoc acc hnod
 
-/-- The dense linear like-term merge. Proven `= denseMergeTerms` and installed via `@[csimp]`. -/
-def denseMergeTermsFast (ts : List (VarId × ZMod p)) : List (VarId × ZMod p) :=
-  if ts.length ≤ 32 then
-    ts.foldl (fun acc t => denseAddCoeff t.1 t.2 acc) []
-  else
-    let st := ts.foldl denseMtStep (#[], ∅)
-    st.1.toList.map (fun v => (v, (st.2[v]?).getD 0))
+/-- Boxed twins of the merge steps: `p` is a runtime value, so each inline `+`/`0` rebuilds the
+    whole `CommRing (ZMod p)` chain. Threading a `DenseZModOps p` costs one chain per merged list
+    instead of one per term. -/
+def denseAddCoeffWith (ops : DenseZModOps p) (v : VarId) (c : ZMod p) :
+    List (VarId × ZMod p) → List (VarId × ZMod p)
+  | [] => [(v, c)]
+  | (v', c') :: rest =>
+      if v' = v then (v', ops.add c' c) :: rest
+      else (v', c') :: denseAddCoeffWith ops v c rest
 
-@[csimp] theorem denseMergeTerms_eq_fast : @denseMergeTerms = @denseMergeTermsFast := by
-  funext p ts
-  show denseMergeTerms ts = denseMergeTermsFast ts
-  unfold denseMergeTermsFast
+theorem denseAddCoeffWith_eq (ops : DenseZModOps p) (v : VarId) (c : ZMod p)
+    (ts : List (VarId × ZMod p)) : denseAddCoeffWith ops v c ts = denseAddCoeff v c ts := by
+  induction ts with
+  | nil => rfl
+  | cons t rest ih =>
+      obtain ⟨v', c'⟩ := t
+      simp only [denseAddCoeffWith, denseAddCoeff, ops.add_eq, ih]
+
+def denseMtStepWith (ops : DenseZModOps p) (st : Array VarId × Std.HashMap VarId (ZMod p))
+    (t : VarId × ZMod p) : Array VarId × Std.HashMap VarId (ZMod p) :=
+  match st.2[t.1]? with
+  | some c0 => (st.1, st.2.insert t.1 (ops.add c0 t.2))
+  | none => (st.1.push t.1, st.2.insert t.1 t.2)
+
+theorem denseMtStepWith_eq (ops : DenseZModOps p) :
+    denseMtStepWith (p := p) ops = denseMtStep := by
+  funext st t
+  simp only [denseMtStepWith, denseMtStep, ops.add_eq]
+
+/-- The dense linear like-term merge. Proven `= denseMergeTerms`; `denseMergeTermsFast` below
+    installs it via `@[csimp]`. -/
+def denseMergeTermsWith (ops : DenseZModOps p) (ts : List (VarId × ZMod p)) :
+    List (VarId × ZMod p) :=
+  if ts.length ≤ 32 then
+    ts.foldl (fun acc t => denseAddCoeffWith ops t.1 t.2 acc) []
+  else
+    let st := ts.foldl (denseMtStepWith ops) (#[], ∅)
+    st.1.toList.map (fun v => (v, (st.2[v]?).getD ops.zero))
+
+def denseMergeTermsFast (ts : List (VarId × ZMod p)) : List (VarId × ZMod p) :=
+  denseMergeTermsWith denseZModOps ts
+
+theorem denseMergeTermsWith_eq (ops : DenseZModOps p) (ts : List (VarId × ZMod p)) :
+    denseMergeTermsWith ops ts = denseMergeTerms ts := by
+  simp only [denseMergeTermsWith, denseAddCoeffWith_eq, denseMtStepWith_eq, ops.zero_eq]
   split
   · rfl
   · have hbase : DenseMergeCorr ([] : List (VarId × ZMod p)) (#[] : Array VarId)
         (∅ : Std.HashMap VarId (ZMod p)) :=
       ⟨by simp, by simp, fun v => by simp [denseAssocCoeff]⟩
     have hcorr := denseMtFold_corr ts [] #[] ∅ hbase
-    exact (denseRecon _ _ _ hcorr).symm
+    exact denseRecon _ _ _ hcorr
+
+@[csimp] theorem denseMergeTerms_eq_fast : @denseMergeTerms = @denseMergeTermsFast := by
+  funext p ts
+  exact (denseMergeTermsWith_eq denseZModOps ts).symm
 
 /-- The fully-merged normal form of a dense linear form: combine like terms, drop zeros. -/
 def DenseLinExpr.norm (l : DenseLinExpr p) : DenseLinExpr p :=
   ⟨l.const, (denseMergeTerms l.terms).filter (fun t => t.2 ≠ 0)⟩
+
+/-- Boxed twin of the zero-drop: without it the `≠ 0` test rebuilds the instance chain per term. -/
+def denseDropZeroWith (ops : DenseZModOps p) :
+    List (VarId × ZMod p) → List (VarId × ZMod p)
+  | [] => []
+  | t :: ts => if t.2 = ops.zero then denseDropZeroWith ops ts else t :: denseDropZeroWith ops ts
+
+theorem denseDropZeroWith_eq (ops : DenseZModOps p) (ts : List (VarId × ZMod p)) :
+    denseDropZeroWith ops ts = ts.filter (fun t => t.2 ≠ 0) := by
+  induction ts with
+  | nil => rfl
+  | cons t rest ih =>
+      by_cases hz : t.2 = 0
+      · rw [List.filter_cons_of_neg (by simpa using hz)]
+        simp only [denseDropZeroWith, ops.zero_eq, if_pos hz, ih]
+      · rw [List.filter_cons_of_pos (by simpa using hz)]
+        simp only [denseDropZeroWith, ops.zero_eq, if_neg hz, ih]
+
+/-- One `DenseZModOps p` for the whole normal form: the merge and the zero-drop share it. -/
+def DenseLinExpr.normWith (ops : DenseZModOps p) (l : DenseLinExpr p) : DenseLinExpr p :=
+  ⟨l.const, denseDropZeroWith ops (denseMergeTermsWith ops l.terms)⟩
+
+def DenseLinExpr.normFast (l : DenseLinExpr p) : DenseLinExpr p :=
+  DenseLinExpr.normWith denseZModOps l
+
+theorem DenseLinExpr.normWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p) :
+    l.normWith ops = l.norm := by
+  simp only [DenseLinExpr.normWith, DenseLinExpr.norm, denseMergeTermsWith_eq, denseDropZeroWith_eq]
+
+@[csimp] theorem DenseLinExpr.norm_eq_fast : @DenseLinExpr.norm = @DenseLinExpr.normFast := by
+  funext p l
+  exact (DenseLinExpr.normWith_eq denseZModOps l).symm
 
 /-! ## The dense normalization traversal -/
 
@@ -572,6 +641,56 @@ def denseNormalizeFusedFast : DenseExpr p → DenseNormRes p
           else if lb.terms.isEmpty then .lin (la.scale lb.const)
           else .opq (.mul ra.expr rb.expr)
       | _, _ => .opq (.mul ra.expr rb.expr)
+
+/-- Boxed twin of the deferred walk: `lin?` on a `var` builds `⟨0, [(x, 1)]⟩`, and a parent asks
+    both children for it, so every node otherwise pays two instance chains. -/
+def DenseNormRes.lin?With (ops : DenseZModOps p) : DenseNormRes p → Option (DenseLinExpr p)
+  | .var x => some ⟨ops.zero, [(x, ops.one)]⟩
+  | .lin l => some l
+  | .opq _ => none
+
+theorem DenseNormRes.lin?With_eq (ops : DenseZModOps p) (r : DenseNormRes p) :
+    r.lin?With ops = r.lin? := by
+  cases r <;> simp only [DenseNormRes.lin?With, DenseNormRes.lin?, ops.zero_eq, ops.one_eq]
+
+def denseNormalizeResWith (ops : DenseZModOps p) : DenseExpr p → DenseNormRes p
+  | .const n => .lin ⟨n, []⟩
+  | .var x => .var x
+  | .add a b =>
+      let ra := denseNormalizeResWith ops a
+      let rb := denseNormalizeResWith ops b
+      match ra.lin?With ops, rb.lin?With ops with
+      | some la, some lb => .lin (la.addWith ops lb)
+      | _, _ => .opq (.add ra.expr rb.expr)
+  | .mul a b =>
+      let ra := denseNormalizeResWith ops a
+      let rb := denseNormalizeResWith ops b
+      match ra.lin?With ops, rb.lin?With ops with
+      | some la, some lb =>
+          if la.terms.isEmpty then .lin (lb.scaleWith ops la.const)
+          else if lb.terms.isEmpty then .lin (la.scaleWith ops lb.const)
+          else .opq (.mul ra.expr rb.expr)
+      | _, _ => .opq (.mul ra.expr rb.expr)
+
+theorem denseNormalizeResWith_eq (ops : DenseZModOps p) (e : DenseExpr p) :
+    denseNormalizeResWith ops e = denseNormalizeFusedFast e := by
+  induction e with
+  | const n => rfl
+  | var x => rfl
+  | add a b iha ihb =>
+      simp only [denseNormalizeResWith, denseNormalizeFusedFast, iha, ihb,
+        DenseNormRes.lin?With_eq, DenseLinExpr.addWith_eq]
+  | mul a b iha ihb =>
+      simp only [denseNormalizeResWith, denseNormalizeFusedFast, iha, ihb,
+        DenseNormRes.lin?With_eq, DenseLinExpr.scaleWith_eq]
+
+def denseNormalizeResFast (e : DenseExpr p) : DenseNormRes p :=
+  denseNormalizeResWith denseZModOps e
+
+@[csimp] theorem denseNormalizeFusedFast_eq_res :
+    @denseNormalizeFusedFast = @denseNormalizeResFast := by
+  funext p e
+  exact (denseNormalizeResWith_eq denseZModOps e).symm
 
 def denseNormalizeFusedPair (e : DenseExpr p) : DenseExpr p × Option (DenseLinExpr p) :=
   let r := denseNormalizeFusedFast e


### PR DESCRIPTION
Runtime only. Every change is a `@[csimp]` twin proven equal to the definition it replaces, so the
optimizer's output is unchanged — verified identical vars/constraints/bus on all four APCs below.

## The problem

`p` is a runtime value, so `ZMod p` is a runtime-dispatched type and no instance can be resolved
statically. Lean therefore emits the whole `CommRing (ZMod p)` chain at every use site — **inside
the loop**. Generated C for the zero-test in `DenseLinExpr.norm`:

```c
_start:                                       /* ← loop head; the tail call jumps back here */
  v355 = lp_mathlib_ZMod_commRing(p);         /* 9 lean_alloc_closure                       */
  v356 = CommRing_toNonUnitalCommRing___redArg(v355);
  v357 = NonUnitalNonAssocRing_toNonUnitalNonAssocSemiring___redArg(v356);
  v358 = NonUnitalNonAssocSemiring_toMulZeroClass___redArg(v357);
  ...
  x367 = lp_mathlib_ZMod_decidableEq(p, snd, toZero);   /* the 3 instructions we wanted */
  goto _start;                                /* rebuild all of the above, per list cell    */
```

One `c' + c` or one `t.2 ≠ 0` costs roughly 15-25 heap objects, against ~5 cycles for the
arithmetic itself.

A gauss-isolated `perf` profile (`Main.lean` patched to re-run one pass N times, so gauss is ~85%
of the process) on `openvm-eth/apc_037`:

| % self | symbol |
|---:|---|
| 29.9 | `lean_dec_ref_cold` |
| 16.1 | mimalloc + `lean_alloc_object` |
| 7.3 | `lp_mathlib_ZMod_commRing` |
| 3.7 | `CommRing_toNonUnitalCommRing___redArg` |
| 2.3 | `denseSparseSubstFused` (the actual substitution walk) |
| 2.8 | the remaining dictionary projections |

Grouped: **allocator + refcounting 61.7%**, **instance-dictionary construction 13.7% self**,
recognizable pass code ~20%. The pass is allocation-bound, and the allocations are almost all
typeclass dictionaries.

## The change

`DenseZModOps p` (`Encoding.lean`) already exists for exactly this and calls `ZMod.commRing` once —
but it was wired into only `denseCoeffIdx` and `densePivotDescs`. This extends the same
`…With ops` / `…Fast` / `@[csimp]` pattern (`denseCoeffIdxWith` is the template) to the rest of the
affine layer, so a traversal builds one `DenseZModOps p` instead of one instance chain per element:

- `denseLinearizeAcc`, `denseScaleAppend`, `DenseLinExpr.scale` / `coeff`
- `DenseLinExpr.norm`, sharing one `ops` between the like-term merge and the zero-drop
- `denseSparseSubstFused`, `denseLinSubstF`, `denseLinAdd` / `denseLinScale`, `denseSparseSolveAt`
- `denseMarkowitzPivots` — it re-inlines `densePivotDescs` rather than calling it, so that
  function's `@[csimp]` never reached the two descriptor scans. This one only affects systems above
  `denseMarkowitzMinRows`, which is where the multi-second outliers are.
- the runtime normalize walk (`denseNormalizeFusedFast`, `DenseNormRes.lin?`), whose `var` leaf
  builds `⟨0, [(x, 1)]⟩` and is asked for it by both parents of every node

`DenseLinExpr.add` deliberately gets **no** `@[csimp]`: it performs a single operation, and building
a `DenseZModOps p` costs about one instance chain itself, so a twin there measures as a small loss.
Its `…With` form stays available to callers that already hold an `ops`.

## Results

Mean of 3 interleaved A/B runs on one machine (within-pair spread <2%):

| APC | total | gauss | normalize1 | normalize2 | carryBranch |
|---|---|---|---|---|---|
| `openvm-eth/apc_037` | 3972 → 3195 (1.24×) | 487 → 207 (2.35×) | 240 → 92 (2.61×) | 169 → 79 (2.15×) | 411 → 299 (1.37×) |
| `openvm-eth/apc_012` | 2055 → 1787 (1.15×) | 201 → 90 (2.24×) | 143 → 58 (2.45×) | 91 → 49 (1.85×) | 149 → 122 (1.22×) |
| `wasm-eth/apc_063` | 25964 → 21121 (1.23×) | 2839 → 1590 (1.79×) | 1186 → 448 (2.65×) | 833 → 384 (2.17×) | 2764 → 1879 (1.47×) |
| `keccak/apc_001` | 21288 → 16796 (1.27×) | 2001 → 1319 (1.52×) | 1048 → 472 (2.22×) | 655 → 392 (1.67×) | 1156 → 954 (1.21×) |

`carryBranch` and the other passes gain without being touched — they share the affine layer.

`keccak`'s smaller gauss factor is the Markowitz scheduler: its per-pivot work is dominated by
re-substituting the original source row at every heap pop rather than using the incrementally
maintained `st.rows[rowId].reduced`, which this PR does not address.

## Verification

- `lake build` clean, no warnings.
- `Scripts/check-proof-integrity.sh` passes (28 `@[csimp]` roots, no unused theorems, correctness
  theorems still on the three standard axioms only).
- `apc-optimizer run` output identical to `main` on all four APCs above:
  689/525/445, 685/160/474, 1954/1895/1029, 2021/186/1748.
- Post-change profile: allocator + refcounting 61.7% → 44.8%, dictionaries 13.7% → ~4.4%. What is
  left is the real data structures (cons cells and boxed pairs for term lists).

## Follow-ups this does not do

Found while profiling, in rough order of expected value:

1. `denseSparseSubstFused` merges affine children with `DenseLinExpr.add` = `a.terms ++ b.terms`, so
   a left-nested chain recopies its prefix at every node — O(terms²). Inputs *are* left-nested
   because `DenseLinExpr.toExpr` folds with `foldl (.add acc …)`. This is the problem
   `denseLinearizeAcc` was written to solve for `denseLinearize`; the fused walk reintroduced it.
2. `DenseSparseSolved.revDeps` is quadratic twice: `rd.insert z ((rd[z]?.getD ∅).insert x)` copies
   the whole inner `HashSet` (its refcount is ≥2), and it is never pruned after a pivot, so
   `touched` rescans a growing stale set.
3. `denseLinSubstF` looks σ up twice per term and builds a full `flatMap` list only for `norm` to
   walk it again.
4. `Std.HashMap VarId _` → dense arrays: `VarId` erases to a tagged scalar and `VarRegistry.byId`
   is append-only, so σ, `occ`, the coefficient index and the merge scratch can all be `Array`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)