### PR TITLE
perf: thread the ZMod zero through the point evaluator + denseConstDiffNZ (reencode 1.7x, busPairCancel 1.43x, busUnify 1.31x, pipeline 1.15x on wasm; effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -190,6 +190,25 @@ def denseConstDiffNZ (a b : DenseLinExpr p) : Bool :=
   let d := (a.add (b.scale (-1))).norm
   d.terms.isEmpty && decide (d.const ≠ 0)
 
+/-- Boxed twin: called from the nested `any`/`any` over branch pairs, and the `-1`, the `add`, the
+    `scale`, the `norm` and the `≠ 0` each derive their own instance chain. One shared
+    `DenseZModOps p` covers all five. -/
+def denseConstDiffNZWith (ops : DenseZModOps p) (a b : DenseLinExpr p) : Bool :=
+  let d := (a.addWith ops (b.scaleWith ops ops.negOne)).normWith ops
+  d.terms.isEmpty && decide (d.const ≠ ops.zero)
+
+def denseConstDiffNZFast (a b : DenseLinExpr p) : Bool :=
+  denseConstDiffNZWith denseZModOps a b
+
+theorem denseConstDiffNZWith_eq (ops : DenseZModOps p) (a b : DenseLinExpr p) :
+    denseConstDiffNZWith ops a b = denseConstDiffNZ a b := by
+  simp only [denseConstDiffNZWith, denseConstDiffNZ, DenseLinExpr.addWith_eq,
+    DenseLinExpr.scaleWith_eq, DenseLinExpr.normWith_eq, ops.negOne_eq, ops.zero_eq]
+
+@[csimp] theorem denseConstDiffNZ_eq_fast : @denseConstDiffNZ = @denseConstDiffNZFast := by
+  funext p a b
+  exact (denseConstDiffNZWith_eq denseZModOps a b).symm
+
 /-! ## The expression- and address-level certificates -/
 
 /-- Two dense expressions provably evaluate differently: some two-root reduction of each yields

--- a/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
@@ -28,6 +28,37 @@ def denseSplitSumMax (B : Std.HashMap VarId Nat) :
       else none
     | _, _ => none
 
+/-- Boxed twin: `-a` derives the `Neg (ZMod p)` instance chain per term otherwise. -/
+def denseSplitSumMaxW (neg : ZMod p → ZMod p) (B : Std.HashMap VarId Nat) :
+    List (VarId × ZMod p) → Option (Nat × Nat)
+  | [] => some (0, 0)
+  | (v, a) :: rest =>
+    match B[v]?, denseSplitSumMaxW neg B rest with
+    | some bound, some acc =>
+      if 1 ≤ bound then
+        if a.val * (bound - 1) ≤ (neg a).val * (bound - 1) then
+          some (a.val * (bound - 1) + acc.1, acc.2)
+        else
+          some (acc.1, (neg a).val * (bound - 1) + acc.2)
+      else none
+    | _, _ => none
+
+theorem denseSplitSumMaxW_eq (B : Std.HashMap VarId Nat) (l : List (VarId × ZMod p)) :
+    denseSplitSumMaxW (fun a => -a) B l = denseSplitSumMax B l := by
+  induction l with
+  | nil => rfl
+  | cons t rest ih =>
+      obtain ⟨v, a⟩ := t
+      simp only [denseSplitSumMaxW, denseSplitSumMax, ih]
+
+def denseSplitSumMaxFast (B : Std.HashMap VarId Nat) (l : List (VarId × ZMod p)) :
+    Option (Nat × Nat) :=
+  denseSplitSumMaxW (Neg.neg) B l
+
+@[csimp] theorem denseSplitSumMax_eq_fast : @denseSplitSumMax = @denseSplitSumMaxFast := by
+  funext p B l
+  exact (denseSplitSumMaxW_eq B l).symm
+
 /-- Certifies `l`'s value stays strictly within an interval of length `< p` that never wraps
     around `0` (hence nonzero). -/
 def denseIntervalCert (B : Std.HashMap VarId Nat) (l : DenseLinExpr p) : Bool :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -201,6 +201,35 @@ def denseIExprEvalWith (add mul : ZMod p → ZMod p → ZMod p) (pt : List (VarI
   | .add a b => add (denseIExprEvalWith add mul pt a) (denseIExprEvalWith add mul pt b)
   | .mul a b => mul (denseIExprEvalWith add mul pt a) (denseIExprEvalWith add mul pt b)
 
+/-- Boxed twin: takes the lookup zero too, so an evaluation costs one instance chain rather than
+    one per `.ix` node. -/
+def denseIExprEvalWithZ (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
+    (pt : List (VarId × ZMod p)) : IExpr p → ZMod p
+  | .const n => n
+  | .ix i => denseLookupIxW zero pt i
+  | .add a b =>
+      add (denseIExprEvalWithZ add mul zero pt a) (denseIExprEvalWithZ add mul zero pt b)
+  | .mul a b =>
+      mul (denseIExprEvalWithZ add mul zero pt a) (denseIExprEvalWithZ add mul zero pt b)
+
+theorem denseIExprEvalWithZ_eq (add mul : ZMod p → ZMod p → ZMod p)
+    (pt : List (VarId × ZMod p)) (ie : IExpr p) :
+    denseIExprEvalWithZ add mul 0 pt ie = denseIExprEvalWith add mul pt ie := by
+  induction ie with
+  | const n => rfl
+  | ix i => exact denseLookupIxW_eq pt i
+  | add a b iha ihb => simp only [denseIExprEvalWithZ, denseIExprEvalWith, iha, ihb]
+  | mul a b iha ihb => simp only [denseIExprEvalWithZ, denseIExprEvalWith, iha, ihb]
+
+def denseIExprEvalWithFast (add mul : ZMod p → ZMod p → ZMod p) (pt : List (VarId × ZMod p))
+    (ie : IExpr p) : ZMod p :=
+  denseIExprEvalWithZ add mul 0 pt ie
+
+@[csimp] theorem denseIExprEvalWith_eq_fast :
+    @denseIExprEvalWith = @denseIExprEvalWithFast := by
+  funext p add mul pt ie
+  exact (denseIExprEvalWithZ_eq add mul pt ie).symm
+
 /-! ### Compiling dense items to `IExpr`/`CBi` -/
 
 /-- First position of `y` in dense `keys`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -148,14 +148,20 @@ def denseSurvZeroCW (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr 
     otherwise be rebuilt per constraint per point of the group's domain box. -/
 def denseSurvZeroCWZ (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
     (ces : List (IExpr p)) (a : List (VarId × ZMod p)) : Bool :=
-  ces.all (fun ie => decide (denseIExprEvalWith add mul a ie = zero))
+  ces.all (fun ie => decide (denseIExprEvalWithZ add mul zero a ie = zero))
+
+theorem denseSurvZeroCWZ_eq (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr p)) :
+    denseSurvZeroCWZ add mul 0 ces = denseSurvZeroCW add mul ces := by
+  funext a
+  simp only [denseSurvZeroCWZ, denseSurvZeroCW, denseIExprEvalWithZ_eq]
 
 def denseSurvZeroCWFast (add mul : ZMod p → ZMod p → ZMod p) (ces : List (IExpr p))
     (a : List (VarId × ZMod p)) : Bool :=
   denseSurvZeroCWZ add mul 0 ces a
 
 @[csimp] theorem denseSurvZeroCW_eq_fast : @denseSurvZeroCW = @denseSurvZeroCWFast := by
-  funext p add mul ces a; rfl
+  funext p add mul ces a
+  exact (congrFun (denseSurvZeroCWZ_eq add mul ces) a).symm
 
 /-- The surviving group values: enumerate the group's domains, keep those satisfying the covered
     constraints. -/
@@ -188,7 +194,12 @@ def denseGroupSurvivorsEFast (es : List (DenseExpr p)) (doms : List (VarId × Li
 
 @[csimp] theorem denseGroupSurvivorsE_eq_fast :
     @denseGroupSurvivorsE = @denseGroupSurvivorsEFast := by
-  funext p es doms; rfl
+  funext p es doms
+  show denseGroupSurvivorsE es doms = denseGroupSurvivorsEW _ _ 0 es doms
+  unfold denseGroupSurvivorsE denseGroupSurvivorsEW
+  split
+  · rw [denseSurvZeroCWZ_eq]
+  · rfl
 
 /-- `filter P l` if it keeps at most `cap` elements, `none` as soon as a `cap + 1`-st hit shows
     up — the tail is not scanned. -/
@@ -237,7 +248,12 @@ def denseGroupSurvivorsECapFast (es : List (DenseExpr p))
 
 @[csimp] theorem denseGroupSurvivorsECap_eq_fast :
     @denseGroupSurvivorsECap = @denseGroupSurvivorsECapFast := by
-  funext p es doms cap; rfl
+  funext p es doms cap
+  show denseGroupSurvivorsECap es doms cap = denseGroupSurvivorsECapW _ _ 0 es doms cap
+  unfold denseGroupSurvivorsECap denseGroupSurvivorsECapW
+  split
+  · rw [denseSurvZeroCWZ_eq]
+  · rfl
 
 /-! ## The checked re-encoding certificate -/
 


### PR DESCRIPTION
Third round of the #225 / #226 hoist. Runtime only; both twins are proven equal to the definitions
they replace, and output is verified identical on four APCs.

## Where the remaining dictionary cost was

LBR attribution of `ZMod.commRing` over a whole `wasm-eth/apc_063` run on `main`, counting the
frame immediately above each construction:

```
  31.3%  denseZModOps            ← the per-call ops record itself
  10.4%  DenseExpr.foldAdd
   9.9%  denseLookupIxFast
   6.8%  DenseExpr.foldMul
   6.2%  DenseLinExpr.add
   5.7%  denseConstDiffNZ
   5.3%  denseSplitSumMax
```

This PR takes `denseLookupIx`, `denseConstDiffNZ` and `denseSplitSumMax`.

- **`denseIExprEvalWith`** calls `denseLookupIx`, which since #226 derives its miss-case `0` once
  per lookup. Taking the zero as a parameter and threading it (`denseIExprEvalWithZ`) makes that one
  chain per *evaluation*; and `denseSurvZeroCWZ` already holds a zero, so reencode's group
  enumeration now derives it **once for the whole enumeration** instead of once per `.ix` node.
- **`denseConstDiffNZ`** derives five separate chains (`-1`, `add`, `scale`, `norm`, `≠ 0`) and runs
  inside the nested `any`/`any` over branch pairs in `denseExprTwoRootNeq`. One shared
  `DenseZModOps p` covers all five.
- **`denseSplitSumMax`** derives `Neg (ZMod p)` per term (separate commit, see caveat below).

## Results

Mean of 3 interleaved A/B runs against `main` (`4c1f54e`):

| APC | total | reencode | busPairCancel | busUnify | carryBranch |
|---|---|---|---|---|---|
| `openvm-eth/apc_037` | 2599 → 2520 (1.03×) | 310 → 254 (1.22×) | 144 → 143 | 98 → 96 | 234 → 221 (1.06×) |
| `openvm-eth/apc_012` | 1548 → 1512 (1.02×) | 340 → 294 (1.16×) | 45 → 46 | 43 → 41 | 98 → 103 (0.95×) |
| `wasm-eth/apc_063` | 16717 → 14566 (**1.15×**) | 1348 → 773 (**1.74×**) | 2707 → 1889 (1.43×) | 2266 → 1726 (1.31×) | 1523 → 1221 (1.25×) |
| `keccak/apc_001` | 14182 → 13232 (**1.07×**) | 949 → 561 (**1.69×**) | 1114 → 975 (1.14×) | 3102 → 2705 (1.15×) | 754 → 791 (0.95×) |

Cumulative over #225 + #226 + this, `wasm-eth/apc_063`: 25964 → 14566, **1.78×**.

### Caveat on the second commit

`denseSplitSumMax` trades a chain per term for a chain per call plus a closure call per term, so a
one- or two-term row comes out slightly behind: `carryBranch` is 1.25× on `wasm-eth/apc_063` but
0.95× on `keccak` and `openvm-eth/apc_012`. Net across the four APCs it is −260 ms, so I kept it,
but it is a separate commit and can be dropped on its own if the corpus benchmark disagrees.

## A measured negative result: do not hoist `DenseExpr.fold`

`DenseExpr.foldAdd`/`foldMul` were the second-largest bucket (17.2%), and hoisting a
`DenseZModOps p` through the fold walk does speed up the `constFold*` passes (1.3–1.8×). I dropped
it anyway, because it is a **net regression**:

| | base | fold hoisted | without |
|---|---|---|---|
| `wasm-eth/apc_063` total | 16770 | 14863 | **14613** |
| `keccak/apc_001` total | 14210 | 14344 | **13387** |

The reason: `foldAdd`/`foldMul` only touch a `ZMod p` value when one side is a `.const`. A
constant-free tree takes the `| a, b => .add a b` branch and needs no instance at all — so building
one record per tree *adds* cost for every such call, and `fold` is called on many small
constant-free expressions from `trivialConstr`, `zeroRegister`, `hintCollapse`, `busUnify` and
`busPairCancel`. That showed up as a consistent 4–13% regression in `domainBatch`, `carryBranch` and
`busPairCancel` that more than paid back the `constFold` win.

Rule of thumb this adds to the two from #226: **hoisting only pays when the traversal reaches the
arithmetic on most iterations.** Where the instance is needed on a minority of nodes, per-call
derivation is cheaper.

## Verification

- `lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` passes (39 `@[csimp]` roots).
- The `csimp`-effectiveness audit from #226 (does any replaced definition remain reachable from live
  code?) reports all 39 pairs effective.
- `apc-optimizer run` output identical to `main` on `openvm-eth/apc_037`, `openvm-eth/apc_012`,
  `wasm-eth/apc_063`, `keccak/apc_001`.

## Remaining

`denseZModOps` construction itself is now the largest single bucket (31.3%), 80% of it from
`DenseLinExpr.norm`, `denseLinearize` and `DenseLinExpr.scale`. Cutting it needs either lighter
per-use accessors (`scale` only needs `mul`; `norm` only needs `add` and `zero`) or threading one
`ops` per pass rather than per call. `DenseLinExpr.add` (6.2%) wants hoisting at its loop callers
rather than in itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)