### PR TITLE
perf: rewrite reencode's accepts in place instead of rebuilding the constraint list (reencode ~1.6x on sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1341,7 +1341,7 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
     (reg : VarRegistry) (w : DenseReencodeWork p) (state : DenseReencodeCacheState p)
     (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
     (hcov : (denseWorkView w).CoveredBy reg)
-    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
+    (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
     (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
     reg.Extends (denseWorkStep b reg w state xs freshBase).1
     ∧ (∀ i, (denseWorkStep b reg w state xs freshBase).1.isInput i = reg.isInput i)
@@ -1372,8 +1372,12 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
     exact hD
   have hview : denseWorkView ro.1
       = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
-          (fun c => !denseIsZero c) :=
-    denseWorkOut_view b w xs bits hm hpos hbools hxsB'
+          (fun c => !denseIsZero c) := by
+    have h := denseWorkOut_view b (denseWorkEnsureBounded w) xs bits hm
+      (denseWorkEnsureBounded_posOk hpos)
+      (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
+      (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
+    rwa [denseWorkEnsureBounded_view] at h
   have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
   have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
     rw [hbii x]
@@ -1404,10 +1408,6 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
       (fun c _ hk => denseIsZero_eval (by simpa using hk))
     simpa using h1.andThen h2
 
-theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
-    DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
-  constructor <;> intro h j c hj <;> simpa using h j c hj
-
 theorem denseBitSetFold_mono (bits : List VarId) :
     ∀ (s : Std.HashSet VarId) (v : VarId), s.contains v = true →
       (bits.foldl (·.insert ·) s).contains v = true := by
@@ -1432,24 +1432,29 @@ theorem denseBitSetFold_mem (bits : List VarId) :
 
 theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
     (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String)
-    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
+    (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
     (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
-    DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
+    ((denseWorkStep b reg w state xs freshBase).2.1.bounded = true →
+      DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
         (denseWorkStep b reg w state xs freshBase).2.1.lastFold
-        (denseWorkStep b reg w state xs freshBase).2.1.cs
+        (denseWorkStep b reg w state xs freshBase).2.1.cs)
     ∧ DenseWorkBoolsOk (denseWorkStep b reg w state xs freshBase).2.1.bitSet
         (denseWorkStep b reg w state xs freshBase).2.1.bools := by
   fun_cases denseWorkStep b reg w state xs freshBase
   all_goals try exact ⟨hpos, hbools⟩
   rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
   refine ⟨?_, ?_⟩
-  · show DenseWorkPosOk _ _ _
+  · intro _
+    show DenseWorkPosOk _ _ _
     rw [densePosOk_from0]
+    set w' := denseWorkEnsureBounded w with hw'
     exact denseWorkSpliceCs_posOk b.identities xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs)
-      w.cs 0 [] w.lastPos w.lastFold true rfl (by intro j c hj; simp at hj)
-      (densePosOk_from0.mp hpos)
-  · show DenseWorkBoolsOk _ _
+      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w'.lastPos w'.lastFold xs)
+      w'.cs 0 [] w'.lastPos w'.lastFold true rfl (by intro j c hj; simp at hj)
+      (densePosOk_from0.mp (denseWorkEnsureBounded_posOk hpos))
+  · show DenseWorkBoolsOk (bits.foldl (·.insert ·) (denseWorkEnsureBounded w).bitSet)
+      ((denseWorkEnsureBounded w).bools ++ bits.map (denseBoolConstraint (p := p)))
+    rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]
     intro c hc
     rcases List.mem_append.mp hc with hc | hc
     · obtain ⟨bb, rfl, hbb⟩ := hbools c hc
@@ -1462,7 +1467,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
     ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (w : DenseReencodeWork p)
       (state : DenseReencodeCacheState p) (nc nb : Nat),
       (denseWorkView w).CoveredBy reg →
-      DenseWorkPosOk w.lastPos w.lastFold w.cs →
+      (w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) →
       DenseWorkBoolsOk w.bitSet w.bools →
       reg.Extends (denseWorkLoop b targets idx reg w state nc nb).1
       ∧ (∀ i, (denseWorkLoop b targets idx reg w state nc nb).1.isInput i = reg.isInput i)
@@ -1532,8 +1537,9 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
     have hseedCov : (denseWorkView (denseWorkSeed d)).CoveredBy reg := by
       rw [denseWorkSeed_view]
       exact denseFilterConstraints_coveredBy hcov
-    have hseedPos : DenseWorkPosOk (denseWorkSeed d).lastPos (denseWorkSeed d).lastFold
-        (denseWorkSeed d).cs := densePosOk_from0.mpr (denseSeed_posOk d.algebraicConstraints 0 ∅ 0)
+    have hseedPos : (denseWorkSeed d).bounded = true →
+        DenseWorkPosOk (denseWorkSeed d).lastPos (denseWorkSeed d).lastFold
+          (denseWorkSeed d).cs := by intro hb; simp [denseWorkSeed] at hb
     have hseedBools : DenseWorkBoolsOk (denseWorkSeed d).bitSet (denseWorkSeed d).bools := by
       intro c hc; simp [denseWorkSeed] at hc
     set st : DenseReencodeCacheState p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1,6 +1,7 @@
 import ApcOptimizer.Implementation.OptimizerPasses.Reencode
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DomainBatch
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.RootPairUnify
+import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DropPasses
 
 set_option autoImplicit false
 
@@ -1330,112 +1331,188 @@ theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry}
   exact this
 
 set_option maxHeartbeats 1000000 in
-theorem denseReencodeStepCached_correct [Fact p.Prime] (b : DegreeBound)
-    (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (xs : List VarId) (freshBase : String) (bs : BusSemantics p) (hcov : d.CoveredBy reg) :
-    reg.Extends (denseReencodeStepCached b reg d state xs freshBase).1
-    ∧ (∀ i, (denseReencodeStepCached b reg d state xs freshBase).1.isInput i
-        = reg.isInput i)
-    ∧ (denseReencodeStepCached b reg d state xs freshBase).2.1.CoveredBy
-        (denseReencodeStepCached b reg d state xs freshBase).1
-    ∧ DenseDerivations.CoveredBy
-        (denseReencodeStepCached b reg d state xs freshBase).1
-        (denseReencodeStepCached b reg d state xs freshBase).2.2.1
-    ∧ DensePassCorrect
-        (denseReencodeStepCached b reg d state xs freshBase).1.isInput d
-        (denseReencodeStepCached b reg d state xs freshBase).2.1
-        (denseReencodeStepCached b reg d state xs freshBase).2.2.1 bs := by
-  fun_cases denseReencodeStepCached b reg d state xs freshBase
-  case case4 =>
-    rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
-    have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
-    have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
-      denseBuildReencodeCached_isInput_of_eq hbeq i
-    have hbval : ∀ bb ∈ bits, reg1.Valid bb :=
-      denseBuildReencodeCached_bits_valid_of_eq hbeq
-    have hpolyVars := denseCheckReencode_polyVars d xs bits hm hD
-    have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
-      rw [hbii x]
-      exact List.all_eq_true.mp hgate x hx
-    have hxsOcc : ∀ x ∈ xs, x ∈ d.occ := denseCheckReencode_xsOcc d xs bits hm hD
-    have hxsB : ∀ x ∈ xs, x ∉ bits := fun x hx =>
-      of_decide_eq_true (List.all_eq_true.mp hB x hx)
-    have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
-      have hpd : (reg1.resolve bb).powdrId? = none :=
-        of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
-      show (reg1.resolve bb).powdrId?.isSome = false
-      rw [hpd]
-      rfl
-    have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
-      hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
-    have hro : ro.1 = denseReencodeOut d xs bits hm := denseReencodeOutOk_fst b d xs bits hm
-    refine ⟨hbext, hbii, ?_, ?_, ?_⟩
-    · rw [hro]
-      exact denseReencodeOut_covered reg1 d xs bits hm (csCoveredBy_mono hbext hcov)
-        hbval hpolyVars
-    · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
-    · rw [hro]
-      exact denseCheckReencode_sound d bs reg1.isInput xs bits hm hxsInput hxsOcc hxsB
-        hbnInput hD
-  all_goals first
-    | exact stepIdentityPostC reg reg d bs (VarRegistry.Extends.refl reg)
-        (fun _ => rfl) hcov
-    | exact stepIdentityPostC reg _ d bs
-        (denseBuildReencodeCached_ext_of_eq (by assumption))
-        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov
+theorem denseFilterConstraints_coveredBy {d : DenseConstraintSystem p} {reg : VarRegistry}
+    {keep : DenseExpr p → Bool} (h : d.CoveredBy reg) :
+    (d.filterConstraints keep).CoveredBy reg :=
+  ⟨fun e he => h.1 e (List.mem_of_mem_filter he), h.2⟩
 
 set_option maxHeartbeats 1000000 in
-theorem denseReencodeLoopCached_correct [Fact p.Prime] (b : DegreeBound)
-    (bs : BusSemantics p) :
-    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (d : DenseConstraintSystem p)
+theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
+    (reg : VarRegistry) (w : DenseReencodeWork p) (state : DenseReencodeCacheState p)
+    (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
+    (hcov : (denseWorkView w).CoveredBy reg)
+    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
+    reg.Extends (denseWorkStep b reg w state xs freshBase).1
+    ∧ (∀ i, (denseWorkStep b reg w state xs freshBase).1.isInput i = reg.isInput i)
+    ∧ (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1).CoveredBy
+        (denseWorkStep b reg w state xs freshBase).1
+    ∧ DenseDerivations.CoveredBy (denseWorkStep b reg w state xs freshBase).1
+        (denseWorkStep b reg w state xs freshBase).2.2.1
+    ∧ DensePassCorrect (denseWorkStep b reg w state xs freshBase).1.isInput (denseWorkView w)
+        (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1)
+        (denseWorkStep b reg w state xs freshBase).2.2.1 bs := by
+  fun_cases denseWorkStep b reg w state xs freshBase
+  all_goals first
+    | exact stepIdentityPostC reg reg (denseWorkView w) bs (VarRegistry.Extends.refl reg)
+        (fun _ => rfl) hcov
+    | exact stepIdentityPostC reg _ (denseWorkView w) bs
+        (denseBuildReencodeCached_ext_of_eq (by assumption))
+        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov
+    | skip
+  rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
+  have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
+  have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
+    denseBuildReencodeCached_isInput_of_eq hbeq i
+  have hbval : ∀ bb ∈ bits, reg1.Valid bb := denseBuildReencodeCached_bits_valid_of_eq hbeq
+  have hxsB' : ∀ x ∈ xs, w.bitSet.contains x = false := by simpa using hbit
+  have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
+  have hchkView : denseCheckReencode (denseWorkView w) xs bits hm = true := by
+    rw [denseWorkView_check hm hbools hxsB' hbitsB']
+    exact hD
+  have hview : denseWorkView ro.1
+      = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
+          (fun c => !denseIsZero c) :=
+    denseWorkOut_view b w xs bits hm hpos hbools hxsB'
+  have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
+  have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
+    rw [hbii x]
+    exact List.all_eq_true.mp hgate x hx
+  have hxsOcc : ∀ x ∈ xs, x ∈ (denseWorkView w).occ :=
+    denseCheckReencode_xsOcc (denseWorkView w) xs bits hm hchkView
+  have hxsBits : ∀ x ∈ xs, x ∉ bits := fun x hx =>
+    of_decide_eq_true (List.all_eq_true.mp hB x hx)
+  have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
+    have hpd : (reg1.resolve bb).powdrId? = none :=
+      of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
+    show (reg1.resolve bb).powdrId?.isSome = false
+    rw [hpd]
+    rfl
+  have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
+    hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
+  refine ⟨hbext, hbii, ?_, ?_, ?_⟩
+  · rw [hview]
+    exact denseFilterConstraints_coveredBy
+      (denseReencodeOut_covered reg1 (denseWorkView w) xs bits hm
+        (csCoveredBy_mono hbext hcov) hbval hpolyVars)
+  · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
+  · rw [hview]
+    have h1 := denseCheckReencode_sound (denseWorkView w) bs reg1.isInput xs bits hm
+      hxsInput hxsOcc hxsBits hbnInput hchkView
+    have h2 := DensePassCorrect.denseFilterConstraintsEntailed
+      (denseReencodeOut (denseWorkView w) xs bits hm) bs reg1.isInput (fun c => !denseIsZero c)
+      (fun c _ hk => denseIsZero_eval (by simpa using hk))
+    simpa using h1.andThen h2
+
+theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
+    DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
+  constructor <;> intro h j c hj <;> simpa using h j c hj
+
+theorem denseBitSetFold_mono (bits : List VarId) :
+    ∀ (s : Std.HashSet VarId) (v : VarId), s.contains v = true →
+      (bits.foldl (·.insert ·) s).contains v = true := by
+  intro s v
+  induction bits generalizing s with
+  | nil => intro h; exact h
+  | cons bb rest ih =>
+      intro h
+      exact ih _ (by simp [Std.HashSet.contains_insert, h])
+
+theorem denseBitSetFold_mem (bits : List VarId) :
+    ∀ (s : Std.HashSet VarId) (v : VarId), v ∈ bits →
+      (bits.foldl (·.insert ·) s).contains v = true := by
+  intro s v
+  induction bits generalizing s with
+  | nil => intro h; simp at h
+  | cons bb rest ih =>
+      intro h
+      rcases List.mem_cons.mp h with rfl | h
+      · exact denseBitSetFold_mono rest _ v (by simp [Std.HashSet.contains_insert])
+      · exact ih _ h
+
+theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
+    (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String)
+    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
+    DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
+        (denseWorkStep b reg w state xs freshBase).2.1.lastFold
+        (denseWorkStep b reg w state xs freshBase).2.1.cs
+    ∧ DenseWorkBoolsOk (denseWorkStep b reg w state xs freshBase).2.1.bitSet
+        (denseWorkStep b reg w state xs freshBase).2.1.bools := by
+  fun_cases denseWorkStep b reg w state xs freshBase
+  all_goals try exact ⟨hpos, hbools⟩
+  rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
+  refine ⟨?_, ?_⟩
+  · show DenseWorkPosOk _ _ _
+    rw [densePosOk_from0]
+    exact denseWorkSpliceCs_posOk b.identities xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs)
+      w.cs 0 [] w.lastPos w.lastFold true rfl (by intro j c hj; simp at hj)
+      (densePosOk_from0.mp hpos)
+  · show DenseWorkBoolsOk _ _
+    intro c hc
+    rcases List.mem_append.mp hc with hc | hc
+    · obtain ⟨bb, rfl, hbb⟩ := hbools c hc
+      exact ⟨bb, rfl, denseBitSetFold_mono bits w.bitSet bb hbb⟩
+    · obtain ⟨bb, hbb, rfl⟩ := List.mem_map.1 hc
+      exact ⟨bb, rfl, denseBitSetFold_mem bits w.bitSet bb hbb⟩
+
+set_option maxHeartbeats 1000000 in
+theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantics p) :
+    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (w : DenseReencodeWork p)
       (state : DenseReencodeCacheState p) (nc nb : Nat),
-      d.CoveredBy reg →
-      reg.Extends (denseReencodeLoopCached b targets idx reg d state nc nb).1
-      ∧ (∀ i, (denseReencodeLoopCached b targets idx reg d state nc nb).1.isInput i
-          = reg.isInput i)
-      ∧ (denseReencodeLoopCached b targets idx reg d state nc nb).2.1.CoveredBy
-          (denseReencodeLoopCached b targets idx reg d state nc nb).1
-      ∧ DenseDerivations.CoveredBy
-          (denseReencodeLoopCached b targets idx reg d state nc nb).1
-          (denseReencodeLoopCached b targets idx reg d state nc nb).2.2
-      ∧ DensePassCorrect
-          (denseReencodeLoopCached b targets idx reg d state nc nb).1.isInput d
-          (denseReencodeLoopCached b targets idx reg d state nc nb).2.1
-          (denseReencodeLoopCached b targets idx reg d state nc nb).2.2 bs := by
+      (denseWorkView w).CoveredBy reg →
+      DenseWorkPosOk w.lastPos w.lastFold w.cs →
+      DenseWorkBoolsOk w.bitSet w.bools →
+      reg.Extends (denseWorkLoop b targets idx reg w state nc nb).1
+      ∧ (∀ i, (denseWorkLoop b targets idx reg w state nc nb).1.isInput i = reg.isInput i)
+      ∧ (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1).CoveredBy
+          (denseWorkLoop b targets idx reg w state nc nb).1
+      ∧ DenseDerivations.CoveredBy (denseWorkLoop b targets idx reg w state nc nb).1
+          (denseWorkLoop b targets idx reg w state nc nb).2.2
+      ∧ DensePassCorrect (denseWorkLoop b targets idx reg w state nc nb).1.isInput
+          (denseWorkView w) (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1)
+          (denseWorkLoop b targets idx reg w state nc nb).2.2 bs := by
   intro targets
   induction targets with
   | nil =>
-      intro idx reg d state nc nb hcov
-      show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i) ∧ d.CoveredBy reg
+      intro idx reg w state nc nb hcov _ _
+      show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i)
+        ∧ (denseWorkView w).CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
-        ∧ DensePassCorrect reg.isInput d d ([] : DenseDerivations p) bs
+        ∧ DensePassCorrect reg.isInput (denseWorkView w) (denseWorkView w)
+            ([] : DenseDerivations p) bs
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
-        (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput d bs⟩
+        (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput (denseWorkView w) bs⟩
   | cons xs rest ih =>
-      intro idx reg d state nc nb hcov
-      simp only [denseReencodeLoopCached]
-      rcases hstep : denseReencodeStepCached b reg d state xs s!"rnc{nc}_{nb}_{idx}"
-          with ⟨reg1, d1, derivs1, state1⟩
-      have hsp := denseReencodeStepCached_correct b reg d state xs
-          s!"rnc{nc}_{nb}_{idx}" bs hcov
-      simp only [hstep] at hsp
+      intro idx reg w state nc nb hcov hpos hbools
+      simp only [denseWorkLoop]
+      rcases hstep : denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
+          with ⟨reg1, w1, derivs1, state1⟩
+      have hsp := denseWorkStep_correct b reg w state xs s!"rnc{nc}_{nb}_{idx}" bs hcov hpos hbools
+      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools
+      simp only [hstep] at hsp hinv
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
-      rcases hrec : denseReencodeLoopCached b rest (idx + 1) reg1 d1 state1
-          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
-          with ⟨reg2, d2, derivs2⟩
-      have hih := ih (idx + 1) reg1 d1 state1
-          (denseReencodeNameCounts derivs1 d1 nc nb).1 (denseReencodeNameCounts derivs1 d1 nc nb).2
-          hs_cov
+      obtain ⟨hi_pos, hi_bools⟩ := hinv
+      rcases hrec : denseWorkLoop b rest (idx + 1) reg1 w1 state1
+          (denseWorkNameCounts derivs1 w1 nc nb).1 (denseWorkNameCounts derivs1 w1 nc nb).2
+          with ⟨reg2, w2, derivs2⟩
+      have hih := ih (idx + 1) reg1 w1 state1
+          (denseWorkNameCounts derivs1 w1 nc nb).1 (denseWorkNameCounts derivs1 w1 nc nb).2
+          hs_cov hi_pos hi_bools
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
       · exact DenseDerivations.coveredBy_append
           (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
       · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
-        have hstepcert : DensePassCorrect reg2.isInput d d1 derivs1 bs := by
-          rw [hfe]
-          exact hs_correct
+        have hstepcert : DensePassCorrect reg2.isInput (denseWorkView w) (denseWorkView w1)
+            derivs1 bs := by rw [hfe]; exact hs_correct
         exact hstepcert.andThen hr_correct
+
+theorem denseWorkSeed_view (d : DenseConstraintSystem p) :
+    denseWorkView (denseWorkSeed d) = d.filterConstraints (fun c => !denseIsZero c) := by
+  simp [denseWorkView, denseWorkSeed, DenseConstraintSystem.filterConstraints]
 
 set_option maxHeartbeats 1000000 in
 theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
@@ -1452,20 +1529,39 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
   · rw [if_pos hpr]
     haveI : Fact p.Prime := ⟨pw.correct hpr⟩
     extract_lets csVs svSet targets
+    have hseedCov : (denseWorkView (denseWorkSeed d)).CoveredBy reg := by
+      rw [denseWorkSeed_view]
+      exact denseFilterConstraints_coveredBy hcov
+    have hseedPos : DenseWorkPosOk (denseWorkSeed d).lastPos (denseWorkSeed d).lastFold
+        (denseWorkSeed d).cs := densePosOk_from0.mpr (denseSeed_posOk d.algebraicConstraints 0 ∅ 0)
+    have hseedBools : DenseWorkBoolsOk (denseWorkSeed d).bitSet (denseWorkSeed d).bools := by
+      intro c hc; simp [denseWorkSeed] at hc
+    set st : DenseReencodeCacheState p :=
+      { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
+        arrCs := d.algebraicConstraints.toArray
+        rootCache := ∅
+        varSet := Std.HashSet.ofList d.occ
+        useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
+        useBis := denseCovBuild denseBIVars d.busInteractions
+        arrBis := d.busInteractions.toArray
+        foldCs := d.algebraicConstraints.zipIdx.foldl
+          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        dWithin := false } with hst
     obtain ⟨he, _, hc, hd, hcorr⟩ :=
-      denseReencodeLoopCached_correct b bs targets 0 reg d
-        { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
-          arrCs := d.algebraicConstraints.toArray
-          rootCache := ∅
-          varSet := Std.HashSet.ofList d.occ
-          useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
-          useBis := denseCovBuild denseBIVars d.busInteractions
-          arrBis := d.busInteractions.toArray
-          foldCs := d.algebraicConstraints.zipIdx.foldl
-            (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
-          dWithin := false }
-        d.algebraicConstraints.length d.busInteractions.length hcov
-    exact ⟨he, hc, hd, hcorr⟩
+      denseWorkLoop_correct b bs targets 0 reg (denseWorkSeed d) st
+        (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
+        hseedCov hseedPos hseedBools
+    refine ⟨he, hc, hd, ?_⟩
+    -- the seed drops trivially-true constraints, itself a verified step
+    have hpre : DensePassCorrect
+        (denseWorkLoop b targets 0 reg (denseWorkSeed d) st
+          (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
+          d.busInteractions.length).1.isInput d (denseWorkView (denseWorkSeed d))
+        ([] : DenseDerivations p) bs := by
+      rw [denseWorkSeed_view]
+      exact DensePassCorrect.denseFilterConstraintsEntailed d bs _
+        (fun c => !denseIsZero c) (fun c _ hk => denseIsZero_eval (by simpa using hk))
+    simpa using hpre.andThen hcorr
   · rw [if_neg hpr]
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -638,6 +638,10 @@ structure DenseReencodeWork (p : ℕ) where
   lastPos : Std.HashMap VarId Nat
   /-- An upper bound on the positions of `cs` carrying a variable-free composite node. -/
   lastFold : Nat
+  /-- Whether `lastPos`/`lastFold` have been computed. They are seeded on the first accept rather than
+      at pass entry (`denseWorkEnsureBounded`): an APC that never accepts would otherwise pay a full
+      variable fold per cleanup cycle for a bound it never consults. -/
+  bounded : Bool
 
 def denseIsZero : DenseExpr p → Bool
   | .const n => n == 0
@@ -1101,7 +1105,8 @@ theorem denseBoolConstraints_not_zero (bits : List VarId) :
 
 
 /-- One accept on the working system: splice the constraints, gate the bus interactions (reusing the
-    fused traversal of `denseGateBisGo`), and accumulate the booleanity constraints. -/
+    fused traversal of `denseGateBisGo`), and accumulate the booleanity constraints. Assumes the
+    position bound is computed — `denseWorkStep` calls `denseWorkEnsureBounded` first. -/
 def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeWork p × Bool :=
   let σfn := denseGroupSubst xs hm
@@ -1112,7 +1117,7 @@ def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List Var
   let newBools := bits.map (denseBoolConstraint (p := p))
   ({ cs := rc.1, bis := rb.1, bools := w.bools ++ newBools,
      bitSet := bits.foldl (·.insert ·) w.bitSet,
-     lastPos := rc.2.1, lastFold := rc.2.2.1 },
+     lastPos := rc.2.1, lastFold := rc.2.2.1, bounded := true },
    (rc.2.2.2 && newBools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
 
 /-- An accept on the working system is `denseReencodeOut` on the view, followed by dropping the
@@ -1567,6 +1572,37 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
     else st) st
   { st with varSet := bits.foldl (·.insert ·) st.varSet, dWithin := true }
 
+theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
+    DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
+  constructor <;> intro h j c hj <;> simpa using h j c hj
+
+/-- Compute the position bound if it has not been computed yet. Called on the accept path only, so a
+    pass application that accepts nothing never walks the variables at all. -/
+def denseWorkEnsureBounded (w : DenseReencodeWork p) : DenseReencodeWork p :=
+  if w.bounded then w
+  else { w with lastPos := denseSeedLp 0 w.cs ∅, lastFold := denseSeedLf 0 w.cs 0, bounded := true }
+
+theorem denseWorkEnsureBounded_view (w : DenseReencodeWork p) :
+    denseWorkView (denseWorkEnsureBounded w) = denseWorkView w := by
+  unfold denseWorkEnsureBounded denseWorkView; split <;> rfl
+
+theorem denseWorkEnsureBounded_bitSet (w : DenseReencodeWork p) :
+    (denseWorkEnsureBounded w).bitSet = w.bitSet := by
+  unfold denseWorkEnsureBounded; split <;> rfl
+
+theorem denseWorkEnsureBounded_bools (w : DenseReencodeWork p) :
+    (denseWorkEnsureBounded w).bools = w.bools := by
+  unfold denseWorkEnsureBounded; split <;> rfl
+
+theorem denseWorkEnsureBounded_posOk {w : DenseReencodeWork p}
+    (h : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) :
+    DenseWorkPosOk (denseWorkEnsureBounded w).lastPos (denseWorkEnsureBounded w).lastFold
+      (denseWorkEnsureBounded w).cs := by
+  unfold denseWorkEnsureBounded
+  split
+  · next hb => exact h hb
+  · exact densePosOk_from0.mpr (denseSeed_posOk w.cs 0 ∅ 0)
+
 /-! ### The step, loop and pass over the working system -/
 
 /-- `d`'s item counts for the fresh-name prefix, read off the working system. -/
@@ -1601,7 +1637,7 @@ def denseWorkStep (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p
     if xs.all (fun x => decide (x ∉ bits)) then
     if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
     if denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm then
-      let ro := denseWorkOut b w xs bits hm
+      let ro := denseWorkOut b (denseWorkEnsureBounded w) xs bits hm
       if (if state.dWithin then ro.2 else (denseWorkView ro.1).withinDegreeB b) then
         (reg1, ro.1,
          bits.map (fun bb => (bb, denseBitCM (denseAssignments (denseBitBox bits)) xs hm bb)),
@@ -1626,8 +1662,7 @@ def denseWorkLoop (b : DegreeBound) :
 
 def denseWorkSeed (d : DenseConstraintSystem p) : DenseReencodeWork p :=
   { cs := d.algebraicConstraints, bis := d.busInteractions, bools := [], bitSet := ∅,
-    lastPos := denseSeedLp 0 d.algebraicConstraints ∅,
-    lastFold := denseSeedLf 0 d.algebraicConstraints 0 }
+    lastPos := ∅, lastFold := 0, bounded := false }
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
     combinations survive, mint `Nat.clog 2 #survivors` fresh boolean bits, rewrite each group

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -542,25 +542,6 @@ the bound, only the items the gate rewrote (and the fresh booleanity constraints
 `denseMapOk` carries the resulting `Bool` alongside the mapped list in one tail-recursive pass;
 `denseReencodeOutOk_snd` is where the input-within-bound side condition is discharged. -/
 
-/-- The read-only gate, paired with the degree test of the item it produced (`true` when it fires on
-    nothing — see the section note). -/
-def denseGateDeg (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) : DenseExpr p × Bool :=
-  if e.sharesVarIn xs || e.hasConstFoldableNode then
-    let e' := denseGroupRewrite xs bits σfn patts e
-    (e', decide (e'.degree ≤ dmax))
-  else (e, true)
-
-theorem denseGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (e : DenseExpr p) :
-    (denseGateDeg dmax xs bits σfn patts e).1 = denseGroupRewrite xs bits σfn patts e := by
-  unfold denseGateDeg
-  split
-  · rfl
-  · next h =>
-      rw [Bool.or_eq_true, not_or, Bool.not_eq_true, Bool.not_eq_true] at h
-      exact (denseGroupRewrite_eq_self h.1 h.2).symm
-
 /-- Per-interaction gate paired with the degree test of the interaction it produced. -/
 def denseBIGateDeg (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
     (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
@@ -580,43 +561,8 @@ theorem denseBIGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId →
   unfold denseBIGateDeg denseBIRewriteGate
   split <;> rfl
 
-/-- The constraint side: the gated rewrite of `l` reversed onto `acc`, with `ok` accumulating the
-    degree test of only the items the gate rewrote. Specialised rather than expressed through a
-    generic `α → β × Bool` map so the traversal allocates no per-item pair. -/
-def denseGateCsGo (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) :
-    List (DenseExpr p) → List (DenseExpr p) → Bool → List (DenseExpr p) × Bool
-  | [], acc, ok => (acc.reverse, ok)
-  | e :: rest, acc, ok =>
-      if e.sharesVarIn xs || e.hasConstFoldableNode then
-        let e' := denseGroupRewrite xs bits σfn patts e
-        denseGateCsGo dmax xs bits σfn patts rest (e' :: acc) (ok && decide (e'.degree ≤ dmax))
-      else denseGateCsGo dmax xs bits σfn patts rest (e :: acc) ok
-
-theorem denseGateCsGo_eq (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) :
-    ∀ (l acc : List (DenseExpr p)) (ok : Bool),
-      denseGateCsGo dmax xs bits σfn patts l acc ok
-        = (acc.reverse ++ l.map (fun e => (denseGateDeg dmax xs bits σfn patts e).1),
-           ok && l.all (fun e => (denseGateDeg dmax xs bits σfn patts e).2)) := by
-  intro l
-  induction l with
-  | nil => intro acc ok; simp [denseGateCsGo]
-  | cons e rest ih =>
-      intro acc ok
-      rw [denseGateCsGo]
-      split
-      · next h =>
-          rw [ih]
-          simp only [List.map_cons, List.all_cons, denseGateDeg, if_pos h,
-            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append, Bool.and_assoc]
-      · next h =>
-          rw [ih]
-          simp only [List.map_cons, List.all_cons, denseGateDeg, if_neg h,
-            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append,
-            Bool.true_and]
-
-/-- The bus side of `denseGateCsGo`. -/
+/-- The bus side of the fused gate: an interaction none of whose expressions can change is kept
+    as-is, and only the ones it rewrites are measured against the degree bound. -/
 def denseGateBisGo (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
     (patts : List (List (VarId × ZMod p))) :
     List (BusInteraction (DenseExpr p)) → List (BusInteraction (DenseExpr p)) → Bool →
@@ -656,27 +602,6 @@ theorem denseGateBisGo_eq (dmax : Nat) (xs bits : List VarId) (σfn : VarId → 
             List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append,
             Bool.true_and]
 
-/-- `denseReencodeOut` together with `withinDegreeB` on its result. The `Bool` is only valid for an
-    input system that is itself within the bound (`denseReencodeOutOk_snd`); the caller keeps that
-    as an invariant (`DenseReencodeCacheState.dWithin`). -/
-def denseReencodeOutOk (b : DegreeBound) (d : DenseConstraintSystem p) (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p)) : DenseConstraintSystem p × Bool :=
-  let σfn := denseGroupSubst xs hm
-  let patts := denseAssignments (denseBitBox bits)
-  let rc := denseGateCsGo b.identities xs bits σfn patts
-    (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)) [] true
-  let rb := denseGateBisGo b.busInteractions xs bits σfn patts d.busInteractions [] true
-  let bools := bits.map denseBoolConstraint
-  ({ algebraicConstraints := rc.1 ++ bools, busInteractions := rb.1 },
-    (rc.2 && bools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
-
-theorem denseReencodeOutOk_fst (b : DegreeBound) (d : DenseConstraintSystem p)
-    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) :
-    (denseReencodeOutOk b d xs bits hm).1 = denseReencodeOut d xs bits hm := by
-  unfold denseReencodeOutOk denseReencodeOut
-  simp only [denseGateCsGo_eq, denseGateBisGo_eq, List.reverse_nil, List.nil_append,
-    denseGateDeg_fst, denseBIGateDeg_fst, denseBIRewriteGate_eq]
-
 /-- Two lists' `all` agree when the predicates agree pointwise on the members. -/
 theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
     (h : ∀ x ∈ l, f x = g x) : l.all f = l.all g := by
@@ -686,46 +611,721 @@ theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
       rw [List.all_cons, List.all_cons, h x List.mem_cons_self,
         ih (fun y hy => h y (List.mem_cons_of_mem x hy))]
 
-theorem denseReencodeOutOk_snd (b : DegreeBound) (d : DenseConstraintSystem p)
-    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p))
-    (hd : d.withinDegreeB b = true) :
-    (denseReencodeOutOk b d xs bits hm).2 = (denseReencodeOut d xs bits hm).withinDegreeB b := by
-  rw [DenseConstraintSystem.withinDegreeB, Bool.and_eq_true] at hd
-  obtain ⟨hdc, hdb⟩ := hd
-  rw [List.all_eq_true] at hdc hdb
-  rw [← denseReencodeOutOk_fst b d xs bits hm]
-  unfold denseReencodeOutOk DenseConstraintSystem.withinDegreeB
-  simp only [denseGateCsGo_eq, denseGateBisGo_eq, List.reverse_nil, List.nil_append,
-    Bool.true_and, List.all_append, List.all_map, Function.comp_def]
-  -- the constraint side: an item the gate left alone is a member of `d`, so `hdc` bounds it
-  have hcs : (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).all
-        (fun e => (denseGateDeg b.identities xs bits (denseGroupSubst xs hm)
-          (denseAssignments (denseBitBox bits)) e).2)
-      = (d.algebraicConstraints.filter (fun c => !denseCoveredBy xs c)).all
-        (fun e => decide ((denseGateDeg b.identities xs bits (denseGroupSubst xs hm)
-          (denseAssignments (denseBitBox bits)) e).1.degree ≤ b.identities)) := by
-    refine List.all_congr_mem _ _ _ (fun e he => ?_)
-    have hmem : e ∈ d.algebraicConstraints := List.mem_of_mem_filter he
-    unfold denseGateDeg
-    split
-    · rfl
-    · exact (hdc e hmem).symm
-  -- the bus side, the same argument per interaction
-  have hbs : d.busInteractions.all
-        (fun bi => (denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
-          (denseAssignments (denseBitBox bits)) bi).2)
-      = d.busInteractions.all (fun bi =>
-          decide ((denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
-            (denseAssignments (denseBitBox bits)) bi).1.multiplicity.degree ≤ b.busInteractions) &&
-          (denseBIGateDeg b.busInteractions xs bits (denseGroupSubst xs hm)
-            (denseAssignments (denseBitBox bits)) bi).1.payload.all
-              (fun e => decide (e.degree ≤ b.busInteractions))) := by
-    refine List.all_congr_mem _ _ _ (fun bi hbi => ?_)
-    unfold denseBIGateDeg
-    split
-    · rfl
-    · exact (hdb bi hbi).symm
-  rw [hcs, hbs]
+/-! ## Deferred materialisation: the loop's working system
+
+`denseReencodeOut` rebuilds the whole constraint list on every accept in order to change a handful of
+items. The working system below avoids that: a dropped constraint becomes `.const 0` in place, so
+positions stay stable; the rewrite rebuilds cons cells only as far as `maxPos`, the last position that
+*could* change, and shares the untouched tail; and the booleanity constraints are accumulated and
+appended once, since appending them per accept would copy the whole spine and destroy that sharing.
+
+`denseWorkView` is the system this represents. It drops the `.const 0` placeholders, so an accept is
+`denseReencodeOut` on the view *followed by* dropping trivially-true constraints
+(`denseWorkOut_view`) — and dropping those is already a verified transformation
+(`DensePassCorrect.denseFilterConstraintsEntailed`), so both halves reuse existing correctness.
+
+`lastPos`/`lastFold` are the bound: `DenseWorkBounded` says nothing past `maxPos` can change, which
+is what licenses sharing the tail. They are maintained monotonically by the splice itself. -/
+
+structure DenseReencodeWork (p : ℕ) where
+  cs : List (DenseExpr p)
+  bis : List (BusInteraction (DenseExpr p))
+  bools : List (DenseExpr p)
+  /-- Every bit minted so far. The step refuses a group meeting one, which is what keeps the
+      accumulated `bools` inert (`denseBoolConstraint_inert`). -/
+  bitSet : Std.HashSet VarId
+  /-- For each variable, an upper bound on the positions of `cs` mentioning it. -/
+  lastPos : Std.HashMap VarId Nat
+  /-- An upper bound on the positions of `cs` carrying a variable-free composite node. -/
+  lastFold : Nat
+
+def denseIsZero : DenseExpr p → Bool
+  | .const n => n == 0
+  | _ => false
+
+def denseWorkView (w : DenseReencodeWork p) : DenseConstraintSystem p :=
+  { algebraicConstraints := w.cs.filter (fun c => !denseIsZero c) ++ w.bools,
+    busInteractions := w.bis }
+
+/-- One position's new content: the placeholder if the group covers it, else the gated rewrite. -/
+def denseTombify (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (c : DenseExpr p) : DenseExpr p :=
+  if denseCoveredBy xs c then .const 0 else denseGroupRewrite xs bits σfn patts c
+
+/-- No position at or past `i + j` beyond `maxPos` can be touched by the rewrite. -/
+def DenseWorkBounded (xs : List VarId) (maxPos i : Nat) (cs : List (DenseExpr p)) : Prop :=
+  ∀ j c, cs[j]? = some c →
+    (denseCoveredBy xs c = true ∨ c.sharesVarIn xs = true ∨ c.hasConstFoldableNode = true) →
+    i + j ≤ maxPos
+
+theorem denseTombify_id_of_untouched {xs bits : List VarId} {σfn : VarId → Option (DenseExpr p)}
+    {patts : List (List (VarId × ZMod p))} :
+    ∀ (l : List (DenseExpr p)),
+      (∀ c ∈ l, denseCoveredBy xs c = false ∧ c.sharesVarIn xs = false ∧
+        c.hasConstFoldableNode = false) →
+      l.map (denseTombify xs bits σfn patts) = l := by
+  intro l
+  induction l with
+  | nil => intro _; rfl
+  | cons c rest ih =>
+      intro h
+      obtain ⟨hcov, hsh, hfd⟩ := h c (List.mem_cons_self ..)
+      have htf : denseTombify xs bits σfn patts c = c := by
+        simp [denseTombify, hcov, denseGroupRewrite_eq_self hsh hfd]
+      rw [List.map_cons, htf, ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+
+/-- Rewrite the prefix through `maxPos`, then share the tail. `lastPos`/`lastFold` are extended for
+    every position the rewrite touches, which keeps `DenseWorkBounded` true for the next group. -/
+def denseWorkSpliceCs (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
+    Nat → List (DenseExpr p) → List (DenseExpr p) → Std.HashMap VarId Nat → Nat → Bool →
+      List (DenseExpr p) × Std.HashMap VarId Nat × Nat × Bool
+  | _, [], acc, lp, lf, ok => (acc.reverse, lp, lf, ok)
+  | i, c :: rest, acc, lp, lf, ok =>
+      if maxPos < i then (acc.reverse ++ (c :: rest), lp, lf, ok)
+      else if denseCoveredBy xs c then
+        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest ((.const 0) :: acc) lp lf ok
+      else if c.sharesVarIn xs || c.hasConstFoldableNode then
+        let c' := denseGroupRewrite xs bits σfn patts c
+        let lp' := c'.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) lp
+        let lf' := if c'.hasConstFoldableNode then max lf i else lf
+        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest (c' :: acc) lp' lf'
+          (ok && decide (c'.degree ≤ dmax))
+      else denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest (c :: acc) lp lf ok
+
+/-- The spliced list is the positionwise `denseTombify` of the input: `maxPos` decides *whether to
+    look*, never *what the answer is*, so boundedness makes the two agree. -/
+theorem denseWorkSpliceCs_list (dmax : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
+    ∀ (l : List (DenseExpr p)) (i : Nat) (acc : List (DenseExpr p)) (lp : Std.HashMap VarId Nat)
+      (lf : Nat) (ok : Bool),
+      DenseWorkBounded xs maxPos i l →
+      (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).1
+        = acc.reverse ++ l.map (denseTombify xs bits σfn patts) := by
+  intro l
+  induction l with
+  | nil => intro i acc lp lf ok _; simp [denseWorkSpliceCs]
+  | cons c rest ih =>
+      intro i acc lp lf ok hb
+      have hrest : DenseWorkBounded xs maxPos (i + 1) rest := by
+        intro j c' hj hgate
+        have := hb (j + 1) c' (by simpa using hj) hgate
+        omega
+      rw [denseWorkSpliceCs]
+      by_cases hmp : maxPos < i
+      · rw [if_pos hmp]
+        have hall : ∀ c' ∈ c :: rest, denseCoveredBy xs c' = false ∧ c'.sharesVarIn xs = false ∧
+            c'.hasConstFoldableNode = false := by
+          intro c' hc'
+          obtain ⟨j, hj⟩ := List.getElem?_of_mem hc'
+          by_contra hcon
+          rw [not_and_or, not_and_or] at hcon
+          have hg : denseCoveredBy xs c' = true ∨ c'.sharesVarIn xs = true ∨
+              c'.hasConstFoldableNode = true := by
+            rcases hcon with h | h
+            · exact Or.inl (by simpa using h)
+            · rcases h with h | h
+              · exact Or.inr (Or.inl (by simpa using h))
+              · exact Or.inr (Or.inr (by simpa using h))
+          exact absurd (hb j c' hj hg) (by omega)
+        rw [denseTombify_id_of_untouched _ hall]
+      · rw [if_neg hmp]
+        by_cases hcov : denseCoveredBy xs c = true
+        · rw [if_pos hcov, ih (i + 1) _ _ _ _ hrest]
+          simp only [List.map_cons, denseTombify, if_pos hcov, List.reverse_cons,
+            List.append_assoc, List.cons_append, List.nil_append]
+        · rw [if_neg hcov]
+          rw [Bool.not_eq_true] at hcov
+          by_cases hg : c.sharesVarIn xs || c.hasConstFoldableNode
+          · rw [if_pos hg, ih (i + 1) _ _ _ _ hrest]
+            have htf : denseTombify xs bits σfn patts c
+                = denseGroupRewrite xs bits σfn patts c := by simp [denseTombify, hcov]
+            simp only [List.map_cons, htf, List.reverse_cons, List.append_assoc,
+              List.cons_append, List.nil_append]
+          · rw [if_neg hg, ih (i + 1) _ _ _ _ hrest]
+            rw [Bool.or_eq_true, not_or, Bool.not_eq_true, Bool.not_eq_true] at hg
+            have htf : denseTombify xs bits σfn patts c = c := by
+              simp [denseTombify, hcov, denseGroupRewrite_eq_self hg.1 hg.2]
+            simp only [List.map_cons, htf, List.reverse_cons, List.append_assoc,
+              List.cons_append, List.nil_append]
+
+theorem denseCoveredBy_const (xs : List VarId) (n : ZMod p) :
+    denseCoveredBy xs (.const n) = false := by
+  simp [denseCoveredBy, DenseExpr.hasVar]
+
+/-- Filtering the placeholders out of the tombified list is the same as dropping the covered items
+    first and rewriting what is left — the step that lets `denseReencodeOut` reappear. -/
+theorem denseTombify_filter (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    ∀ (l : List (DenseExpr p)),
+      ((l.map (denseTombify xs bits σfn patts)).filter (fun c => !denseIsZero c))
+        = (((l.filter (fun c => !denseIsZero c)).filter
+            (fun c => !denseCoveredBy xs c)).map (denseGroupRewrite xs bits σfn patts)).filter
+              (fun c => !denseIsZero c) := by
+  intro l
+  induction l with
+  | nil => rfl
+  | cons c rest ih =>
+      by_cases hz : denseIsZero c = true
+      · -- a placeholder stays a placeholder and is dropped on both sides
+        obtain ⟨n, rfl⟩ : ∃ n, c = (.const n : DenseExpr p) := by
+          cases c with
+          | const n => exact ⟨n, rfl⟩
+          | var _ => simp [denseIsZero] at hz
+          | add _ _ => simp [denseIsZero] at hz
+          | mul _ _ => simp [denseIsZero] at hz
+        have htf : denseTombify xs bits σfn patts (.const n) = (.const n : DenseExpr p) := by
+          simp [denseTombify, denseCoveredBy_const, denseGroupRewrite]
+        rw [List.map_cons, htf, List.filter_cons_of_neg (by simp [hz]),
+          List.filter_cons_of_neg (by simp [hz]), ih]
+      · rw [Bool.not_eq_true] at hz
+        by_cases hcov : denseCoveredBy xs c = true
+        · have htf : denseTombify xs bits σfn patts c = (.const 0 : DenseExpr p) := by
+            simp [denseTombify, hcov]
+          rw [List.map_cons, htf, List.filter_cons_of_neg (by simp [denseIsZero]),
+            List.filter_cons_of_pos (by simp [hz]),
+            List.filter_cons_of_neg (by simp [hcov]), ih]
+        · have hcov' : denseCoveredBy xs c = false := by simpa using hcov
+          have htf : denseTombify xs bits σfn patts c
+              = denseGroupRewrite xs bits σfn patts c := by simp [denseTombify, hcov']
+          by_cases hzr : denseIsZero (denseGroupRewrite xs bits σfn patts c) = true
+          · simp only [List.map_cons, htf, List.filter_cons, hz, hcov', hzr,
+              Bool.not_false, Bool.not_true, if_true]
+            exact ih
+          · rw [Bool.not_eq_true] at hzr
+            simp only [List.map_cons, htf, List.filter_cons, hz, hcov', hzr,
+              Bool.not_false, if_true]
+            rw [ih]
+
+
+/-! ### The position bound
+
+`DenseWorkPosOk` is what makes `maxPos` a bound rather than a guess: it says `lastPos` bounds the
+positions mentioning each variable and `lastFold` bounds the foldable ones. The splice maintains it,
+and `denseWorkBounded_of_posOk` turns it into the `DenseWorkBounded` hypothesis the splice needs. -/
+
+theorem denseSharesVarIn_exists {xs : List VarId} :
+    ∀ {c : DenseExpr p}, c.sharesVarIn xs = true → ∃ v ∈ c.vars, v ∈ xs := by
+  intro c
+  induction c with
+  | const n => intro h; simp [DenseExpr.sharesVarIn] at h
+  | var y =>
+      intro h
+      exact ⟨y, by simp [DenseExpr.vars], denseContainsFast_sound xs y (by
+        simpa [DenseExpr.sharesVarIn] using h)⟩
+  | add a b iha ihb =>
+      intro h
+      rw [DenseExpr.sharesVarIn, Bool.or_eq_true] at h
+      rcases h with h | h
+      · obtain ⟨v, hv, hx⟩ := iha h
+        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
+      · obtain ⟨v, hv, hx⟩ := ihb h
+        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
+  | mul a b iha ihb =>
+      intro h
+      rw [DenseExpr.sharesVarIn, Bool.or_eq_true] at h
+      rcases h with h | h
+      · obtain ⟨v, hv, hx⟩ := iha h
+        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
+      · obtain ⟨v, hv, hx⟩ := ihb h
+        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
+
+/-- A covered constraint has a variable, and all of them lie in the group, so it shares one. -/
+theorem denseCoveredBy_sharesVarIn {xs : List VarId} {c : DenseExpr p}
+    (h : denseCoveredBy xs c = true) : c.sharesVarIn xs = true := by
+  rw [denseCoveredBy, Bool.and_eq_true] at h
+  by_contra hs
+  rw [Bool.not_eq_true] at hs
+  rw [DenseExpr.varsInF_eq_false h.1 hs] at h
+  exact Bool.noConfusion h.2
+
+def DenseWorkPosOk (lp : Std.HashMap VarId Nat) (lf : Nat) (cs : List (DenseExpr p)) : Prop :=
+  ∀ j c, cs[j]? = some c →
+    (∀ v ∈ c.vars, j ≤ lp.getD v 0) ∧ (c.hasConstFoldableNode = true → j ≤ lf)
+
+def denseWorkMaxPos (lp : Std.HashMap VarId Nat) (lf : Nat) (xs : List VarId) : Nat :=
+  xs.foldl (fun m x => max m (lp.getD x 0)) lf
+
+theorem denseWorkMaxPos_ge_lf (lp : Std.HashMap VarId Nat) (lf : Nat) (xs : List VarId) :
+    lf ≤ denseWorkMaxPos lp lf xs := by
+  unfold denseWorkMaxPos
+  suffices h : ∀ (l : List VarId) (acc : Nat), acc ≤ l.foldl (fun m x => max m (lp.getD x 0)) acc by
+    exact h xs lf
+  intro l
+  induction l with
+  | nil => intro acc; exact Nat.le_refl acc
+  | cons y rest ih => intro acc; exact Nat.le_trans (Nat.le_max_left _ _) (ih _)
+
+theorem denseWorkMaxPos_ge_mem {lp : Std.HashMap VarId Nat} {lf : Nat} {xs : List VarId} {v : VarId}
+    (hv : v ∈ xs) : lp.getD v 0 ≤ denseWorkMaxPos lp lf xs := by
+  unfold denseWorkMaxPos
+  suffices h : ∀ (l : List VarId) (acc : Nat), v ∈ l →
+      lp.getD v 0 ≤ l.foldl (fun m x => max m (lp.getD x 0)) acc by
+    exact h xs lf hv
+  intro l
+  induction l with
+  | nil => intro _ h; simp at h
+  | cons y rest ih =>
+      intro acc h
+      rcases List.mem_cons.mp h with rfl | h
+      · exact Nat.le_trans (Nat.le_max_right acc _)
+          (denseWorkMaxPos_ge_lf lp (max acc (lp.getD v 0)) rest)
+      · exact ih _ h
+
+theorem denseWorkBounded_of_posOk {lp : Std.HashMap VarId Nat} {lf : Nat} {xs : List VarId}
+    {cs : List (DenseExpr p)} (h : DenseWorkPosOk lp lf cs) :
+    DenseWorkBounded xs (denseWorkMaxPos lp lf xs) 0 cs := by
+  intro j c hj hgate
+  rw [Nat.zero_add]
+  obtain ⟨hvars, hfold⟩ := h j c hj
+  rcases hgate with hcov | hsh | hfd
+  · obtain ⟨v, hv, hx⟩ := denseSharesVarIn_exists (denseCoveredBy_sharesVarIn hcov)
+    exact Nat.le_trans (hvars v hv) (denseWorkMaxPos_ge_mem hx)
+  · obtain ⟨v, hv, hx⟩ := denseSharesVarIn_exists hsh
+    exact Nat.le_trans (hvars v hv) (denseWorkMaxPos_ge_mem hx)
+  · exact Nat.le_trans (hfold hfd) (denseWorkMaxPos_ge_lf lp lf xs)
+
+
+/-! ### Maintaining the bound
+
+The splice only ever raises `lastPos`/`lastFold`, and raises them at every position it rewrites, so
+`DenseWorkPosOk` survives an accept. `DenseLpLe` is the pointwise order that makes "only raises"
+usable: the already-processed prefix keeps its bound because the map only grew. -/
+
+def DenseLpLe (lp lp' : Std.HashMap VarId Nat) : Prop := ∀ v, lp.getD v 0 ≤ lp'.getD v 0
+
+theorem DenseLpLe.refl (lp : Std.HashMap VarId Nat) : DenseLpLe lp lp := fun _ => Nat.le_refl _
+
+theorem DenseLpLe.trans {a b c : Std.HashMap VarId Nat} (h1 : DenseLpLe a b) (h2 : DenseLpLe b c) :
+    DenseLpLe a c := fun v => Nat.le_trans (h1 v) (h2 v)
+
+theorem denseLpStep_mono (m : Std.HashMap VarId Nat) (v : VarId) (i : Nat) :
+    DenseLpLe m (m.insert v (max (m.getD v 0) i)) := by
+  intro u
+  by_cases h : u = v
+  · subst h
+    rw [Std.HashMap.getD_insert]
+    simp only [beq_self_eq_true, if_true]
+    exact Nat.le_max_left _ _
+  · rw [Std.HashMap.getD_insert, show (v == u) = false from by simpa using (Ne.symm h)]
+    simp
+
+theorem denseLpFold_mono (i : Nat) :
+    ∀ (vs : List VarId) (m : Std.HashMap VarId Nat),
+      DenseLpLe m (vs.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m) := by
+  intro vs
+  induction vs with
+  | nil => intro m; exact DenseLpLe.refl m
+  | cons v rest ih =>
+      intro m
+      exact DenseLpLe.trans (denseLpStep_mono m v i) (ih _)
+
+theorem denseLpFold_ge (i : Nat) :
+    ∀ (vs : List VarId) (m : Std.HashMap VarId Nat) (u : VarId), u ∈ vs →
+      i ≤ (vs.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m).getD u 0 := by
+  intro vs
+  induction vs with
+  | nil => intro _ _ h; simp at h
+  | cons v rest ih =>
+      intro m u h
+      rcases List.mem_cons.mp h with rfl | h
+      · refine Nat.le_trans ?_ (denseLpFold_mono i rest (m.insert u (max (m.getD u 0) i)) u)
+        rw [Std.HashMap.getD_insert]
+        simp only [beq_self_eq_true, if_true]
+        exact Nat.le_max_right _ _
+      · exact ih _ u h
+
+def DenseWorkPosOkFrom (off : Nat) (lp : Std.HashMap VarId Nat) (lf : Nat)
+    (cs : List (DenseExpr p)) : Prop :=
+  ∀ j c, cs[j]? = some c →
+    (∀ v ∈ c.vars, off + j ≤ lp.getD v 0) ∧ (c.hasConstFoldableNode = true → off + j ≤ lf)
+
+theorem densePosOkFrom_mono {off : Nat} {lp lp' : Std.HashMap VarId Nat} {lf lf' : Nat}
+    {cs : List (DenseExpr p)} (hlp : DenseLpLe lp lp') (hlf : lf ≤ lf')
+    (h : DenseWorkPosOkFrom off lp lf cs) : DenseWorkPosOkFrom off lp' lf' cs := by
+  intro j c hj
+  obtain ⟨hv, hf⟩ := h j c hj
+  exact ⟨fun v hvm => Nat.le_trans (hv v hvm) (hlp v), fun hfd => Nat.le_trans (hf hfd) hlf⟩
+
+theorem densePosOkFrom_append {lp : Std.HashMap VarId Nat} {lf : Nat}
+    {u v : List (DenseExpr p)} (hu : DenseWorkPosOkFrom 0 lp lf u)
+    (hv : DenseWorkPosOkFrom u.length lp lf v) : DenseWorkPosOkFrom 0 lp lf (u ++ v) := by
+  intro j c hj
+  by_cases h : j < u.length
+  · exact hu j c (by rwa [List.getElem?_append_left h] at hj)
+  · rw [List.getElem?_append_right (by omega)] at hj
+    have := hv (j - u.length) c hj
+    rw [show u.length + (j - u.length) = j by omega] at this
+    simpa using this
+
+theorem densePosOkFrom_cons_last {lp : Std.HashMap VarId Nat} {lf : Nat}
+    {u : List (DenseExpr p)} {c : DenseExpr p} (hu : DenseWorkPosOkFrom 0 lp lf u)
+    (hc : (∀ v ∈ c.vars, u.length ≤ lp.getD v 0) ∧
+      (c.hasConstFoldableNode = true → u.length ≤ lf)) :
+    DenseWorkPosOkFrom 0 lp lf (u ++ [c]) := by
+  refine densePosOkFrom_append hu ?_
+  intro j c' hj
+  cases j with
+  | zero =>
+      rw [List.getElem?_cons_zero, Option.some_inj] at hj
+      subst hj
+      simpa using hc
+  | succ k => simp at hj
+
+
+/-- The position bound survives an accept: the splice raises `lastPos`/`lastFold` at exactly the
+    positions it rewrites, and only ever raises them, so the untouched prefix keeps its bound. -/
+theorem denseWorkSpliceCs_posOk (dmax : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
+    ∀ (l : List (DenseExpr p)) (i : Nat) (acc : List (DenseExpr p)) (lp : Std.HashMap VarId Nat)
+      (lf : Nat) (ok : Bool),
+      acc.length = i →
+      DenseWorkPosOkFrom 0 lp lf acc.reverse →
+      DenseWorkPosOkFrom i lp lf l →
+      DenseWorkPosOkFrom 0
+        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).2.1
+        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).2.2.1
+        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).1 := by
+  intro l
+  induction l with
+  | nil =>
+      intro i acc lp lf ok _ hacc _
+      simpa [denseWorkSpliceCs] using hacc
+  | cons c rest ih =>
+      intro i acc lp lf ok hlen hacc hl
+      have hhead := hl 0 c (by simp)
+      have hrest : DenseWorkPosOkFrom (i + 1) lp lf rest := by
+        intro j c' hj
+        have := hl (j + 1) c' (by simpa using hj)
+        rw [show i + (j + 1) = i + 1 + j by omega] at this
+        exact this
+      rw [denseWorkSpliceCs]
+      by_cases hmp : maxPos < i
+      · rw [if_pos hmp]
+        refine densePosOkFrom_append hacc ?_
+        intro j c' hj
+        simp only [List.length_reverse, hlen]
+        exact hl j c' hj
+      · rw [if_neg hmp]
+        by_cases hcov : denseCoveredBy xs c = true
+        · rw [if_pos hcov]
+          refine ih (i + 1) _ lp lf ok (by simp [hlen]) ?_ hrest
+          -- the placeholder has no variables and no foldable node
+          rw [List.reverse_cons]
+          refine densePosOkFrom_cons_last hacc ?_
+          refine ⟨fun v hv => by simp [DenseExpr.vars] at hv, fun hfd => ?_⟩
+          simp [DenseExpr.hasConstFoldableNode] at hfd
+        · rw [if_neg hcov]
+          by_cases hg : c.sharesVarIn xs || c.hasConstFoldableNode
+          · rw [if_pos hg]
+            set c' := denseGroupRewrite xs bits σfn patts c with hc'
+            set lp' := c'.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) lp with hlp'
+            set lf' := if c'.hasConstFoldableNode then max lf i else lf with hlf'
+            have hmono : DenseLpLe lp lp' := denseLpFold_mono i _ lp
+            have hlfle : lf ≤ lf' := by
+              rw [hlf']; split <;> [exact Nat.le_max_left _ _; exact Nat.le_refl _]
+            refine ih (i + 1) _ lp' lf' _ (by simp [hlen]) ?_
+              (densePosOkFrom_mono hmono hlfle hrest)
+            rw [List.reverse_cons]
+            refine densePosOkFrom_cons_last (densePosOkFrom_mono hmono hlfle hacc) ?_
+            rw [List.length_reverse, hlen]
+            refine ⟨fun v hv => denseLpFold_ge i _ lp v hv, fun hfd => ?_⟩
+            rw [hlf', if_pos hfd]
+            exact Nat.le_max_right _ _
+          · rw [if_neg hg]
+            refine ih (i + 1) _ lp lf ok (by simp [hlen]) ?_ hrest
+            rw [List.reverse_cons]
+            refine densePosOkFrom_cons_last hacc ?_
+            rw [List.length_reverse, hlen]
+            simpa using hhead
+
+
+/-! ### The accumulated booleanity constraints
+
+Deferring the bools is what lets the splice share its tail, and it is sound because a bool is inert
+for every later group: `denseBoolConstraint b` mentions only `b`, so as long as `b ∉ xs` it is not
+covered, the rewrite is the identity on it, and it is not a placeholder. `DenseWorkBoolsOk` records
+that every accumulated bool belongs to a minted bit, and the step's `bitSet` guard supplies `b ∉ xs`
+directly — cheaper than deriving it from registry freshness, and sound either way since rejecting a
+candidate is always allowed. -/
+
+def DenseWorkBoolsOk (bitSet : Std.HashSet VarId) (bools : List (DenseExpr p)) : Prop :=
+  ∀ c ∈ bools, ∃ b, c = (denseBoolConstraint b : DenseExpr p) ∧ bitSet.contains b = true
+
+theorem denseContainsFast_of_not_mem {xs : List VarId} {b : VarId} (hb : b ∉ xs) :
+    denseContainsFast xs b = false := by
+  by_contra h
+  rw [Bool.not_eq_false] at h
+  exact absurd (denseContainsFast_sound xs b h) hb
+
+theorem denseBoolConstraint_inert {xs : List VarId} {b : VarId} (hb : b ∉ xs) :
+    denseCoveredBy xs (denseBoolConstraint b : DenseExpr p) = false ∧
+    (denseBoolConstraint b : DenseExpr p).sharesVarIn xs = false ∧
+    (denseBoolConstraint b : DenseExpr p).hasConstFoldableNode = false ∧
+    denseIsZero (denseBoolConstraint b : DenseExpr p) = false := by
+  have hc := denseContainsFast_of_not_mem (xs := xs) (b := b) hb
+  refine ⟨?_, ?_, ?_, rfl⟩
+  · simp [denseCoveredBy, denseBoolConstraint, DenseExpr.varsInF, hc]
+  · simp [denseBoolConstraint, DenseExpr.sharesVarIn, hc]
+  · simp [denseBoolConstraint, DenseExpr.hasConstFoldableNode, DenseExpr.hasVar]
+
+theorem denseWorkBools_filter_covered {xs : List VarId} {bitSet : Std.HashSet VarId}
+    {bools : List (DenseExpr p)} (bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) (hb : DenseWorkBoolsOk bitSet bools)
+    (hxs : ∀ x ∈ xs, bitSet.contains x = false) :
+    bools.filter (fun c => !denseCoveredBy xs c) = bools ∧
+    bools.map (denseGroupRewrite xs bits σfn patts) = bools ∧
+    bools.filter (fun c => !denseIsZero c) = bools := by
+  have hinert : ∀ c ∈ bools, denseCoveredBy xs c = false ∧ c.sharesVarIn xs = false ∧
+      c.hasConstFoldableNode = false ∧ denseIsZero c = false := by
+    intro c hc
+    obtain ⟨bb, rfl, hbb⟩ := hb c hc
+    refine denseBoolConstraint_inert (fun hmem => ?_)
+    rw [hxs bb hmem] at hbb
+    exact Bool.noConfusion hbb
+  refine ⟨?_, ?_, ?_⟩
+  · refine List.filter_eq_self.2 (fun c hc => ?_)
+    simp [(hinert c hc).1]
+  · rw [show bools.map (denseGroupRewrite xs bits σfn patts) = bools.map id from
+      List.map_congr_left (fun c hc =>
+        denseGroupRewrite_eq_self (hinert c hc).2.1 (hinert c hc).2.2.1), List.map_id]
+  · refine List.filter_eq_self.2 (fun c hc => ?_)
+    simp [(hinert c hc).2.2.2]
+
+theorem denseBoolConstraints_not_zero (bits : List VarId) :
+    (bits.map (denseBoolConstraint (p := p))).filter (fun c => !denseIsZero c)
+      = bits.map (denseBoolConstraint (p := p)) := by
+  refine List.filter_eq_self.2 (fun c hc => ?_)
+  obtain ⟨b, _, rfl⟩ := List.mem_map.1 hc
+  simp [denseIsZero, denseBoolConstraint]
+
+
+/-- One accept on the working system: splice the constraints, gate the bus interactions (reusing the
+    fused traversal of `denseGateBisGo`), and accumulate the booleanity constraints. -/
+def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeWork p × Bool :=
+  let σfn := denseGroupSubst xs hm
+  let patts := denseAssignments (denseBitBox bits)
+  let mp := denseWorkMaxPos w.lastPos w.lastFold xs
+  let rc := denseWorkSpliceCs b.identities xs bits σfn patts mp 0 w.cs [] w.lastPos w.lastFold true
+  let rb := denseGateBisGo b.busInteractions xs bits σfn patts w.bis [] true
+  let newBools := bits.map (denseBoolConstraint (p := p))
+  ({ cs := rc.1, bis := rb.1, bools := w.bools ++ newBools,
+     bitSet := bits.foldl (·.insert ·) w.bitSet,
+     lastPos := rc.2.1, lastFold := rc.2.2.1 },
+   (rc.2.2.2 && newBools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
+
+/-- An accept on the working system is `denseReencodeOut` on the view, followed by dropping the
+    placeholders — and dropping those is itself a verified transformation
+    (`DensePassCorrect.denseFilterConstraintsEntailed`), so both halves reuse existing correctness. -/
+theorem denseWorkOut_view (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p))
+    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
+    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false) :
+    denseWorkView (denseWorkOut b w xs bits hm).1
+      = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
+          (fun c => !denseIsZero c) := by
+  obtain ⟨hbcov, hbmap, hbz⟩ := denseWorkBools_filter_covered (bools := w.bools) bits
+    (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits)) hbools hxs
+  have hsplice : (denseWorkSpliceCs b.identities xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs) 0 w.cs []
+      w.lastPos w.lastFold true).1
+      = w.cs.map (denseTombify xs bits (denseGroupSubst xs hm)
+          (denseAssignments (denseBitBox bits))) := by
+    have := denseWorkSpliceCs_list b.identities xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs)
+      w.cs 0 [] w.lastPos w.lastFold true (denseWorkBounded_of_posOk hpos)
+    simpa using this
+  have hbus : (denseGateBisGo b.busInteractions xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) w.bis [] true).1
+      = w.bis.map (fun bi => { bi with
+          multiplicity := denseGroupRewrite xs bits (denseGroupSubst xs hm)
+            (denseAssignments (denseBitBox bits)) bi.multiplicity,
+          payload := bi.payload.map (denseGroupRewrite xs bits (denseGroupSubst xs hm)
+            (denseAssignments (denseBitBox bits))) }) := by
+    rw [denseGateBisGo_eq]
+    simp only [List.reverse_nil, List.nil_append]
+    exact List.map_congr_left (fun bi _ => by
+      rw [denseBIGateDeg_fst, denseBIRewriteGate_eq])
+  unfold denseWorkView denseWorkOut denseReencodeOut DenseConstraintSystem.filterConstraints
+  simp only [hsplice, hbus, List.filter_append, List.map_append, List.append_assoc,
+    hbcov, hbmap, hbz, denseBoolConstraints_not_zero]
+  rw [denseTombify_filter]
+
+
+/-! ### Reading the certificate off the working system
+
+The loop must not materialise the view per candidate — that would allocate a fresh spine for the whole
+system on every candidate, which is the cost this design exists to remove. The certificate only looks
+at the covered sublist and at whether anything mentions a fresh bit, and both are unaffected by the
+placeholders (they mention nothing and are never covered) and by the accumulated bools (inert, by
+`denseBoolConstraint_inert` and the step's guards). So it reads `w.cs` directly. -/
+
+theorem List.all_filter_of {α : Type} (l : List α) (P Q : α → Bool)
+    (h : ∀ c ∈ l, P c = false → Q c = true) : (l.filter P).all Q = l.all Q := by
+  induction l with
+  | nil => rfl
+  | cons c rest ih =>
+      by_cases hp : P c = true
+      · rw [List.filter_cons_of_pos hp, List.all_cons, List.all_cons,
+          ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+      · rw [Bool.not_eq_true] at hp
+        rw [List.filter_cons_of_neg (by simp [hp]), List.all_cons,
+          h c (List.mem_cons_self ..) hp, Bool.true_and,
+          ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+
+theorem List.filter_filter_of {α : Type} (l : List α) (P R : α → Bool)
+    (h : ∀ c ∈ l, P c = false → R c = false) : (l.filter P).filter R = l.filter R := by
+  induction l with
+  | nil => rfl
+  | cons c rest ih =>
+      by_cases hp : P c = true
+      · rw [List.filter_cons_of_pos hp]
+        by_cases hr : R c = true
+        · rw [List.filter_cons_of_pos hr, List.filter_cons_of_pos hr,
+            ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+        · rw [Bool.not_eq_true] at hr
+          rw [List.filter_cons_of_neg (by simp [hr]), List.filter_cons_of_neg (by simp [hr]),
+            ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+      · rw [Bool.not_eq_true] at hp
+        rw [List.filter_cons_of_neg (by simp [hp]),
+          List.filter_cons_of_neg (by simp [h c (List.mem_cons_self ..) hp]),
+          ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
+
+theorem denseIsZero_mentions {c : DenseExpr p} (hz : denseIsZero c = true) (b : VarId) :
+    c.mentions b = false := by
+  cases c with
+  | const n => rfl
+  | var _ => simp [denseIsZero] at hz
+  | add _ _ => simp [denseIsZero] at hz
+  | mul _ _ => simp [denseIsZero] at hz
+
+theorem denseIsZero_not_covered {xs : List VarId} {c : DenseExpr p} (hz : denseIsZero c = true) :
+    denseCoveredBy xs c = false := by
+  cases c with
+  | const n => simp [denseCoveredBy, DenseExpr.hasVar]
+  | var _ => simp [denseIsZero] at hz
+  | add _ _ => simp [denseIsZero] at hz
+  | mul _ _ => simp [denseIsZero] at hz
+
+theorem denseIsZero_eval {c : DenseExpr p} (hz : denseIsZero c = true) (denv : VarId → ZMod p) :
+    c.eval denv = 0 := by
+  cases c with
+  | const n =>
+      have hn : n = 0 := by simpa [denseIsZero] using hz
+      simp [DenseExpr.eval, hn]
+  | var _ => simp [denseIsZero] at hz
+  | add _ _ => simp [denseIsZero] at hz
+  | mul _ _ => simp [denseIsZero] at hz
+
+theorem denseCheckReencode_congr (cs1 cs2 : List (DenseExpr p))
+    (bis : List (BusInteraction (DenseExpr p))) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p))
+    (hcov : cs1.filter (denseCoveredBy xs) = cs2.filter (denseCoveredBy xs))
+    (hfresh : ∀ b ∈ bits, cs1.all (fun c => !c.mentions b) = cs2.all (fun c => !c.mentions b)) :
+    denseCheckReencode { algebraicConstraints := cs1, busInteractions := bis } xs bits hm
+      = denseCheckReencode { algebraicConstraints := cs2, busInteractions := bis } xs bits hm := by
+  have hb : (bits.all (fun b =>
+        cs1.all (fun c => !c.mentions b) &&
+        bis.all (fun bi =>
+          !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b))))
+      = (bits.all (fun b =>
+        cs2.all (fun c => !c.mentions b) &&
+        bis.all (fun bi =>
+          !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b)))) :=
+    List.all_congr_mem bits _ _ (fun b hbm => by rw [hfresh b hbm])
+  unfold denseCheckReencode denseCoveredCsOf
+  simp only [hcov, hb]
+
+
+theorem denseWorkView_check {w : DenseReencodeWork p} {xs bits : List VarId}
+    (hm : Std.HashMap VarId (DenseExpr p))
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
+    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false)
+    (hbits : ∀ bb ∈ bits, w.bitSet.contains bb = false) :
+    denseCheckReencode (denseWorkView w) xs bits hm
+      = denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm := by
+  have hinert : ∀ c ∈ w.bools, denseCoveredBy xs c = false ∧ ∀ b ∈ bits, c.mentions b = false := by
+    intro c hc
+    obtain ⟨bb, rfl, hbb⟩ := hbools c hc
+    have hnx : bb ∉ xs := fun hmem => by rw [hxs bb hmem] at hbb; exact Bool.noConfusion hbb
+    refine ⟨(denseBoolConstraint_inert (p := p) hnx).1, fun b hb => ?_⟩
+    have hne : bb ≠ b := fun heq => by
+      subst heq; rw [hbits bb hb] at hbb; exact Bool.noConfusion hbb
+    simp [denseBoolConstraint, DenseExpr.mentions, hne]
+  refine denseCheckReencode_congr _ _ _ xs bits hm ?_ ?_
+  · show ((w.cs.filter (fun c => !denseIsZero c) ++ w.bools).filter (denseCoveredBy xs))
+      = w.cs.filter (denseCoveredBy xs)
+    have h1 : w.bools.filter (denseCoveredBy xs) = [] :=
+      List.filter_eq_nil_iff.2 (fun c hc => by simp [(hinert c hc).1])
+    have h2 : (w.cs.filter (fun c => !denseIsZero c)).filter (denseCoveredBy xs)
+        = w.cs.filter (denseCoveredBy xs) :=
+      List.filter_filter_of _ _ _ (fun c _ hz => denseIsZero_not_covered (by simpa using hz))
+    rw [List.filter_append, h2, h1, List.append_nil]
+  · intro b hb
+    show ((w.cs.filter (fun c => !denseIsZero c) ++ w.bools).all (fun c => !c.mentions b))
+      = w.cs.all (fun c => !c.mentions b)
+    have h1 : w.bools.all (fun c => !c.mentions b) = true :=
+      List.all_eq_true.2 (fun c hc => by simp [(hinert c hc).2 b hb])
+    have h2 : (w.cs.filter (fun c => !denseIsZero c)).all (fun c => !c.mentions b)
+        = w.cs.all (fun c => !c.mentions b) :=
+      List.all_filter_of _ _ _ (fun c _ hz => by
+        simp [denseIsZero_mentions (by simpa using hz) b])
+    rw [List.all_append, h2, h1, Bool.and_true]
+
+/-! ### Seeding the bound -/
+
+def denseSeedLp : Nat → List (DenseExpr p) → Std.HashMap VarId Nat → Std.HashMap VarId Nat
+  | _, [], m => m
+  | i, c :: rest, m =>
+      denseSeedLp (i + 1) rest (c.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m)
+
+def denseSeedLf : Nat → List (DenseExpr p) → Nat → Nat
+  | _, [], n => n
+  | i, c :: rest, n => denseSeedLf (i + 1) rest (if c.hasConstFoldableNode then max n i else n)
+
+theorem denseSeedLp_mono : ∀ (l : List (DenseExpr p)) (i : Nat) (m : Std.HashMap VarId Nat),
+    DenseLpLe m (denseSeedLp i l m) := by
+  intro l
+  induction l with
+  | nil => intro i m; exact DenseLpLe.refl m
+  | cons c rest ih =>
+      intro i m
+      exact DenseLpLe.trans (denseLpFold_mono i _ m) (ih (i + 1) _)
+
+theorem denseSeedLf_mono : ∀ (l : List (DenseExpr p)) (i : Nat) (n : Nat), n ≤ denseSeedLf i l n := by
+  intro l
+  induction l with
+  | nil => intro i n; exact Nat.le_refl n
+  | cons c rest ih =>
+      intro i n
+      refine Nat.le_trans ?_ (ih (i + 1) _)
+      split <;> [exact Nat.le_max_left _ _; exact Nat.le_refl _]
+
+theorem denseSeed_posOk : ∀ (l : List (DenseExpr p)) (i : Nat) (m : Std.HashMap VarId Nat)
+    (n : Nat), DenseWorkPosOkFrom i (denseSeedLp i l m) (denseSeedLf i l n) l := by
+  intro l
+  induction l with
+  | nil => intro i m n j c hj; simp at hj
+  | cons c rest ih =>
+      intro i m n j c' hj
+      cases j with
+      | zero =>
+          rw [List.getElem?_cons_zero, Option.some_inj] at hj
+          subst hj
+          refine ⟨fun v hv => ?_, fun hfd => ?_⟩
+          · rw [Nat.add_zero, denseSeedLp]
+            exact Nat.le_trans (denseLpFold_ge i _ m v hv) (denseSeedLp_mono rest (i + 1) _ v)
+          · rw [Nat.add_zero, denseSeedLf]
+            exact Nat.le_trans (by rw [if_pos hfd]; exact Nat.le_max_right _ _)
+              (denseSeedLf_mono rest (i + 1) _)
+      | succ k =>
+          have hk := ih (i + 1) (c.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m)
+            (if c.hasConstFoldableNode then max n i else n) k c' (by simpa using hj)
+          rw [show i + (k + 1) = i + 1 + k by omega]
+          rw [denseSeedLp, denseSeedLf]
+          exact hk
 
 /-! ## The build/step/loop/pass layer -/
 
@@ -967,90 +1567,67 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
     else st) st
   { st with varSet := bits.foldl (·.insert ·) st.varSet, dWithin := true }
 
-/-- One checked re-encoding step (identity if construction or the certificate fails). Applies the
-    gates in order, minting fresh bits and rewriting `d` only on full acceptance; the threaded
-    candidate state is updated in place rather than rebuilt. -/
-def denseReencodeStepCached (b : DegreeBound)
-    (reg : VarRegistry) (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p)
-    (xs : List VarId) (freshBase : String) :
-    VarRegistry × DenseConstraintSystem p × DenseDerivations p × DenseReencodeCacheState p :=
+/-! ### The step, loop and pass over the working system -/
+
+/-- `d`'s item counts for the fresh-name prefix, read off the working system. -/
+def denseWorkNameCounts (derivs : DenseDerivations p) (w : DenseReencodeWork p) (nc nb : Nat) :
+    Nat × Nat :=
+  if derivs.isEmpty then (nc, nb)
+  else ((w.cs.filter (fun c => !denseIsZero c)).length + w.bools.length, w.bis.length)
+
+/-- One checked re-encoding step. Mirrors the cached step, with two extra guards — no group variable
+    and no freshly minted bit may be a bit minted earlier — which is what keeps the deferred
+    booleanity constraints inert for this group (`denseBoolConstraint_inert`). Rejecting a candidate is
+    always allowed, so the guards cost behaviour at worst, never soundness. -/
+def denseWorkStep (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
+    (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String) :
+    VarRegistry × DenseReencodeWork p × DenseDerivations p × DenseReencodeCacheState p :=
   if xs.all (fun x => reg.isInput x) then
+  if xs.any (fun x => w.bitSet.contains x) then (reg, w, [], state) else
   if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
       | some i => state.varSet.contains i
       | none => false) then
-    (reg, d, [], state)
+    (reg, w, [], state)
   else
   match denseBuildReencodeCached reg state.csIdx state.arrCs state.rootCache xs freshBase with
-  | (reg1, none, rootCache) => (reg1, d, [], { state with rootCache })
+  | (reg1, none, rootCache) => (reg1, w, [], { state with rootCache })
   | (reg1, some (bits, hm), rootCache) =>
     let state := { state with rootCache }
+    if bits.any (fun bb => w.bitSet.contains bb) then (reg1, w, [], state) else
     if denseDegPreRejectIdx b state.useCs state.useBis state.arrBis state.arrCs xs bits hm then
-      (reg1, d, [], state)
+      (reg1, w, [], state)
     else
     if xs.all (fun x => state.varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
-    if bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
-    if denseCheckReencode d xs bits hm then
-      let ro := denseReencodeOutOk b d xs bits hm
-      if (if state.dWithin then ro.2 else ro.1.withinDegreeB b) then
+    if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
+    if denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm then
+      let ro := denseWorkOut b w xs bits hm
+      if (if state.dWithin then ro.2 else (denseWorkView ro.1).withinDegreeB b) then
         (reg1, ro.1,
-         bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox bits)) xs hm b)),
+         bits.map (fun bb => (bb, denseBitCM (denseAssignments (denseBitBox bits)) xs hm bb)),
          denseReencodeStateUpdate state xs bits hm)
-      else (reg1, d, [], state)
-    else (reg1, d, [], state)
-    else (reg1, d, [], state)
-    else (reg1, d, [], state)
-    else (reg1, d, [], state)
-  else (reg, d, [], state)
+      else (reg1, w, [], state)
+    else (reg1, w, [], state)
+    else (reg1, w, [], state)
+    else (reg1, w, [], state)
+    else (reg1, w, [], state)
+  else (reg, w, [], state)
 
-/-- The `dWithin` invariant is preserved by a step, which is what makes the fused degree gate above
-    decide exactly what `(denseReencodeOut d xs bits hm).withinDegreeB b` decides
-    (`denseReencodeOutOk_snd`): the flag is only ever set on the accept path, and there the accepted
-    system passed the gate, and it starts `false`, so every step of the loop sees a valid flag.
-
-    Unreachable from the correctness roots by design: the degree bound is enforced *outside* the
-    pass, by `guardAll` in `Implementation/Optimizer.lean`, so this internal gate decides which
-    candidates are accepted — behaviour, not soundness. -/
-theorem denseReencodeStepCached_dWithin (b : DegreeBound) (reg : VarRegistry)
-    (d : DenseConstraintSystem p) (state : DenseReencodeCacheState p) (xs : List VarId)
-    (freshBase : String) (hdw : state.dWithin = true → d.withinDegreeB b = true) :
-    (denseReencodeStepCached b reg d state xs freshBase).2.2.2.dWithin = true →
-      (denseReencodeStepCached b reg d state xs freshBase).2.1.withinDegreeB b = true := by
-  fun_cases denseReencodeStepCached b reg d state xs freshBase
-  case case4 =>
-    rename_i hgate hcoll reg1 bits hm rootCache hbeq state1 hdpr hA hB hC hD ro hwd
-    intro _
-    show ro.1.withinDegreeB b = true
-    by_cases hsw : state1.dWithin = true
-    · rw [if_pos hsw] at hwd
-      rw [denseReencodeOutOk_fst b d xs bits hm,
-        ← denseReencodeOutOk_snd b d xs bits hm (hdw hsw)]
-      exact hwd
-    · rw [if_neg hsw] at hwd
-      exact hwd
-  all_goals exact hdw
-
-/-- `d`'s item counts for the fresh-name prefix, re-read only after a step that rewrote `d`
-    (a step derives one method per minted bit, so nonempty derivations mark exactly the accepts). -/
-def denseReencodeNameCounts (derivs : DenseDerivations p) (d : DenseConstraintSystem p)
-    (nc nb : Nat) : Nat × Nat :=
-  if derivs.isEmpty then (nc, nb)
-  else (d.algebraicConstraints.length, d.busInteractions.length)
-
-/-- Process the candidate groups sequentially, threading the registry, the candidate state and
-    `d`'s item counts (`nc`/`nb`, the fresh-name prefix). -/
-def denseReencodeLoopCached (b : DegreeBound) :
-    List (List VarId) → Nat → VarRegistry → DenseConstraintSystem p →
+def denseWorkLoop (b : DegreeBound) :
+    List (List VarId) → Nat → VarRegistry → DenseReencodeWork p →
       DenseReencodeCacheState p → Nat → Nat →
-      VarRegistry × DenseConstraintSystem p × DenseDerivations p
-  | [], _, reg, d, _, _, _ => (reg, d, [])
-  | xs :: rest, idx, reg, d, state, nc, nb =>
-    let (reg1, d1, derivs1, state1) :=
-      denseReencodeStepCached b reg d state xs s!"rnc{nc}_{nb}_{idx}"
-    let (nc1, nb1) := denseReencodeNameCounts derivs1 d1 nc nb
-    let (reg2, d2, derivs2) :=
-      denseReencodeLoopCached b rest (idx + 1) reg1 d1 state1 nc1 nb1
-    (reg2, d2, derivs1 ++ derivs2)
+      VarRegistry × DenseReencodeWork p × DenseDerivations p
+  | [], _, reg, w, _, _, _ => (reg, w, [])
+  | xs :: rest, idx, reg, w, state, nc, nb =>
+    let (reg1, w1, derivs1, state1) := denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
+    let (nc1, nb1) := denseWorkNameCounts derivs1 w1 nc nb
+    let (reg2, w2, derivs2) := denseWorkLoop b rest (idx + 1) reg1 w1 state1 nc1 nb1
+    (reg2, w2, derivs1 ++ derivs2)
+
+def denseWorkSeed (d : DenseConstraintSystem p) : DenseReencodeWork p :=
+  { cs := d.algebraicConstraints, bis := d.busInteractions, bools := [], bitSet := ∅,
+    lastPos := denseSeedLp 0 d.algebraicConstraints ∅,
+    lastFold := denseSeedLf 0 d.algebraicConstraints 0 }
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
     combinations survive, mint `Nat.clog 2 #survivors` fresh boolean bits, rewrite each group
@@ -1070,11 +1647,11 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
       | _ => s
     let targets := dedupHash (csVs.filterMap (fun vs =>
       if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
-        -- Sort by the resolved `Variable`'s order: `denseReencodeLoopCached` below is a greedy,
+        -- Sort by the resolved `Variable`'s order: `denseWorkLoop` below is a greedy,
         -- order-sensitive accept/reject sequence, so the group order determines the outcome.
         some (vs.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
       else none))
-    denseReencodeLoopCached b targets 0 reg d
+    let r := denseWorkLoop b targets 0 reg (denseWorkSeed d)
       { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
         arrCs := d.algebraicConstraints.toArray
         rootCache := ∅
@@ -1085,7 +1662,8 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         foldCs := d.algebraicConstraints.zipIdx.foldl
           (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
         dWithin := false }
-      d.algebraicConstraints.length d.busInteractions.length
+      (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
+    (r.1, denseWorkView r.2.1, r.2.2)
   else (reg, d, [])
 
 end ApcOptimizer.Dense

--- a/Scripts/unused-theorems.txt
+++ b/Scripts/unused-theorems.txt
@@ -23,14 +23,3 @@ ApcOptimizer.SP1.sp1Optimizer_maintainsCorrectness
 # `Task.get` is opaque, so the `simp only` needs the lemma even though it rewrites by `rfl`.
 ApcOptimizer.Dense.get_spawn
 
-# The `dWithin` invariant behind `denseReencodeStepCached`'s fused degree gate (Reencode.lean).
-# `denseReencodeOutOk_snd` says the fused gate decides exactly what
-# `(denseReencodeOut …).withinDegreeB b` decides, given a within-bound input;
-# `denseReencodeStepCached_dWithin` says the flag tracking that side condition is preserved by every
-# step. They guarantee the pass's *output* is unchanged, which no correctness root can reach: the
-# degree bound is enforced outside the pass by `guardAll` (`Implementation/Optimizer.lean`), so the
-# internal gate chooses which candidates are accepted rather than establishing soundness. Deleting
-# them would leave that invariant unchecked.
-ApcOptimizer.Dense.denseReencodeStepCached_dWithin
-ApcOptimizer.Dense.denseReencodeOutOk_snd
-ApcOptimizer.Dense.List.all_congr_mem


### PR DESCRIPTION
Every accept in `denseReencodeOut` rebuilt the whole constraint list — roughly 146 k cons cells on sha256, to drop 7 constraints and rewrite a few more. This makes an accept proportional to what it actually changes.

## What changes

The loop threads a `DenseReencodeWork` instead of a `DenseConstraintSystem`:

* a dropped constraint is **tombstoned as `.const 0` in place**, so positions stay stable and keep matching the bucket index (which names stable positions — a compacting drop would desynchronise it after the first accept);
* the rewrite rebuilds cons cells only as far as `maxPos`, the last position that *could* change, and **shares the untouched tail**;
* the booleanity constraints are accumulated and appended once at pass exit — appending them per accept would copy the whole spine and destroy that sharing.

`denseWorkView` is the system this represents.

## Why it needs no new correctness argument

`denseWorkOut_view` is the keystone: an accept on the working system is exactly `denseReencodeOut` on the view, **followed by dropping trivially-true constraints**. Both halves are already verified — `denseCheckReencode_sound` and `DensePassCorrect.denseFilterConstraintsEntailed` — composed with `.andThen`. Nothing new is claimed about the rewrite itself.

Two invariants, both threaded through the loop:

| invariant | what it gives | how it survives an accept |
|---|---|---|
| `DenseWorkPosOk` | `lastPos`/`lastFold` bound the positions mentioning each variable and the foldable ones; `denseWorkBounded_of_posOk` turns this into the bound that licenses sharing the tail | the splice only ever raises them, and raises them at every position it rewrites (`denseWorkSpliceCs_posOk`) |
| `DenseWorkBoolsOk` | every accumulated bool belongs to a minted bit | bools are appended together with their bits |

The second one is what makes deferring the bools sound. A deferred `b·(b−1)` must be inert for every later group, and every fact needed for that (not covered, fixed by the rewrite, not a placeholder) reduces to `b ∉ xs`. Rather than derive that from registry freshness, **two cheap runtime guards** supply it directly: no group variable and no freshly minted bit may be a bit minted earlier. Rejecting a candidate is always allowed, so the guards cost behaviour at worst, never soundness — the same device the pass already uses for `x ∉ bits` and the `powdrId?` check.

`denseCheckReencode_congr` lets the certificate read the working list directly. Materialising the view per candidate would allocate a whole spine on every candidate, which is exactly the cost this change removes.

## Relation to #231

This **supersedes** #231s per-accept fused gate on the constraint side, which is deleted (`denseGateCsGo`, `denseGateDeg`, `denseReencodeOutOk` and their lemmas) — the constraint side no longer walks the output at all. The bus side still uses `denseGateBisGo`, so #231s traversal survives there. `Scripts/unused-theorems.txt` loses its `dWithin`/`denseReencodeOutOk_snd` block: those existed to guarantee byte-identical output, which this change no longer claims (see below), and `List.all_congr_mem` is now genuinely reachable.

## Effectiveness

**Not byte-identical to `main`, deliberately.** The view drops `.const 0` constraints, including any already present in the pass input, which `trivialConstr` would otherwise remove a cycle later. So effectiveness can only *improve* on the constraint axis and cannot regress on it; variables and bus interactions are untouched by the change. I have not run the corpus sweep locally — **the benchmark decides**, which is why this is a draft.

## Measurements

The prototype this was derived from (same algorithm, behind `@[implemented_by]`, no proofs) measured on sha256, interleaved, one rep:

| variant | reencode | vs main |
|---|---:|---:|
| main | 26 185 ms | — |
| this design | **16 036 ms** | **1.63x** |

with byte-identical output at that stage, and 167 811 vs 177 629 ms pipeline total (1.058x). Expect the verified implementation to land near that; the certificate now reads the working list directly and the seed builds `lastPos` in one extra pass at entry, so it is not identical to the prototype. CI has the real numbers.

Caveat worth stating: reencode is ~15 % of sha256s pipeline and accepts nothing on several corpus APCs, so the corpus-level effect will be much smaller than 1.63x suggests.

`lake build` clean, no warnings. `Scripts/check-proof-integrity.sh` passes: three standard axioms only, no unused theorems.