### PR TITLE
perf: decide reencode's degree gate while rewriting instead of walking the output again (reencode 1.15x on sha256, 1.12x on openvm-eth; effectiveness identical)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1368,11 +1368,14 @@ theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound)
       rfl
     have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
       hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
+    have hro : ro.1 = denseReencodeOut d xs bits hm := denseReencodeOutOk_fst b d xs bits hm
     refine ⟨hbext, hbii, ?_, ?_, ?_⟩
-    · exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov)
+    · rw [hro]
+      exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov)
         hbval hpolyVars
     · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
-    · exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB
+    · rw [hro]
+      exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB
         hbnInput hD
   all_goals first
     | exact stepIdentityPostC reg reg d bs (VarRegistry.Extends.refl reg)
@@ -1459,7 +1462,8 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
           useBis := denseCovBuild denseBIVars d.busInteractions
           arrBis := d.busInteractions.toArray
           foldCs := d.algebraicConstraints.zipIdx.foldl
-            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
+            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+          dWithin := false }
         d.algebraicConstraints.length d.busInteractions.length hcov
     exact ⟨he, hc, hd, hcorr⟩
   · rw [if_neg hpr]

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -532,6 +532,201 @@ theorem denseReencodeOut_eq_fast : @denseReencodeOut = @denseReencodeOutFast := 
   simp only [denseReencodeOut, denseReencodeOutFast, denseBIRewriteGate_eq,
     denseGroupRewriteGate_eq]
 
