### PR TITLE
perf: cut two per-item recomputations out of reencode (reencode 1.15x on the openvm-eth family, 1.13x on sha256; effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFold.lean
@@ -36,6 +36,40 @@ def DenseExpr.hasConstFoldableNode : DenseExpr p → Bool
   | .add a b => !(DenseExpr.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
   | .mul a b => !(DenseExpr.mul a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
 
+/-- `(hasVar, hasConstFoldableNode)` in one walk. The plain `hasConstFoldableNode` re-runs `hasVar`
+    over the subtree at every node, so it is O(nodes × depth) on the left-nested trees
+    `DenseLinExpr.toExpr` produces. -/
+def DenseExpr.hvFold : DenseExpr p → Bool × Bool
+  | .const _ => (false, false)
+  | .var _ => (true, false)
+  | .add a b =>
+      let ra := a.hvFold
+      let rb := b.hvFold
+      let v := ra.1 || rb.1
+      (v, !v || ra.2 || rb.2)
+  | .mul a b =>
+      let ra := a.hvFold
+      let rb := b.hvFold
+      let v := ra.1 || rb.1
+      (v, !v || ra.2 || rb.2)
+
+theorem DenseExpr.hvFold_eq (e : DenseExpr p) :
+    e.hvFold = (e.hasVar, e.hasConstFoldableNode) := by
+  induction e with
+  | const n => rfl
+  | var y => rfl
+  | add a b iha ihb =>
+      simp only [DenseExpr.hvFold, iha, ihb, DenseExpr.hasVar, DenseExpr.hasConstFoldableNode]
+  | mul a b iha ihb =>
+      simp only [DenseExpr.hvFold, iha, ihb, DenseExpr.hasVar, DenseExpr.hasConstFoldableNode]
+
+def DenseExpr.hasConstFoldableNodeFast (e : DenseExpr p) : Bool := e.hvFold.2
+
+@[csimp] theorem DenseExpr.hasConstFoldableNode_eq_fast :
+    @DenseExpr.hasConstFoldableNode = @DenseExpr.hasConstFoldableNodeFast := by
+  funext p e
+  rw [DenseExpr.hasConstFoldableNodeFast, DenseExpr.hvFold_eq]
+
 /-! ## Dense `findDomainAlg`, `coveredBy`, `coveredCsOf` -/
 
 /-- Find `i`'s finite domain: the roots (`denseRootsIn`) of the first constraint mentioning `i`

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -340,6 +340,14 @@ theorem denseFreshFused_eq (d : DenseConstraintSystem p) (bits : List VarId) :
     exact ⟨fun c hc b hb => (h b hb).1 c hc, fun bi hbi =>
       ⟨fun b hb => ((h b hb).2 bi hbi).1, fun e he b hb => ((h b hb).2 bi hbi).2 e he⟩⟩
 
+/-- Freshness against a prebuilt bit set. The set is a parameter of the function that *contains*
+    the walks, so it is built once per certificate rather than once per item (a `let` in the caller
+    would be zeta-expanded straight back into the `all` bodies). -/
+def denseFreshAgainst (s : Std.HashSet VarId) (d : DenseConstraintSystem p) : Bool :=
+  d.algebraicConstraints.all (fun c => !c.mentionsAny s) &&
+    d.busInteractions.all (fun bi =>
+      !bi.multiplicity.mentionsAny s && bi.payload.all (fun e => !e.mentionsAny s))
+
 /-- `denseCheckReencode` with the covered set shared between the domain and soundness conjuncts
     and the freshness conjunct decided in one system walk. -/
 def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
@@ -362,14 +370,11 @@ def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
           = denseEnvOfFast s x)))) &&
     patts.all (fun aβ => es.all (fun c =>
       decide ((c.substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ) = 0))) &&
-    (d.algebraicConstraints.all (fun c => !c.mentionsAny (Std.HashSet.ofList bits)) &&
-      d.busInteractions.all (fun bi =>
-        !bi.multiplicity.mentionsAny (Std.HashSet.ofList bits) &&
-        bi.payload.all (fun e => !e.mentionsAny (Std.HashSet.ofList bits))))
+    denseFreshAgainst (Std.HashSet.ofList bits) d
 
 @[csimp] theorem denseCheckReencode_eq_fast : @denseCheckReencode = @denseCheckReencodeFast := by
   funext q d xs bits hm
