### PR TITLE
ci(docs): install texlive-plain-generic so the PDF builds

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,28 +37,26 @@ jobs:
           build: false
       # LaTeX toolchain for the PDF: xelatex + latexmk, the base-35 URW fonts hyperref needs
       # (texlive-fonts-recommended — e.g. ZapfDingbats/pzdr for link annotations), the Source Pro /
-      # DejaVu fonts the Verso preamble uses (texlive-fonts-extra), and rsvg-convert (librsvg2-bin)
-      # for the figures. `texlive-fonts-recommended` is a *Recommends*, so it must be listed
-      # explicitly under `--no-install-recommends`.
+      # DejaVu fonts the Verso preamble uses (texlive-fonts-extra), `ulem` for the `\uwave` the
+      # preamble's diagnostic decorations build on (texlive-plain-generic), and rsvg-convert
+      # (librsvg2-bin) for the figures. `texlive-fonts-recommended` is a *Recommends*, so it must be
+      # listed explicitly under `--no-install-recommends`.
       - name: Install TeX + SVG tools
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             texlive-xetex texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra \
-            latexmk librsvg2-bin
-      # Build the PDF (best-effort — never block publishing the site on it), then the site, then
-      # drop the PDF into the site so it deploys at <site>/apc_optimizer.pdf.
+            texlive-plain-generic latexmk librsvg2-bin
+      # Build the PDF, then the site, then drop the PDF into the site so it deploys at
+      # <site>/apc_optimizer.pdf. Both are required: the README links the PDF unconditionally, so
+      # deploying a site without it replaces a working link with a 404 — failing here instead leaves
+      # the previous deploy (PDF included) serving until the build is fixed.
       - name: Build site + PDF
         run: |
-          if docs/build.sh --pdf; then
-            cp docs/_out/tex/apc_optimizer.pdf "$RUNNER_TEMP/apc_optimizer.pdf"
-          else
-            echo "::warning::PDF build failed; publishing the site without it"
-          fi
+          docs/build.sh --pdf
+          cp docs/_out/tex/apc_optimizer.pdf "$RUNNER_TEMP/apc_optimizer.pdf"
           docs/build.sh
-          if [ -f "$RUNNER_TEMP/apc_optimizer.pdf" ]; then
-            cp "$RUNNER_TEMP/apc_optimizer.pdf" docs/_out/html-single/
-          fi
+          cp "$RUNNER_TEMP/apc_optimizer.pdf" docs/_out/html-single/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_out/html-single

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,10 @@ statements live from the compiled source. Published at
 
 `docs/build.sh --pdf` builds a PDF (`docs/_out/tex/apc_optimizer.pdf`) from Verso's TeX output
 instead of the site; it needs `xelatex` and `latexmk` (plus `rsvg-convert` for the figures), and
-stops after writing `main.tex` if they are missing.
+stops after writing `main.tex` if they are missing. Verso's preamble also pulls in fonts and
+packages beyond a base TeX Live install — the `Install TeX + SVG tools` step in
+[`.github/workflows/deploy-docs.yml`](../.github/workflows/deploy-docs.yml) is the working package
+list.
 
 Build and serve locally with `docs/build.sh --serve` (or `--watch` to rebuild and live-reload on
 save); it serves at <http://127.0.0.1:8017>. Serving over HTTP is required — opening `index.html`


### PR DESCRIPTION
## Why the PDF link 404s

The README links the PDF at `https://powdr-labs.github.io/apc-optimizer/apc_optimizer.pdf`, which currently returns **404** (the site itself is fine — 200).

The docs workflow has been green, because the PDF build was best-effort. In the [latest `Docs` run on main](https://github.com/powdr-labs/apc-optimizer/actions/runs/30373303011/job/90322460616) the `Build site + PDF` step logged:

```
! LaTeX Error: File `ulem.sty' not found.
...
l.45 \newcommand{\coloredwave}[2]{\textcolor{#1}{\uwave{\textcolor{black}{#2...
PDF build failed — see docs/_out/tex/apc_optimizer.log
##[warning]PDF build failed; publishing the site without it
```

Verso's TeX preamble does `\usepackage[normalem]{ulem}` unconditionally — see `verso-manual/VersoManual/TeX.lean:51`, which uses `\uwave` for the error/info/warning decorations — so every Verso PDF build needs `ulem.sty`. On Ubuntu that file ships in **`texlive-plain-generic`** (`/usr/share/texlive/texmf-dist/tex/generic/ulem/ulem.sty`), which none of the installed `texlive-*` packages pull in. xelatex hit an emergency stop, produced no pages, and the site was published without the PDF — replacing a working link with a 404.

## Changes

1. **Add `texlive-plain-generic`** to the `Install TeX + SVG tools` package list.
2. **Make the PDF build required.** The soft-fail is why this went unnoticed for two runs on main: `#237` and `#239` both went green with the link broken. Since the README links the PDF unconditionally, deploying a site without it actively turns a working link into a 404, whereas failing the job leaves the previous deploy — PDF included — serving until the build is fixed. This also drops the `if`/`-f` guards, so the step is just four straight-line commands.
3. **`docs/README.md`**: the PDF prerequisite note listed only `xelatex`/`latexmk`/`rsvg-convert`, which is the under-specification behind both this break and `#239`. It now points at the workflow step as the working package list.

## Verification

Installed the workflow's exact package list plus `texlive-plain-generic` locally and ran the full step sequence:

- `docs/build.sh --pdf` → `Wrote docs/_out/tex/apc_optimizer.pdf`, **18 pages**, `autoprecompiles.svg` converted and included as `\includegraphics{autoprecompiles.pdf}`.
- No unresolved-file or missing-package warnings left in `apc_optimizer.log`.
- The whole `Build site + PDF` script exits 0 and lands a valid PDF at `docs/_out/html-single/apc_optimizer.pdf` — the directory uploaded as the Pages artifact, so it deploys at `<site>/apc_optimizer.pdf`.

Confirmed `memoir` is still resolved (it is a `.cls`, not affected).

No Lean sources touched, so the audited surface and proof integrity are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjkxrGoXWNvkcP9jpHJvGa)_