### PR TITLE
spec: readability cleanups in the audited surface

### DIFF
--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -181,9 +181,8 @@ private theorem memory_recv_bytes (busMap : Nat → Option OpenVmBusType)
   have has' : (a0.val == 1 || a0.val == 2) = true := by
     rcases has with h | h <;> simp [h]
   simp only [memoryPayload?, MemoryPayload.isByteChecked, decide_true, has', Bool.true_and,
-    Bool.not_eq_false', List.all_eq_true, List.mem_cons, List.not_mem_nil, or_false,
-    forall_eq_or_imp, forall_eq, isByte, decide_eq_true_eq] at hok
-  exact ⟨hok.1, hok.2.1, hok.2.2.1, hok.2.2.2⟩
+    Bool.not_eq_false', Vector.all_eq_true, isByte, decide_eq_true_eq] at hok
+  exact ⟨hok 0 (by omega), hok 1 (by omega), hok 2 (by omega), hok 3 (by omega)⟩
 
 /-- A memory message that is not a receive (multiplicity ≠ -1) never violates. -/
 private theorem memory_nonRecv_ok (busMap : Nat → Option OpenVmBusType)

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -180,9 +180,9 @@ private theorem memory_recv_bytes (busMap : Nat → Option OpenVmBusType)
   rw [hbus, hpay, hm] at hok
   have has' : (a0.val == 1 || a0.val == 2) = true := by
     rcases has with h | h <;> simp [h]
-  simp only [decide_true, has', Bool.true_and, Bool.not_eq_false', List.all_eq_true,
-    List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq,
-    isByte, decide_eq_true_eq] at hok
+  simp only [memoryPayload?, MemoryPayload.isByteChecked, decide_true, has', Bool.true_and,
+    Bool.not_eq_false', List.all_eq_true, List.mem_cons, List.not_mem_nil, or_false,
+    forall_eq_or_imp, forall_eq, isByte, decide_eq_true_eq] at hok
   exact ⟨hok.1, hok.2.1, hok.2.2.1, hok.2.2.2⟩
 
 /-- A memory message that is not a receive (multiplicity ≠ -1) never violates. -/
@@ -194,7 +194,7 @@ private theorem memory_nonRecv_ok (busMap : Nat → Option OpenVmBusType)
   unfold violates
   rw [hbus]
   rcases payload with _ | ⟨a0, _ | ⟨a1, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2, _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩ <;>
-    simp [hm]
+    simp [memoryPayload?, hm]
 
 /-- A memory *send* (multiplicity 1) never violates: either the characteristic is > 2 and a
     send is not a receive, or `p ∣ 2` and every value is trivially a byte. -/