-  unfold denseCheckReencode denseCheckReencodeFast
+  unfold denseCheckReencode denseCheckReencodeFast denseFreshAgainst
   simp only [denseFreshFused_eq]
 
 /-! ## Derived-variable methods for the fresh bits


### PR DESCRIPTION
Follow-up to #229. Two per-item recomputations on reencode's hot paths, both output-identical by
construction (`@[csimp]`). One commit each so either can be dropped on its own.

## Commit 1 — `hasVar` and `hasConstFoldableNode` in one walk

```lean
| .add a b => !(DenseExpr.add a b).hasVar || a.hasConstFoldableNode || b.hasConstFoldableNode
```

`(DenseExpr.add a b).hasVar` is a fresh walk over the subtree rooted at the current node, and the
recursion into both children repeats it — O(nodes × depth). The trees are left-nested
(`DenseLinExpr.toExpr` folds with `foldl (.add acc …)`), so depth is size. In the pass-isolated
`openvm-eth/apc_005` profile the pair accounts for **19.4 % + 8.3 % of `denseReencodeOut`**, the
largest phase, where the predicate is the read-only gate applied to every item of the system on
every accepted group. It is also the gate in `DomainFoldRuntime.lean`, so `domainFold` sees it.

`DenseExpr.hvFold` returns both flags in a single pass; `hvFold_eq` proves it equal to the pair by
structural induction. Leaf cases compile to static closed constants and the composite case reuses the
child cell when exclusive, so the `Bool × Bool` costs little — the measurement below is the check on
that.

## Commit 2 — build the certificate's bit set once, not once per item

`denseCheckReencodeFast`'s freshness conjunct wrote `Std.HashSet.ofList bits` *inside* the `all`
bodies. The generated C showed it plainly — `denseCheckReencodeFast___lam__4`, the per-constraint
lambda, opened with `…insertManyIfNewUnit…(bits, …)` and closed with `lean_dec_ref` on the set it had
just built, while the bus-side lambda already received the set as a parameter. So the set was rebuilt
once per algebraic constraint of the whole system, per certificate evaluation. The set machinery
(`insertIfNew`, `instHashableVarId_hash`, `AssocList.contains`, `lean_copy_expand_array`) is ~15 % of
`denseCheckReencode`.

A `let` in the caller does not fix this — it is zeta-expanded back into the loop bodies — so the set
has to be a parameter of the function that *contains* the walks (`OptimizationAnalysisProcess.md`
§6.3.3). That is `denseFreshAgainst`. `denseFreshFused_eq` already proves the conjunct equal to the
specification's per-bit form, so the existing `@[csimp]` proof needed only the new name in its
`unfold`.

## Measurements

Three binaries side by side (`main`, +commit 1, +commit 2), interleaved per APC, **3 repetitions**,
means reported. Cumulative factors vs `main`. Sixteen passes recorded.

| APC | `reencode` main | +c1 | | +c2 | | total main | total +c2 | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `openvm-eth/apc_005_pc0x32ab5c` | 614 ms | 565 | 1.09× | **533** | **1.15×** | 2424 ms | 2311 | 1.05× |
| `openvm-eth/apc_006_pc0x26b740` | 191 ms | 182 | 1.05× | **173** | **1.11×** | 1679 ms | 1638 | 1.03× |
| `wasm-eth/apc_012_pc0x09097C` | 436 ms | 416 | 1.05× | 419 | 1.04× | 16579 ms | 16605 | 1.00× |
| `wasm-eth/apc_036_pc0x224240` | 710 ms | 696 | 1.02× | 706 | 1.01× | 13564 ms | 13569 | 1.00× |
| `keccak/apc_001_pckeccak` | 507 ms | 505 | 1.00× | 499 | 1.02× | 12963 ms | 12823 | 1.01× |

`sha256/apc_001_pcsha256`, the worst absolute case (reencode is 30 s of 182 s), two runs each:
reencode 30543 / 29995 → **26572 / 26933 ms = 1.13×**; total 183019 / 182394 → 178300 / 179017 ms
= 1.02×. `domainBatch` and `domainFold` there are flat (19555/19343 → 19346/19533 and
4785/4790 → 4793/4791).

