### PR TITLE
perf: reencode 1.8-2.6x + fix a csimp ordering bug that disabled #225's denseLinearize hoist (pipeline 1.18-1.26x, effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -155,15 +155,6 @@ theorem denseLinearizeAcc_eq (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
             · simp [denseLinearize, ha, hb, h1, h2, DenseLinExpr.scale, denseScaleAppend_eq]
             · simp [denseLinearize, ha, hb, h1, h2]
 
-def denseLinearizeFast (e : DenseExpr p) : Option (DenseLinExpr p) :=
-  (denseLinearizeAcc e []).map (fun r => ⟨r.1, r.2⟩)
-
-@[csimp] theorem denseLinearize_eq_fast : @denseLinearize = @denseLinearizeFast := by
-  funext p e
-  show denseLinearize e = _
-  simp only [denseLinearizeFast, denseLinearizeAcc_eq, Option.map_map, List.append_nil]
-  cases denseLinearize e <;> rfl
-
 /-- Boxed twin of `denseScaleAppend`; see the `…With` note above. -/
 def denseScaleAppendWith (ops : DenseZModOps p) (k : ZMod p) :
     List (VarId × ZMod p) → List (VarId × ZMod p) → List (VarId × ZMod p)
@@ -235,6 +226,15 @@ def denseLinearizeAccFast (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
 @[csimp] theorem denseLinearizeAcc_eq_fast : @denseLinearizeAcc = @denseLinearizeAccFast := by
   funext p e acc
   exact (denseLinearizeAccWith_eq denseZModOps e acc).symm
+
+def denseLinearizeFast (e : DenseExpr p) : Option (DenseLinExpr p) :=
+  (denseLinearizeAcc e []).map (fun r => ⟨r.1, r.2⟩)
+
+@[csimp] theorem denseLinearize_eq_fast : @denseLinearize = @denseLinearizeFast := by
+  funext p e
+  show denseLinearize e = _
+  simp only [denseLinearizeFast, denseLinearizeAcc_eq, Option.map_map, List.append_nil]
+  cases denseLinearize e <;> rfl
 
 /-- Turn a dense linear form back into a dense expression. -/
 def DenseLinExpr.toExpr (l : DenseLinExpr p) : DenseExpr p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -61,6 +61,21 @@ def denseMemEqConstraints (shape : MemoryBusShape) (S Rt : BusInteraction (Dense
   ((List.range S.payload.length).filter (fun i => decide (i ∉ shape.addressFields))).map
     (fun i => denseEqExpr ((Rt.payload[i]?).getD (.const 0)) ((S.payload[i]?).getD (.const 0)))
 
+/-- Boxed twin: the `-1` of `denseEqExpr` and the `0` padding are `ZMod p` literals, so inside the
+    slot `map` each one rebuilds the whole `CommRing (ZMod p)` chain per payload slot. -/
+def denseMemEqConstraintsW (negOne pad : DenseExpr p) (shape : MemoryBusShape)
+    (S Rt : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
+  ((List.range S.payload.length).filter (fun i => decide (i ∉ shape.addressFields))).map
+    (fun i => .add ((Rt.payload[i]?).getD pad) (.mul negOne ((S.payload[i]?).getD pad)))
+
+def denseMemEqConstraintsFast (shape : MemoryBusShape) (S Rt : BusInteraction (DenseExpr p)) :
+    List (DenseExpr p) :=
+  denseMemEqConstraintsW (.const (-1)) (.const 0) shape S Rt
+
+@[csimp] theorem denseMemEqConstraints_eq_fast :
+    @denseMemEqConstraints = @denseMemEqConstraintsFast := by
+  funext p shape S Rt; rfl
+
 /-! ## Address inequality -/
 
 /-- Some address slot carries provably-different constants: the two interactions provably have

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -136,6 +136,31 @@ def denseEnvOfFast : List (VarId × ZMod p) → VarId → ZMod p
   | [], _ => 0
   | (x, v) :: rest, y => if (y == x) = true then v else denseEnvOfFast rest y
 
+/-! ### Boxed runtime twins of the point lookups
+
+`p` is a runtime value, so the `0` in the miss case is a full `CommRing (ZMod p)` instance chain,
+and Lean builds it at the head of each recursive step — once per list cell walked, not once per
+lookup. Taking the zero as a parameter hoists it out of the walk. -/
+
+def denseEnvOfW (zero : ZMod p) : List (VarId × ZMod p) → VarId → ZMod p
+  | [], _ => zero
+  | (x, v) :: rest, y => if (y == x) = true then v else denseEnvOfW zero rest y
+
+theorem denseEnvOfW_eq (pt : List (VarId × ZMod p)) (y : VarId) :
+    denseEnvOfW 0 pt y = denseEnvOfFast pt y := by
+  induction pt with
+  | nil => rfl
+  | cons t rest ih =>
+      obtain ⟨x, v⟩ := t
+      simp only [denseEnvOfW, denseEnvOfFast, ih]
+
+def denseEnvOfFastFast (pt : List (VarId × ZMod p)) (y : VarId) : ZMod p :=
+  denseEnvOfW 0 pt y
+
+@[csimp] theorem denseEnvOfFast_eq_fast : @denseEnvOfFast = @denseEnvOfFastFast := by
+  funext p pt y
+  exact (denseEnvOfW_eq pt y).symm
+
 def denseContainsFast (xs : List VarId) (y : VarId) : Bool :=
   match xs with
   | [] => false
@@ -148,6 +173,25 @@ def denseLookupIx : List (VarId × ZMod p) → Nat → ZMod p
   | [], _ => 0
   | (_, v) :: _, 0 => v
   | _ :: rest, i + 1 => denseLookupIx rest i
+
+/-- Boxed twin of `denseLookupIx`; see the note on `denseEnvOfW` above. -/
+def denseLookupIxW (zero : ZMod p) : List (VarId × ZMod p) → Nat → ZMod p
+  | [], _ => zero
+  | (_, v) :: _, 0 => v
+  | _ :: rest, i + 1 => denseLookupIxW zero rest i
+
+theorem denseLookupIxW_eq (pt : List (VarId × ZMod p)) (i : Nat) :
+    denseLookupIxW 0 pt i = denseLookupIx pt i := by
+  induction pt generalizing i with
+  | nil => rfl
+  | cons t rest ih => cases i <;> simp only [denseLookupIxW, denseLookupIx, ih]
+
+def denseLookupIxFast (pt : List (VarId × ZMod p)) (i : Nat) : ZMod p :=
+  denseLookupIxW 0 pt i
+
+@[csimp] theorem denseLookupIx_eq_fast : @denseLookupIx = @denseLookupIxFast := by
+  funext p pt i
+  exact (denseLookupIxW_eq pt i).symm
 
 /-- Evaluate a compiled `IExpr` over a dense point; positional. -/
 def denseIExprEvalWith (add mul : ZMod p → ZMod p → ZMod p) (pt : List (VarId × ZMod p)) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -45,6 +45,22 @@ def denseGroupSubst (xs : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) :
 def denseBitBox (bits : List VarId) : List (VarId × List (ZMod p)) :=
   bits.map (fun b => (b, ([0, 1] : List (ZMod p))))
 
+/-! ### Boxed runtime twins
+
+Each `ZMod p` literal Lean compiles inline rebuilds the whole `CommRing (ZMod p)` chain, and here
+the literals sit inside `map`/`foldl`/`all` bodies, so they are rebuilt per element. A `let` does
+not help — it is zeta-expanded back into the loop body — so the literal has to become a *parameter*
+of the traversal, which is what the `…W` twins below do. -/
+
+def denseBitBoxW (box : List (ZMod p)) (bits : List VarId) : List (VarId × List (ZMod p)) :=
+  bits.map (fun b => (b, box))
+
+def denseBitBoxFast (bits : List VarId) : List (VarId × List (ZMod p)) :=
+  denseBitBoxW [0, 1] bits
+
+@[csimp] theorem denseBitBox_eq_fast : @denseBitBox = @denseBitBoxFast := by
+  funext p bits; rfl
+
 /-! ## Degree-aware group rewriting -/
 
 /-- `Π_j (bit_j or its complement)`: `1` exactly at the given pattern. -/
@@ -52,6 +68,18 @@ def denseIndicatorExpr (aβ : List (VarId × ZMod p)) : DenseExpr p :=
   aβ.foldl (fun acc bv =>
     .mul acc (if bv.2 = 1 then .var bv.1
               else .add (.const 1) (.mul (.const (-1)) (.var bv.1)))) (.const 1)
+
+def denseIndicatorExprW (one negOne : ZMod p) (aβ : List (VarId × ZMod p)) : DenseExpr p :=
+  aβ.foldl (fun acc bv =>
+    .mul acc (if bv.2 = one then .var bv.1
+              else .add (.const one) (.mul (.const negOne) (.var bv.1)))) (.const one)
+
+def denseIndicatorExprFast (aβ : List (VarId × ZMod p)) : DenseExpr p :=
+  denseIndicatorExprW 1 (-1) aβ
+
+@[csimp] theorem denseIndicatorExpr_eq_fast :
+    @denseIndicatorExpr = @denseIndicatorExprFast := by
+  funext p aβ; rfl
 
 /-- Interpolate a subexpression over the bit patterns from its precomputed per-pattern values. -/
 def denseInterpOfV (patts : List (List (VarId × ZMod p))) (vals : List (ZMod p)) : DenseExpr p :=
@@ -116,6 +144,19 @@ def denseSurvZeroCW (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr 
     (a : List (VarId × ZMod p)) : Bool :=
   ces.all (fun ie => decide (denseIExprEvalWith add mul a ie = 0))
 
+/-- Boxed twin of `denseSurvZeroCW`: this runs once per enumerated assignment, so the `0` would
+    otherwise be rebuilt per constraint per point of the group's domain box. -/
+def denseSurvZeroCWZ (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
+    (ces : List (IExpr p)) (a : List (VarId × ZMod p)) : Bool :=
+  ces.all (fun ie => decide (denseIExprEvalWith add mul a ie = zero))
+
+def denseSurvZeroCWFast (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr p))
+    (a : List (VarId × ZMod p)) : Bool :=
+  denseSurvZeroCWZ add mul 0 ces a
+
+@[csimp] theorem denseSurvZeroCW_eq_fast : @denseSurvZeroCW = @denseSurvZeroCWFast := by
+  funext p add mul ces a; rfl
+
 /-- The surviving group values: enumerate the group's domains, keep those satisfying the covered
     constraints. -/
 def denseGroupSurvivorsE (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p))) :
@@ -127,6 +168,27 @@ def denseGroupSurvivorsE (es : List (DenseExpr p)) (doms : List (VarId × List (
   | none =>
     (denseAssignments doms).filter
       (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = 0)))
+
+/-- Boxed twin. The `add`/`mul`/`zero` must be parameters of the function that *contains* the
+    enumeration loop: the specializer inlines the predicate into the `filter`, and anything derived
+    inside this function is then floated back into the loop body. -/
+def denseGroupSurvivorsEW (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
+    (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p))) :
+    List (List (VarId × ZMod p)) :=
+  match denseCompileEs (doms.map Prod.fst) es with
+  | some ces => (denseAssignments doms).filter (denseSurvZeroCWZ add mul zero ces)
+  | none =>
+    (denseAssignments doms).filter
+      (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = zero)))
+
+def denseGroupSurvivorsEFast (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p))) :
+    List (List (VarId × ZMod p)) :=
+  denseGroupSurvivorsEW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul 0
+    es doms
+
+@[csimp] theorem denseGroupSurvivorsE_eq_fast :
+    @denseGroupSurvivorsE = @denseGroupSurvivorsEFast := by
+  funext p es doms; rfl
 
 /-- `filter P l` if it keeps at most `cap` elements, `none` as soon as a `cap + 1`-st hit shows
     up — the tail is not scanned. -/