@@ -216,7 +216,7 @@ private theorem memory_send_ok [NeZero p] (busMap : Nat → Option OpenVmBusType
     unfold violates
     rw [hbus]
     rcases payload with _ | ⟨a0, _ | ⟨a1, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2, _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩ <;>
-      simp [isByte, hbyte]
+      simp [memoryPayload?, MemoryPayload.isByteChecked, isByte, hbyte]
   · exact memory_nonRecv_ok busMap m hbus (by rw [hm]; exact hc)
 
 /-- A memory *receive* (multiplicity -1) with byte data limbs (payload slots 2–5, where
@@ -236,7 +236,7 @@ private theorem memory_recv_ok (busMap : Nat → Option OpenVmBusType)
   have h1 : d1.val < 256 := hslots 3 (by simp) d1 rfl
   have h2 : d2.val < 256 := hslots 4 (by simp) d2 rfl
   have h3 : d3.val < 256 := hslots 5 (by simp) d3 rfl
-  simp [isByte, h0, h1, h2, h3]
+  simp [memoryPayload?, MemoryPayload.isByteChecked, isByte, h0, h1, h2, h3]
 
 /-- A memory message whose address-space slot (slot 0) is a constant ∉ {1, 2} never violates:
     `violates` only rejects non-byte data on address spaces 1 and 2. -/
@@ -258,7 +258,7 @@ private theorem memory_recv_nonByte_ok (busMap : Nat → Option OpenVmBusType)
     rw [has]
     simp only [Bool.or_eq_false_iff, beq_eq_false_iff_ne]
     exact ⟨hne1, hne2⟩
-  simp only [hmid, Bool.and_false, Bool.false_and]
+  simp only [memoryPayload?, MemoryPayload.isByteChecked, hmid, Bool.and_false, Bool.false_and]
 
 /-- A bus with a declared last-write-wins shape (memory or execution bridge) is stateful. -/
 theorem openVm_isStateful_of_memShape {p : ℕ} (busMap : Nat → Option OpenVmBusType)

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -309,7 +309,7 @@ private theorem memory_nonGetPrev_ok (busMap : Nat → Option Sp1BusType)
   unfold violates
   rw [hbus]
   rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
-    _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [hm]
+    _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [memoryPayload?, hm]
 
 /-- A memory `getPrevious` (multiplicity 1) with 16-bit data limbs (slots 5–8) never violates. -/
 private theorem memory_getPrev_ok (busMap : Nat → Option Sp1BusType)
@@ -327,7 +327,7 @@ private theorem memory_getPrev_ok (busMap : Nat → Option Sp1BusType)
   have h1 : d1.val < 65536 := hslots 6 (by simp) d1 rfl
   have h2 : d2.val < 65536 := hslots 7 (by simp) d2 rfl
   have h3 : d3.val < 65536 := hslots 8 (by simp) d3 rfl
-  simp [is16Bit, hm, h0, h1, h2, h3]
+  simp [memoryPayload?, is16Bit, hm, h0, h1, h2, h3]
 
 /-- The four data limbs (slots 5–8) of an accepted memory `getPrevious` (multiplicity `1`, ≥9-slot
     record) are 16-bit (converse of `memory_getPrev_ok`). -/
@@ -342,7 +342,7 @@ private theorem memory_read_data (busMap : Nat → Option Sp1BusType)
   rw [hbus, hm] at hok
   rcases hs with rfl | rfl | rfl | rfl <;>
     (rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
-      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp_all [is16Bit, List.all_cons, List.all_nil])
+      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp_all [memoryPayload?, is16Bit, List.all_cons, List.all_nil])
 
 /-- A memory `setNew` (multiplicity -1) never violates. -/
 private theorem memory_setNew_ok [NeZero p] (busMap : Nat → Option Sp1BusType)
@@ -362,7 +362,7 @@ private theorem memory_setNew_ok [NeZero p] (busMap : Nat → Option Sp1BusType)
     unfold violates
     rw [hbus]
     rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
-      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [is16Bit, h16]
+      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [memoryPayload?, is16Bit, h16]
   · exact memory_nonGetPrev_ok busMap m hbus (by rw [hm]; exact fun h => hc h.symm)
 
 /-- The proven facts about `sp1BusSemantics`, for any bus map. -/

--- a/ApcOptimizer/Implementation/Variable.lean
+++ b/ApcOptimizer/Implementation/Variable.lean
@@ -23,8 +23,11 @@ def Variable.ofPowdrName (raw : String) : Variable :=
       | none => { name := raw }
   | _ => { name := raw }
 
-/-- `Spec.lean` pins `BEq Variable` to `decide (a = b)`; this is its lawfulness, from which
-    `EquivBEq`/`LawfulHashable` (the hash-map key obligations) are inferred. -/
+/-- Pinned to `Variable`'s `DecidableEq`, so `LawfulBEq` below holds by `decide`. -/
+instance : BEq Variable := ⟨fun a b => decide (a = b)⟩
+
+/-- Lawfulness of the `BEq` above, from which `EquivBEq`/`LawfulHashable` (the hash-map key
+    obligations) are inferred. -/
 instance : LawfulBEq Variable where
   rfl := by simp [BEq.beq]
   eq_of_beq h := by simpa [BEq.beq] using h

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -61,6 +61,28 @@ def OpenVmBusType.isStateful : OpenVmBusType → Bool
 /-- Whether a field element is a byte (`0 ≤ x < 256`). -/
 def isByte (x : ZMod p) : Bool := decide (x.val < 256)
 
+/-- The named fields of an OpenVM memory payload,
+    `(address_space, pointer, data… (4 limbs), timestamp)`. `memShapeOf` and `x0ReturnsZero` address
+    the same layout by slot index. -/
+structure MemoryPayload (p : ℕ) where
+  /-- `1` = registers, `2` = main memory; other address spaces carry no byte invariant. -/
+  addressSpace : ZMod p
+  /-- The cell's address within its address space. -/
+  pointer : ZMod p
+  /-- The four limbs of the memory word. -/
+  data : List (ZMod p)
+
+/-- Read a memory payload's named fields; `none` if it is too short to be one. -/
+def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
+  | addressSpace :: pointer :: d0 :: d1 :: d2 :: d3 :: _timestamp =>
+      some { addressSpace := addressSpace, pointer := pointer, data := [d0, d1, d2, d3] }
+  | _ => none
+
+/-- Whether the address space is one whose words OpenVM byte-range-checks: registers (`1`) or main
+    memory (`2`). -/
+def MemoryPayload.isByteChecked (f : MemoryPayload p) : Bool :=
+  f.addressSpace.val == 1 || f.addressSpace.val == 2
+
 /-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
 def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   match busMap msg.busId, msg.payload with
@@ -108,11 +130,10 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
 
   -- In OpenVM, the invariant is that only range-checked values are sent to
   -- the register & memory address spaces.
-  | some .memory, addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
-    decide (msg.multiplicity = -1) &&
-      (addressSpace.val == 1 || addressSpace.val == 2) &&
-      !([b0, b1, b2, b3].all isByte)
-  | some .memory, _ => false
+  | some .memory, payload =>
+    match memoryPayload? payload with
+    | some f => decide (msg.multiplicity = -1) && f.isByteChecked && !(f.data.all isByte)
+    | none => false
 
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => true
@@ -130,15 +151,12 @@ def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
     !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
   -- Memory is stateful (multiplicity 1 or -1), and additionally maintains the invariant
   -- that data limbs written to the register / main-memory address spaces (1 and 2) are
-  -- byte-range. The payload is `(address_space, pointer, data.. (4 bytes), timestamp)`.
+  -- byte-range.
   | some .memory =>
     !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
-    (match msg.payload with
-      | addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
-        bif (addressSpace.val == 1 || addressSpace.val == 2) then
-          !([b0, b1, b2, b3].all isByte)
-        else false
-      | _ => false)
+    (match memoryPayload? msg.payload with
+      | some f => bif f.isByteChecked then !(f.data.all isByte) else false
+      | none => false)
   -- Circuits should not send messages to an unknown bus.
   | none => true
 

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -138,9 +138,9 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => true
 
-/-- Whether a message breaks an invariant on which soundness depends. -/
+/-- Whether a message breaks an invariant on which soundness depends. Only meaningful for an
+    *active* message — the multiplicity tests below reject `0`, and callers guard on it. -/
 def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
-  -- Note that this function is not called for multiplicity = 0
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).
   | some .pcLookup | some .variableRangeChecker | some .bitwiseLookup

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -62,20 +62,19 @@ def OpenVmBusType.isStateful : OpenVmBusType → Bool
 def isByte (x : ZMod p) : Bool := decide (x.val < 256)
 
 /-- The named fields of an OpenVM memory payload,
