### PR TITLE
perf: run reencode's incremental candidate loop unconditionally (reencode 2.08x on the openvm-eth family, effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1142,35 +1142,18 @@ theorem denseRegisterBits_valid_of_eq {reg r : VarRegistry} {fb : String} {k : N
     {bs : List VarId} (h : denseRegisterBits reg fb k = (r, bs)) : ∀ b ∈ bs, r.Valid b := by
   have := (denseRegisterBits_props reg fb k).2.2; rw [h] at this; exact this
 
-theorem denseBuildReencode_props (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (xs : List VarId) (freshBase : String) :
-    reg.Extends (denseBuildReencode reg useIdx csIdx arrCs xs freshBase).1
-    ∧ (∀ i, (denseBuildReencode reg useIdx csIdx arrCs xs freshBase).1.isInput i = reg.isInput i)
-    ∧ (∀ bits hm, (denseBuildReencode reg useIdx csIdx arrCs xs freshBase).2 = some (bits, hm) →
-        ∀ b ∈ bits, (denseBuildReencode reg useIdx csIdx arrCs xs freshBase).1.Valid b) := by
-  fun_cases denseBuildReencode reg useIdx csIdx arrCs xs freshBase <;>
-    first
-      | exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, by intro bits hm h; simp at h⟩
-      | (refine ⟨denseRegisterBits_extends_of_eq (by assumption),
-                fun i => denseRegisterBits_isInput_of_eq (by assumption) i, ?_⟩
-         intro bits hm heq b hb
-         dsimp only at heq
-         rw [Option.some.injEq, Prod.mk.injEq] at heq
-         obtain ⟨rfl, -⟩ := heq
-         exact denseRegisterBits_valid_of_eq (by assumption) b hb)
-
-theorem denseBuildReencodeCached_props (reg : VarRegistry) (useIdx : Bool)
+theorem denseBuildReencodeCached_props (reg : VarRegistry)
     (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p))
     (cache : DenseReencodeRootCache p) (xs : List VarId) (freshBase : String) :