@@ -155,6 +217,27 @@ def denseGroupSurvivorsECap (es : List (DenseExpr p)) (doms : List (VarId × Lis
   | none =>
     denseFilterCap (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = 0)))
       cap (denseAssignments doms)
+
+/-- Boxed twin of `denseGroupSurvivorsECap`; see `denseGroupSurvivorsEW`. -/
+def denseGroupSurvivorsECapW (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
+    (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p))) (cap : Nat) :
+    Option (List (List (VarId × ZMod p))) :=
+  match denseCompileEs (doms.map Prod.fst) es with
+  | some ces =>
+    denseFilterCap (denseSurvZeroCWZ add mul zero ces) cap (denseAssignments doms)
+  | none =>
+    denseFilterCap (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = zero)))
+      cap (denseAssignments doms)
+
+def denseGroupSurvivorsECapFast (es : List (DenseExpr p))
+    (doms : List (VarId × List (ZMod p))) (cap : Nat) :
+    Option (List (List (VarId × ZMod p))) :=
+  denseGroupSurvivorsECapW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul 0
+    es doms cap
+
+@[csimp] theorem denseGroupSurvivorsECap_eq_fast :
+    @denseGroupSurvivorsECap = @denseGroupSurvivorsECapFast := by
+  funext p es doms cap; rfl
 
 /-! ## The checked re-encoding certificate -/
 