-    `(address_space, pointer, data… (4 limbs), timestamp)`. `memShapeOf` and `x0ReturnsZero` address
-    the same layout by slot index. -/
+    `(address_space, pointer, data… (4 limbs), timestamp)`. -/
 structure MemoryPayload (p : ℕ) where
-  /-- `1` = registers, `2` = main memory; other address spaces carry no byte invariant. -/
+  /-- `1` = registers, `2` = main memory. -/
   addressSpace : ZMod p
   /-- The cell's address within its address space. -/
   pointer : ZMod p
   /-- The four limbs of the memory word. -/
-  data : List (ZMod p)
+  data : Vector (ZMod p) 4
 
 /-- Read a memory payload's named fields; `none` if it is too short to be one. -/
 def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
   | addressSpace :: pointer :: d0 :: d1 :: d2 :: d3 :: _timestamp =>
-      some { addressSpace := addressSpace, pointer := pointer, data := [d0, d1, d2, d3] }
+      some { addressSpace := addressSpace, pointer := pointer, data := #v[d0, d1, d2, d3] }
   | _ => none
 
 /-- Whether the address space is one whose words OpenVM byte-range-checks: registers (`1`) or main

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -136,7 +136,7 @@ def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
     (match msg.payload with
       | addressSpace :: _pointer :: b0 :: b1 :: b2 :: b3 :: _timeStamp =>
         bif (addressSpace.val == 1 || addressSpace.val == 2) then
-          !([b0, b1, b2, b3].all (fun d => decide (d.val < 256)))
+          !([b0, b1, b2, b3].all isByte)
         else false
       | _ => false)
   -- Circuits should not send messages to an unknown bus.

--- a/ApcOptimizer/Sp1Semantics.lean
+++ b/ApcOptimizer/Sp1Semantics.lean
@@ -63,6 +63,23 @@ def isByte (x : ZMod p) : Bool := decide (x.val < 256)
 /-- Whether a field element is a 16-bit limb (`0 ≤ x < 2^16`). -/
 def is16Bit (x : ZMod p) : Bool := decide (x.val < 2 ^ 16)
 
+/-- The named fields of an SP1 memory payload,
+    `(clk… (2 fields), address… (3 limbs), data… (4 × 16-bit limbs))`. `memShapeOf` and
+    `x0ReturnsZero` address the same layout by slot index. -/
+structure MemoryPayload (p : ℕ) where
+  /-- The two clock fields. -/
+  clk : List (ZMod p)
+  /-- The three address limbs. -/
+  address : List (ZMod p)
+  /-- The four limbs of the memory word. -/
+  data : List (ZMod p)
+
+/-- Read a memory payload's named fields; `none` if it is too short to be one. -/
+def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
+  | c0 :: c1 :: a0 :: a1 :: a2 :: d0 :: d1 :: d2 :: d3 :: _ =>
+      some { clk := [c0, c1], address := [a0, a1, a2], data := [d0, d1, d2, d3] }
+  | _ => none
+
 /-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
 def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   match busMap msg.busId, msg.payload with
@@ -96,11 +113,11 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   | some .executionBridge, _ => false
 
   -- In SP1, the invariant is that memory data limbs are 16-bit range-checked. A *send*
-  -- (multiplicity 1) reads the previous record, so its data must be 16-bit. The payload is
-  -- `(clk, clk, address, address, address, data, data, data, data)`.
-  | some .memory, _ :: _ :: _ :: _ :: _ :: d0 :: d1 :: d2 :: d3 :: _ =>
-    decide (msg.multiplicity = 1) && !([d0, d1, d2, d3].all is16Bit)
-  | some .memory, _ => false
+  -- (multiplicity 1) reads the previous record, so its data must be 16-bit.
+  | some .memory, payload =>
+    match memoryPayload? payload with
+    | some f => decide (msg.multiplicity = 1) && !(f.data.all is16Bit)
+    | none => false
 
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => true
@@ -116,13 +133,12 @@ def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   | some .executionBridge =>
     !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
   -- Memory is stateful (multiplicity 1 or -1), and additionally maintains the invariant that its
-  -- data limbs are 16-bit range. The payload is `(clk, clk, address×3, data×4)`.
+  -- data limbs are 16-bit range.
   | some .memory =>
     !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
-    (match msg.payload with
-      | _ :: _ :: _ :: _ :: _ :: d0 :: d1 :: d2 :: d3 :: _ =>
-        !([d0, d1, d2, d3].all is16Bit)
-      | _ => false)
+    (match memoryPayload? msg.payload with
+      | some f => !(f.data.all is16Bit)
+      | none => false)
   -- Circuits should not send messages to an unknown bus.
   | none => true
 

--- a/ApcOptimizer/Sp1Semantics.lean
+++ b/ApcOptimizer/Sp1Semantics.lean
@@ -64,20 +64,19 @@ def isByte (x : ZMod p) : Bool := decide (x.val < 256)
 def is16Bit (x : ZMod p) : Bool := decide (x.val < 2 ^ 16)
 
 /-- The named fields of an SP1 memory payload,
-    `(clk… (2 fields), address… (3 limbs), data… (4 × 16-bit limbs))`. `memShapeOf` and
-    `x0ReturnsZero` address the same layout by slot index. -/
+    `(clk… (2 fields), address… (3 limbs), data… (4 × 16-bit limbs))`. -/
 structure MemoryPayload (p : ℕ) where
   /-- The two clock fields. -/
-  clk : List (ZMod p)
+  clk : Vector (ZMod p) 2
   /-- The three address limbs. -/
-  address : List (ZMod p)
+  address : Vector (ZMod p) 3
   /-- The four limbs of the memory word. -/
-  data : List (ZMod p)
+  data : Vector (ZMod p) 4
 
-/-- Read a memory payload's named fields; `none` if it is too short to be one. -/
+/-- Read a memory payload's named fields; `none` if the number of entries is wrong. -/
 def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
   | c0 :: c1 :: a0 :: a1 :: a2 :: d0 :: d1 :: d2 :: d3 :: _ =>
-      some { clk := [c0, c1], address := [a0, a1, a2], data := [d0, d1, d2, d3] }
+      some { clk := #v[c0, c1], address := #v[a0, a1, a2], data := #v[d0, d1, d2, d3] }
   | _ => none
 
 /-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
@@ -122,8 +121,8 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => true
 
-/-- Whether a message breaks an invariant on which soundness depends. Only meaningful for an
-    *active* message — the multiplicity tests below reject `0`, and callers guard on it. -/
+/-- Whether a message breaks an invariant on which soundness depends. Only called for
+    message with nonzero multiplicity. -/
 def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).

--- a/ApcOptimizer/Sp1Semantics.lean
+++ b/ApcOptimizer/Sp1Semantics.lean
@@ -122,9 +122,9 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => true
 
-/-- Whether a message breaks an invariant on which soundness depends. -/
+/-- Whether a message breaks an invariant on which soundness depends. Only meaningful for an
+    *active* message — the multiplicity tests below reject `0`, and callers guard on it. -/
 def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
-  -- Note that this function is not called for multiplicity = 0
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).
   | some .pcLookup | some .byteLookup | some .instructionFetch | some .pageProt =>

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -134,16 +134,13 @@ structure BusSemantics (p : ℕ) where
       *another* chip.
       An example of this is sending a message that conflicts with a lookup
       table entry.