+/-! ### The rewrite fused with its degree gate
+
+`denseReencodeStepCached` needs the rewritten system *and* `withinDegreeB` on it. Measured
+separately those are two whole-system walks — the gate walk and a `DenseExpr.degree` walk over every
+item of the output — and the second is redundant: the gate leaves most items untouched, and an
+untouched item's degree is whatever it was in the input. So when the input system is already within
+the bound, only the items the gate rewrote (and the fresh booleanity constraints) need measuring.
+`denseMapOk` carries the resulting `Bool` alongside the mapped list in one tail-recursive pass;
+`denseReencodeOutOk_snd` is where the input-within-bound side condition is discharged. -/
+
+/-- The read-only gate, paired with the degree test of the item it produced (`true` when it fires on
+    nothing — see the section note). -/
+def denseGateDeg (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) : DenseExpr p × Bool :=
+  if e.sharesVarIn xs || e.hasConstFoldableNode then
+    let e' := denseGroupRewrite xs bits σfn patts e
+    (e', decide (e'.degree ≤ dmax))
+  else (e, true)
+
+theorem denseGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) :
+    (denseGateDeg dmax xs bits σfn patts e).1 = denseGroupRewrite xs bits σfn patts e := by
+  unfold denseGateDeg
+  split
+  · rfl
+  · next h =>
+      rw [Bool.or_eq_true, not_or, Bool.not_eq_true, Bool.not_eq_true] at h
+      exact (denseGroupRewrite_eq_self h.1 h.2).symm
+
+/-- Per-interaction gate paired with the degree test of the interaction it produced. -/
+def denseBIGateDeg (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
+    BusInteraction (DenseExpr p) × Bool :=
+  if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
+      || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
+    let bi' : BusInteraction (DenseExpr p) :=
+      { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
+                payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
+    (bi', decide (bi'.multiplicity.degree ≤ dmax) &&
+      bi'.payload.all (fun e => decide (e.degree ≤ dmax)))
+  else (bi, true)
+
+theorem denseBIGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
+    (denseBIGateDeg dmax xs bits σfn patts bi).1 = denseBIRewriteGate xs bits σfn patts bi := by
+  unfold denseBIGateDeg denseBIRewriteGate
+  split <;> rfl
+
+/-- The constraint side: the gated rewrite of `l` reversed onto `acc`, with `ok` accumulating the
+    degree test of only the items the gate rewrote. Specialised rather than expressed through a
+    generic `α → β × Bool` map so the traversal allocates no per-item pair. -/
+def denseGateCsGo (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    List (DenseExpr p) → List (DenseExpr p) → Bool → List (DenseExpr p) × Bool
+  | [], acc, ok => (acc.reverse, ok)
+  | e :: rest, acc, ok =>
+      if e.sharesVarIn xs || e.hasConstFoldableNode then
+        let e' := denseGroupRewrite xs bits σfn patts e
+        denseGateCsGo dmax xs bits σfn patts rest (e' :: acc) (ok && decide (e'.degree ≤ dmax))
+      else denseGateCsGo dmax xs bits σfn patts rest (e :: acc) ok
+
+theorem denseGateCsGo_eq (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    ∀ (l acc : List (DenseExpr p)) (ok : Bool),
+      denseGateCsGo dmax xs bits σfn patts l acc ok
+        = (acc.reverse ++ l.map (fun e => (denseGateDeg dmax xs bits σfn patts e).1),
+           ok && l.all (fun e => (denseGateDeg dmax xs bits σfn patts e).2)) := by
+  intro l
+  induction l with
+  | nil => intro acc ok; simp [denseGateCsGo]
+  | cons e rest ih =>
+      intro acc ok
+      rw [denseGateCsGo]
+      split
+      · next h =>
+          rw [ih]
+          simp only [List.map_cons, List.all_cons, denseGateDeg, if_pos h,
+            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append, Bool.and_assoc]
+      · next h =>
+          rw [ih]
+          simp only [List.map_cons, List.all_cons, denseGateDeg, if_neg h,
+            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append,
+            Bool.true_and]
+
+/-- The bus side of `denseGateCsGo`. -/
+def denseGateBisGo (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    List (BusInteraction (DenseExpr p)) → List (BusInteraction (DenseExpr p)) → Bool →
+      List (BusInteraction (DenseExpr p)) × Bool
+  | [], acc, ok => (acc.reverse, ok)
+  | bi :: rest, acc, ok =>
+      if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
+          || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
+        let bi' : BusInteraction (DenseExpr p) :=
+          { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
+                    payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
+        denseGateBisGo dmax xs bits σfn patts rest (bi' :: acc)
+          (ok && (decide (bi'.multiplicity.degree ≤ dmax) &&
+            bi'.payload.all (fun e => decide (e.degree ≤ dmax))))
+      else denseGateBisGo dmax xs bits σfn patts rest (bi :: acc) ok
+
+theorem denseGateBisGo_eq (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    ∀ (l acc : List (BusInteraction (DenseExpr p))) (ok : Bool),
+      denseGateBisGo dmax xs bits σfn patts l acc ok
+        = (acc.reverse ++ l.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1),
+           ok && l.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) := by
+  intro l
+  induction l with
+  | nil => intro acc ok; simp [denseGateBisGo]
+  | cons bi rest ih =>
+      intro acc ok
+      rw [denseGateBisGo]
+      split
+      · next h =>
+          rw [ih]
+          simp only [List.map_cons, List.all_cons, denseBIGateDeg, if_pos h,
+            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append, Bool.and_assoc]
+      · next h =>
+          rw [ih]
+          simp only [List.map_cons, List.all_cons, denseBIGateDeg, if_neg h,
+            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append,
+            Bool.true_and]
+
+/-- `denseReencodeOut` together with `withinDegreeB` on its result. The `Bool` is only valid for an
+    input system that is itself within the bound (`denseReencodeOutOk_snd`); the caller keeps that
+    as an invariant (`DenseReencodeCacheState.dWithin`). -/
+def denseReencodeOutOk (b : DegreeBound) (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : DenseConstraintSystem p × Bool :=
+  let σfn := denseGroupSubst xs hm
+  let patts := denseAssignments (denseBitBox bits)
+  let rc := denseGateCsGo b.identities xs bits σfn patts
+    (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)) [] true
+  let rb := denseGateBisGo b.busInteractions xs bits σfn patts d.busInteractions [] true
+  let bools := bits.map denseBoolConstraint
+  ({ algebraicConstraints := rc.1 ++ bools, busInteractions := rb.1 },
+    (rc.2 && bools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
+
+theorem denseReencodeOutOk_fst (b : DegreeBound) (d : DenseConstraintSystem p)
+    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) :
+    (denseReencodeOutOk b d xs bits hm).1 = denseReencodeOut d xs bits hm := by
+  unfold denseReencodeOutOk denseReencodeOut
+  simp only [denseGateCsGo_eq, denseGateBisGo_eq, List.reverse_nil, List.nil_append,
+    denseGateDeg_fst, denseBIGateDeg_fst, denseBIRewriteGate_eq]
+
+/-- Two lists' `all` agree when the predicates agree pointwise on the members. -/
+theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
+    (h : ∀ x ∈ l, f x = g x) : l.all f = l.all g := by
+  induction l with
+  | nil => rfl
+  | cons x rest ih =>
+      rw [List.all_cons, List.all_cons, h x List.mem_cons_self,
+        ih (fun y hy => h y (List.mem_cons_of_mem x hy))]
+
+theorem denseReencodeOutOk_snd (b : DegreeBound) (d : DenseConstraintSystem p)
+    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p))
+    (hd : d.withinDegreeB b = true) :
+    (denseReencodeOutOk b d xs bits hm).2 = (denseReencodeOut d xs bits hm).withinDegreeB b := by
+  rw [DenseConstraintSystem.withinDegreeB, Bool.and_eq_true] at hd
+  obtain ⟨hdc, hdb⟩ := hd
+  rw [List.all_eq_true] at hdc hdb
+  rw [← denseReencodeOutOk_fst b d xs bits hm]
+  unfold denseReencodeOutOk DenseConstraintSystem.withinDegreeB
+  simp only [denseGateCsGo_eq, denseGateBisGo_eq, List.reverse_nil, List.nil_append,
+    Bool.true_and, List.all_append, List.all_map, Function.comp_def]
+  -- the constraint side: an item the gate left alone is a member of `d`, so `hdc` bounds it
+  have hcs : (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).all
+        (fun e => (denseGateDeg b.identities xs bits (denseGroupSubst xs hm)
+          (denseAssignments (denseBitBox bits)) e).2)
+      = (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).all
+        (fun e => decide ((denseGateDeg b.identities xs bits (denseGroupSubst xs hm)
+          (denseAssignments (denseBitBox bits)) e).1.degree ≤ b.identities)) := by
+    refine List.all_congr_mem _ _ _ (fun e he => ?_)
+    have hmem : e ∈ d.algebraicConstraints := List.mem_of_mem_filter he
+    unfold denseGateDeg
+    split
+    · rfl
+    · exact (hdc e hmem).symm
+  -- the bus side, the same argument per interaction
+  have hbs : d.busInteractions.all
+        (fun bi => (denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
+          (denseAssignments (denseBitBox bits)) bi).2)
+      = d.busInteractions.all (fun bi =>
+          decide ((denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
+            (denseAssignments (denseBitBox bits)) bi).1.multiplicity.degree ≤ b.busInteractions) &&
+          (denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
+            (denseAssignments (denseBitBox bits)) bi).1.payload.all
+              (fun e => decide (e.degree ≤ b.busInteractions))) := by
+    refine List.all_congr_mem _ _ _ (fun bi hbi => ?_)
+    unfold denseBIGateDeg
+    split
+    · rfl
+    · exact (hdb bi hbi).symm
+  rw [hcs, hbs]
+
 /-! ## The build/step/loop/pass layer -/
 
 inductive DenseReencodeRootPlan (p : ℕ)
@@ -714,6 +909,14 @@ structure DenseReencodeCacheState (p : ℕ) where
   useBis : DenseCovIndex
   arrBis : Array (BusInteraction (DenseExpr p))
   foldCs : Std.HashSet Nat
+  /-- Whether `d` is *known* to be within the degree bound — the side condition that makes
+      `denseReencodeOutOk`'s fused degree test agree with measuring the rewritten system outright
+      (`denseReencodeOutOk_snd`). Starts `false`, so the first candidate to reach the gate measures
+      the rewritten system the plain way; from the first accept on it is `true`, since an accepted
+      `ro` passed the gate and becomes the new `d`. Deliberately not seeded with
+      `d.withinDegreeB b`: that walk would be charged to every APC, including the ones where no
+      candidate is ever accepted. -/
+  dWithin : Bool
 
 /-- Apply an accepted rewrite to the threaded state in place, mirroring `denseReencodeOut` on the
     stable-position arrays: only positions holding a group variable (bucket candidates) or a
@@ -762,7 +965,7 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
                     (HashedDedup.hashedDedup (hash ·) (denseBIVars bi')) i }
       else st
     else st) st
-  { st with varSet := bits.foldl (·.insert ·) st.varSet }
+  { st with varSet := bits.foldl (·.insert ·) st.varSet, dWithin := true }
 
 /-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
     gates in order, minting fresh bits and rewriting `d` only on full acceptance; the threaded
@@ -788,9 +991,9 @@ def denseReencodeStepCached (b : DegreeBound)
     if xs.all (fun x => decide (x ∉ bits)) then
     if bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
     if denseCheckReencode d xs bits hm then
-      let ro := denseReencodeOut d xs bits hm
-      if ro.withinDegreeB b then
-        (reg1, ro,
+      let ro := denseReencodeOutOk b d xs bits hm
+      if (if state.dWithin then ro.2 else ro.1.withinDegreeB b) then
+        (reg1, ro.1,
          bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
          denseReencodeStateUpdate state xs bits hm)
       else (reg1, d, [], state)
@@ -799,6 +1002,33 @@ def denseReencodeStepCached (b : DegreeBound)
     else (reg1, d, [], state)
     else (reg1, d, [], state)
   else (reg, d, [], state)
+
+/-- The `dWithin` invariant is preserved by a step, which is what makes the fused degree gate above
+    decide exactly what `(denseReencodeOut d xs bits hm).withinDegreeB b` decides
+    (`denseReencodeOutOk_snd`): the flag is only ever set on the accept path, and there the accepted
+    system passed the gate, and it starts `false`, so every step of the loop sees a valid flag.
+
+    Unreachable from the correctness roots by design: the degree bound is enforced *outside* the
+    pass, by `guardAll` in `Implementation/Optimizer.lean`, so this internal gate decides which
+    candidates are accepted — behaviour, not soundness. -/
+theorem denseReencodeStepCached_dWithin (b : DegreeBound) (reg : VarRegistry)
+    (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p) (xs : List VarId)
+    (freshBase : String) (hdw : state.dWithin = true → d.withinDegreeB b = true) :
+    (denseReencodeStepCached b reg d state xs freshBase).2.2.2.dWithin = true →
+      (denseReencodeStepCached b reg d state xs freshBase).2.1.withinDegreeB b = true := by
+  fun_cases denseReencodeStepCached b reg d state xs freshBase
+  case case4 =>
+    rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
+    intro _
+    show ro.1.withinDegreeB b = true
+    by_cases hsw : state1.dWithin = true
+    · rw [if_pos hsw] at hwd
+      rw [denseReencodeOutOk_fst b d xs bits hm,
+        ← denseReencodeOutOk_snd b d xs bits hm (hdw hsw)]
+      exact hwd
+    · rw [if_neg hsw] at hwd
+      exact hwd
+  all_goals exact hdw
 
 /-- `d`'s item counts for the fresh-name prefix, re-read only after a step that rewrote `d`
     (a step derives one method per minted bit, so nonempty derivations mark exactly the accepts). -/
@@ -853,7 +1083,8 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         useBis := denseCovBuild denseBIVars d.busInteractions
         arrBis := d.busInteractions.toArray
         foldCs := d.algebraicConstraints.zipIdx.foldl
-          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅ }
+          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        dWithin := false }
       d.algebraicConstraints.length d.busInteractions.length
   else (reg, d, [])
 

--- a/Scripts/unused-theorems.txt
+++ b/Scripts/unused-theorems.txt
@@ -22,3 +22,15 @@ ApcOptimizer.SP1.sp1Optimizer_maintainsCorrectness
 # `(Task.spawn f).get = f ()`, used in `denseCollectForcedV_eq_serial` (Proofs/DomainBatch.lean);
 # `Task.get` is opaque, so the `simp only` needs the lemma even though it rewrites by `rfl`.
 ApcOptimizer.Dense.get_spawn
+
+# The `dWithin` invariant behind `denseReencodeStepCached`'s fused degree gate (Reencode.lean).
+# `denseReencodeOutOk_snd` says the fused gate decides exactly what
+# `(denseReencodeOut …).withinDegreeB b` decides, given a within-bound input;
+# `denseReencodeStepCached_dWithin` says the flag tracking that side condition is preserved by every
+# step. They guarantee the pass's *output* is unchanged, which no correctness root can reach: the
+# degree bound is enforced outside the pass by `guardAll` (`Implementation/Optimizer.lean`), so the
+# internal gate chooses which candidates are accepted rather than establishing soundness. Deleting
+# them would leave that invariant unchecked.
+ApcOptimizer.Dense.denseReencodeStepCached_dWithin
+ApcOptimizer.Dense.denseReencodeOutOk_snd
+ApcOptimizer.Dense.List.all_congr_mem


### PR DESCRIPTION
Re-profiled `reencode` on `main` after #229 first, because the target had moved. Regenerated
`openvm-profile.csv` / `ranked_passes.md` over all 202 APCs at `f340de3`:

| | `ac143f8` | `main` |
|---|---:|---:|
| reencode corpus | 44.67 s | **39.32 s** (1.14× from #229) |
| max (`sha256/apc_001`) | 29.01 s | 29.73 s (**1.00×** — #229 did nothing there) |
| rank | 1 (84.5) | 1 (84.1); `domainBatch` now 81.9 |

**`sha256/apc_001` alone is now 75.6 % of the pass corpus**; inputs ≥ 8192 constraints are 83.5 %,
the 195 smaller APCs 16.5 %. The `openvm-eth` family #229 targeted dropped from 40–53 % of its APC's
runtime to ~25 %. So this PR is measured on sha256 first and the small cases second.

## What the profile said

LBR, samples charged to the innermost reencode phase frame (sha256 profiled directly, 77 235
samples; `openvm-eth/apc_036_pc0x32b1d4` with `APC_REPEAT_N=25`, isolation 0.89):

| phase | sha256 | openvm-eth/apc_036 |
|---|---:|---:|
| `denseReencodeOut` + gates | 32.2 % | 40.6 % |
| `denseCheckReencode` | 23.2 % | 25.5 % |
| `withinDegreeB` | **22.7 %** | 9.5 % |

Both regimes now agree — #229 removed the phases that made them differ. Caller attribution splits
the `withinDegreeB` row **51.7 % reencode's own `ro.withinDegreeB b` gate / 48.3 % the pipeline's
`guardAll`/`DenseVerifiedPassW.guardDegree` walk over reencode's output**, which `denseApplyTimed`
charges to the pass. This PR addresses the first half only. 71 % of the phase is `DenseExpr.degree`.

## The change

The internal gate is a whole-system degree walk run once per candidate that passes the certificate,
and it is nearly all redundant: `denseReencodeOut`'s read-only gate leaves most items untouched, and
an untouched item's degree is whatever it was in the input. So when the input system is already
within the bound, only the items the gate rewrote — plus the fresh booleanity constraints, of degree
2 — need measuring. `denseReencodeOutOk` produces the rewritten system and that verdict in the
traversal that was already happening.

Correctness is untouched: `denseReencodeOutOk_fst` returns the same system unconditionally, and the
proofs continue to reason about `denseReencodeOut`. What needs guarding is *output identity*, and
that is proven too:

* `denseReencodeOutOk_snd` — the fused verdict equals `(denseReencodeOut d xs bits hm).withinDegreeB b`
  for a within-bound input.
* `denseReencodeStepCached_dWithin` — the flag tracking that side condition
  (`DenseReencodeCacheState.dWithin`) is preserved by every step.

Both are registered in `Scripts/unused-theorems.txt` with a reason: they guarantee the pass's output
is unchanged, which no correctness root reaches, because the degree bound is enforced *outside* the
pass by `guardAll` — reencode's internal gate chooses which candidates are accepted rather than
establishing soundness. Without the ignore entry the linter would have had me delete the one thing
that checks this invariant.

## Measurements

Two binaries side by side, interleaved per APC, 3 repetitions (2 for sha256), spreads ≤ 5.4 %.
Sixteen passes recorded.

| APC | reencode | | pipeline total |
|---|---:|---:|---:|
| `sha256/apc_001_pcsha256` | 30101 → **26162 ms** | **1.15×** | 1.02× |
| `openvm-eth/apc_036_pc0x32b1d4` | 606 → **542 ms** | **1.12×** | 1.03× |
| `openvm-eth/apc_006_pc0x26b740` | 192 → **181 ms** | **1.06×** | 1.01× |
| `wasm-eth/apc_036_pc0x224240` | 703 → 705 ms | 1.00× | 1.01× |
| `wasm-eth/apc_012_pc0x09097C` | 429 → 433 ms | 0.99× | 1.00× |
| `keccak/apc_001_pckeccak` | 502 → 511 ms | 0.98× | 1.00× |

Corpus estimate **39.32 → ~35.0 s, 1.12× on the pass**, comparable to #229's 1.14×. Re-profiled after
the change, reencode's own gate is **0.24 %** of the pass on sha256, down from 11.7 % — the whole of
its target.

`keccak/apc_001` reads 0.98× at 2.0 % spread, just outside noise; the two wasm cases are flat. Those
are the APCs where accepts are rare, so the fused gate has little to save and the residue is the
extra branch. Flagging rather than hiding it. No other recorded pass moved outside its own spread.

## Two things the measurements decided

* **A generic `α → β × Bool` map cost more than it saved.** It allocates one pair per item; on a
  199 740-constraint system that ate most of the win — 1.145× against 1.16× for hand-written
  traversals. `denseGateCsGo` / `denseGateBisGo` are written out and allocate nothing per item.
* **Do not seed `dWithin` with `d.withinDegreeB b`.** That charges one whole-system degree walk per
  pass application to every APC, including those where no candidate is ever accepted — measured
  0.97–0.99× on `wasm-eth/apc_012` and `keccak/apc_001`. Starting from `false` makes the first
  candidate to reach the gate measure the plain way and costs nothing elsewhere, since an accept sets
  the flag and the accepted system becomes the new `d`.

## A prediction I got wrong

I sized this at 1.29× from the 22.7 % phase share. It is 1.15×, and the reason is the caller split
above: my phase script treats `withinDegreeB` as a phase marker, and the pipeline's guard reaches it
with no reencode frame on the stack, so guard samples from *every* pass landed in reencode's
`withinDegree` row. The real internal-gate share was 11.7 %, and 1/(1−0.117) = 1.13× — which the
measurement matches. A phase marker naming a function also called from outside the pass is a trap.

## Verification

* `lake build` — clean, no errors or warnings.
* `./Scripts/check-proof-integrity.sh` — passes; correctness theorems still on `propext`,
  `Classical.choice`, `Quot.sound`; no unused theorems (4861 reachable constants, 4 ignored).
* Repo-wide `@[csimp]` audit — 41 pairs, 0 ineffective.
* **Effectiveness identical**: same vars/constraints/bus on 20 APCs (`openvm-eth` ×12,
  `wasm-eth` ×7, `keccak/apc_001`) plus `sha256/apc_001` (11906 / 3194 / 10498 on both sides).

## Next, and one thing deliberately not done

`denseReencodeOut` is now **36.9 %** of the pass on sha256 (same absolute cost over a smaller total),
73.5 % of it read-only gates, and `denseCheckReencode` 26.6 %. Those are the next two items — the
first needs an index-completeness invariant threaded through the cached loop, which is why it did not
come first.

Separately: the pipeline's `guardDegree` walk measures **9.2 % of the whole sha256 run** (~17 s of
180 s), spread over all ~40 passes. For reencode it is redundant — the pass returns either a system it
has already tested or its input unchanged — but acting on that means letting a pass carry its own
`respectsDeg` proof, i.e. changing `Pass.lean`, which is off-limits framework glue. Recorded in the
analysis notes as an observation only, so nobody chases it inside the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)