### PR DESCRIPTION
Follow-up to #225, applying the same recipe outside the affine layer — plus a bug in #225 itself
that the investigation turned up. Runtime only; every twin is proven equal to the definition it
replaces, and output is verified identical on four APCs.

## 1. `csimp` ordering bug in #225

**`@[csimp]` only rewrites call sites compiled after the lemma is declared.** In #225 I put the
`denseLinearizeAcc` twin *after* `denseLinearizeFast` — the one function that calls it. So
`denseLinearizeFast` kept calling the unhoisted spec, and `denseLinearize`, the affine entry point
every pass goes through, never got the hoist at all.

Found by LBR call-graph attribution of `ZMod.commRing` under an isolated `busUnify` run:

```
  32.1%  denseLinearizeAcc        ← should have been unreachable
  23.5%  denseZModOps
   9.0%  denseConstDiffNZ
   7.0%  DenseLinExpr.add
```

The fix is a pure code move. I also audited **all 36 `@[csimp]` pairs** by checking, in the
generated C, whether the replaced definition is still reachable from live code — this was the only
instance, and the audit is clean afterwards. Worth keeping as a habit: `csimp` failing is silent.

## 2. Reencode's enumeration loops

Pass-isolated profile of `wasm-eth/apc_063` before this PR: **15.7%** of `reencode`'s cycles in
`CommRing (ZMod p)` construction, **66.0%** in the allocator it drives.