-    reg.Extends (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1
-    ∧ (∀ i, (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1.isInput i
+    reg.Extends (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1
+    ∧ (∀ i, (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1.isInput i
         = reg.isInput i)
     ∧ (∀ bits hm,
-        (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).2.1
+        (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).2.1
           = some (bits, hm) →
         ∀ b ∈ bits,
-          (denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase).1.Valid b) := by
-  fun_cases denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase <;>
+          (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1.Valid b) := by
+  fun_cases denseBuildReencodeCached reg csIdx arrCs cache xs freshBase <;>
     first
       | exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl,
           by intro bits hm h; simp at h⟩
@@ -1228,17 +1211,6 @@ theorem denseBitCM_covered (reg1 : VarRegistry) (xs bits : List VarId)
   exact ⟨hbits b hb, denseCM_coveredBy_of_vars _
     (fun i hi => hxsValid i (denseBitCM_vars _ xs hm b i hi))⟩
 
-
-theorem stepIdentityPost (reg reg' : VarRegistry) (d : DenseConstraintSystem p)
-    (varSet : Std.HashSet VarId) (bs : BusSemantics p)
-    (hext : reg.Extends reg') (hii : ∀ i, reg'.isInput i = reg.isInput i)
-    (hcov : d.CoveredBy reg) (hvs : ∀ x, varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends reg' ∧ (∀ i, reg'.isInput i = reg.isInput i) ∧ d.CoveredBy reg'
-    ∧ DenseDerivations.CoveredBy reg' ([] : DenseDerivations p)
-    ∧ (∀ x, varSet.contains x = true → x ∈ d.occ)
-    ∧ DensePassCorrect reg'.isInput d d ([] : DenseDerivations p) bs :=
-  ⟨hext, hii, csCoveredBy_mono hext hcov, (by intro x hx; simp at hx), hvs,
-   DensePassCorrect.refl reg'.isInput d bs⟩
 
 /-- `stepIdentityPost` for the cached step, which does not carry the variable-set invariant
     (its `varSet` over-approximates the live variables; see `DenseReencodeCacheState`). -/
@@ -1323,129 +1295,57 @@ theorem denseCheckReencode_polyVars (d : DenseConstraintSystem p) (xs bits : Lis
     ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs hm)).vars, v ∈ bits := by
   grind [denseCheckReencode, List.contains_iff_mem]
 
-theorem denseBuildReencode_ext_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)} {xs : List VarId} {freshBase : String}
-    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencode reg useIdx csIdx arrCs xs freshBase = (reg1, o)) : reg.Extends reg1 := by
-  have := (denseBuildReencode_props reg useIdx csIdx arrCs xs freshBase).1; rw [h] at this; exact this
-
-theorem denseBuildReencode_isInput_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)} {xs : List VarId} {freshBase : String}
-    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencode reg useIdx csIdx arrCs xs freshBase = (reg1, o)) (i : VarId) :
-    reg1.isInput i = reg.isInput i := by
-  have := (denseBuildReencode_props reg useIdx csIdx arrCs xs freshBase).2.1 i; rw [h] at this
-  exact this
-
-theorem denseBuildReencode_bits_valid_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)} {xs : List VarId} {freshBase : String}
-    {bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
-    (h : denseBuildReencode reg useIdx csIdx arrCs xs freshBase = (reg1, some (bits, hm))) :
-    ∀ bb ∈ bits, reg1.Valid bb := by
-  have := (denseBuildReencode_props reg useIdx csIdx arrCs xs freshBase).2.2 bits hm (by rw [h])
-  rw [h] at this; exact this
-
-theorem denseBuildReencodeCached_ext_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+theorem denseBuildReencodeCached_ext_of_eq {reg reg1 : VarRegistry}
     {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
     {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
     {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
       (reg1, o, cache1)) : reg.Extends reg1 := by
-  have := (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).1
+  have := (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).1
   rw [h] at this
   exact this
 
-theorem denseBuildReencodeCached_isInput_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+theorem denseBuildReencodeCached_isInput_of_eq {reg reg1 : VarRegistry}
     {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
     {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
     {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
       (reg1, o, cache1)) (i : VarId) :
     reg1.isInput i = reg.isInput i := by
   have :=
-    (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).2.1 i
+    (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).2.1 i
   rw [h] at this
   exact this
 
-theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry} {useIdx : Bool}
+theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry}
     {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
     {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
     {bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
-    (h : denseBuildReencodeCached reg useIdx csIdx arrCs cache xs freshBase =
+    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
       (reg1, some (bits, hm), cache1)) :
     ∀ bb ∈ bits, reg1.Valid bb := by
-  have := (denseBuildReencodeCached_props reg useIdx csIdx arrCs cache xs freshBase).2.2
+  have := (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).2.2
     bits hm (by rw [h])
   rw [h] at this
   exact this
 
 set_option maxHeartbeats 1000000 in
-theorem denseReencodeStep_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
-    (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
-    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId)
-    (freshBase : String) (bs : BusSemantics p)
-    (hcov : d.CoveredBy reg) (hvs : ∀ x, varSet.contains x = true → x ∈ d.occ) :
-    reg.Extends (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
-    ∧ (∀ i, (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1.isInput i
-        = reg.isInput i)
-    ∧ (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
-    ∧ DenseDerivations.CoveredBy
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.1
-    ∧ (∀ x, (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.2.2.2.contains x
-          = true →
-        x ∈ (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1.occ)
-    ∧ DensePassCorrect
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).1.isInput d
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.1
-        (denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs freshBase
-  case case4 =>
-    rename_i hgate hcoll reg1 bits hm hbeq hdpr hA hB hC hD ro hwd
-    have hbext : reg.Extends reg1 := denseBuildReencode_ext_of_eq hbeq
-    have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
-      denseBuildReencode_isInput_of_eq hbeq i
-    have hbval : ∀ bb ∈ bits, reg1.Valid bb := denseBuildReencode_bits_valid_of_eq hbeq
-    have hpolyVars := denseCheckReencode_polyVars d xs bits hm hD
-    have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
-      rw [hbii x]; exact List.all_eq_true.mp hgate x hx
-    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := fun x hx => hvs x (List.all_eq_true.mp hA x hx)
-    have hxsB : ∀ x ∈ xs, x ∉ bits := fun x hx => of_decide_eq_true (List.all_eq_true.mp hB x hx)
-    have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
-      have hpd : (reg1.resolve bb).powdrId? = none := of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
-      show (reg1.resolve bb).powdrId?.isSome = false
-      rw [hpd]; rfl
-    have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
-      hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
-    refine ⟨hbext, hbii, ?_, ?_, ?_, ?_⟩
-    · exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov) hbval hpolyVars
-    · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
-    · intro x hx; rw [Std.HashSet.contains_ofList] at hx; exact List.contains_iff_mem.mp hx
-    · exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB hbnInput hD
-  all_goals first
-    | exact stepIdentityPost reg reg d varSet bs (VarRegistry.Extends.refl reg) (fun _ => rfl) hcov hvs
-    | exact stepIdentityPost reg _ d varSet bs (denseBuildReencode_ext_of_eq (by assumption))
-        (fun i => denseBuildReencode_isInput_of_eq (by assumption) i) hcov hvs
-
-set_option maxHeartbeats 1000000 in
-theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
+theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
     (xs : List VarId) (freshBase : String) (bs : BusSemantics p) (hcov : d.CoveredBy reg) :
-    reg.Extends (denseReencodeStepCached b useIdx reg d state xs freshBase).1
-    ∧ (∀ i, (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput i
+    reg.Extends (denseReencodeStepCached b reg d state xs freshBase).1
+    ∧ (∀ i, (denseReencodeStepCached b reg d state xs freshBase).1.isInput i
         = reg.isInput i)
-    ∧ (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
+    ∧ (denseReencodeStepCached b reg d state xs freshBase).2.1.CoveredBy
+        (denseReencodeStepCached b reg d state xs freshBase).1
     ∧ DenseDerivations.CoveredBy
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1
+        (denseReencodeStepCached b reg d state xs freshBase).1
+        (denseReencodeStepCached b reg d state xs freshBase).2.2.1
     ∧ DensePassCorrect
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).1.isInput d
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.1
-        (denseReencodeStepCached b useIdx reg d state xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStepCached b useIdx reg d state xs freshBase
+        (denseReencodeStepCached b reg d state xs freshBase).1.isInput d
+        (denseReencodeStepCached b reg d state xs freshBase).2.1
+        (denseReencodeStepCached b reg d state xs freshBase).2.2.1 bs := by
+  fun_cases denseReencodeStepCached b reg d state xs freshBase
   case case4 =>
     rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
     have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
@@ -1482,77 +1382,23 @@ theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx
         (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov
 
 set_option maxHeartbeats 1000000 in
-theorem denseReencodeLoop_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
-    (bs : BusSemantics p) :
-    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
-      (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
-      (use : Thunk (DenseReencodeUseIdx p)) (nc nb : Nat),
-      d.CoveredBy reg → (∀ x, varSet.contains x = true → x ∈ d.occ) →
-      reg.Extends (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
-      ∧ (∀ i, (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1.isInput i
-          = reg.isInput i)
-      ∧ (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.1.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
-      ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.2
-      ∧ DensePassCorrect
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).1.isInput d
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.1
-          (denseReencodeLoop b useIdx targets idx reg d csIdx arrCs varSet use nc nb).2.2 bs := by
-  intro targets
-  induction targets with
-  | nil =>
-      intro idx reg d csIdx arrCs varSet use nc nb hcov hvs
-      show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
-        ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
-        ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
-      exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov, (by intro x hx; simp at hx),
-        DensePassCorrect.refl reg.isInput d bs⟩
-  | cons xs rest ih =>
-      intro idx reg d csIdx arrCs varSet use nc nb hcov hvs
-      simp only [denseReencodeLoop]
-      rcases hstep : denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs
-          s!"rnc{nc}_{nb}_{idx}" with ⟨reg1, d1, derivs1, csIdx1, arrCs1, varSet1⟩
-      have hsp := denseReencodeStep_correct b useIdx reg d csIdx arrCs varSet use xs
-          s!"rnc{nc}_{nb}_{idx}" bs hcov hvs
-      simp only [hstep] at hsp
-      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_vs, hs_correct⟩ := hsp
-      rcases hrec : denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
-          (denseReencodeUseNext derivs1 d1 use)
-          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
-          with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1 (denseReencodeUseNext derivs1 d1 use)
-          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
-          hs_cov hs_vs
-      simp only [hrec] at hih
-      obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
-      refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
-      · exact DenseDerivations.coveredBy_append
-          (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
-      · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
-        have hstepcert : DensePassCorrect reg2.isInput d d1 derivs1 bs := by
-          rw [hfe]; exact hs_correct
-        exact hstepcert.andThen hr_correct
-
-set_option maxHeartbeats 1000000 in
-theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx : Bool)
+theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound)
     (bs : BusSemantics p) :
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
       (state : DenseReencodeCacheState p) (nc nb : Nat),
       d.CoveredBy reg →
-      reg.Extends (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
-      ∧ (∀ i, (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1.isInput i
+      reg.Extends (denseReencodeLoopCached b targets idx reg d state nc nb).1
+      ∧ (∀ i, (denseReencodeLoopCached b targets idx reg d state nc nb).1.isInput i
           = reg.isInput i)
-      ∧ (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.1.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
+      ∧ (denseReencodeLoopCached b targets idx reg d state nc nb).2.1.CoveredBy
+          (denseReencodeLoopCached b targets idx reg d state nc nb).1
       ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.2
+          (denseReencodeLoopCached b targets idx reg d state nc nb).1
+          (denseReencodeLoopCached b targets idx reg d state nc nb).2.2
       ∧ DensePassCorrect
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).1.isInput d
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.1
-          (denseReencodeLoopCached b useIdx targets idx reg d state nc nb).2.2 bs := by
+          (denseReencodeLoopCached b targets idx reg d state nc nb).1.isInput d
+          (denseReencodeLoopCached b targets idx reg d state nc nb).2.1
+          (denseReencodeLoopCached b targets idx reg d state nc nb).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
@@ -1565,13 +1411,13 @@ theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound) (useIdx
   | cons xs rest ih =>
       intro idx reg d state nc nb hcov
       simp only [denseReencodeLoopCached]
-      rcases hstep : denseReencodeStepCached b useIdx reg d state xs s!"rnc{nc}_{nb}_{idx}"
+      rcases hstep : denseReencodeStepCached b reg d state xs s!"rnc{nc}_{nb}_{idx}"
           with ⟨reg1, d1, derivs1, state1⟩
-      have hsp := denseReencodeStepCached_correct b useIdx reg d state xs
+      have hsp := denseReencodeStepCached_correct b reg d state xs
           s!"rnc{nc}_{nb}_{idx}" bs hcov
       simp only [hstep] at hsp
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
-      rcases hrec : denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1
+      rcases hrec : denseReencodeLoopCached b rest (idx + 1) reg1 d1 state1
           (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
           with ⟨reg2, d2, derivs2⟩
       have hih := ih (idx + 1) reg1 d1 state1
@@ -1602,32 +1448,20 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
   by_cases hpr : pw.isPrime = true
   · rw [if_pos hpr]
     haveI : Fact p.Prime := ⟨pw.correct hpr⟩
-    extract_lets csVs svSet targets targetSlots targetVars useRootCache useIdx
-    by_cases hcache : useIdx ∧ useRootCache
-    · rw [if_pos hcache]
-      obtain ⟨he, _, hc, hd, hcorr⟩ :=
-        denseReencodeLoopCached_correct b useIdx bs targets 0 reg d
-          { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
-            arrCs := d.algebraicConstraints.toArray
-            rootCache := ∅
-            varSet := Std.HashSet.ofList d.occ
-            useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
-            useBis := denseCovBuild denseBIVars d.busInteractions
-            arrBis := d.busInteractions.toArray
-            foldCs := d.algebraicConstraints.zipIdx.foldl
-              (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
-          d.algebraicConstraints.length d.busInteractions.length hcov
-      exact ⟨he, hc, hd, hcorr⟩
-    · rw [if_neg hcache]
-      obtain ⟨he, _, hc, hd, hcorr⟩ := denseReencodeLoop_correct b useIdx bs targets 0 reg d
-        (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-        d.algebraicConstraints.toArray (Std.HashSet.ofList d.occ)
-        (Thunk.mk (fun _ => denseBuildUseIdx d))
+    extract_lets csVs svSet targets
+    obtain ⟨he, _, hc, hd, hcorr⟩ :=
+      denseReencodeLoopCached_correct b bs targets 0 reg d
+        { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
+          arrCs := d.algebraicConstraints.toArray
+          rootCache := ∅
+          varSet := Std.HashSet.ofList d.occ
+          useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
+          useBis := denseCovBuild denseBIVars d.busInteractions
+          arrBis := d.busInteractions.toArray
+          foldCs := d.algebraicConstraints.zipIdx.foldl
+            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
         d.algebraicConstraints.length d.busInteractions.length hcov
-        (fun x hx => by
-          rw [Std.HashSet.contains_ofList] at hx
-          exact List.contains_iff_mem.mp hx)
-      exact ⟨he, hc, hd, hcorr⟩
+    exact ⟨he, hc, hd, hcorr⟩
   · rw [if_neg hpr]
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -637,46 +637,15 @@ def denseRegisterBits (reg : VarRegistry) (freshBase : String) (k : Nat) :
     (reg, [])
 
 /-- Construct the bits and the substitution map for a candidate group (proof-free — the checked
-    certificate re-verifies everything). Registers fresh bits only on the single accepting path. -/
-def denseBuildReencode (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (xs : List VarId) (freshBase : String) :
-    VarRegistry × Option (List VarId × Std.HashMap VarId (DenseExpr p)) :=
-  let es := if useIdx then denseCoveredIdx csIdx arrCs (denseCoveredBy xs) xs
-    else arrCs.foldr (fun c acc => if denseCoveredBy xs c then c :: acc else acc) []
-  match denseGroupDoms es xs with
-  | none => (reg, none)
-  | some doms =>
-    let boxSize := (doms.map (fun yd => yd.2.length)).prod
-    if boxSize ≤ 256 then
-      if es.length == xs.length && es.all (fun c => c.vars.eraseDups.length == 1)
-          && xs.length ≤ Nat.clog 2 boxSize then
-        -- single-var-only covered set (one per variable): survivors = box; unencodable
-        (reg, none)
-      else
-      match denseGroupSurvivorsECap es doms (2 ^ (xs.length - 1)) with
-      | none => (reg, none)
-      | some survs =>
-      if 2 ≤ survs.length then
-        let k := Nat.clog 2 survs.length
-        if k < xs.length then
-          let (reg1, bits) := denseRegisterBits reg freshBase k
-          let patts := denseAssignments (denseBitBox bits)
-          let survsP := survs ++ List.replicate (patts.length - survs.length) (survs.headD [])
-          let pz := patts.zip survsP
-          (reg1, some (bits, Std.HashMap.ofList (xs.map (fun x => (x, (denseInterpPoly pz x).fold)))))
-        else (reg, none)
-      else (reg, none)
-    else (reg, none)
-
-/-- Construct a candidate using the retained per-constraint root cache. -/
-def denseBuildReencodeCached (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseCovIndex)
+    certificate re-verifies everything). Registers fresh bits only on the single accepting path.
+    Positions come from the bucket index, and the per-constraint root plans from the retained
+    cache. -/
+def denseBuildReencodeCached (reg : VarRegistry) (csIdx : DenseCovIndex)
     (arrCs : Array (DenseExpr p)) (cache : DenseReencodeRootCache p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × Option (List VarId × Std.HashMap VarId (DenseExpr p)) ×
       DenseReencodeRootCache p :=
-  let planned := if useIdx then denseCoveredIdxPos csIdx arrCs xs
-    else arrCs.toList.zipIdx.foldr
-      (fun c acc => if denseCoveredBy xs c.1 then (c.2, c.1) :: acc else acc) []
+  let planned := denseCoveredIdxPos csIdx arrCs xs
   let es := planned.map Prod.snd
   let (doms?, cache) := denseGroupDomsCached planned xs cache
   match doms? with
@@ -704,18 +673,6 @@ def denseBuildReencodeCached (reg : VarRegistry) (useIdx : Bool) (csIdx : DenseC
         else (reg, none, cache)
       else (reg, none, cache)
     else (reg, none, cache)
-
-/-- Whole-system posting index for the degree pre-gate, thunked so only runs that construct a
-    candidate pay for it. Positions are `d`'s list order, so they index `arrCs` and `arrBis`. -/
-structure DenseReencodeUseIdx (p : ℕ) where
-  csIdx : DenseCovIndex
-  biIdx : DenseCovIndex
-  arrBis : Array (BusInteraction (DenseExpr p))
-
-def denseBuildUseIdx (d : DenseConstraintSystem p) : DenseReencodeUseIdx p :=
-  ⟨denseCovBuild DenseExpr.vars d.algebraicConstraints,
-   denseCovBuild denseBIVars d.busInteractions,
-   d.busInteractions.toArray⟩
 
 /-- The index's candidate positions for `xs`, each once (an item is bucketed per variable
     occurrence, and the gate below rewrites every position it visits). -/
@@ -748,52 +705,6 @@ def denseDegPreRejectIdx (b : DegreeBound) (csIdxUse biIdxUse : DenseCovIndex)
         e.sharesVarIn xs &&
           decide (b.busInteractions < (denseGroupRewrite xs bits σ patts e).degree))
     | none => false)
-
-def denseDegPreReject (b : DegreeBound) (use : Thunk (DenseReencodeUseIdx p))
-    (arrCs : Array (DenseExpr p)) (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
-  denseDegPreRejectIdx b use.get.csIdx use.get.biIdx use.get.arrBis arrCs xs bits hm
-
-/-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
-    gates in order, minting fresh bits and rewriting `d` only on full acceptance. -/
-def denseReencodeStep (b : DegreeBound) (useIdx : Bool)
-    (reg : VarRegistry) (d : DenseConstraintSystem p) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (varSet : Std.HashSet VarId)
-    (use : Thunk (DenseReencodeUseIdx p)) (xs : List VarId)
-    (freshBase : String) :
-    VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseCovIndex ×
-      Array (DenseExpr p) × Std.HashSet VarId :=
-  if xs.all (fun x => reg.isInput x) then
-  if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
-      | some i => varSet.contains i
-      | none => false) then
-    -- fresh-name collision: `denseCheckReencode` would reject after the full freshness scan anyway
-    (reg, d, [], csIdx, arrCs, varSet)
-  else
-  match denseBuildReencode reg useIdx csIdx arrCs xs freshBase with
-  | (reg1, none) => (reg1, d, [], csIdx, arrCs, varSet)
-  | (reg1, some (bits, hm)) =>
-    -- Degree pre-gate: reject early what the final `withinDegreeB` gate would reject anyway.
-    if denseDegPreReject b use arrCs xs bits hm then (reg1, d, [], csIdx, arrCs, varSet)
-    else
-    if xs.all (fun x => varSet.contains x) then
-    if xs.all (fun x => decide (x ∉ bits)) then
-    if bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
-    if denseCheckReencode d xs bits hm then
-      let ro := denseReencodeOut d xs bits hm
-      if ro.withinDegreeB b then
-        -- `d` changed: rebuild the index and variable set for `ro`.
-        (reg1, ro,
-         bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
-         (if useIdx then denseBuildPruned DenseExpr.vars 8 ro.algebraicConstraints else ⟨∅, []⟩),
-         ro.algebraicConstraints.toArray,
-         Std.HashSet.ofList ro.occ)
-      else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-    else (reg1, d, [], csIdx, arrCs, varSet)
-  else (reg, d, [], csIdx, arrCs, varSet)
 
 /-- The cached loop's candidate-state, kept on stable positions across accepts: dropped
     constraints become `.const 0` tombstones (variable-free, so every index query skips them),
@@ -861,7 +772,10 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
     else st) st
   { st with varSet := bits.foldl (·.insert ·) st.varSet }
 
-def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
+/-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
+    gates in order, minting fresh bits and rewriting `d` only on full acceptance; the threaded
+    candidate state is updated in place rather than rebuilt. -/
+def denseReencodeStepCached (b : DegreeBound)
     (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseReencodeCacheState p :=
@@ -871,7 +785,7 @@ def denseReencodeStepCached (b : DegreeBound) (useIdx : Bool)
       | none => false) then
     (reg, d, [], state)
   else
-  match denseBuildReencodeCached reg useIdx state.csIdx state.arrCs state.rootCache xs freshBase with
+  match denseBuildReencodeCached reg state.csIdx state.arrCs state.rootCache xs freshBase with
   | (reg1, none, rootCache) => (reg1, d, [], { state with rootCache })
   | (reg1, some (bits, hm), rootCache) =>
     let state := { state with rootCache }
@@ -901,39 +815,19 @@ def denseReencodeNameCounts (derivs : DenseDerivations p) (d : DenseConstraintSy
   if derivs.isEmpty then (nc, nb)
   else (d.algebraicConstraints.length, d.busInteractions.length)
 
-/-- The pre-gate index for the next step: kept while the steps leave `d` alone (see
-    `denseReencodeNameCounts` for the accept marker), rebuilt for a rewritten system. -/
-def denseReencodeUseNext (derivs : DenseDerivations p) (d : DenseConstraintSystem p)
-    (use : Thunk (DenseReencodeUseIdx p)) : Thunk (DenseReencodeUseIdx p) :=
-  if derivs.isEmpty then use else Thunk.mk (fun _ => denseBuildUseIdx d)
-
-/-- Process the candidate groups sequentially, threading the registry, indexes, variable set, and
+/-- Process the candidate groups sequentially, threading the registry, the candidate state and
     `d`'s item counts (`nc`/`nb`, the fresh-name prefix). -/
-def denseReencodeLoop (b : DegreeBound) (useIdx : Bool) :
-    List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p → DenseCovIndex →
-      Array (DenseExpr p) → Std.HashSet VarId → Thunk (DenseReencodeUseIdx p) → Nat → Nat →
-      VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _, _, _, _, _, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, csIdx, arrCs, varSet, use, nc, nb =>
-    let (reg1, d1, derivs1, csIdx1, arrCs1, varSet1) :=
-      denseReencodeStep b useIdx reg d csIdx arrCs varSet use xs s!"rnc{nc}_{nb}_{idx}"
-    let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
-    let (reg2, d2, derivs2) :=
-      denseReencodeLoop b useIdx rest (idx + 1) reg1 d1 csIdx1 arrCs1 varSet1
-        (denseReencodeUseNext derivs1 d1 use) nc1 nb1
-    (reg2, d2, derivs1 ++ derivs2)
-
-def denseReencodeLoopCached (b : DegreeBound) (useIdx : Bool) :
+def denseReencodeLoopCached (b : DegreeBound) :
     List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
       DenseReencodeCacheState p → Nat → Nat →
       VarRegistry × DenseConstraintSystem p × DenseDerivations p
   | [], _, reg, d, _, _, _ => (reg, d, [])
   | xs :: rest, idx, reg, d, state, nc, nb =>
     let (reg1, d1, derivs1, state1) :=
-      denseReencodeStepCached b useIdx reg d state xs s!"rnc{nc}_{nb}_{idx}"
+      denseReencodeStepCached b reg d state xs s!"rnc{nc}_{nb}_{idx}"
     let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
     let (reg2, d2, derivs2) :=
-      denseReencodeLoopCached b useIdx rest (idx + 1) reg1 d1 state1 nc1 nb1
+      denseReencodeLoopCached b rest (idx + 1) reg1 d1 state1 nc1 nb1
     (reg2, d2, derivs1 ++ derivs2)
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
@@ -954,35 +848,21 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
       | _ => s
     let targets := dedupHash (csVs.filterMap (fun vs =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
-        -- Sort by the resolved `Variable`'s order: `denseReencodeLoop` below is a greedy,
+        -- Sort by the resolved `Variable`'s order: `denseReencodeLoopCached` below is a greedy,
         -- order-sensitive accept/reject sequence, so the group order determines the outcome.
         some (vs.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
       else none))
-    let targetSlots := (targets.map List.length).sum
-    let targetVars := targets.foldl
-      (fun vars xs => xs.foldl (fun vars x => vars.insert x) vars)
-      (∅ : Std.HashSet VarId)
-    let useRootCache := 64 ≤ targetSlots - targetVars.size
-    let useIdx := 8192 ≤ d.algebraicConstraints.length
-    if useIdx ∧ useRootCache then
-      denseReencodeLoopCached b useIdx targets 0 reg d
-        { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
-          arrCs := d.algebraicConstraints.toArray
-          rootCache := ∅
-          varSet := Std.HashSet.ofList d.occ
-          useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
-          useBis := denseCovBuild denseBIVars d.busInteractions
-          arrBis := d.busInteractions.toArray
-          foldCs := d.algebraicConstraints.zipIdx.foldl
-            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
-        d.algebraicConstraints.length d.busInteractions.length
-    else
-      denseReencodeLoop b useIdx targets 0 reg d
-        (if useIdx then denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints else ⟨∅, []⟩)
-        d.algebraicConstraints.toArray
-        (Std.HashSet.ofList d.occ)
-        (Thunk.mk (fun _ => denseBuildUseIdx d))
-        d.algebraicConstraints.length d.busInteractions.length
+    denseReencodeLoopCached b targets 0 reg d
+      { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
+        arrCs := d.algebraicConstraints.toArray
+        rootCache := ∅
+        varSet := Std.HashSet.ofList d.occ
+        useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
+        useBis := denseCovBuild denseBIVars d.busInteractions
+        arrBis := d.busInteractions.toArray
+        foldCs := d.algebraicConstraints.zipIdx.foldl
+          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
+      d.algebraicConstraints.length d.busInteractions.length
   else (reg, d, [])
 
 end ApcOptimizer.Dense


### PR DESCRIPTION
`reencode` is rank 1 in `ranked_passes.md` — 44.67 s corpus, 14.7 % of corpus time, max 29 s. It is
no longer dictionary-bound (the Mathlib instance chain is **1.2 %** of the isolated profile after
#226/#227/#228); it is bound by whole-system work redone per candidate group. This PR turns on the
incremental implementation of that work which the pass already contained but gated off.

## What was slow

`denseReencodeF` carried two loops:

* `denseReencodeLoop` — after every accepted group it rebuilds the pruned bucket index
  (`denseBuildPruned`), the constraint array, the variable set (`Std.HashSet.ofList ro.occ`) and
  re-mints the degree pre-gate's posting-index `Thunk` (`denseReencodeUseNext`).
* `denseReencodeLoopCached` — the same step with all of that threaded as `DenseReencodeCacheState`:
  dropped constraints become variable-free `.const 0` tombstones on stable positions, the bucket
  indexes are grow-only, the root-plan cache is keyed by position, and `denseReencodeStateUpdate`
  touches only the positions an accept can change.

The incremental one was reachable only when `8192 ≤ #constraints ∧ useRootCache`. **140 of the 147
APCs where reencode is nonzero start under 8192 constraints and never entered it** — including the
seven `openvm-eth` APCs at exactly 4652/2253, where reencode is 40–53 % of pipeline runtime.

## Profile evidence

Pass isolated with the `APC_REPEAT_PASS`/`APC_REPEAT_N` harness (`openvm-eth/apc_005`, ×25 →
**94.8 %** of process time), LBR call graphs, samples charged to the innermost reencode phase frame:

| phase | share of pass |
|---|---:|
| `denseReencodeOut` + its read-only gates | **25.0 %** |
| `denseBuildUseIdx` (pre-gate posting index) | **18.0 %** |
| `denseCheckReencode` | 14.4 % |
| `Std.HashSet.ofList ro.occ` | **11.2 %** |
| `denseReencodeStep` residue (incl. `denseBuildPruned`) | 7.8 % |
| `denseDegPreRejectIdx` | 7.7 % |
| `ro.withinDegreeB` | 6.6 % |
| `denseBuildReencode` / survivor enumeration | 1.5 % / 1.4 % |

~61 % of the pass is per-accept state rebuilding; the actual candidate construction and enumeration
are under 3 %. Two supporting attributions:

* **~99 % of all `DenseExpr.varsAcc` samples sit under `denseBIVars`**, and of those 47.9 % arrive
  via `DenseConstraintSystem.occ` and 42.3 % via `denseBuildStep` — i.e. the two whole-system
  rebuilds, not anything intrinsic to the pass.
* **`lean_mark_mt` is 3.7 % of the profile, 99.4 % of it under `lean_thunk_get_core`, 99.2 % of
  that under `denseDegPreReject`.** `lean_thunk_get_core` deep-marks its result multi-threaded, so
  every re-thunked pre-gate index pays a *second* full traversal of the graph it just built. No
  amount of tuning inside `denseBuildUseIdx` would have found that; deleting the `Thunk` does.

## The change

Delete the gate and the plain loop. `denseReencodeLoopCached_correct` takes **only**
`d.CoveredBy reg` — no coherence condition relating the threaded state to `d` — so which loop runs
was already a pure runtime decision and **no new proof obligation arises**. `denseReencodeLoop`,
`denseReencodeStep`, `denseBuildReencode`, `denseBuildUseIdx`, `denseReencodeUseNext`,
`denseDegPreReject` and `DenseReencodeUseIdx` go with it, along with their correctness lemmas
(`denseBuildReencode_props`, `denseReencodeStep_correct`, `denseReencodeLoop_correct`, …), and
`useIdx` disappears as a parameter throughout. Net −289 lines.

The cached step's covered-set lookup loses its non-indexed branch in the same commit, and that part
is not optional — see the negative result below.

## Measurements

Two binaries side by side, variants interleaved per APC, **3 repetitions**, means reported;
within-pair spread under 3.5 % on every cell. Eleven passes recorded, not just `reencode`.

| APC | reencode | | pipeline total | |
|---|---:|---:|---:|---:|
| `openvm-eth/apc_005_pc0x32ab5c` | 1275 → **614 ms** | **2.08×** | 3061 → 2374 ms | **1.29×** |
| `openvm-eth/apc_006_pc0x26b740` | 358 → **191 ms** | **1.88×** | 1835 → 1646 ms | **1.11×** |
| `wasm-eth/apc_036_pc0x224240` | 756 → 700 ms | 1.08× | 13481 → 13405 ms | 1.01× |
| `keccak/apc_001_pckeccak` | 563 → 499 ms | 1.13× | 12887 → 12726 ms | 1.01× |

`sha256/apc_001_pcsha256` is **neutral**: reencode 30037/30225 → 30261/30697 ms, total
181171/182832 → 181854/184041 ms (two runs each; the base pair alone spreads 0.6–0.9 %). Expected —
at 199740 constraints both gates were already satisfied, so its early cycles already ran the cached
loop; only the tail, once the system drops below 8192, is new.

The other ten passes (`domainBatch`, `domainFold`, `busPairCancel`, `busUnify`, `flagFold`, `gauss`,
`carryBranch`, `rootPairUnify`, `normalize1`, `intervalForce`) all stayed inside their own
run-to-run spread on all four APCs.

## Negative result

Dropping the gate while leaving `useIdx` on its 8192 threshold — the obvious first attempt —
**regresses the large cases**:

| APC | reencode |  |
|---|---:|---:|
| `openvm-eth/apc_005` | 1259 → 555 ms | 2.27× |
| `openvm-eth/apc_006` | 353 → 211 ms | 1.67× |
| `wasm-eth/apc_036` | 759 → **973 ms** | **0.78×** |
| `keccak/apc_001` | 563 → **929 ms** | **0.61×** |

Cause: with `useIdx = false` the cached step took `arrCs.toList.zipIdx.foldr …`, materialising a
whole-system `List (DenseExpr × Nat)` **per candidate group**, against the plain step's
allocation-free `arrCs.foldr`. That branch was dead under the old gate, so it had never been
optimised. Removing it is why this PR is a win on both regimes.

(Those numbers come from a prototype that also carried three unrelated micro-fixes, so they are not
directly comparable to the table above; the sign and the mechanism are the point.)

## Verification

* `lake build` — clean, no errors or warnings.
* `./Scripts/check-proof-integrity.sh` — passes; the three correctness theorems still rest only on
  `propext`, `Classical.choice`, `Quot.sound`; no unused theorems (4862 reachable constants).
* Repo-wide `@[csimp]` effectiveness audit — 42 pairs checked, 0 ineffective.
* **Effectiveness identical**: `apc-optimizer run` reports the same vars/constraints/bus on 18 APCs
  (`openvm-eth` ×10, `wasm-eth` ×7, `keccak/apc_001`) plus `sha256/apc_001`
  (11906 vars / 3194 constraints / 10498 bus, both sides).

## Follow-ups this profile identified (not in this PR)

Post-merge the top of the list becomes `denseReencodeOut`'s read-only gates, the certificate, and
the degree pre-gate. Concretely: `denseCoveredBy` tests `hasVar` before `varsInF` and the `hasVar`
descent is redundant (22 % vs 10 % of `denseBuildReencode` on wasm); `hasConstFoldableNode`
re-descends via `hasVar` at every node, making it O(nodes × depth) on left-nested trees (19.4 % +
8.3 % of `denseReencodeOut`); and the freshness walk rebuilds `Std.HashSet.ofList bits` **per
constraint** (visible in `denseCheckReencodeFast___lam__4`, while the bus-side lambda already takes
it as a parameter). A prototype of those three measured a further 1.10–1.11× on the openvm-eth cases
and 1.13× on sha256 — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)