-      Only consulted for *active* messages: `Circuit.satisfies` guards on
-      `multiplicity ≠ 0`, so the value at multiplicity `0` is never used. -/
+      Only consulted for messages with nonzero multiplicity. -/
   violatesConstraint (busInteractionMessage : BusInteraction (ZMod p)) : Bool
   /-- Whether sending this bus interaction message breaks an invariant on which
       soundness of the system depends.
       For example, a memory bus might have the invariant that all sent values
       must be in a certain range.
-      Only consulted for *active* messages: `Circuit.guaranteesInvariants`
-      guards on `multiplicity ≠ 0`, so the value at multiplicity `0` is never
-      used. -/
+      Only consulted for messages with nonzero multiplicity. -/
   breaksInvariant (busInteractionMessage : BusInteraction (ZMod p)) : Bool
   /-- A property on *stateful* bus messages with nonzero multiplicity.
       Completeness is only required for assignments whose stateful messages
@@ -211,6 +208,7 @@ def Derivations.methodFor :
   | [], _ => none
   | (u, cm) :: rest, v =>
       match Derivations.methodFor rest v with
+      -- If `v` is derived later, that derivation overrides this one.
       | some later => some later
       | none => if u = v then some cm else none
 

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -133,12 +133,17 @@ structure BusSemantics (p : ℕ) where
   /-- Whether sending this bus interaction message violates a constraint in
       *another* chip.
       An example of this is sending a message that conflicts with a lookup