- `denseLookupIx` / `denseEnvOfFast` (`DomainBatch.lean`) build the miss-case `0` **at the head of
  each recursive step** — once per list cell walked, not once per lookup. These sit on the inner
  loop of reencode's per-assignment evaluation.
- `denseGroupSurvivorsE` / `…ECap` filter `2^k` assignments with a `= 0` test per constraint.
- `denseBitBox` builds `[0, 1]` per bit; `denseIndicatorExpr` builds `1` and `-1` per bit of every
  pattern product.
- `denseMemEqConstraints` (`BusUnify.lean`) builds `denseEqExpr`'s `-1` and the `0` padding per
  payload slot.

### Two things that do *not* hoist

Worth recording, because both look like they should:

1. **`let` does not hoist.** `let zero : ZMod p := 0; xs.map (… zero …)` is zeta-expanded straight
   back into the loop body — I checked the generated C and the `ZMod.commRing` call was still at the
   loop head. The constant has to be a *parameter*.
2. **A parameter of the enclosing function is not enough if the loop is in that same function.** For
   a predicate passed to `filter`, the specializer inlines the predicate and floats anything derived
   locally back into the loop. That is why `denseGroupSurvivorsE`'s pre-existing
   `(inferInstance : Add (ZMod p)).add` hoist was not actually taking effect. The constant must be a
   parameter of the function that *contains* the loop — hence `denseGroupSurvivorsEW`.

## Results

Mean of 3 interleaved A/B runs against `main` (`74e1f48`), within-pair spread <2%:

| APC | total | reencode | busUnify | gauss | carryBranch | busPairCancel |
|---|---|---|---|---|---|---|
| `openvm-eth/apc_037` | 3180 → 2613 (1.22×) | 565 → 309 (1.83×) | 138 → 98 (1.41×) | 208 → 211 | 298 → 238 (1.25×) | 182 → 144 (1.27×) |
| `wasm-eth/apc_063` | 21146 → 16827 (1.26×) | 3522 → 1355 (2.60×) | 2750 → 2267 (1.21×) | 1588 → 1207 (1.32×) | 1875 → 1526 (1.23×) | 2885 → 2715 (1.06×) |
| `keccak/apc_001` | 16796 → 14253 (1.18×) | 1971 → 950 (2.08×) | 3550 → 3109 (1.14×) | 1322 → 994 (1.33×) | 950 → 760 (1.25×) | 1165 → 1126 (1.03×) |

Split between the two commits (`wasm-eth/apc_063` total): 21146 → 18983 from the reencode work,
18983 → 16827 from the ordering fix. The ordering fix is what moves `gauss`, `busUnify` and
`carryBranch`, since they all go through `denseLinearize`.

Cumulative with #225 on `wasm-eth/apc_063`: 25964 → 16827, i.e. **1.54×** on the whole pipeline.

## Verification

- `lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` passes (36 `@[csimp]` roots,
  no unused theorems, correctness theorems on the three standard axioms only).
- `apc-optimizer run` output identical to `main` on `openvm-eth/apc_037`, `openvm-eth/apc_012`,
  `wasm-eth/apc_063`, `keccak/apc_001`.
- Generated-C scan: no function reachable from live code rebuilds a dictionary inside a loop in
  `Reencode`, `BusUnify` or `DomainBatch`.

## Still outstanding

From the same LBR attribution, the remaining dictionary callers are `denseZModOps` itself (23.5% —
the per-call `ops` construction; hoisting it to once per pass is the "Tier 2" threading I deferred
in #225), then `denseConstDiffNZ` (9.0%), `DenseLinExpr.add` (7.0%) and `DenseExpr.foldAdd` (5.8%),
which belong to `busPairCancel` / `constFold` and would be the next targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)