### PR TITLE
ci(docs): install texlive-fonts-recommended so the PDF builds

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,13 +35,17 @@ jobs:
       - uses: leanprover/lean-action@v1
         with:
           build: false
-      # LaTeX toolchain for the PDF: xelatex + latexmk, the Source Pro / DejaVu fonts the Verso
-      # preamble uses (texlive-fonts-extra), and rsvg-convert (librsvg2-bin) for the figures.
+      # LaTeX toolchain for the PDF: xelatex + latexmk, the base-35 URW fonts hyperref needs
+      # (texlive-fonts-recommended — e.g. ZapfDingbats/pzdr for link annotations), the Source Pro /
+      # DejaVu fonts the Verso preamble uses (texlive-fonts-extra), and rsvg-convert (librsvg2-bin)
+      # for the figures. `texlive-fonts-recommended` is a *Recommends*, so it must be listed
+      # explicitly under `--no-install-recommends`.
       - name: Install TeX + SVG tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            texlive-xetex texlive-latex-extra texlive-fonts-extra latexmk librsvg2-bin
+            texlive-xetex texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra \
+            latexmk librsvg2-bin
       # Build the PDF (best-effort — never block publishing the site on it), then the site, then
       # drop the PDF into the site so it deploys at <site>/apc_optimizer.pdf.
       - name: Build site + PDF


### PR DESCRIPTION
The Pages deploy for #237 built and published the site, but the best-effort PDF step failed, so `apc_optimizer.pdf` is missing from the site.

**Cause:** xelatex aborted with `! Font \XeTeXLink@font=pzdr ... not loadable: Metric (TFM) file ... not found`. `pzdr` is ZapfDingbats, which `hyperref` loads for its XeTeX link annotations. Its metrics ship in the base-35 URW fonts in **`texlive-fonts-recommended`** — which is only a *Recommends* of `texlive-latex-extra`, so the `--no-install-recommends` in the install step dropped it.

**Fix:** list `texlive-fonts-recommended` explicitly in the apt install.

This only affects the CI PDF build; the site itself was unaffected (the PDF step is best-effort and warns rather than failing the deploy). Once merged, the deploy re-runs on `main` and the PDF lands at `https://powdr-labs.github.io/apc-optimizer/apc_optimizer.pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)