-      table entry. -/
+      table entry.
+      Only consulted for *active* messages: `Circuit.satisfies` guards on
+      `multiplicity ≠ 0`, so the value at multiplicity `0` is never used. -/
   violatesConstraint (busInteractionMessage : BusInteraction (ZMod p)) : Bool
   /-- Whether sending this bus interaction message breaks an invariant on which
       soundness of the system depends.
       For example, a memory bus might have the invariant that all sent values
-      must be in a certain range. -/
+      must be in a certain range.
+      Only consulted for *active* messages: `Circuit.guaranteesInvariants`
+      guards on `multiplicity ≠ 0`, so the value at multiplicity `0` is never
+      used. -/
   breaksInvariant (busInteractionMessage : BusInteraction (ZMod p)) : Bool
   /-- A property on *stateful* bus messages with nonzero multiplicity.
       Completeness is only required for assignments whose stateful messages

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -18,8 +18,6 @@ structure Variable where
   powdrId? : Option Nat := none
   deriving DecidableEq, Repr
 
-instance : BEq Variable := ⟨fun a b => decide (a = b)⟩
-
 /-- An arithmetic expression over structured variables and field constants. -/
 inductive Expression (p : ℕ) where
   /-- A constant field element. -/
@@ -207,8 +205,9 @@ def Derivations.methodFor :
     Derivations p → Variable → Option (ComputationMethod p)
   | [], _ => none
   | (u, cm) :: rest, v =>
