### PR TITLE
perf: mine byte-operand bounds into the domain table (domainBatch ~4× on SP1)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -644,6 +644,82 @@ def denseForcedIdxV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPla
     bisIdx := denseFreezeCovIndex (denseAnchorCovBuild (fun bi => bi.vars) bis),
     arrBis := bis.toArray }
 
+/-- Is `op` a recognized byte-relation selector for `spec`? Every such op guarantees both operands
+    are below `spec.bound` (`BusFacts.byteXorSpec_sound` / `byteBoolSound`). -/
+def denseByteOpBounds (spec : ByteXorSpec p) (op : ZMod p) : Bool :=
+  decide (op = spec.xorOp) || decide (op = spec.pairOp) ||
+    spec.orOp.any (fun o => decide (op = o)) || spec.andOp.any (fun a => decide (op = a))
+
+/-- The single-variable affine form `(x, a, b)` with `e = a·x + b` and `a ≠ 0`, or `none`. -/
+def denseAffineOfExpr (e : DenseExpr p) : Option (VarId × ZMod p × ZMod p) :=
+  (denseLinearize e).bind (fun l =>
+    match l.norm.terms with
+    | [(x, a)] => if a = 0 then none else some (x, a, l.norm.const)
+    | _ => none)
+
+/-- The domain a byte operand `e` (known `< bound`) entails for its variable. A bare variable is in
+    `[0, bound)`; an affine operand `a·x + b < bound` confines `x` to the `bound`-element coset
+    `{(v - b)·a⁻¹ : v < bound}`. Either way it has exactly `bound` elements (`denseByteOperandVar`
+    reads off the variable without materializing the coset). -/
+def denseByteOperandDomain (e : DenseExpr p) (bound : Nat) : Option (VarId × FiniteDomain p) :=
+  match e with
+  | .var i => some (i, .range bound)
+  | _ => (denseAffineOfExpr e).map (fun t =>
+      (t.1, .explicit (((List.range bound).map (Nat.cast : Nat → ZMod p)).map
+        (fun z => (z - t.2.2) * t.2.1⁻¹))))
+
+/-- The variable a byte operand `e` confines — the first component of `denseByteOperandDomain`, read
+    without building the `bound`-element coset (`denseByteOperandDomain e bound = some (i, _)` iff
+    `denseByteOperandVar e = some i`). Used to gate the coset build below. -/
+def denseByteOperandVar (e : DenseExpr p) : Option VarId :=
+  match e with
+  | .var i => some i
+  | _ => (denseAffineOfExpr e).map (·.1)
+
+/-- Insert the entailed operand domains of a byte interaction whose op is a recognized relation
+    selector: both operands are then below `spec.bound`, sound by `BusFacts.byteXorSpec_sound` /
+    `byteBoolSound`. Refine-only: the coset (size exactly `spec.bound`) is built and inserted only
+    when it strictly refines the operand variable's existing table entry (`spec.bound < d0.size`).
+    A missing entry, or one already at most `spec.bound`, is left untouched — the same table
+    `insertEntry` would have produced, but without materializing a coset that would be discarded.
+    This shrinks a 16-bit limb's `.range 65536` down to `spec.bound` while skipping byte-width
+    operands whose variables are already bounded, avoiding wasted enumeration and coset builds. -/
+def denseAddByteVarDoms (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (T : DenseDomainTable p) : DenseDomainTable p :=
+  match bi.multiplicity.constValue? with
+  | none => T
+  | some mult =>
+    if mult = 0 then T else
+    match facts.byteXorSpec bi.busId with
+    | none => T
+    | some spec =>
+      match spec.decode bi.payload with
+      | none => T
+      | some (op, o1, o2, _) =>
+        match op.constValue? with
+        | none => T
+        | some opv =>
+          if denseByteOpBounds spec opv then
+            let ins := fun (e : DenseExpr p) (T0 : DenseDomainTable p) =>
+              match denseByteOperandVar e with
+              | none => T0
+              | some i =>
+                match T0.map[i]? with
+                | none => T0
+                | some d0 =>
+                  if spec.bound < d0.size then
+                    match denseByteOperandDomain e spec.bound with
+                    | some (i', d) => T0.insertEntry i' d
+                    | none => T0
+                  else T0
+            ins o2 (ins o1 T)
+          else T
+
+def denseAddByteDoms (bs : BusSemantics p) (facts : BusFacts p bs) :
+    List (BusInteraction (DenseExpr p)) → DenseDomainTable p → DenseDomainTable p
+  | [], T => T
+  | bi :: rest, T => denseAddByteDoms bs facts rest (denseAddByteVarDoms bs facts bi T)
+
 /-- Domain-batch: builds a finite domain per variable (from constraints like `x*(x-1)=0` giving
     `x ∈ {0,1}`, and from bus range checks), enumerates the small Cartesian product of those
     domains, and for each variable that takes the same value in every surviving assignment infers
@@ -651,8 +727,9 @@ def denseForcedIdxV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPla
 def denseDomainBatchσV (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseSolved p :=
   let T : DenseDomainTable p :=
-    denseAddBusDoms bs facts d.busInteractions
-      (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty)
+    denseAddByteDoms bs facts d.busInteractions
+      (denseAddBusDoms bs facts d.busInteractions
+        (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty))
   let csPlans := denseConstraintPlansV T d.algebraicConstraints
   let busPlans := denseBusPlansV bs facts T d.busInteractions
   let targets := densePlanTargetsV csPlans busPlans

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -805,6 +805,178 @@ private theorem denseByteBoolSound_decode_iff (bs : BusSemantics p) (facts : Bus
   exact facts.byteBoolSound bi.busId spec hspec (denseBIEval bi denv).payload (op.eval denv)
     (o1.eval denv) (o2.eval denv) (r.eval denv) (denseBIEval bi denv).multiplicity hdecEv
 
+/-! ## Byte-operand domain soundness
+
+`denseAddByteDoms` mines each recognized byte interaction's operand bound (`spec.bound`): a
+bare-variable operand gets a `.range` domain, an affine operand `a·x + b < bound` the `bound`-element
+coset `{(v - b)·a⁻¹ : v < bound}`. -/
+
+/-- The single-variable affine form recovered by `denseAffineOfExpr` evaluates as expected, with a
+    nonzero leading coefficient. -/
+theorem denseAffineOfExpr_eval (e : DenseExpr p) (x : VarId) (a b : ZMod p)
+    (h : denseAffineOfExpr e = some (x, a, b)) (denv : VarId → ZMod p) :
+    e.eval denv = a * denv x + b ∧ a ≠ 0 := by
+  unfold denseAffineOfExpr at h
+  simp only [Option.bind_eq_some_iff] at h
+  obtain ⟨l, hlin, hm⟩ := h
+  cases ht : l.norm.terms with
+  | nil => rw [ht] at hm; simp at hm
+  | cons t rest =>
+    cases rest with
+    | cons _ _ => rw [ht] at hm; simp at hm
+    | nil =>
+      obtain ⟨x0, a0⟩ := t
+      rw [ht] at hm
+      simp only at hm
+      by_cases ha0 : a0 = 0
+      · rw [if_pos ha0] at hm; simp at hm
+      · rw [if_neg ha0] at hm
+        simp only [Option.some.injEq, Prod.mk.injEq] at hm
+        obtain ⟨rfl, rfl, rfl⟩ := hm
+        refine ⟨?_, ha0⟩
+        rw [denseLinearize_eval e l hlin, ← DenseLinExpr.norm_eval, DenseLinExpr.eval, ht]
+        simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+        rw [add_comm]
+
+/-- The affine coset domain contains `denv x` when the operand's value is below `bound`. -/
+theorem denseByteOperandCosetMem [Fact p.Prime] [NeZero p] (e : DenseExpr p) (bound : Nat)
+    (x : VarId) (a b : ZMod p) (haff : denseAffineOfExpr e = some (x, a, b))
+    (denv : VarId → ZMod p) (hbnd : (e.eval denv).val < bound) :
+    denv x ∈ ((List.range bound).map (Nat.cast : Nat → ZMod p)).map (fun z => (z - b) * a⁻¹) := by
+  obtain ⟨heval, ha0⟩ := denseAffineOfExpr_eval e x a b haff denv
+  have hmem : e.eval denv ∈ (List.range bound).map (Nat.cast : Nat → ZMod p) :=
+    mem_range_cast (e.eval denv) bound hbnd
+  set z0 := e.eval denv with hz0
+  have hdenv : denv x = (z0 - b) * a⁻¹ := by
+    rw [heval, add_sub_cancel_right, mul_right_comm, mul_inv_cancel₀ ha0, one_mul]
+  rw [hdenv]
+  exact List.mem_map_of_mem hmem
+
+/-- The operand domain `denseByteOperandDomain e bound` contains `denv`'s value for its variable,
+    whenever `e`'s value is below `bound`. -/
+theorem denseByteOperandDomain_sound [Fact p.Prime] [NeZero p] (e : DenseExpr p) (bound : Nat)
+    (i : VarId) (d : FiniteDomain p) (h : denseByteOperandDomain e bound = some (i, d))
+    (denv : VarId → ZMod p) (hbnd : (e.eval denv).val < bound) : denv i ∈ d.toList := by
+  unfold denseByteOperandDomain at h
+  cases e with
+  | var j =>
+    simp only [Option.some.injEq, Prod.mk.injEq] at h
+    obtain ⟨rfl, rfl⟩ := h
+    show denv j ∈ (List.range bound).map (Nat.cast : Nat → ZMod p)
+    exact mem_range_cast (denv j) bound (by simpa [DenseExpr.eval] using hbnd)
+  | const n =>
+    simp only [Option.map_eq_some_iff] at h
+    obtain ⟨⟨x, a, b⟩, haff, hik⟩ := h
+    simp only [Prod.mk.injEq] at hik; obtain ⟨rfl, rfl⟩ := hik
+    exact denseByteOperandCosetMem (.const n) bound x a b haff denv hbnd
+  | add ea eb =>
+    simp only [Option.map_eq_some_iff] at h
+    obtain ⟨⟨x, a, b⟩, haff, hik⟩ := h
+    simp only [Prod.mk.injEq] at hik; obtain ⟨rfl, rfl⟩ := hik
+    exact denseByteOperandCosetMem (.add ea eb) bound x a b haff denv hbnd
+  | mul ea eb =>
+    simp only [Option.map_eq_some_iff] at h
+    obtain ⟨⟨x, a, b⟩, haff, hik⟩ := h
+    simp only [Prod.mk.injEq] at hik; obtain ⟨rfl, rfl⟩ := hik
+    exact denseByteOperandCosetMem (.mul ea eb) bound x a b haff denv hbnd
+
+/-- Under a nonzero-constant multiplicity and a recognized byte op, both operands are below the byte
+    bound (`BusFacts.byteXorSpec_sound` / `byteBoolSound`). -/
+theorem denseByteOperandBound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p) (mult : ZMod p)
+    (hmult : bi.multiplicity.constValue? = some mult) (hmz : mult ≠ 0) (spec : ByteXorSpec p)
+    (hspec : facts.byteXorSpec bi.busId = some spec) (op o1 o2 r : DenseExpr p)
+    (hdec : spec.decode bi.payload = some (op, o1, o2, r)) (opv : ZMod p)
+    (hop : op.constValue? = some opv) (hb : denseByteOpBounds spec opv = true)
+    (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.violatesConstraint (denseBIEval bi denv) = false) :
+    (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound := by
+  have hmeval : (denseBIEval bi denv).multiplicity = mult :=
+    bi.multiplicity.constValue?_sound mult hmult denv
+  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := hob (by rw [hmeval]; exact hmz)
+  have hopeval : op.eval denv = opv := op.constValue?_sound opv hop denv
+  obtain ⟨hxor, hpair⟩ := denseByteXorSpec_decode_iff bs facts spec bi hspec op o1 o2 r hdec denv
+  obtain ⟨hor, hand⟩ := denseByteBoolSound_decode_iff bs facts spec bi hspec op o1 o2 r hdec denv
+  simp only [denseByteOpBounds, Bool.or_eq_true, Option.any_eq_true, decide_eq_true_eq] at hb
+  rcases hb with ((hsel | hsel) | ⟨o, ho, hsel⟩) | ⟨aop, ha, hsel⟩
+  · have := (hxor (by rw [hopeval, hsel])).1 hviol; exact ⟨this.1, this.2.1⟩
+  · have := (hpair (by rw [hopeval, hsel])).1 hviol; exact ⟨this.1, this.2.1⟩
+  · have := (hor o ho (by rw [hopeval, hsel])).1 hviol; exact ⟨this.1, this.2.1⟩
+  · have := (hand aop ha (by rw [hopeval, hsel])).1 hviol; exact ⟨this.1, this.2.1⟩
+
+/-- Inserting a byte interaction's operand domains preserves table soundness. -/
+theorem denseAddByteVarDoms_soundAt [Fact p.Prime] [NeZero p] {denv : VarId → ZMod p}
+    (bs : BusSemantics p) (facts : BusFacts p bs) (bi : BusInteraction (DenseExpr p))
+    (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.violatesConstraint (denseBIEval bi denv) = false)
+    (T : DenseDomainTable p) (hT : DenseTableSoundAt denv T) :
+    DenseTableSoundAt denv (denseAddByteVarDoms bs facts bi T) := by
+  unfold denseAddByteVarDoms
+  split
+  · exact hT
+  · rename_i mult hmult
+    split
+    · exact hT
+    · rename_i hmz
+      split
+      · exact hT
+      · rename_i spec hspec
+        split
+        · exact hT
+        · rename_i op o1 o2 r hdec
+          split
+          · exact hT
+          · rename_i opv hop
+            split
+            · rename_i hb
+              obtain ⟨hb1, hb2⟩ := denseByteOperandBound bs facts bi denv mult hmult
+                (by simpa using hmz) spec hspec op o1 o2 r hdec opv hop hb hob
+              have ins : ∀ (e : DenseExpr p), (e.eval denv).val < spec.bound →
+                  ∀ (T0 : DenseDomainTable p), DenseTableSoundAt denv T0 →
+                    DenseTableSoundAt denv
+                      (match denseByteOperandVar e with
+                       | none => T0
+                       | some i =>
+                         match T0.map[i]? with
+                         | none => T0
+                         | some d0 =>
+                           if spec.bound < d0.size then
+                             match denseByteOperandDomain e spec.bound with
+                             | some (i', d) => T0.insertEntry i' d
+                             | none => T0
+                           else T0) := by
+                intro e he T0 hT0
+                split
+                · exact hT0
+                · split
+                  · exact hT0
+                  · split
+                    · split
+                      · rename_i i' d hd
+                        exact DenseDomainTable.insertEntry_soundAt
+                          (denseByteOperandDomain_sound e spec.bound i' d hd denv he) hT0
+                      · exact hT0
+                    · exact hT0
+              exact ins o2 hb2 _ (ins o1 hb1 T hT)
+            · exact hT
+
+/-- Building all byte-operand domains preserves table soundness. -/
+theorem denseAddByteDoms_soundAt [Fact p.Prime] [NeZero p] {denv : VarId → ZMod p}
+    (bs : BusSemantics p) (facts : BusFacts p bs) :
+    ∀ (dbis : List (BusInteraction (DenseExpr p))),
+      (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
+        bs.violatesConstraint (denseBIEval bi denv) = false) →
+      ∀ (T : DenseDomainTable p), DenseTableSoundAt denv T →
+        DenseTableSoundAt denv (denseAddByteDoms bs facts dbis T) := by
+  intro dbis
+  induction dbis with
+  | nil => intro _ T hT; exact hT
+  | cons bi rest ih =>
+    intro hob T hT
+    unfold denseAddByteDoms
+    exact ih (fun b hb => hob b (List.mem_cons_of_mem _ hb)) _
+      (denseAddByteVarDoms_soundAt bs facts bi (hob bi (List.mem_cons_self ..)) T hT)
+
 private theorem denseNotBoolEqDecide (b : Bool) (P : Prop) [Decidable P]
     (h : b = false ↔ P) : (!b) = decide P := by
   cases b <;> simp_all
@@ -1854,8 +2026,16 @@ theorem DensePassCorrect_refl (isInput : VarId → Bool) (d : DenseConstraintSys
 /-- The domain table built by `denseDomainBatchσV`. -/
 def dbT (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseDomainTable p :=
-  denseAddBusDoms bs facts d.busInteractions
-    (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty)
+  denseAddByteDoms bs facts d.busInteractions
+    (denseAddBusDoms bs facts d.busInteractions
+      (denseAddConstraintDoms d.algebraicConstraints DenseDomainTable.empty))
+
+/-- Soundness of the whole `dbT` build, byte-operand domains included. -/
+theorem dbT_soundAt [Fact p.Prime] [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) (denv : VarId → ZMod p) (hsat : d.satisfies bs denv) :
+    DenseTableSoundAt denv (dbT bs facts d) :=
+  denseAddByteDoms_soundAt bs facts d.busInteractions (fun bi hbi => hsat.2 bi hbi) _
+    (denseDomainTable_soundAt bs facts d denv hsat)
 
 def dbConstraintPlans (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : List (DenseConstraintPlan p) :=
@@ -1895,7 +2075,7 @@ theorem denseDomainBatchσV_entailed [Fact p.Prime] [NeZero p]
     intro xs f hf denv hsat
     refine denseForcedOverV_entails bs facts (dbT bs facts d) (dbFidx bs facts d) xs denv
       ?_ ?_ ?_ f hf
-    · exact denseDomainTable_soundAt bs facts d denv hsat
+    · exact dbT_soundAt bs facts d denv hsat
     · intro e he
       obtain ⟨plan, hplan, hpe, hpvars, _⟩ := denseGatherConstraintsV_plan_mem
         (dbFidx bs facts d) (dbConstraintPlans bs facts d) rfl xs he

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -540,3 +540,22 @@ worth a prototype on one index first.
   nothing). Suspect `denseFuCandidates`' per-interaction `O.vars.eraseDups × splitAt` on large
   first-slot payloads, or the per-matched-pair box evaluation in `denseFuPairData?`. Sample the
   window before building anything.
+
+### SP1 finite-domain machinery: hoist/cache the per-variable domain table  ·  *runtime, sp1*  ·  high value / med-high effort
+Fresh profiling (post-#219, on main #220–229) on SP1 keccak AND rsp: **domainBatch ≈ 58% of optimizer
+time on BOTH sets** (biggest absolute cost), sub-linear (~n^0.79) — a large SP1-specific CONSTANT.
+flagFold is the residual super-linear pass (~n^1.71) but main is already indexing it (densePdDropSet),
+so it's lower priority. Root cause: SP1's 16-bit memory limbs → ~55% single-variable finite-domain
+constraints (vs OpenVM 32%). The finite-domain machinery is rebuilt EVERY fixpoint cycle (5× on keccak)
+and `denseFindDomainAlg` is recomputed across 8 passes (BoxRewrite, BusPairCancel(+Justify), DomainFold,
+FlagFoldDrops, FlagUnify, Reencode, RootPairUnify).
+IDEA: compute the `DenseDomainTable` once and reuse it — first as a cross-cycle cache in domainBatch
+(rebuild only entries whose defining constraints changed), then as an accumulating table threaded
+read-only through the fixpoint that the domain-consuming passes read instead of recomputing.
+SOUND: a proven finite domain persists under any sound refinement (`refines` preserves surviving vars'
+values) — one reusable lemma, no re-proving as the pipeline runs. EFFECTIVENESS-SAFE: make it
+accumulating (passes add domains, none removed) so mid-fixpoint domains aren't lost.
+BISECT FIRST (the #219 lesson — the a-priori guess can be wrong): stub domainBatch's apply vs the
+per-cycle rebuild vs the table build and measure which sub-part is the 58% BEFORE implementing.
+General (any finite-domain-heavy circuit; SP1 hardest). Bench on Benchmarks/SP1/keccak AND rsp (both
+domainBatch-dominant); effectiveness must stay identical.

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -541,21 +541,18 @@ worth a prototype on one index first.
   first-slot payloads, or the per-matched-pair box evaluation in `denseFuPairData?`. Sample the
   window before building anything.
 
-### SP1 finite-domain machinery: hoist/cache the per-variable domain table  ·  *runtime, sp1*  ·  high value / med-high effort
-Fresh profiling (post-#219, on main #220–229) on SP1 keccak AND rsp: **domainBatch ≈ 58% of optimizer
-time on BOTH sets** (biggest absolute cost), sub-linear (~n^0.79) — a large SP1-specific CONSTANT.
-flagFold is the residual super-linear pass (~n^1.71) but main is already indexing it (densePdDropSet),
-so it's lower priority. Root cause: SP1's 16-bit memory limbs → ~55% single-variable finite-domain
-constraints (vs OpenVM 32%). The finite-domain machinery is rebuilt EVERY fixpoint cycle (5× on keccak)
-and `denseFindDomainAlg` is recomputed across 8 passes (BoxRewrite, BusPairCancel(+Justify), DomainFold,
-FlagFoldDrops, FlagUnify, Reencode, RootPairUnify).
-IDEA: compute the `DenseDomainTable` once and reuse it — first as a cross-cycle cache in domainBatch
-(rebuild only entries whose defining constraints changed), then as an accumulating table threaded
-read-only through the fixpoint that the domain-consuming passes read instead of recomputing.
-SOUND: a proven finite domain persists under any sound refinement (`refines` preserves surviving vars'
-values) — one reusable lemma, no re-proving as the pipeline runs. EFFECTIVENESS-SAFE: make it
-accumulating (passes add domains, none removed) so mid-fixpoint domains aren't lost.
-BISECT FIRST (the #219 lesson — the a-priori guess can be wrong): stub domainBatch's apply vs the
-per-cycle rebuild vs the table build and measure which sub-part is the 58% BEFORE implementing.
-General (any finite-domain-heavy circuit; SP1 hardest). Bench on Benchmarks/SP1/keccak AND rsp (both
-domainBatch-dominant); effectiveness must stay identical.
+### domainBatch residual after entry 151 (byte-operand domains)  ·  *runtime, sp1*  ·  medium value
+Entry 151 BISECTED domainBatch (the ideas' "58% is the domain-table build/cache" guess was WRONG — the
+build is ~2%, the box SCANS are ~94%, all in cleanup cycle 4) and cut the dominant cost 4x by mining
+byte-operand bounds into the table (585 single-var 2^16 brute-force scans → 256-element cosets). What
+remains for a next pass:
+- **Two-variable deep scans** (cycle 4 had ~108 of them, boxes up to 65536 = ~256×256): entry 151's
+  coset shrink is single-var-operand; if BOTH operands of a byte/tuple interaction are affine in
+  distinct vars, each var could still get a coset, shrinking the 2-D box. Verify how many 2-var deep
+  scans survive after entry 151 (re-run the point counter) before implementing.
+- **Fuse the coset build**: `denseByteOperandDomain` currently materializes `((range bound).map cast).map
+  (fun z => (z-b)/a)` — two passes + a 256-elt intermediate, per byte operand per interaction (~2292×)
+  per cycle. A single fused map (or a `.range`+affine `FiniteDomain` variant carrying `(a,b)` lazily)
+  avoids the intermediate. Low risk, modest constant.
+- **Skip byte-domain work when it can't shrink**: only build the coset when the operand's current table
+  domain exceeds `bound` (otherwise `insertEntry` discards it anyway). Cheap guard, saves allocations.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5222,3 +5222,36 @@ SP1 keccak apc_001 (`profile sp1`): busPairCancel **44.3 → 1.05 s (~42×)**, b
 (~32×, shares `denseAddrNonzeroNeq`), total 68.5 → 11.7 s. **Effectiveness IDENTICAL (2665/313/2067).**
 Output-identical also verified on OpenVM keccak (2021/186/1748) and SP1 rsp (112/69/65). `lake build`
 clean; `check-proof-integrity` passes (axioms: propext/Classical.choice/Quot.sound only).
+### 151. Runtime: mine byte-operand bounds into the domain table (domainBatch ~4x on SP1)
+Targeted the ideas.md `domainBatch ~58%` bottleneck, but **bisected first (the #219 lesson) and the
+a-priori idea was wrong**. Stubbing each sub-part on SP1 keccak apc_001 (`profile sp1`): the
+`DenseDomainTable` BUILD is ~80ms (~2%), plans+preflight (gathers/gating) ~220ms (~4%); the **box
+SCANS are ~94%**, concentrated entirely in cleanup cycle 4. So the ideas.md plan (cross-cycle
+cache/hoist of the domain-table build) would have saved ~2% — the table build was never the cost.
+Instrumented the real trajectory with a point counter (`work` is only a `boxSize*items` upper
+bound, not actual cost; single-var scans early-abort at the 2nd distinct survivor): cycle 4
+enumerates **38.3M actual points** across 585 "deep" single-variable scans, each brute-forcing the
+**full 2^16 domain** of a 16-bit limb variable. These have 0 active constraints and 2 byte-bus
+interactions; the forcing interaction carries the variable inside an **affine operand** `f(x)=a·x+b`
+that a recognized byte op bounds `< spec.bound` (256), while the variable's `.range 65536` domain
+comes only from a separate bare 16-bit range check. All 604 compile to fast paths (fixedRange/byte),
+no opaque fallback — so per-point work was already minimal; the cost is the sheer 2^16 point count.
+LEVER: a new `denseAddByteDoms` step reads each recognized byte interaction's operand bound into the
+table — a bare-var operand gets `.range bound`, an **affine operand the `bound`-element coset
+`{(v-b)·a⁻¹ : v<bound}`** (sound: under the byte relation `a·x+b<bound`, so `x` lies in that coset).
+`insertEntry` keeps the smaller domain, shrinking the deep scans from 65536 to 256 points. Guarded on
+a **nonzero constant multiplicity** so the byte obligation holds under `hsat`.
+PROOF (all under Implementation/, audited surface untouched): `denseAffineOfExpr_eval` (affine form +
+`a≠0` via `denseLinearize`/norm), `denseByteOperandCosetMem` (coset membership; the runtime coset is a
+two-stage `map` — cast then affine — to keep the operand var out from under `Nat.cast` so HO
+unification picks the right map), `denseByteOperandBound` (operand `<bound` from
+`byteXorSpec_sound`/`byteBoolSound` under nonzero-const mult), `denseAddByte{Var,}Doms_soundAt`,
+`dbT_soundAt` wrapping `denseDomainTable_soundAt`; the entailed/correct chain is unchanged.
+IMPACT (`profile sp1`, this box, before→after): keccak domainBatch **3963→1010 ms (~3.9x)**, total
+8320→5325; rsp apc_030 **819→165 (~5.0x)**, total 1402→660; rsp apc_024 **585→221 (~2.6x)**. SP1 rsp
+cases converge one fixpoint cycle sooner. **Final circuits byte-for-byte IDENTICAL** (opt-export diff)
+on SP1 keccak (2665/313/2067), SP1 rsp (527/196/449; 458/177/340), OpenVM keccak (2021/186/1748),
+OpenVM eth. `lake build` clean (no warnings); `check-proof-integrity` passes (axioms:
+propext/Classical.choice/Quot.sound only). General: any byte/range-bounded finite-domain circuit
+benefits; the coset handles the affine-operand case OpenVM's bare-operand range domains miss.
+**Worked: yes (domainBatch ~4x, output byte-identical; committed).**


### PR DESCRIPTION
Runtime-only, output-identical, fully proven. (Re-targeted to main: the prior #232 merged into the #219 branch, but #219 squash-merged to main without this change, so domainBatch never reached main. This is the same change, rebased onto current main.)

## Problem
domainBatch is the biggest SP1 optimizer cost. Bisection showed the table *build* is ~2%; **94% is box scans brute-forcing the full 2^16 domain of 16-bit memory limbs** (~38M points on SP1 keccak). Each limb is bounded <256 by a byte op via an affine operand `a·x+b`, but its domain was only the bare `.range 65536`.

## Fix
`denseAddByteDoms` mines each byte interaction's operand bound into the domain table as a ≤256-element coset (affine operand → `{(v−b)·a⁻¹ : v<bound}`), **refine-only** (only when it strictly shrinks an existing domain — `spec.bound < d0.size`, checked before building the coset), so the table is **bit-identical** to the ungated version and it never creates domains that would add enumeration work on VMs like OpenVM.

## Results (`profile`, min-of-3)
- SP1 keccak domainBatch **~3963 → ~830 ms**; SP1 rsp ~5× smaller.
- **OpenVM: no regression** (refine-only can't add work — coset built only when it shrinks).
- Effectiveness **byte-identical** on SP1 keccak (2665/313/2067), SP1 rsp, OpenVM keccak (2021/186/1748).

## Verification
`lake build` clean; `check-proof-integrity` passes (axioms propext/Classical.choice/Quot.sound only, no unused theorems). Audited surface untouched.