Both commits are worth roughly the same on `openvm-eth/apc_005` (1.09× then a further 1.06×) and
the win concentrates where the certificate and the system rewrite actually run — i.e. where accepts
are frequent. On `wasm`/`keccak`, accepts are rare and both phases are ~2 % of the pass, so the
measured 1.01–1.04× is about what is available.

**Non-target columns.** `domainBatch` on the two large wasm cases reads 0.98× / 0.97×. I do not
believe that is these commits: bisecting a third binary put the same wobble on a *different* variant
in an earlier run of the same matrix (there `main` → +R2 was 0.97× and +commit 1 restored it), so it
flips sign between runs and does not track the code. Neither commit touches domainBatch's path —
commit 2 is confined to `denseCheckReencodeFast`. Reading it as ±3 % between-binary layout noise,
which the within-run spread metric (1.2 %) does not capture. Flagging it rather than burying it; CI's
own numbers are a useful second opinion.

## Negative result: the `denseCoveredBy` conjunct order, dropped

The analysis behind #229 also identified `denseCoveredBy xs c = c.hasVar && c.varsInF xs` as a
wasted walk: on a non-covered constraint `hasVar` descends to the first variable and `varsInF` then
descends to the same leaf and refutes there, so the `hasVar` half is redundant. Inside
`denseBuildReencode` the two split 22.0 % / 10.3 % of the phase. I implemented it
(`denseCoveredByFast`, `@[csimp]` = `Bool.and_comm`) and measured it as a third commit:

| APC | `reencode` main | + conjunct swap |
|---|---:|---:|
| `openvm-eth/apc_005` | 603 ms | 601 (1.00×) |
| `openvm-eth/apc_006` | 193 ms | 195 (0.99×) |
| `wasm-eth/apc_036` | 710 ms | 708 (1.00×) |
| `wasm-eth/apc_012` | 422 ms | 429 (0.98×) |
| `keccak/apc_001` | 503 ms | 505 (1.00×) |

Null, with `domainBatch` down 1–3 % across all five. **Its evidence had expired.** That 22 % / 10 %
split was measured on the pre-#229 binary, where the plain loop's `denseBuildReencode` scanned the
whole `arrCs` per candidate group. #229 deleted that path; the covered-set lookup now goes through
`denseCoveredIdxPos` over the pruned bucket index and visits far fewer positions, so the redundant
`hasVar` walk is no longer hot enough to matter. Dropped rather than shipped as dead weight — worth
recording so nobody re-derives it from the same profile.

## Verification

* `lake build` — clean, no errors or warnings.
* `./Scripts/check-proof-integrity.sh` — passes; the three correctness theorems still rest only on
  `propext`, `Classical.choice`, `Quot.sound`; no unused theorems (4851 reachable constants).
* Repo-wide `@[csimp]` effectiveness audit — 42 pairs, 0 ineffective. Confirmed in the generated C
  that all 9 gate sites in `Reencode.c` and both in `DomainFoldRuntime.c` reach
  `hasConstFoldableNodeFast`, and that `Std.HashSet.ofList bits` is now built once in
  `denseCheckReencodeFast` instead of inside the per-item lambdas.
* **Effectiveness identical**: `apc-optimizer run` reports the same vars/constraints/bus on 18 APCs
  (`openvm-eth` ×10, `wasm-eth` ×7, `keccak/apc_001`) plus `sha256/apc_001`
  (11906 vars / 3194 constraints / 10498 bus, both sides).

## Still open from the same analysis

`denseReencodeOut`'s gates and `denseCheckReencode` are still the top two phases on the small cases.
The remaining items there are structural rather than local: the certificate re-derives the covered
set, the domains and the survivor list that the construction step already computed; the degree
pre-gate builds each rewritten expression only to read `.degree` off it, and `denseReencodeOut` then
builds the same rewrites again on accept; and `ro.withinDegreeB` is a whole-system degree walk that a
threaded "`d` is within bound" invariant would reduce to the changed items. Those need re-profiling
against this branch first — the lesson above is that phase shares do not survive a change of caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)