-      (Derivations.methodFor rest v).orElse
-        (fun _ => if u = v then some cm else none)
+      match Derivations.methodFor rest v with
+      | some later => some later
+      | none => if u = v then some cm else none
 
 -- ANCHOR: witgen
 /-- Whether `ds` lets witness generation produce every element of `outputVars`

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ apc-optimizer, it should be sufficient to review:
 3. [`ApcOptimizer/MemoryBus.lean`](./ApcOptimizer/MemoryBus.lean): The memory-discipline utility the semantics above build on (its `direction` selects OpenVM's send-then-receive convention or SP1's reverse); likely useful for other VMs as well.
 4. The correctness theorems in [`ApcOptimizer/Optimizer.lean`](./ApcOptimizer/Optimizer.lean): `optimizerWithBusFacts_maintainsCorrectness` — the master statement that the optimizer maintains correctness for *any* proven bus facts — together with its instances, `simpleOptimizer_maintainsCorrectness` (the fact-free optimizer), `openVmOptimizer_maintainsCorrectness` (the `openVmOptimizer` the CLI actually runs), and `sp1Optimizer_maintainsCorrectness` (the SP1 optimizer). Audit the statements and check that the proofs are correct by running `lake build`.
 
+### Assumptions (all VMs)
+
+Completeness (`isCompleteReplacementOf`) is stated *conditionally* on *every variable of the input
+circuit carrying a powdr ID*: witness generation reconstructs the optimized assignment from the
+input variables, so a variable with no ID has nothing to be reconstructed from. powdr's exporter
+satisfies this, and the parser assigns IDs to all parsed variables — but the spec states it as a
+hypothesis rather than enforcing it, so an input circuit violating it gets no completeness
+guarantee (soundness is unconditional).
+
 ### Assumptions (OpenVM)
 
 The theorem is proven against the spec and the OpenVM semantics above. For the guarantee to carry over to a real OpenVM circuit, the auditor must verify that the following assumptions hold on the *input* circuits:

--- a/README.md
+++ b/README.md
@@ -17,12 +17,8 @@ apc-optimizer, it should be sufficient to review:
 
 ### Assumptions (all VMs)
 
-Completeness (`isCompleteReplacementOf`) is stated *conditionally* on *every variable of the input
-circuit carrying a powdr ID*: witness generation reconstructs the optimized assignment from the
-input variables, so a variable with no ID has nothing to be reconstructed from. powdr's exporter
-satisfies this, and the parser assigns IDs to all parsed variables — but the spec states it as a
-hypothesis rather than enforcing it, so an input circuit violating it gets no completeness
-guarantee (soundness is unconditional).
+All variables in the input circuit carry a powdr ID. If that was not the case, the completeness
+statement would be meaningless.
 
 ### Assumptions (OpenVM)
 


### PR DESCRIPTION
First of four PRs from a readability review of the bus-semantics spec, working
from the principle that the audited surface should be optimized for readability
regardless of what it costs the implementation. This one is the low-risk set;
none of it changes what the spec *means* (except where noted, nothing changes at
all — only how it reads).

## Implementation leakage out of `Spec.lean`

`instance : BEq Variable` had no user in the audited surface — it exists for the
parser's `Std.HashMap Variable` keys — and it was not `LawfulBEq` there either.
It moves next to its lawfulness proof in `Implementation/Variable.lean`.

## Two audited definitions that did not read like their docstrings

- `breaksInvariant` inlined `decide (d.val < 256)` where `violates`, in the same
  file, calls `isByte`. Both call `isByte` now.
- `Derivations.methodFor` implements "later derivations override earlier ones" by
  recursing on the tail and falling back to the head via `orElse`, which reads
  backwards from the docstring. Matching on the recursive call states it
  directly.

## The memory payload layout, named once

`violates` and `breaksInvariant` each opened a memory payload by position, with
the layout spelled out in a comment repeated above both. A `MemoryPayload` record
with a `memoryPayload?` projection states the layout once, and both arms then
read `f.data` / `f.isByteChecked` — for OpenVM and SP1 alike.

Meaning-preserving: both arms already returned `false` for a payload too short to
open, which is exactly where `memoryPayload?` is `none`.

`x0ReturnsZero` deliberately keeps its slot indices. Its conclusion is stated per
slot as `payload[i]? = some 0`, which still bites for a payload too short to hold
all six fields, and a record-shaped assumption would go vacuous there — which
`BusFacts.zeroCell` cannot absorb, since its `addrReq` has no way to express a
length side condition. Making that change would have weakened an assumption to
buy formatting.

## An unstated contract

`violatesConstraint` and `breaksInvariant` are only ever consulted for messages
of nonzero multiplicity — every call site in `Spec.lean` guards on it — but the
`BusSemantics` field docs never said so, and the two VM instances buried it in a
body comment. It is now stated where the fields are declared, so it lands in the
rendered API docs.

## Also

The README's assumptions section did not mention that completeness is stated
*conditionally* on every input variable carrying a powdr ID. Now it does.

## Verification

- `lake build` — clean, no warnings (2554 jobs)
- `lake build docs` — clean (no spec/docs anchor drift)
- `Scripts/check-proof-integrity.sh` — passes; correctness theorems still rest
  only on `propext`, `Classical.choice`, `Quot.sound`, and no theorem is orphaned

Proof repair needed for the above was confined to `Implementation/` (four simp
lists in `OpenVmFacts`/`Sp1Facts` needed `memoryPayload?`, and one case split in
`Implementation/Optimizer.lean` for the `methodFor` restatement).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKMeZM6XGPcv89SyzvYcUf)_