### PR TITLE
spec: state the bus predicates positively, as Props

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -73,7 +73,7 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       (x : ZMod p),
       slotBound m.busId m.multiplicity pattern slot = some bound →
       Matches m.payload pattern →
-      bs.violatesConstraint m = false →
+      bs.accepts m →
       m.payload[slot]? = some x →
       x.val < bound
   /-- Functional dependence: for accepted messages matching `pattern`, `outSlot`'s value is `f` of
@@ -86,20 +86,26 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       (f : List (ZMod p) → ZMod p) (z : ZMod p),
       slotFun m.busId pattern outSlot = some f →
       Matches m.payload pattern →
-      bs.violatesConstraint m = false →
+      bs.accepts m →
       m.payload[outSlot]? = some z →
       z = f (m.payload.set outSlot 0)
-  /-- Buses whose messages never violate a constraint (e.g. stateful buses with no table). -/
+  /-- Buses that accept every message (e.g. stateful buses with no table). -/
   neverViolates : (busId : Nat) → Bool
   neverViolates_sound :
     ∀ (m : BusInteraction (ZMod p)),
-      neverViolates m.busId = true → bs.violatesConstraint m = false
+      neverViolates m.busId = true → bs.accepts m
   /-- Buses whose only table obligation is the payload arity: a message of the declared arity never
       violates, whatever its values (both VMs' instruction-table lookups are of this shape). -/
   neverViolatesArity : (busId : Nat) → (arity : Nat) → Bool
   neverViolatesArity_sound :
     ∀ (m : BusInteraction (ZMod p)),
-      neverViolatesArity m.busId m.payload.length = true → bs.violatesConstraint m = false
+      neverViolatesArity m.busId m.payload.length = true → bs.accepts m
+  /-- Decides `bs.accepts`. The audited `accepts` is a `Prop`, so this is how a pass evaluates the
+      bus semantics at runtime. It is a full decision procedure, not merely sound: passes rewrite
+      between it and the semantic condition (see `Proofs/DomainBatch.lean`), which needs both
+      directions. -/
+  acceptsDec : BusInteraction (ZMod p) → Bool
+  acceptsDec_iff : ∀ (m : BusInteraction (ZMod p)), acceptsDec m = true ↔ bs.accepts m
   /-- Last-write-wins shape declared for a bus, or `none` (see `ApcOptimizer/MemoryBus.lean`). -/
   memShape : (busId : Nat) → Option MemoryBusShape
   /-- Table obligations of a memory-style stateful bus, for pair cancellation:
@@ -113,10 +119,10 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (pattern : List (Option (ZMod p))) (slots : List Nat) (bound : Nat),
       recvByteSlots busId pattern = some (slots, bound) →
       ∀ (m : BusInteraction (ZMod p)), m.busId = busId →
-        (m.multiplicity = shape.setNewMult → bs.violatesConstraint m = false) ∧
+        (m.multiplicity = shape.setNewMult → bs.accepts m) ∧
         (m.multiplicity = -shape.setNewMult → Matches m.payload pattern →
           (∀ slot ∈ slots, ∀ x : ZMod p, m.payload[slot]? = some x → x.val < bound) →
-          bs.violatesConstraint m = false)
+          bs.accepts m)
   /-- Every bus with a declared shape is stateful. -/
   memShape_stateful : ∀ (busId : Nat) (shape : MemoryBusShape),
     memShape busId = some shape → bs.isStateful busId = true
@@ -157,8 +163,7 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (busId : Nat), varRangeBus busId = true →
       bs.isStateful busId = false ∧
       ∀ (x b mult : ZMod p),
-        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, b] }
-            = false ↔ (b.val ≤ 17 ∧ x.val < 2 ^ b.val)
+        bs.accepts { busId := busId, multiplicity := mult, payload := [x, b] } ↔ (b.val ≤ 17 ∧ x.val < 2 ^ b.val)
   /-- Tuple-range-checker stateless bus: `[x, y]` accepted iff `x.val < s1 ∧ y.val < s2`, and at
       multiplicity `1` breaks no invariant. -/
   tupleRangeBus : (busId : Nat) → Option (Nat × Nat)
@@ -166,10 +171,9 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (busId s1 s2 : Nat), tupleRangeBus busId = some (s1, s2) →
       bs.isStateful busId = false ∧
       (∀ (x y : ZMod p),
-        bs.breaksInvariant { busId := busId, multiplicity := 1, payload := [x, y] } = false) ∧
+        bs.maintainsInvariants { busId := busId, multiplicity := 1, payload := [x, y] }) ∧
       ∀ (x y mult : ZMod p),
-        bs.violatesConstraint { busId := busId, multiplicity := mult, payload := [x, y] }
-            = false ↔ (x.val < s1 ∧ y.val < s2)
+        bs.accepts { busId := busId, multiplicity := mult, payload := [x, y] } ↔ (x.val < s1 ∧ y.val < s2)
   /-- Real-trace fixed-zero cells (e.g. the RISC-V `x0` register):
       `zeroCell busId = some (addrReq, dataSlots)` asserts that on the stateful bus `busId`, every
       active message with `payload[s] = v` for each `(s, v) ∈ addrReq` carries `0` in every slot of
@@ -192,7 +196,7 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (busId : Nat), zeroRangeEq busId = true →
       bs.isStateful busId = false ∧
       ∀ (x : ZMod p),
-        bs.violatesConstraint { busId := busId, multiplicity := 1, payload := [x, 0] } = false
+        bs.accepts { busId := busId, multiplicity := 1, payload := [x, 0] }
           ↔ x = 0
   /-- VM-neutral bitwise/byte-lookup fact (`ByteXorSpec`): a payload decoding to `(op, o₁, o₂, r)`
       is accepted, when `op = xorOp`, iff `o₁, o₂` are bytes and `r = o₁ ⊕ o₂`; when `op = pairOp`,
@@ -203,14 +207,14 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
     ∀ (busId : Nat) (spec : ByteXorSpec p), byteXorSpec busId = some spec →
       bs.isStateful busId = false ∧
       (∀ (pl : List (ZMod p)),
-        bs.breaksInvariant { busId := busId, multiplicity := 1, payload := pl } = false) ∧
+        bs.maintainsInvariants { busId := busId, multiplicity := 1, payload := pl }) ∧
       ∀ (pl : List (ZMod p)) (op o1 o2 r mult : ZMod p),
         spec.decode pl = some (op, o1, o2, r) →
         (op = spec.xorOp →
-           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+           (bs.accepts { busId := busId, multiplicity := mult, payload := pl }
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r.val = Nat.xor o1.val o2.val)) ∧
         (op = spec.pairOp →
-           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+           (bs.accepts { busId := busId, multiplicity := mult, payload := pl }
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r = 0))
   /-- Soundness of the optional `orOp`/`andOp` relations, for a payload decoding to
       `(op, o₁, o₂, r)`: when `op = orOp`, accepted iff `o₁, o₂` are bytes and `r = o₁ | o₂`; when
@@ -220,10 +224,10 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       ∀ (pl : List (ZMod p)) (op o1 o2 r mult : ZMod p),
         spec.decode pl = some (op, o1, o2, r) →
         (∀ oop, spec.orOp = some oop → op = oop →
-           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+           (bs.accepts { busId := busId, multiplicity := mult, payload := pl }
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r.val = Nat.lor o1.val o2.val)) ∧
         (∀ aop, spec.andOp = some aop → op = aop →
-           (bs.violatesConstraint { busId := busId, multiplicity := mult, payload := pl } = false
+           (bs.accepts { busId := busId, multiplicity := mult, payload := pl }
              ↔ o1.val < spec.bound ∧ o2.val < spec.bound ∧ r.val = Nat.land o1.val o2.val))
   /-- A single-value range check at an arbitrary payload position:
       `rangeCheckAt busId pattern = some (valSlot, bound)` means every multiplicity-`1` message on
@@ -236,12 +240,12 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
       bs.isStateful busId = false ∧
       ∀ (m : BusInteraction (ZMod p)), m.busId = busId → m.multiplicity = 1 →
         Matches m.payload pattern →
-        bs.breaksInvariant m = false ∧
+        bs.maintainsInvariants m ∧
         ∀ (x : ZMod p), m.payload[valSlot]? = some x →
-          (bs.violatesConstraint m = false ↔ x.val < bound)
+          (bs.accepts m ↔ x.val < bound)
 
 /-- The fact-free instance: claims nothing, exists for every semantics. -/
-def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
+def BusFacts.trivial (bs : BusSemantics p) [DecidablePred bs.accepts] : BusFacts p bs where
   slotBound _ _ _ _ := none
   slotBound_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
   slotFun _ _ _ := none
@@ -250,6 +254,8 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   neverViolates_sound := by intro _ h; exact absurd h (by simp)
   neverViolatesArity _ _ := false
   neverViolatesArity_sound := by intro _ h; exact absurd h (by simp)
+  acceptsDec m := decide (bs.accepts m)
+  acceptsDec_iff := by intro _; exact decide_eq_true_iff
   recvByteSlots _ _ := none
   recvByteSlots_sound := by intro _ _ h; exact absurd h (by simp)
   memShape _ := none

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -8,13 +8,145 @@ set_option autoImplicit false
 # Proven bus facts for the OpenVM semantics
 
 The `BusFacts` instance for `openVmBusSemantics` (see `ApcOptimizer/Implementation/BusFacts.lean`
-for the design). Every claim is proven against the concrete `violates`, so none needs auditing.
-Parameterized by the bus map (defaulting to `defaultBusMap`).
+for the design). Every claim is proven against the audited `accepts`/`maintainsInvariants`, so none
+needs auditing. Parameterized by the bus map (defaulting to `defaultBusMap`).
 -/
 
 namespace ApcOptimizer.OpenVM
 
 variable {p : ℕ}
+
+
+/-! ## Deciding the semantics
+
+The audited `accepts`/`maintainsInvariants` are `Prop`s, so a pass cannot evaluate them. `violates`
+and `breaksInvariant` below are the `Bool` decision procedures the pipeline actually runs, each
+proven equivalent to its audited counterpart (`violates_eq_false_iff`,
+`breaksInvariant_eq_false_iff`); the helper lemmas in this file are stated over them and bridged at
+the `BusFacts` interface. -/
+
+private def isByteB (x : ZMod p) : Bool := decide (x.val < 256)
+
+private theorem isByteB_iff (x : ZMod p) : isByteB x = true ↔ isByte x := by
+  simp [isByteB, isByte]
+
+private def isByteCheckedB (f : MemoryPayload p) : Bool :=
+  f.addressSpace.val == 1 || f.addressSpace.val == 2
+
+private theorem isByteCheckedB_iff (f : MemoryPayload p) :
+    isByteCheckedB f = true ↔ f.isByteChecked := by
+  simp [isByteCheckedB, MemoryPayload.isByteChecked]
+
+/-- Bool decision procedure for `accepts` (`violates_eq_false_iff`). -/
+private def violates (busMap : Nat → Option OpenVmBusType) (msg : BusInteraction (ZMod p)) : Bool :=
+  match busMap msg.busId, msg.payload with
+  | some .pcLookup, args => !decide (args.length = 9)
+  | some .bitwiseLookup, [x, y, z, op] =>
+    match op.val with
+    | 0 => !(isByteB x && isByteB y && decide (z.val = 0))
+    | 1 => !(isByteB x && isByteB y && decide (z.val = Nat.xor x.val y.val))
+    | _ => true
+  | some .variableRangeChecker, [x, bits] =>
+    !(decide (bits.val ≤ 17) && decide (x.val < 2 ^ bits.val))
+  | some (.tupleRangeChecker s1 s2), [x, y] =>
+    !(decide (x.val < s1) && decide (y.val < s2))
+  | some .bitwiseLookup, _ => true
+  | some .variableRangeChecker, _ => true
+  | some (.tupleRangeChecker _ _), _ => true
+  | some .executionBridge, _ => false
+  | some .memory, payload =>
+    match memoryPayload? payload with
+    | some f => decide (msg.multiplicity = -1) && isByteCheckedB f && !(f.data.all isByteB)
+    | none => false
+  | none, _ => true
+
+/-- Bool decision procedure for `maintainsInvariants` (`breaksInvariant_eq_false_iff`). -/
+private def breaksInvariant (busMap : Nat → Option OpenVmBusType)
+    (msg : BusInteraction (ZMod p)) : Bool :=
+  match busMap msg.busId with
+  | some .pcLookup | some .variableRangeChecker | some .bitwiseLookup
+  | some (.tupleRangeChecker _ _) =>
+    !decide (msg.multiplicity = 1)
+  | some .executionBridge =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
+  | some .memory =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
+    (match memoryPayload? msg.payload with
+      | some f => bif isByteCheckedB f then !(f.data.all isByteB) else false
+      | none => false)
+  | none => true
+
+private theorem all_isByteB_iff (v : Vector (ZMod p) 4) :
+    v.all isByteB = true ↔ ∀ d ∈ v, isByte d := by
+  rw [Vector.all_eq_true_iff_forall_mem]
+  simp only [isByteB_iff]
+
+private theorem forall_isByteB_iff (v : Vector (ZMod p) 4) :
+    (∀ (i : Nat) (h : i < 4), isByteB v[i] = true) ↔ ∀ d ∈ v, isByte d :=
+  Vector.all_eq_true.symm.trans (all_isByteB_iff v)
+
+private theorem violates_eq_false_iff (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) : violates busMap m = false ↔ accepts busMap m := by
+  obtain ⟨bid, mult, payload⟩ := m
+  unfold violates accepts
+  cases hb : busMap bid with
+  | none => simp
+  | some t =>
+    cases t with
+    | executionBridge => simp
+    | pcLookup => simp
+    | variableRangeChecker =>
+        rcases payload with _ | ⟨x, _ | ⟨b, _ | ⟨w, rest⟩⟩⟩ <;> simp
+    | tupleRangeChecker s1 s2 =>
+        rcases payload with _ | ⟨x, _ | ⟨y, _ | ⟨w, rest⟩⟩⟩ <;> simp
+    | bitwiseLookup =>
+        rcases payload with _ | ⟨x, _ | ⟨y, _ | ⟨z, _ | ⟨op, _ | ⟨w, rest⟩⟩⟩⟩⟩ <;> try simp
+        rcases op.val with _ | _ | n <;> simp [isByteB_iff, and_assoc]
+    | memory =>
+        cases hp : memoryPayload? payload with
+        | none => simp [hp]
+        | some f =>
+            simp [hp, isByteCheckedB_iff, forall_isByteB_iff, imp_iff_not_or, or_assoc]
+
+private theorem breaksInvariant_eq_false_iff (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) :
+    breaksInvariant busMap m = false ↔ maintainsInvariants busMap m := by
+  obtain ⟨bid, mult, payload⟩ := m
+  unfold breaksInvariant maintainsInvariants
+  cases hb : busMap bid with
+  | none => simp
+  | some t =>
+    cases t with
+    | pcLookup => simp
+    | variableRangeChecker => simp
+    | bitwiseLookup => simp
+    | tupleRangeChecker s1 s2 => simp
+    | executionBridge => simp [or_iff_not_imp_left]
+    | memory =>
+        cases hp : memoryPayload? payload with
+        | none => simp [or_iff_not_imp_left]
+        | some f =>
+            cases hc : isByteCheckedB f with
+            | false =>
+                have hnc : ¬ f.isByteChecked := fun h => by
+                  simp [(isByteCheckedB_iff f).mpr h] at hc
+                simp [hc, hnc, or_iff_not_imp_left]
+            | true =>
+                simp [hc, (isByteCheckedB_iff f).mp hc, forall_isByteB_iff,
+                  or_iff_not_imp_left]
+
+
+/-- The `BusFacts` interface speaks the audited `accepts`; the lemmas here speak `violates`. Marked
+`@[simp]` so field proofs translate without restating each one. -/
+@[simp] private theorem openVm_accepts_iff (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) :
+    (openVmBusSemantics p busMap).accepts m ↔ violates busMap m = false :=
+  (violates_eq_false_iff busMap m).symm
+
+@[simp] private theorem openVm_maintains_iff (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) :
+    (openVmBusSemantics p busMap).maintainsInvariants m ↔ breaksInvariant busMap m = false :=
+  (breaksInvariant_eq_false_iff busMap m).symm
 
 
 private def slotBoundImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat) (mult : ZMod p)
@@ -154,7 +286,8 @@ private theorem payload_seven {payload : List (ZMod p)}
 /-- An execution-bridge message never violates. -/
 private theorem execBridge_ok (busMap : Nat → Option OpenVmBusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .executionBridge) :
-    violates busMap m = false := by
+    (openVmBusSemantics p busMap).accepts m := by
+  rw [openVm_accepts_iff]
   unfold violates
   rw [hbus]
 
@@ -180,14 +313,15 @@ private theorem memory_recv_bytes (busMap : Nat → Option OpenVmBusType)
   rw [hbus, hpay, hm] at hok
   have has' : (a0.val == 1 || a0.val == 2) = true := by
     rcases has with h | h <;> simp [h]
-  simp only [memoryPayload?, MemoryPayload.isByteChecked, decide_true, has', Bool.true_and,
-    Bool.not_eq_false', Vector.all_eq_true, isByte, decide_eq_true_eq] at hok
+  simp only [memoryPayload?, isByteCheckedB, decide_true, has', Bool.true_and,
+    Bool.not_eq_false', Vector.all_eq_true, isByteB, decide_eq_true_eq] at hok
   exact ⟨hok 0 (by omega), hok 1 (by omega), hok 2 (by omega), hok 3 (by omega)⟩
 
 /-- A memory message that is not a receive (multiplicity ≠ -1) never violates. -/
 private theorem memory_nonRecv_ok (busMap : Nat → Option OpenVmBusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
-    (hm : m.multiplicity ≠ -1) : violates busMap m = false := by
+    (hm : m.multiplicity ≠ -1) : (openVmBusSemantics p busMap).accepts m := by
+  rw [openVm_accepts_iff]
   obtain ⟨bid, mult, payload⟩ := m
   simp only at hbus hm
   unfold violates
@@ -199,7 +333,8 @@ private theorem memory_nonRecv_ok (busMap : Nat → Option OpenVmBusType)
     send is not a receive, or `p ∣ 2` and every value is trivially a byte. -/
 private theorem memory_send_ok [NeZero p] (busMap : Nat → Option OpenVmBusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
-    (hm : m.multiplicity = 1) : violates busMap m = false := by
+    (hm : m.multiplicity = 1) : (openVmBusSemantics p busMap).accepts m := by
+  rw [openVm_accepts_iff]
   by_cases hc : (1 : ZMod p) = -1
   · -- `p ∣ 2`: every value is `< 2 ≤ 256`, so the byte test never fails.
     have hadd : (1 : ZMod p) + 1 = 0 := (congrArg (· + 1) hc).trans (neg_add_cancel 1)
@@ -215,8 +350,8 @@ private theorem memory_send_ok [NeZero p] (busMap : Nat → Option OpenVmBusType
     unfold violates
     rw [hbus]
     rcases payload with _ | ⟨a0, _ | ⟨a1, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2, _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩ <;>
-      simp [memoryPayload?, MemoryPayload.isByteChecked, isByte, hbyte]
-  · exact memory_nonRecv_ok busMap m hbus (by rw [hm]; exact hc)
+      simp [memoryPayload?, isByteCheckedB, isByteB, hbyte]
+  · exact (openVm_accepts_iff busMap m).mp (memory_nonRecv_ok busMap m hbus (by rw [hm]; exact hc))
 
 /-- A memory *receive* (multiplicity -1) with byte data limbs (payload slots 2–5, where
     present) never violates. -/
@@ -224,7 +359,8 @@ private theorem memory_recv_ok (busMap : Nat → Option OpenVmBusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
     (hm : m.multiplicity = -1)
     (hslots : ∀ slot ∈ [2, 3, 4, 5], ∀ x : ZMod p, m.payload[slot]? = some x → x.val < 256) :
-    violates busMap m = false := by
+    (openVmBusSemantics p busMap).accepts m := by
+  rw [openVm_accepts_iff]
   obtain ⟨bid, mult, payload⟩ := m
   simp only at hbus hm hslots
   unfold violates
@@ -235,14 +371,15 @@ private theorem memory_recv_ok (busMap : Nat → Option OpenVmBusType)
   have h1 : d1.val < 256 := hslots 3 (by simp) d1 rfl
   have h2 : d2.val < 256 := hslots 4 (by simp) d2 rfl
   have h3 : d3.val < 256 := hslots 5 (by simp) d3 rfl
-  simp [memoryPayload?, MemoryPayload.isByteChecked, isByte, h0, h1, h2, h3]
+  simp [memoryPayload?, isByteCheckedB, isByteB, h0, h1, h2, h3]
 
 /-- A memory message whose address-space slot (slot 0) is a constant ∉ {1, 2} never violates:
     `violates` only rejects non-byte data on address spaces 1 and 2. -/
 private theorem memory_recv_nonByte_ok (busMap : Nat → Option OpenVmBusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
     (as : ZMod p) (hasval : ¬ (as.val = 1 ∨ as.val = 2)) (has : m.payload[0]? = some as) :
-    violates busMap m = false := by
+    (openVmBusSemantics p busMap).accepts m := by
+  rw [openVm_accepts_iff]
   obtain ⟨bid, mult, payload⟩ := m
   simp only at hbus has
   unfold violates
@@ -257,7 +394,7 @@ private theorem memory_recv_nonByte_ok (busMap : Nat → Option OpenVmBusType)
     rw [has]
     simp only [Bool.or_eq_false_iff, beq_eq_false_iff_ne]
     exact ⟨hne1, hne2⟩
-  simp only [memoryPayload?, MemoryPayload.isByteChecked, hmid, Bool.and_false, Bool.false_and]
+  simp only [memoryPayload?, isByteCheckedB, hmid, Bool.and_false, Bool.false_and]
 
 /-- A bus with a declared last-write-wins shape (memory or execution bridge) is stateful. -/
 theorem openVm_isStateful_of_memShape {p : ℕ} (busMap : Nat → Option OpenVmBusType)
@@ -284,10 +421,14 @@ private theorem memShapeOf_setNewMult_eq_one {p : ℕ} (busMap : Nat → Option 
 def openVmFacts (p : ℕ) [NeZero p]
     (busMap : Nat → Option OpenVmBusType := defaultBusMap) :
     BusFacts p (openVmBusSemantics p busMap) where
+  acceptsDec m := !violates busMap m
+  acceptsDec_iff m := by
+    rw [Bool.not_eq_true']
+    exact violates_eq_false_iff busMap m
   slotBound := slotBoundImpl busMap
   slotBound_sound := by
     intro m pattern slot bound x hfact hmatch hok hget
-    have hok' : violates busMap m = false := hok
+    have hok' : violates busMap m = false := (openVm_accepts_iff busMap m).mp hok
     unfold slotBoundImpl at hfact
     split at hfact
     · -- bitwise lookup, slot 0
@@ -448,7 +589,7 @@ def openVmFacts (p : ℕ) [NeZero p]
   slotFun := slotFunImpl busMap
   slotFun_sound := by
     intro m pattern outSlot f z hfact hmatch hok hget
-    have hok' : violates busMap m = false := hok
+    have hok' : violates busMap m = false := (openVm_accepts_iff busMap m).mp hok
     unfold slotFunImpl at hfact
     split at hfact
     · rename_i q0 q1 q2 op hbus
@@ -483,7 +624,8 @@ def openVmFacts (p : ℕ) [NeZero p]
     intro m h
     unfold neverViolatesArityImpl at h
     split at h
-    · rename_i hbus; exact pcLookup_ok busMap m hbus (by simpa using h)
+    · rename_i hbus
+      exact (openVm_accepts_iff busMap m).mpr (pcLookup_ok busMap m hbus (by simpa using h))
     · exact absurd h (by simp)
   recvByteSlots := recvByteSlotsImpl busMap
   recvByteSlots_sound := by
@@ -620,6 +762,7 @@ def openVmFacts (p : ℕ) [NeZero p]
     · intro x
       -- variableRangeChecker `[x, 0]`: `!(0 ≤ 17 ∧ x.val < 2^0) = false ↔ x.val < 1 ↔ x = 0`.
       have hv0 : (0 : ZMod p).val = 0 := ZMod.val_zero
+      rw [openVm_accepts_iff]
       show violates busMap { busId := busId, multiplicity := 1, payload := [x, 0] } = false ↔ x = 0
       unfold violates; rw [hbus]
       rw [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq,
@@ -638,6 +781,7 @@ def openVmFacts (p : ℕ) [NeZero p]
     · show (match busMap busId with | some t => t.isStateful | none => false) = false
       rw [hbus]; rfl
     · intro x b mult
+      rw [openVm_accepts_iff]
       show violates busMap { busId := busId, multiplicity := mult, payload := [x, b] }
           = false ↔ (b.val ≤ 17 ∧ x.val < 2 ^ b.val)
       unfold violates; rw [hbus]
@@ -655,10 +799,12 @@ def openVmFacts (p : ℕ) [NeZero p]
     · show (match busMap busId with | some t => t.isStateful | none => false) = false
       rw [hbus]; rfl
     · intro x y
+      rw [openVm_maintains_iff]
       show breaksInvariant busMap { busId := busId, multiplicity := 1, payload := [x, y] }
         = false
       unfold breaksInvariant; rw [hbus]; simp
     · intro x y mult
+      rw [openVm_accepts_iff]
       show violates busMap { busId := busId, multiplicity := mult, payload := [x, y] }
           = false ↔ (x.val < s1 ∧ y.val < s2)
       unfold violates; rw [hbus]
@@ -714,6 +860,7 @@ def openVmFacts (p : ℕ) [NeZero p]
     · show (match busMap busId with | some t => t.isStateful | none => false) = false
       rw [hbus]; rfl
     · intro pl
+      rw [openVm_maintains_iff]
       show breaksInvariant busMap { busId := busId, multiplicity := 1, payload := pl } = false
       unfold breaksInvariant; rw [hbus]; simp
     · intro pl op o1 o2 r mult hdec
@@ -723,6 +870,7 @@ def openVmFacts (p : ℕ) [NeZero p]
       · -- op = xorOp = 1
         have hop1 : op = 1 := hxor
         subst hop1
+        rw [openVm_accepts_iff]
         show violates busMap { busId := busId, multiplicity := mult, payload := [o1, o2, r, 1] } = false
           ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.xor o1.val o2.val
         unfold violates; rw [hbus]
@@ -733,15 +881,16 @@ def openVmFacts (p : ℕ) [NeZero p]
           have ho1 : o1.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt o1)
           have ho2 : o2.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt o2)
           have hrr : r.val = 0 := Nat.lt_one_iff.1 (ZMod.val_lt r)
-          simp [h1, isByte, ho1, ho2, hrr]
-        · simp [h1, isByte, and_assoc]
+          simp [h1, isByteB, ho1, ho2, hrr]
+        · simp [h1, isByteB, and_assoc]
       · -- op = pairOp = 0
         have hop0 : op = 0 := hpair
         subst hop0
+        rw [openVm_accepts_iff]
         show violates busMap { busId := busId, multiplicity := mult, payload := [o1, o2, r, 0] } = false
           ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
         unfold violates; rw [hbus]
-        simp [isByte, ZMod.val_eq_zero, and_assoc]
+        simp [isByteB, ZMod.val_eq_zero, and_assoc]
   -- OpenVM's bitwise-lookup bus has no OR/AND op (XOR + range only), so `orOp`/`andOp` default to
   -- `none` and the boolean-op soundness is vacuous.
   byteBoolSound := by

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -206,7 +206,7 @@ theorem Circuit.satisfies_congr {cs : Circuit p} {bs : BusSemantics p}
         (fun x hx => hh x (Circuit.mem_vars_of_constraint hc hx))]
       exact hsat.1 c hc
     · have hbe : bi.eval e1 = bi.eval e2 := Circuit.busEval_congr hh hbi
-      show (bi.eval e2).multiplicity ≠ 0 → bs.violatesConstraint (bi.eval e2) = false
+      show (bi.eval e2).multiplicity ≠ 0 → bs.accepts (bi.eval e2)
       rw [← hbe]
       exact hsat.2 bi hbi
   exact ⟨imp f g h, imp g f (fun x hx => (h x hx).symm)⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
@@ -56,7 +56,7 @@ def DenseConstraintSystem.satisfies (d : DenseConstraintSystem p) (bs : BusSeman
   (∀ c ∈ d.algebraicConstraints, c.eval denv = 0) ∧
   (∀ bi ∈ d.busInteractions,
     let message := denseBIEval bi denv
-    message.multiplicity ≠ 0 → bs.violatesConstraint message = false)
+    message.multiplicity ≠ 0 → bs.accepts message)
 
 /-- Dense admissibility: the fired stateful-bus messages satisfy the bus admissibility predicate. -/
 def DenseConstraintSystem.admissible (d : DenseConstraintSystem p) (bs : BusSemantics p)
@@ -69,7 +69,7 @@ def DenseConstraintSystem.guaranteesInvariants (d : DenseConstraintSystem p) (bs
     Prop :=
   ∀ denv, d.satisfies bs denv → ∀ bi ∈ d.busInteractions,
     let message := denseBIEval bi denv
-    message.multiplicity ≠ 0 → bs.breaksInvariant message = false
+    message.multiplicity ≠ 0 → bs.maintainsInvariants message
 
 /-- Every satisfying assignment has a matching one for `other` with equivalent side effects. -/
 def DenseConstraintSystem.implies (self other : DenseConstraintSystem p) (bs : BusSemantics p) :
@@ -130,7 +130,7 @@ theorem DenseConstraintSystem.satisfies_congr {d : DenseConstraintSystem p} {bs 
       exact hsat.1 c hc
     · have hbe : denseBIEval bi e1 = denseBIEval bi e2 :=
         denseBIEval_congr bi e1 e2 (fun i hi => hh i (DenseConstraintSystem.mem_occ_of_bi hbi hi))
-      show (denseBIEval bi e2).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi e2) = false
+      show (denseBIEval bi e2).multiplicity ≠ 0 → bs.accepts (denseBIEval bi e2)
       rw [← hbe]
       exact hsat.2 bi hbi
   exact ⟨imp denv1 denv2 h, imp denv2 denv1 (fun i hi => (h i hi).symm)⟩
@@ -277,7 +277,7 @@ theorem VarRegistry.decodeCS_guaranteesInvariants (reg : VarRegistry) {d : Dense
   constructor
   · -- decode → dense (needs coverage, to transport a dense env to a spec one)
     intro hgi denv hsat bi hbi
-    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.breaksInvariant (denseBIEval bi denv) = false
+    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi denv)
     intro hne
     have hsatE : (reg.decodeCS d).satisfies bs (reg.extendEnv denv (fun _ => 0)) := by
       rw [reg.decodeCS_satisfies]
@@ -298,7 +298,7 @@ theorem VarRegistry.decodeCS_guaranteesInvariants (reg : VarRegistry) {d : Dense
     simp only [VarRegistry.decodeCS, List.mem_map] at hbi'
     obtain ⟨bi, hbi, rfl⟩ := hbi'
     show ((reg.decodeBI bi).eval E).multiplicity ≠ 0
-      → bs.breaksInvariant ((reg.decodeBI bi).eval E) = false
+      → bs.maintainsInvariants ((reg.decodeBI bi).eval E)
     rw [reg.decodeBI_eval]
     rw [reg.decodeCS_satisfies] at hsat
     exact fun hne => hgi _ hsat bi hbi hne

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
@@ -143,14 +143,14 @@ theorem denseDropPair_correct (isInput : VarId → Bool)
     (checks : List (BusInteraction (DenseExpr p)))
     (hchecks : ∀ ck ∈ checks,
       bs.isStateful ck.busId = false ∧
-      (∀ denv, bs.violatesConstraint (denseBIEval R denv) = false →
-        bs.violatesConstraint (denseBIEval ck denv) = false) ∧
-      (∀ denv, bs.breaksInvariant (denseBIEval ck denv) = false) ∧
+      (∀ denv, bs.accepts (denseBIEval R denv) →
+        bs.accepts (denseBIEval ck denv)) ∧
+      (∀ denv, bs.maintainsInvariants (denseBIEval ck denv)) ∧
       (∀ v ∈ denseBIVars ck, v ∈ denseBIVars R))
     (hbyte : ∀ (denv : VarId → ZMod p),
       (∀ c ∈ d.algebraicConstraints, c.eval denv = 0) →
       (∀ bi ∈ A ++ B ++ C ++ checks, (denseBIEval bi denv).multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval bi denv) = false) →
+        bs.accepts (denseBIEval bi denv)) →
       ∀ slot ∈ slots, ∀ x : ZMod p, (denseBIEval R denv).payload[slot]? = some x → x.val < bound)
     (hsplit : d.busInteractions = A ++ S :: B ++ R :: C)
     (hSbus : S.busId = busId) (hRbus : R.busId = busId)
@@ -198,10 +198,10 @@ theorem denseDropPair_correct (isInput : VarId → Bool)
     intro bi hbi
     rw [hsplit]
     simp only [List.mem_append, List.mem_cons] at hbi ⊢; tauto
-  have hnvS : ∀ denv, bs.violatesConstraint (denseBIEval S denv) = false := fun denv =>
+  have hnvS : ∀ denv, bs.accepts (denseBIEval S denv) := fun denv =>
     (facts.recvByteSlots_sound busId shape hshape pattern slots bound hslots (denseBIEval S denv)
       (show (denseBIEval S denv).busId = busId from hSbus)).1 (hSmEv denv)
-  have hnvR : ∀ denv, out.satisfies bs denv → bs.violatesConstraint (denseBIEval R denv) = false := by
+  have hnvR : ∀ denv, out.satisfies bs denv → bs.accepts (denseBIEval R denv) := by
     intro denv hsat
     have hbyteEnv : ∀ slot ∈ slots, ∀ x : ZMod p, (denseBIEval R denv).payload[slot]? = some x →
         x.val < bound := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -160,7 +160,7 @@ the use site in `denseDisconnectedF`. -/
 /-- The two reachable sets: `conn` (variables connected to a stateful bus interaction) and `bad`
     (the co-occurrence closure of any disconnected item the all-zero witness fails on). Treated
     opaquely by the correctness proof. -/
-def denseConnBad (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+def denseConnBad (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     Std.HashSet VarId × Std.HashSet VarId :=
   let (groups, v2g) := denseBuildGraph d
   -- variables connected to a stateful bus interaction
@@ -176,7 +176,7 @@ def denseConnBad (bs : BusSemantics p) (d : DenseConstraintSystem p) :
         then c.vars ++ acc else acc)
       (d.busInteractions.foldl (fun acc bi =>
         if !bs.isStateful bi.busId && !(denseBIVars bi).isEmpty && (denseBIVars bi).all disc
-            && bs.violatesConstraint (denseBIEval bi (fun _ => 0))
+            && !facts.acceptsDec (denseBIEval bi (fun _ => 0))
         then denseBIVars bi ++ acc else acc) [])
   let bad := denseBfsClosure groups v2g ∅ ∅ badSeeds
   (conn, bad)
@@ -186,12 +186,14 @@ def denseConnBad (bs : BusSemantics p) (d : DenseConstraintSystem p) :
 /-- The run-time re-check: the induced partition is a genuine drop, the all-zero witness satisfies
     every removed constraint and non-violates every removed interaction, and every kept item uses
     only non-removable variables. Stated for an arbitrary `remV`. -/
-def denseDropCheck (bs : BusSemantics p) (d : DenseConstraintSystem p) (remV : VarId → Bool) : Bool :=
+def denseDropCheck (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
+    (remV : VarId → Bool) : Bool :=
   (d.algebraicConstraints.any (fun c => !denseKeepConWith remV c) ||
     d.busInteractions.any (fun bi => !denseKeepBiWith bs remV bi)) &&
   d.algebraicConstraints.all (fun c => denseKeepConWith remV c || decide (c.eval (fun _ => 0) = 0)) &&
   d.busInteractions.all (fun bi =>
-    denseKeepBiWith bs remV bi || !bs.violatesConstraint (denseBIEval bi (fun _ => 0))) &&
+    denseKeepBiWith bs remV bi ||
+      facts.acceptsDec (denseBIEval bi (fun _ => 0))) &&
   d.algebraicConstraints.all (fun c =>
     !denseKeepConWith remV c || c.vars.all (fun x => !remV x)) &&
   d.busInteractions.all (fun bi =>
@@ -199,9 +201,9 @@ def denseDropCheck (bs : BusSemantics p) (d : DenseConstraintSystem p) (remV : V
 
 /-- Drop the removable component if the re-check passes; otherwise the identity. Stated for an
     arbitrary `remV` so the correctness proof is generic in the connectivity search. -/
-def denseDropGuarded (bs : BusSemantics p) (d : DenseConstraintSystem p) (remV : VarId → Bool) :
-    DenseConstraintSystem p :=
-  if denseDropCheck bs d remV then
+def denseDropGuarded (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
+    (remV : VarId → Bool) : DenseConstraintSystem p :=
+  if denseDropCheck bs facts d remV then
     { algebraicConstraints := d.algebraicConstraints.filter (denseKeepConWith remV),
       busInteractions := d.busInteractions.filter (denseKeepBiWith bs remV) }
   else d
@@ -209,9 +211,9 @@ def denseDropGuarded (bs : BusSemantics p) (d : DenseConstraintSystem p) (remV :
 /-- Finds a set of constraints and stateless interactions whose variables never reach a stateful
     bus, and — if the all-zero witness satisfies them (re-checked at run time by `denseDropCheck`) —
     drops the whole component. -/
-def denseDisconnectedF (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+def denseDisconnectedF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseConstraintSystem p :=
-  let cb := denseConnBad bs d
-  denseDropGuarded bs d (fun x => !cb.1.contains x && !cb.2.contains x)
+  let cb := denseConnBad bs facts d
+  denseDropGuarded bs facts d (fun x => !cb.1.contains x && !cb.2.contains x)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -163,7 +163,7 @@ def denseCompileCBiPredsV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : 
     | _, _ => none
 
 def denseCBiPredEvalV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (bs : BusSemantics p) (pt : List (ZMod p)) : DenseCBiPred p → Bool
+    {bs : BusSemantics p} (facts : BusFacts p bs) (pt : List (ZMod p)) : DenseCBiPred p → Bool
   | .always => true
   | .varRange mult x width =>
     let multValue := denseIExprEvalWithV ops pt mult
@@ -197,7 +197,7 @@ def denseCBiPredEvalV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     let multValue := denseIExprEvalWithV ops pt cbi.mult
     if isZero multValue then true
     else
-      !bs.violatesConstraint
+      facts.acceptsDec
         { busId := cbi.busId,
           multiplicity := multValue,
           payload := cbi.payload.map (fun ie => denseIExprEvalWithV ops pt ie) }
@@ -205,10 +205,10 @@ def denseCBiPredEvalV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
 /-- `survivesAllCW`, over a value-only point: compiled items' zero test plus interactions'
     obligation check. -/
 def denseSurvivesAllCWV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (bs : BusSemantics p) (ces : List (IExpr p)) (cbis : List (DenseCBiPred p))
-    (pt : List (ZMod p)) : Bool :=
+    {bs : BusSemantics p} (facts : BusFacts p bs) (ces : List (IExpr p))
+    (cbis : List (DenseCBiPred p)) (pt : List (ZMod p)) : Bool :=
   ces.all (fun ie => isZero (denseIExprEvalWithV ops pt ie)) &&
-    cbis.all (denseCBiPredEvalV ops isZero bs pt)
+    cbis.all (denseCBiPredEvalV ops isZero facts pt)
 
 /-! ### The uncompiled fallback
 
@@ -223,21 +223,21 @@ def denseEnvOfKeysV (keys : List VarId) (pt : List (ZMod p)) (y : VarId) : ZMod 
   | x :: ks, v :: vs => if y == x then v else denseEnvOfKeysV ks vs y
 
 /-- One source interaction's obligation over a value-only point. -/
-def denseBiObligationV (bs : BusSemantics p) (bi : BusInteraction (DenseExpr p))
-    (keys : List VarId) (pt : List (ZMod p)) : Bool :=
+def denseBiObligationV {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (keys : List VarId) (pt : List (ZMod p)) : Bool :=
   let mult := bi.multiplicity.eval (denseEnvOfKeysV keys pt)
   if decide (mult = 0) then true
   else
-    !bs.violatesConstraint
+    facts.acceptsDec
       { busId := bi.busId,
         multiplicity := mult,
         payload := bi.payload.map (fun e => e.eval (denseEnvOfKeysV keys pt)) }
 
 /-- Fallback survivor predicate (see the fallback note above). -/
-def denseSurvivesAllMV (bs : BusSemantics p) (es : List (DenseExpr p))
+def denseSurvivesAllMV {bs : BusSemantics p} (facts : BusFacts p bs) (es : List (DenseExpr p))
     (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (pt : List (ZMod p)) : Bool :=
   es.all (fun e => decide (e.eval (denseEnvOfKeysV keys pt) = 0)) &&
-    bis.all (fun bi => denseBiObligationV bs bi keys pt)
+    bis.all (fun bi => denseBiObligationV facts bi keys pt)
 
 /-- A per-target survivor predicate, boxed in a one-field structure so its setup (ring instances,
     compilation, `isZero` closure) runs once per target rather than being eta-expanded into the
@@ -257,8 +257,8 @@ def denseCompiledSurvV (bs : BusSemantics p) (facts : BusFacts p bs) (es : List 
     let ops : DenseZModOps p := denseZModOps
     let dec : DecidableEq (ZMod p) := inferInstance
     let isZero : ZMod p → Bool := fun v => @decide (v = ops.zero) (dec v ops.zero)
-    ⟨fun pt => denseSurvivesAllCWV ops isZero bs ces cbis pt⟩
-  | _, _ => ⟨denseSurvivesAllMV bs es bis keys⟩
+    ⟨fun pt => denseSurvivesAllCWV ops isZero facts ces cbis pt⟩
+  | _, _ => ⟨denseSurvivesAllMV facts es bis keys⟩
 
 /-! ## Value-only lazy box enumeration -/
 
@@ -381,7 +381,7 @@ def denseBytePairDomainRedundantV {bs : BusSemantics p} (facts : BusFacts p bs)
 def denseBiDomainRedundantV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomainTable p)
     (bi : BusInteraction (DenseExpr p)) : Bool :=
   match denseConstBiV? bi with
-  | some value => value.multiplicity = 0 || !bs.violatesConstraint value
+  | some value => value.multiplicity = 0 || facts.acceptsDec value
   | none =>
     if facts.neverViolates bi.busId then true
     else

--- a/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
@@ -33,10 +33,11 @@ def denseConstMessage? (bi : BusInteraction (DenseExpr p)) : Option (BusInteract
 
 /-- Recognizes a tautological lookup: a stateless interaction whose message is fully constant and
     already accepted by the bus — e.g. a range check `[5]` against `[0..255]` — hence droppable. -/
-def denseIsTautoLookup (bs : BusSemantics p) (bi : BusInteraction (DenseExpr p)) : Bool :=
+def denseIsTautoLookup (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
   !bs.isStateful bi.busId &&
     (match denseConstMessage? bi with
-     | some msg => !bs.violatesConstraint msg
+     | some msg => facts.acceptsDec msg
      | none => false)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BoxRewrite.lean
@@ -283,8 +283,7 @@ theorem DenseConstraintSystem.boxRewrite_denseCorrect [Fact p.Prime]
     intro hgi denv hsat bi hbi
     obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
     show (denseBIEval (denseBrBi (denseSingleVarCs d.algebraicConstraints) b bi0) denv).multiplicity
-        ≠ 0 → bs.breaksInvariant
-          (denseBIEval (denseBrBi (denseSingleVarCs d.algebraicConstraints) b bi0) denv) = false
+        ≠ 0 → bs.maintainsInvariants (denseBIEval (denseBrBi (denseSingleVarCs d.algebraicConstraints) b bi0) denv)
     rw [denseBrBi_eval _ _ bi0 denv (hdomOut denv hsat)]
     exact hgi denv ((hiff denv).1 hsat) bi0 hbi0
   · -- output occurrences are input occurrences

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
@@ -160,7 +160,7 @@ theorem denseMkByteCheck_eval (spec : ByteXorSpec p) (busId : Nat) (e : DenseExp
 theorem denseMkByteCheck_breaks (bs : BusSemantics p) (facts : BusFacts p bs)
     (spec : ByteXorSpec p) (busId : Nat) (hspec : facts.byteXorSpec busId = some spec)
     (e : DenseExpr p) (denv : VarId → ZMod p) :
-    bs.breaksInvariant (denseBIEval (denseMkByteCheck spec busId e) denv) = false := by
+    bs.maintainsInvariants (denseBIEval (denseMkByteCheck spec busId e) denv) := by
   obtain ⟨_, hbreak, _⟩ := facts.byteXorSpec_sound busId spec hspec
   rw [denseMkByteCheck_eval]; exact hbreak _
 
@@ -168,7 +168,7 @@ theorem denseMkByteCheck_breaks (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseMkByteCheck_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
     (spec : ByteXorSpec p) (busId : Nat) (hspec : facts.byteXorSpec busId = some spec)
     (e : DenseExpr p) (denv : VarId → ZMod p) :
-    bs.violatesConstraint (denseBIEval (denseMkByteCheck spec busId e) denv) = false
+    bs.accepts (denseBIEval (denseMkByteCheck spec busId e) denv)
       ↔ (e.eval denv).val < spec.bound := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound busId spec hspec
   rw [denseMkByteCheck_eval]
@@ -198,9 +198,9 @@ theorem denseEmitOk_sound (ops : DenseZModOps p) (bs : BusSemantics p)
     (hRbus : R.busId = busId)
     (hRmEv : ∀ denv, (denseBIEval R denv).multiplicity = -shape.setNewMult) :
     bs.isStateful ck.busId = false ∧
-    (∀ denv, bs.violatesConstraint (denseBIEval R denv) = false →
-      bs.violatesConstraint (denseBIEval ck denv) = false) ∧
-    (∀ denv, bs.breaksInvariant (denseBIEval ck denv) = false) ∧
+    (∀ denv, bs.accepts (denseBIEval R denv) →
+      bs.accepts (denseBIEval ck denv)) ∧
+    (∀ denv, bs.maintainsInvariants (denseBIEval ck denv)) ∧
     (∀ v ∈ denseBIVars ck, v ∈ denseBIVars R) := by
   unfold denseEmitOk at h
   rw [ops.one_eq, ops.zero_eq, denseGetPreviousMult_eq ops shape] at h

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
@@ -159,7 +159,7 @@ theorem denseDeepBoundOk_sound [Fact p.Prime] (domIdx : Std.HashMap VarId (List 
     (h : denseDeepBoundOk domIdx bs facts wits x c = true) (denv : VarId → ZMod p)
     (hdom : ∀ v, ∀ c' ∈ denseVarBucketLookup domIdx v, c'.eval denv = 0) (hc0 : c.eval denv = 0)
     (hbus : ∀ v, ∀ bi ∈ wits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (denv x).val < 256 := by
   unfold denseDeepBoundOk at h
   simp only [] at h
@@ -210,7 +210,7 @@ theorem denseDeepByteJustified_sound [Fact p.Prime] [NeZero p]
     (h : denseDeepByteJustified domIdx cands bs facts wits x = true) (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ v, ∀ bi ∈ wits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (denv x).val < 256 := by
   obtain ⟨c, hc, hck⟩ := List.any_eq_true.1 h
   have hc' : c ∈ all := hcands c (List.mem_of_mem_take hc)
@@ -362,7 +362,7 @@ theorem denseFormBoundAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (i : Nat) (Lr : DenseLinExpr p) (Br : Nat)
     (h : denseFormBoundAt facts bi i = some (Lr, Br)) (denv : VarId → ZMod p)
     (hviol : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (Lr.eval denv).val < Br := by
   unfold denseFormBoundAt at h
   cases hmc : bi.multiplicity.constValue? with
@@ -384,7 +384,7 @@ theorem denseFormBoundAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
           obtain ⟨rfl, rfl⟩ := h
           have hmeval : (denseBIEval bi denv).multiplicity = mval :=
             bi.multiplicity.constValue?_sound mval hmc denv
-          have hv : bs.violatesConstraint (denseBIEval bi denv) = false := by
+          have hv : bs.accepts (denseBIEval bi denv) := by
             apply hviol
             rw [hmeval]
             exact hmz
@@ -410,7 +410,7 @@ theorem denseBasisReduceGo_sound (bound : Nat) (bnd : VarId → Option Nat) {bs 
     (denv : VarId → ZMod p)
     (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
     (hfw : ∀ v, ∀ bi ∈ fwits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ (fuel used : Nat) (L : DenseLinExpr p),
       denseBasisReduceGo bound bnd facts fwits fuel used L = true →
       ∃ n : ℕ, L.eval denv = (n : ZMod p) ∧ n + used < bound ∧ n + used < p := by
@@ -486,7 +486,7 @@ theorem denseBasisJustified_sound (bound : Nat) (bnd : VarId → Option Nat) {bs
     (e : DenseExpr p) (denv : VarId → ZMod p)
     (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
     (hfw : ∀ v, ∀ bi ∈ fwits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false)
+      bs.accepts (denseBIEval bi denv))
     (h : denseBasisJustified bound bnd facts fwits e = true) : (e.eval denv).val < bound := by
   unfold denseBasisJustified at h
   cases hL : denseLinearize e with
@@ -523,10 +523,10 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all : List (Dense
     (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (e.eval denv).val < bound := by
   have hbusW : ∀ v, ∀ bi ∈ wits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false :=
+      bs.accepts (denseBIEval bi denv) :=
     fun v bi hbi => hbus bi (hwits v bi hbi)
   unfold denseByteJustifiedW at h
   cases hc : e.constValue? with
@@ -596,7 +596,7 @@ theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all : List (D
     (denv : VarId → ZMod p)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ slot ∈ slots, ∀ x : ZMod p, (denseBIEval R denv).payload[slot]? = some x → x.val < bound := by
   intro slot hslot x hget
   have hcheck := List.all_eq_true.mp h slot hslot

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
@@ -27,7 +27,7 @@ theorem denseMkBytePair_eval (spec : ByteXorSpec p) (busId : Nat) (e₁ e₂ : D
 theorem denseMkBytePair_breaks (bs : BusSemantics p) (facts : BusFacts p bs)
     (spec : ByteXorSpec p) (busId : Nat) (hspec : facts.byteXorSpec busId = some spec)
     (e₁ e₂ : DenseExpr p) (denv : VarId → ZMod p) :
-    bs.breaksInvariant (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv) = false := by
+    bs.maintainsInvariants (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv) := by
   obtain ⟨_, hbreak, _⟩ := facts.byteXorSpec_sound busId spec hspec
   rw [denseMkBytePair_eval]; exact hbreak _
 
@@ -35,7 +35,7 @@ theorem denseMkBytePair_breaks (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseMkBytePair_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
     (spec : ByteXorSpec p) (busId : Nat) (hspec : facts.byteXorSpec busId = some spec)
     (e₁ e₂ : DenseExpr p) (denv : VarId → ZMod p) :
-    bs.violatesConstraint (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv) = false
+    bs.accepts (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv)
       ↔ (e₁.eval denv).val < spec.bound ∧ (e₂.eval denv).val < spec.bound := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound busId spec hspec
   rw [denseMkBytePair_eval]
@@ -47,9 +47,9 @@ theorem denseMkBytePair_accepted (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseMkBytePair_iff_singles (bs : BusSemantics p) (facts : BusFacts p bs)
     (spec : ByteXorSpec p) (busId : Nat) (hspec : facts.byteXorSpec busId = some spec)
     (e₁ e₂ : DenseExpr p) (denv : VarId → ZMod p) :
-    bs.violatesConstraint (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv) = false
-      ↔ bs.violatesConstraint (denseBIEval (denseMkByteCheck spec busId e₁) denv) = false
-        ∧ bs.violatesConstraint (denseBIEval (denseMkByteCheck spec busId e₂) denv) = false := by
+    bs.accepts (denseBIEval (denseMkBytePair spec busId e₁ e₂) denv)
+      ↔ bs.accepts (denseBIEval (denseMkByteCheck spec busId e₁) denv)
+        ∧ bs.accepts (denseBIEval (denseMkByteCheck spec busId e₂) denv) := by
   rw [denseMkBytePair_accepted bs facts spec busId hspec,
       denseMkByteCheck_accepted bs facts spec busId hspec,
       denseMkByteCheck_accepted bs facts spec busId hspec]
@@ -79,11 +79,11 @@ theorem denseByteXorSpec_decode_iff (bs : BusSemantics p) (facts : BusFacts p bs
     (op o1 o2 r : DenseExpr p) (hdec : spec.decode bi.payload = some (op, o1, o2, r))
     (denv : VarId → ZMod p) :
     (op.eval denv = spec.xorOp →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound
             ∧ (r.eval denv).val = Nat.xor (o1.eval denv).val (o2.eval denv).val)) ∧
     (op.eval denv = spec.pairOp →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound ∧ r.eval denv = 0)) := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound bi.busId spec hspec
   have hdecEv : spec.decode (denseBIEval bi denv).payload
@@ -100,11 +100,11 @@ theorem denseByteBoolSound_decode_iff (bs : BusSemantics p) (facts : BusFacts p 
     (op o1 o2 r : DenseExpr p) (hdec : spec.decode bi.payload = some (op, o1, o2, r))
     (denv : VarId → ZMod p) :
     (∀ oop, spec.orOp = some oop → op.eval denv = oop →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound
             ∧ (r.eval denv).val = Nat.lor (o1.eval denv).val (o2.eval denv).val)) ∧
     (∀ aop, spec.andOp = some aop → op.eval denv = aop →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound
             ∧ (r.eval denv).val = Nat.land (o1.eval denv).val (o2.eval denv).val)) := by
   have hdecEv : spec.decode (denseBIEval bi denv).payload
@@ -178,7 +178,7 @@ theorem denseByteShape?_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (sh : DenseByteShape) (spec : ByteXorSpec p)
     (o1 o2 : DenseExpr p) (h : denseByteShape? cmp bs facts bi = some (sh, spec, o1, o2)) :
     bs.isStateful bi.busId = false ∧ (∀ e ∈ sh.operands o1 o2, e ∈ bi.payload) ∧
-      ∀ denv, bs.violatesConstraint (denseBIEval bi denv) = false ↔
+      ∀ denv, bs.accepts (denseBIEval bi denv) ↔
         ∀ e ∈ sh.operands o1 o2, (e.eval denv).val < 256 := by
   unfold denseByteShape? at h
   split at h
@@ -263,7 +263,7 @@ theorem denseSvCheck?_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (e : DenseExpr p)
     (h : denseSvCheck? bs facts bi = some e) :
     bs.isStateful bi.busId = false ∧ bi.multiplicity = DenseExpr.const 1 ∧ e ∈ bi.payload ∧
-      (∀ denv, bs.violatesConstraint (denseBIEval bi denv) = false ↔ (e.eval denv).val < 256) := by
+      (∀ denv, bs.accepts (denseBIEval bi denv) ↔ (e.eval denv).val < 256) := by
   unfold denseSvCheck? at h
   split_ifs at h with hm
   cases hc : denseByteShape? denseCmpStructural bs facts bi with
@@ -319,10 +319,10 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
     (hstC : bs.isStateful C.busId = false)
     (hm1 : D₁.multiplicity = DenseExpr.const 1) (hm2 : D₂.multiplicity = DenseExpr.const 1)
     (hmC : C.multiplicity = DenseExpr.const 1)
-    (hkey : ∀ denv, bs.violatesConstraint (denseBIEval C denv) = false ↔
-        bs.violatesConstraint (denseBIEval D₁ denv) = false ∧
-          bs.violatesConstraint (denseBIEval D₂ denv) = false)
-    (hbrk : ∀ denv, bs.breaksInvariant (denseBIEval C denv) = false)
+    (hkey : ∀ denv, bs.accepts (denseBIEval C denv) ↔
+        bs.accepts (denseBIEval D₁ denv) ∧
+          bs.accepts (denseBIEval D₂ denv))
+    (hbrk : ∀ denv, bs.maintainsInvariants (denseBIEval C denv))
     (hvars : ∀ v ∈ denseBIVars C, v ∈ denseBIVars D₁ ∨ v ∈ denseBIVars D₂)
     (pre mid post : List (BusInteraction (DenseExpr p)))
     (hsplit : d.busInteractions = pre ++ D₁ :: mid ++ D₂ :: post) :
@@ -331,7 +331,7 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
     with hout
   have houtb : out.busInteractions = pre ++ C :: mid ++ post := rfl
   set P : (VarId → ZMod p) → BusInteraction (DenseExpr p) → Prop :=
-    fun denv bi => (denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false
+    fun denv bi => (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)
     with hP
   have hme1 : ∀ denv, (denseBIEval D₁ denv).multiplicity = 1 := fun denv => by
     show D₁.multiplicity.eval denv = 1; rw [hm1]; rfl
@@ -339,11 +339,11 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
     show D₂.multiplicity.eval denv = 1; rw [hm2]; rfl
   have hmeC : ∀ denv, (denseBIEval C denv).multiplicity = 1 := fun denv => by
     show C.multiplicity.eval denv = 1; rw [hmC]; rfl
-  have hP1 : ∀ denv, (P denv D₁ ↔ bs.violatesConstraint (denseBIEval D₁ denv) = false) := fun denv =>
+  have hP1 : ∀ denv, (P denv D₁ ↔ bs.accepts (denseBIEval D₁ denv)) := fun denv =>
     ⟨fun h => h (by rw [hme1 denv]; exact hp1), fun h _ => h⟩
-  have hP2 : ∀ denv, (P denv D₂ ↔ bs.violatesConstraint (denseBIEval D₂ denv) = false) := fun denv =>
+  have hP2 : ∀ denv, (P denv D₂ ↔ bs.accepts (denseBIEval D₂ denv)) := fun denv =>
     ⟨fun h => h (by rw [hme2 denv]; exact hp1), fun h _ => h⟩
-  have hPC : ∀ denv, (P denv C ↔ bs.violatesConstraint (denseBIEval C denv) = false) := fun denv =>
+  have hPC : ∀ denv, (P denv C ↔ bs.accepts (denseBIEval C denv)) := fun denv =>
     ⟨fun h => h (by rw [hmeC denv]; exact hp1), fun h _ => h⟩
   have hsatiff : ∀ denv, d.satisfies bs denv ↔ out.satisfies bs denv := by
     intro denv

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
@@ -142,7 +142,7 @@ theorem denseCarryBranchF_correct (pw : PrimeWitness p) (reg : VarRegistry) (bs 
     -- for any assignment whose bus interactions are non-violating, the built bounds are valid
     have hBof : ∀ denv, (∀ bi ∈ d.busInteractions,
         (denseBIEval bi denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval bi denv) = false) →
+          bs.accepts (denseBIEval bi denv)) →
         ∀ v bound, B[v]? = some bound → (denv v).val < bound := by
       intro denv hbus v bound hlk
       rw [hBdef] at hlk

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DegenRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DegenRange.lean
@@ -47,7 +47,7 @@ theorem denseRangeEq?_stateless (one : Bool) (bs : BusSemantics p) (facts : BusF
 theorem denseRangeEq?_violates_iff (one : Bool) (hone : one = true → Nat.Prime p)
     (bs : BusSemantics p) (facts : BusFacts p bs) (bi : BusInteraction (DenseExpr p))
     (e : DenseExpr p) (denv : VarId → ZMod p) (h : denseRangeEq? one bs facts bi = some e) :
-    bs.violatesConstraint (denseBIEval bi denv) = false ↔ e.eval denv = 0 := by
+    bs.accepts (denseBIEval bi denv) ↔ e.eval denv = 0 := by
   obtain ⟨hm, v, hcase⟩ := denseRangeEq?_spec one bs facts bi e h
   rcases hcase with ⟨hz, hp', rfl⟩ | ⟨hone', hv, hp', rfl⟩
   · have hev : denseBIEval bi denv
@@ -97,7 +97,7 @@ theorem denseBoolCheck?_spec {bs : BusSemantics p} (facts : BusFacts p bs)
 theorem denseBoolCheck?_violates_iff {bs : BusSemantics p} (hp : Nat.Prime p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (c : DenseExpr p) (h : denseBoolCheck? facts bi = some c)
     (denv : VarId → ZMod p) :
-    bs.violatesConstraint (denseBIEval bi denv) = false ↔ c.eval denv = 0 := by
+    bs.accepts (denseBIEval bi denv) ↔ c.eval denv = 0 := by
   obtain ⟨valSlot, x, hrc, hmc, hxp, rfl⟩ := denseBoolCheck?_spec facts bi c h
   obtain ⟨_, hm⟩ := facts.rangeCheckAt_sound bi.busId (bi.payload.map DenseExpr.constValue?)
     valSlot 2 hrc

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DigitFold.lean
@@ -56,7 +56,7 @@ theorem denseProbedSlotBoundAt_sound (bs : BusSemantics p) (facts : BusFacts p b
     (bi : BusInteraction (DenseExpr p)) (i : VarId) (j : Nat) (bound : Nat)
     (h : denseProbedSlotBoundAt bs facts bi i j = some bound) (denv : VarId → ZMod p)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (denv i).val < bound := by
   unfold denseProbedSlotBoundAt at h
   split_ifs at h with hp0
@@ -95,7 +95,7 @@ theorem denseProbedSlotBoundAt_sound (bs : BusSemantics p) (facts : BusFacts p b
   -- the obligation is active
   have hmeval : (denseBIEval bi denv).multiplicity = mval :=
     bi.multiplicity.constValue?_sound mval hm denv
-  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := by
+  have hviol : bs.accepts (denseBIEval bi denv) := by
     apply hob; rw [hmeval]; exact hmz
   have hpat : Matches (denseBIEval bi denv).payload
       (bi.payload.map DenseExpr.constValue?) :=
@@ -177,7 +177,7 @@ theorem denseInsertEntry_soundAt {denv : VarId → ZMod p} {T : Std.HashMap VarI
 theorem denseGoCands_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (i : VarId) (denv : VarId → ZMod p)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ (cl : List (VarId × Nat)) (T : Std.HashMap VarId Nat),
       DenseBMSoundAt denv T → DenseBMSoundAt denv (denseGoCands bs facts bi i cl T) := by
   intro cl
@@ -200,7 +200,7 @@ theorem denseGoCands_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseAddVars_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) (cands : List (VarId × Nat)) :
+      bs.accepts (denseBIEval bi denv)) (cands : List (VarId × Nat)) :
     ∀ (xs : List VarId) (T : Std.HashMap VarId Nat),
       DenseBMSoundAt denv T → DenseBMSoundAt denv (denseAddVars bs facts bi cands xs T) := by
   intro xs
@@ -221,7 +221,7 @@ theorem denseAddVars_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseAddAll_soundAt (bs : BusSemantics p) (facts : BusFacts p bs) (denv : VarId → ZMod p) :
     ∀ (dbis : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval bi denv) = false) →
+        bs.accepts (denseBIEval bi denv)) →
       ∀ (T : Std.HashMap VarId Nat), DenseBMSoundAt denv T →
         DenseBMSoundAt denv (denseAddAll bs facts dbis T) := by
   intro dbis
@@ -230,9 +230,9 @@ theorem denseAddAll_soundAt (bs : BusSemantics p) (facts : BusFacts p bs) (denv 
   | cons bi rest ih =>
       intro hob T hT
       have hbi : (denseBIEval bi denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval bi denv) = false := hob bi (List.mem_cons_self ..)
+          bs.accepts (denseBIEval bi denv) := hob bi (List.mem_cons_self ..)
       have hrest : ∀ b ∈ rest, (denseBIEval b denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval b denv) = false :=
+          bs.accepts (denseBIEval b denv) :=
         fun b hb => hob b (List.mem_cons_of_mem _ hb)
       unfold denseAddAll
       exact ih hrest _ (denseAddVars_soundAt bs facts bi denv hbi (denseProbeCandidatesOf bi)
@@ -246,7 +246,7 @@ theorem denseBuild_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (DenseExpr p))) (i : VarId) (b : Nat)
     (hlk : (denseBuild bs facts bis)[i]? = some b) (denv : VarId → ZMod p)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) : (denv i).val < b := by
+      bs.accepts (denseBIEval bi denv)) : (denv i).val < b := by
   unfold denseBuild at hlk
   exact denseAddAll_soundAt bs facts denv bis hbus ∅ (DenseBMSoundAt.empty denv) i b hlk
 
@@ -262,7 +262,7 @@ theorem densePairByteOps?_bytes (bs : BusSemantics p) (facts : BusFacts p bs)
     (h : densePairByteOps? bs facts bi = some (x, y))
     (h1 : (1 : ZMod p) ≠ 0) (denv : VarId → ZMod p)
     (hacc : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (x.eval denv).val < 256 ∧ (y.eval denv).val < 256 := by
   unfold densePairByteOps? at h
   split at h
@@ -276,7 +276,7 @@ theorem densePairByteOps?_bytes (bs : BusSemantics p) (facts : BusFacts p bs)
       obtain ⟨rfl, rfl⟩ := h
       have hmv : (denseBIEval bi denv).multiplicity = 1 := by
         show bi.multiplicity.eval denv = 1; rw [hm]; rfl
-      have hviol : bs.violatesConstraint (denseBIEval bi denv) = false :=
+      have hviol : bs.accepts (denseBIEval bi denv) :=
         hacc (by rw [hmv]; simpa using h1)
       have hopEv : op.eval denv = spec.pairOp := by rw [hop]; rfl
       have hdecEv : spec.decode (denseBIEval bi denv).payload
@@ -480,7 +480,7 @@ theorem denseFindFold_sound [NeZero p] (hp : 256 < p) (bs : BusSemantics p) (fac
     (hB : ∀ w bnd, bounds[w]? = some bnd → (denv w).val < bnd) :
     ∀ (pending : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ pending, (denseBIEval bi denv).multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval bi denv) = false) →
+        bs.accepts (denseBIEval bi denv)) →
       ∀ i dd, denseFindFold bs facts bounds pending = some (i, dd) → denv i = (dd : ZMod p) := by
   intro pending
   induction pending with
@@ -489,7 +489,7 @@ theorem denseFindFold_sound [NeZero p] (hp : 256 < p) (bs : BusSemantics p) (fac
       intro hpend i dd h
       have hacc := hpend bi (List.mem_cons_self ..)
       have hrest : ∀ b ∈ rest, (denseBIEval b denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval b denv) = false :=
+          bs.accepts (denseBIEval b denv) :=
         fun b hb => hpend b (List.mem_cons_of_mem _ hb)
       have h1 : (1 : ZMod p) ≠ 0 := by
         haveI : Fact (1 < p) := ⟨by omega⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
@@ -111,7 +111,7 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
     (hCkeep : ∀ c ∈ d.algebraicConstraints, keepCon c = true → ∀ x ∈ c.vars, remV x = false)
     (hBrem : ∀ bi ∈ d.busInteractions, keepBi bi = false → ∀ x ∈ denseBIVars bi, remV x = true)
     (hBsat : ∀ bi ∈ d.busInteractions, keepBi bi = false →
-        bs.violatesConstraint (denseBIEval bi w) = false)
+        bs.accepts (denseBIEval bi w))
     (hBstateless : ∀ bi ∈ d.busInteractions, keepBi bi = false → bs.isStateful bi.busId = false)
     (hBkeep : ∀ bi ∈ d.busInteractions, keepBi bi = true → ∀ x ∈ denseBIVars bi, remV x = false) :
     DensePassCorrect isInput d
@@ -146,7 +146,7 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
   have keySat : ∀ env,
       (∀ c ∈ d.algebraicConstraints.filter keepCon, c.eval env = 0) →
       (∀ bi ∈ d.busInteractions.filter keepBi,
-        (denseBIEval bi env).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi env) = false) →
+        (denseBIEval bi env).multiplicity ≠ 0 → bs.accepts (denseBIEval bi env)) →
       d.satisfies bs (m env) := by
     intro env hsc hsb
     refine ⟨fun c hc => ?_, fun bi hbi hne => ?_⟩
@@ -173,7 +173,7 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
     rw [hse]; exact BusState.equiv_refl _
   · -- invariant preservation
     intro hgi env hsat bi hbi
-    show (denseBIEval bi env).multiplicity ≠ 0 → bs.breaksInvariant (denseBIEval bi env) = false
+    show (denseBIEval bi env).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi env)
     have hbimem : bi ∈ d.busInteractions := (List.mem_filter.1 hbi).1
     have hbikeep : keepBi bi = true := (List.mem_filter.1 hbi).2
     have hsatm : d.satisfies bs (m env) := keySat env hsat.1 hsat.2
@@ -210,9 +210,9 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
 
 /-- The guarded drop preserves coverage: both lists are filtered (subsets); the identity branch is
     the input. -/
-theorem denseDropGuarded_covered {reg : VarRegistry} (bs : BusSemantics p)
+theorem denseDropGuarded_covered {reg : VarRegistry} (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (remV : VarId → Bool) (hc : d.CoveredBy reg) :
-    (denseDropGuarded bs d remV).CoveredBy reg := by
+    (denseDropGuarded bs facts d remV).CoveredBy reg := by
   unfold denseDropGuarded
   split_ifs with h
   · exact ⟨fun e he => hc.1 e (List.mem_of_mem_filter he),
@@ -221,9 +221,9 @@ theorem denseDropGuarded_covered {reg : VarRegistry} (bs : BusSemantics p)
 
 /-- The guarded drop is correct for any `remV`: the run-time re-check (`denseDropCheck`) supplies
     exactly the seven `denseDropComponent` hypotheses. -/
-theorem denseDropGuarded_correct (bs : BusSemantics p) (isInput : VarId → Bool)
-    (d : DenseConstraintSystem p) (remV : VarId → Bool) :
-    DensePassCorrect isInput d (denseDropGuarded bs d remV) [] bs := by
+theorem denseDropGuarded_correct (bs : BusSemantics p) (facts : BusFacts p bs)
+    (isInput : VarId → Bool) (d : DenseConstraintSystem p) (remV : VarId → Bool) :
+    DensePassCorrect isInput d (denseDropGuarded bs facts d remV) [] bs := by
   unfold denseDropGuarded
   split_ifs with hchk
   · unfold denseDropCheck at hchk
@@ -254,7 +254,7 @@ theorem denseDropGuarded_correct (bs : BusSemantics p) (isInput : VarId → Bool
       intro bi hbi hkf
       have h1 := (List.all_eq_true.1 hbz) bi hbi
       rw [hkf, Bool.false_or] at h1
-      simpa using h1
+      exact (facts.acceptsDec_iff _).mp (by simpa using h1)
     · -- hBstateless
       intro bi _ hkf
       simp only [denseKeepBiWith, Bool.or_eq_false_iff] at hkf
@@ -269,23 +269,23 @@ theorem denseDropGuarded_correct (bs : BusSemantics p) (isInput : VarId → Bool
 
 /-! ## The dense pass -/
 
-theorem denseDisconnectedF_covered {reg : VarRegistry} (bs : BusSemantics p)
+theorem denseDisconnectedF_covered {reg : VarRegistry} (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (hc : d.CoveredBy reg) :
-    (denseDisconnectedF bs d).CoveredBy reg := by
+    (denseDisconnectedF bs facts d).CoveredBy reg := by
   unfold denseDisconnectedF
-  exact denseDropGuarded_covered bs d _ hc
+  exact denseDropGuarded_covered bs facts d _ hc
 
-theorem denseDisconnectedF_correct (bs : BusSemantics p) (isInput : VarId → Bool)
-    (d : DenseConstraintSystem p) :
-    DensePassCorrect isInput d (denseDisconnectedF bs d) [] bs := by
+theorem denseDisconnectedF_correct (bs : BusSemantics p) (facts : BusFacts p bs)
+    (isInput : VarId → Bool) (d : DenseConstraintSystem p) :
+    DensePassCorrect isInput d (denseDisconnectedF bs facts d) [] bs := by
   unfold denseDisconnectedF
-  exact denseDropGuarded_correct bs isInput d _
+  exact denseDropGuarded_correct bs facts isInput d _
 
 /-- The dense disconnected-component pass (see `denseDisconnectedF`). -/
 def denseDisconnectedPass : DenseVerifiedPassW p :=
-  DenseVerifiedPassW.of (fun bs _ d => denseDisconnectedF bs d) (fun _ _ _ => [])
-    (fun reg bs _ d hcov => denseDisconnectedF_covered bs d hcov)
+  DenseVerifiedPassW.of (fun bs facts d => denseDisconnectedF bs facts d) (fun _ _ _ => [])
+    (fun reg bs facts d hcov => denseDisconnectedF_covered bs facts d hcov)
     (fun _ _ _ _ _ => by intro x hx; simp at hx)
-    (fun reg bs _ d _ => denseDisconnectedF_correct bs reg.isInput d)
+    (fun reg bs facts d _ => denseDisconnectedF_correct bs facts reg.isInput d)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -137,7 +137,7 @@ theorem DenseConstraintSystem.substF_denseCorrect (d : DenseConstraintSystem p)
     simp only [DenseConstraintSystem.substF, List.mem_map] at hbi
     obtain ⟨bi0, hbi0, rfl⟩ := hbi
     show (denseBIEval (denseBIsubstF bi0 df) denv).multiplicity ≠ 0 →
-      bs.breaksInvariant (denseBIEval (denseBIsubstF bi0 df) denv) = false
+      bs.maintainsInvariants (denseBIEval (denseBIsubstF bi0 df) denv)
     rw [denseBIEval_substF]
     exact hinv (denseEnvF df denv) hsatd bi0 hbi0
   · -- no new occurrence at all (hence none introduced at an input column)
@@ -269,7 +269,7 @@ theorem denseInteractionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs
     (bi : BusInteraction (DenseExpr p)) (i : VarId) (bound : Nat)
     (h : denseInteractionBound bs facts bi i = some bound) (denv : VarId → ZMod p)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (denv i).val < bound := by
   unfold denseInteractionBound at h
   split at h
@@ -281,7 +281,7 @@ theorem denseInteractionBound_sound (bs : BusSemantics p) (facts : BusFacts p bs
     · rename_i slot hslot
       have hmeval : (denseBIEval bi denv).multiplicity = mval :=
         bi.multiplicity.constValue?_sound mval hm denv
-      have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := by
+      have hviol : bs.accepts (denseBIEval bi denv) := by
         apply hob; rw [hmeval]; exact hmz
       have hgete : bi.payload[slot]? = some (.var i) := denseVarSlot_sound i bi.payload slot hslot
       have hget : (denseBIEval bi denv).payload[slot]? = some (denv i) := by
@@ -297,7 +297,7 @@ theorem denseInteractionDomainF_sound [NeZero p] (bs : BusSemantics p) (facts : 
     (bi : BusInteraction (DenseExpr p)) (i : VarId) (dm : FiniteDomain p)
     (h : denseInteractionDomainF bs facts bi i = some dm) (denv : VarId → ZMod p)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     denv i ∈ dm.toList := by
   grind [denseInteractionDomainF, FiniteDomain.toList, denseInteractionBound_sound, mem_range_cast]
 
@@ -365,7 +365,7 @@ theorem denseAddConstraintDoms_soundAt [Fact p.Prime] {denv : VarId → ZMod p} 
 theorem denseAddBusVars_soundAt [NeZero p] {denv : VarId → ZMod p} (bs : BusSemantics p)
     (facts : BusFacts p bs) (bi : BusInteraction (DenseExpr p))
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ (xs : List VarId) (T : DenseDomainTable p), DenseTableSoundAt denv T →
       DenseTableSoundAt denv (denseAddBusVars bs facts bi xs T) := by
   intro xs
@@ -384,7 +384,7 @@ theorem denseAddBusDoms_soundAt [NeZero p] {denv : VarId → ZMod p} (bs : BusSe
     (facts : BusFacts p bs) :
     ∀ (dbis : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval bi denv) = false) →
+        bs.accepts (denseBIEval bi denv)) →
       ∀ (T : DenseDomainTable p), DenseTableSoundAt denv T →
         DenseTableSoundAt denv (denseAddBusDoms bs facts dbis T) := by
   intro dbis
@@ -393,9 +393,9 @@ theorem denseAddBusDoms_soundAt [NeZero p] {denv : VarId → ZMod p} (bs : BusSe
   | cons bi rest ih =>
       intro hob T hT
       have hbi : (denseBIEval bi denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval bi denv) = false := hob bi (List.mem_cons_self ..)
+          bs.accepts (denseBIEval bi denv) := hob bi (List.mem_cons_self ..)
       have hrest : ∀ b ∈ rest, (denseBIEval b denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval b denv) = false :=
+          bs.accepts (denseBIEval b denv) :=
         fun b hb => hob b (List.mem_cons_of_mem _ hb)
       unfold denseAddBusDoms
       exact ih hrest _ (denseAddBusVars_soundAt bs facts bi hbi _ T hT)
@@ -768,11 +768,11 @@ private theorem denseByteXorSpec_decode_iff (bs : BusSemantics p) (facts : BusFa
     (op o1 o2 r : DenseExpr p) (hdec : spec.decode bi.payload = some (op, o1, o2, r))
     (denv : VarId → ZMod p) :
     (op.eval denv = spec.xorOp →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound ∧
             (r.eval denv).val = Nat.xor (o1.eval denv).val (o2.eval denv).val)) ∧
     (op.eval denv = spec.pairOp →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound ∧
             r.eval denv = 0)) := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound bi.busId spec hspec
@@ -790,11 +790,11 @@ private theorem denseByteBoolSound_decode_iff (bs : BusSemantics p) (facts : Bus
     (op o1 o2 r : DenseExpr p) (hdec : spec.decode bi.payload = some (op, o1, o2, r))
     (denv : VarId → ZMod p) :
     (∀ oop, spec.orOp = some oop → op.eval denv = oop →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound ∧
             (r.eval denv).val = Nat.lor (o1.eval denv).val (o2.eval denv).val)) ∧
     (∀ aop, spec.andOp = some aop → op.eval denv = aop →
-        (bs.violatesConstraint (denseBIEval bi denv) = false ↔
+        (bs.accepts (denseBIEval bi denv) ↔
           (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound ∧
             (r.eval denv).val = Nat.land (o1.eval denv).val (o2.eval denv).val)) := by
   have hdecEv : spec.decode (denseBIEval bi denv).payload =
@@ -889,11 +889,11 @@ theorem denseByteOperandBound [NeZero p] (bs : BusSemantics p) (facts : BusFacts
     (hdec : spec.decode bi.payload = some (op, o1, o2, r)) (opv : ZMod p)
     (hop : op.constValue? = some opv) (hb : denseByteOpBounds spec opv = true)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (o1.eval denv).val < spec.bound ∧ (o2.eval denv).val < spec.bound := by
   have hmeval : (denseBIEval bi denv).multiplicity = mult :=
     bi.multiplicity.constValue?_sound mult hmult denv
-  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := hob (by rw [hmeval]; exact hmz)
+  have hviol : bs.accepts (denseBIEval bi denv) := hob (by rw [hmeval]; exact hmz)
   have hopeval : op.eval denv = opv := op.constValue?_sound opv hop denv
   obtain ⟨hxor, hpair⟩ := denseByteXorSpec_decode_iff bs facts spec bi hspec op o1 o2 r hdec denv
   obtain ⟨hor, hand⟩ := denseByteBoolSound_decode_iff bs facts spec bi hspec op o1 o2 r hdec denv
@@ -908,7 +908,7 @@ theorem denseByteOperandBound [NeZero p] (bs : BusSemantics p) (facts : BusFacts
 theorem denseAddByteVarDoms_soundAt [Fact p.Prime] [NeZero p] {denv : VarId → ZMod p}
     (bs : BusSemantics p) (facts : BusFacts p bs) (bi : BusInteraction (DenseExpr p))
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false)
+      bs.accepts (denseBIEval bi denv))
     (T : DenseDomainTable p) (hT : DenseTableSoundAt denv T) :
     DenseTableSoundAt denv (denseAddByteVarDoms bs facts bi T) := by
   unfold denseAddByteVarDoms
@@ -965,7 +965,7 @@ theorem denseAddByteDoms_soundAt [Fact p.Prime] [NeZero p] {denv : VarId → ZMo
     (bs : BusSemantics p) (facts : BusFacts p bs) :
     ∀ (dbis : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval bi denv) = false) →
+        bs.accepts (denseBIEval bi denv)) →
       ∀ (T : DenseDomainTable p), DenseTableSoundAt denv T →
         DenseTableSoundAt denv (denseAddByteDoms bs facts dbis T) := by
   intro dbis
@@ -979,6 +979,10 @@ theorem denseAddByteDoms_soundAt [Fact p.Prime] [NeZero p] {denv : VarId → ZMo
 
 private theorem denseNotBoolEqDecide (b : Bool) (P : Prop) [Decidable P]
     (h : b = false ↔ P) : (!b) = decide P := by
+  cases b <;> simp_all
+
+private theorem denseBoolEqDecide (b : Bool) (P : Prop) [Decidable P]
+    (h : b = true ↔ P) : b = decide P := by
   cases b <;> simp_all
 
 private instance denseBytePredKindHoldsDecidable (kind : DenseBytePredKind) (a b r : ZMod p) :
@@ -997,8 +1001,8 @@ private theorem denseVarRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p �
     (hpay : bi.payload = [x, width]) (hfact : facts.varRangeBus bi.busId = true)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (hx : denseCompileE keys x = some ix) (hw : denseCompileE keys width = some iwidth) :
-    denseCBiPredEvalV ops isZero bs pt (.varRange mult ix iwidth)
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.varRange mult ix iwidth)
+      = denseBiObligationV facts bi keys pt := by
   let env := denseEnvOfKeysV keys pt
   have hme := denseCompileE_evalV ops keys pt bi.multiplicity mult hm
   have hxe := denseCompileE_evalV ops keys pt x ix hx
@@ -1006,11 +1010,11 @@ private theorem denseVarRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p �
   have hiff := (facts.varRangeBus_sound bi.busId hfact).2
     (x.eval env) (width.eval env) (bi.multiplicity.eval env)
   have hb :
-      (!bs.violatesConstraint
+      (facts.acceptsDec
           { busId := bi.busId, multiplicity := bi.multiplicity.eval env,
             payload := [x.eval env, width.eval env] })
         = decide ((width.eval env).val ≤ 17 ∧ (x.eval env).val < 2 ^ (width.eval env).val) :=
-    denseNotBoolEqDecide _ _ hiff
+    denseBoolEqDecide _ _ ((facts.acceptsDec_iff _).trans hiff)
   simp only [denseCBiPredEvalV, denseBiObligationV, hme, hxe, hwe, hpay, List.map_cons,
     List.map_nil, hz]
   exact congrArg (fun tail => if decide (bi.multiplicity.eval env = 0) then true else tail) hb.symm
@@ -1024,8 +1028,8 @@ private theorem denseVarRangeConstPred_eval (ops : DenseZModOps p)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (hx : denseCompileE keys x = some ix) (hw : width.constValue? = some widthValue)
     (hle : widthValue.val ≤ 17) :
-    denseCBiPredEvalV ops isZero bs pt (.varRangeConst mult ix (2 ^ widthValue.val))
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.varRangeConst mult ix (2 ^ widthValue.val))
+      = denseBiObligationV facts bi keys pt := by
   let env := denseEnvOfKeysV keys pt
   have hme := denseCompileE_evalV ops keys pt bi.multiplicity mult hm
   have hxe := denseCompileE_evalV ops keys pt x ix hx
@@ -1033,17 +1037,17 @@ private theorem denseVarRangeConstPred_eval (ops : DenseZModOps p)
   have hiff := (facts.varRangeBus_sound bi.busId hfact).2
     (x.eval env) (width.eval env) (bi.multiplicity.eval env)
   have hiff' :
-      bs.violatesConstraint
+      bs.accepts
           { busId := bi.busId, multiplicity := bi.multiplicity.eval env,
-            payload := [x.eval env, width.eval env] } = false
+            payload := [x.eval env, width.eval env] }
         ↔ (x.eval env).val < 2 ^ widthValue.val := by
     simpa [hwe, hle] using hiff
   have hb :
-      (!bs.violatesConstraint
+      (facts.acceptsDec
           { busId := bi.busId, multiplicity := bi.multiplicity.eval env,
             payload := [x.eval env, width.eval env] })
         = decide ((x.eval env).val < 2 ^ widthValue.val) :=
-    denseNotBoolEqDecide _ _ hiff'
+    denseBoolEqDecide _ _ ((facts.acceptsDec_iff _).trans hiff')
   simp only [denseCBiPredEvalV, denseBiObligationV, hme, hxe, hpay, List.map_cons,
     List.map_nil, hz]
   exact congrArg (fun tail => if decide (bi.multiplicity.eval env = 0) then true else tail) hb.symm
@@ -1055,8 +1059,8 @@ private theorem denseTupleRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p
     (hpay : bi.payload = [x, y]) (hfact : facts.tupleRangeBus bi.busId = some (boundX, boundY))
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (hx : denseCompileE keys x = some ix) (hy : denseCompileE keys y = some iy) :
-    denseCBiPredEvalV ops isZero bs pt (.tupleRange mult ix iy boundX boundY)
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.tupleRange mult ix iy boundX boundY)
+      = denseBiObligationV facts bi keys pt := by
   let env := denseEnvOfKeysV keys pt
   have hme := denseCompileE_evalV ops keys pt bi.multiplicity mult hm
   have hxe := denseCompileE_evalV ops keys pt x ix hx
@@ -1064,22 +1068,23 @@ private theorem denseTupleRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p
   have hiff := (facts.tupleRangeBus_sound bi.busId boundX boundY hfact).2.2
     (x.eval env) (y.eval env) (bi.multiplicity.eval env)
   have hb :
-      (!bs.violatesConstraint
+      (facts.acceptsDec
           { busId := bi.busId, multiplicity := bi.multiplicity.eval env,
             payload := [x.eval env, y.eval env] })
         = decide ((x.eval env).val < boundX ∧ (y.eval env).val < boundY) :=
-    denseNotBoolEqDecide _ _ hiff
+    denseBoolEqDecide _ _ ((facts.acceptsDec_iff _).trans hiff)
   simp only [denseCBiPredEvalV, denseBiObligationV, hme, hxe, hye, hpay, List.map_cons,
     List.map_nil, hz]
   exact congrArg (fun tail => if decide (bi.multiplicity.eval env = 0) then true else tail) hb.symm
 
 private theorem denseFallbackPred_eval (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p) (keys : List VarId)
+    (hz : ∀ v, isZero v = decide (v = 0)) {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId)
     (pt : List (ZMod p)) (bi : BusInteraction (DenseExpr p)) (mult : IExpr p)
     (payload : List (IExpr p)) (hm : denseCompileE keys bi.multiplicity = some mult)
     (hpl : denseCompileEs keys bi.payload = some payload) :
-    denseCBiPredEvalV ops isZero bs pt (.fallback ⟨bi.busId, mult, payload⟩)
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.fallback ⟨bi.busId, mult, payload⟩)
+      = denseBiObligationV facts bi keys pt := by
   simp only [denseCBiPredEvalV, denseBiObligationV,
     denseCompileE_evalV ops keys pt bi.multiplicity mult hm,
     denseCompileEs_mapV ops keys pt bi.payload payload hpl, hz]
@@ -1094,8 +1099,8 @@ private theorem denseFixedRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p
     (hslot : bi.payload[slot]? = some e)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (he : denseCompileE keys e = some value) :
-    denseCBiPredEvalV ops isZero bs pt (.fixedRange mult value bound)
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.fixedRange mult value bound)
+      = denseBiObligationV facts bi keys pt := by
   let env := denseEnvOfKeysV keys pt
   let msg : BusInteraction (ZMod p) :=
     { busId := bi.busId,
@@ -1114,45 +1119,45 @@ private theorem denseFixedRangePred_eval (ops : DenseZModOps p) (isZero : ZMod p
     rw [List.getElem?_map, hslot]
     rfl
   have hiff := hiffAt (e.eval env) hget
-  have hb : (!bs.violatesConstraint msg) = decide ((e.eval env).val < bound) :=
-    denseNotBoolEqDecide _ _ hiff
+  have hb : (facts.acceptsDec msg) = decide ((e.eval env).val < bound) :=
+    denseBoolEqDecide _ _ ((facts.acceptsDec_iff _).trans hiff)
   simp only [denseCBiPredEvalV, denseBiObligationV, hme, hee, hz]
   change (if decide (msg.multiplicity = 0) then true
     else decide ((e.eval env).val < bound)) =
-      (if decide (msg.multiplicity = 0) then true else !bs.violatesConstraint msg)
+      (if decide (msg.multiplicity = 0) then true else facts.acceptsDec msg)
   exact congrArg (fun tail => if decide (msg.multiplicity = 0) then true else tail) hb.symm
 
 private theorem denseBytePred_eval (ops : DenseZModOps p) (isZero : ZMod p → Bool)
-    (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p)
+    (hz : ∀ v, isZero v = decide (v = 0)) {bs : BusSemantics p} (facts : BusFacts p bs)
     (keys : List VarId) (pt : List (ZMod p)) (bi : BusInteraction (DenseExpr p))
     (mult : IExpr p) (o1 o2 result : DenseExpr p) (io1 io2 iresult : IExpr p)
     (bound : Nat) (kind : DenseBytePredKind)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (ho1 : denseCompileE keys o1 = some io1) (ho2 : denseCompileE keys o2 = some io2)
     (hresult : denseCompileE keys result = some iresult)
-    (hiff : bs.violatesConstraint (denseBIEval bi (denseEnvOfKeysV keys pt)) = false ↔
+    (hiff : bs.accepts (denseBIEval bi (denseEnvOfKeysV keys pt)) ↔
       (o1.eval (denseEnvOfKeysV keys pt)).val < bound ∧
       (o2.eval (denseEnvOfKeysV keys pt)).val < bound ∧
       kind.Holds (o1.eval (denseEnvOfKeysV keys pt)) (o2.eval (denseEnvOfKeysV keys pt))
         (result.eval (denseEnvOfKeysV keys pt))) :
-    denseCBiPredEvalV ops isZero bs pt (.byte mult io1 io2 iresult bound kind)
-      = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt (.byte mult io1 io2 iresult bound kind)
+      = denseBiObligationV facts bi keys pt := by
   let env := denseEnvOfKeysV keys pt
   have hme := denseCompileE_evalV ops keys pt bi.multiplicity mult hm
   have h1e := denseCompileE_evalV ops keys pt o1 io1 ho1
   have h2e := denseCompileE_evalV ops keys pt o2 io2 ho2
   have hre := denseCompileE_evalV ops keys pt result iresult hresult
-  have hb : (!bs.violatesConstraint (denseBIEval bi env)) = decide
+  have hb : (facts.acceptsDec (denseBIEval bi env)) = decide
       ((o1.eval env).val < bound ∧ (o2.eval env).val < bound ∧
         kind.Holds (o1.eval env) (o2.eval env) (result.eval env)) :=
-    denseNotBoolEqDecide _ _ hiff
+    denseBoolEqDecide _ _ ((facts.acceptsDec_iff _).trans hiff)
   simp only [denseCBiPredEvalV, denseBiObligationV, hme, h1e, h2e, hre, hz,
     denseBytePredRelationV_eq isZero hz]
   change (if decide ((denseBIEval bi env).multiplicity = 0) then true else
       decide ((o1.eval env).val < bound ∧ (o2.eval env).val < bound) &&
         decide (kind.Holds (o1.eval env) (o2.eval env) (result.eval env))) =
     (if decide ((denseBIEval bi env).multiplicity = 0) then true
-      else !bs.violatesConstraint (denseBIEval bi env))
+      else facts.acceptsDec (denseBIEval bi env))
   rw [hb]
   by_cases hm0 : (denseBIEval bi env).multiplicity = 0 <;>
     by_cases h1 : (o1.eval env).val < bound <;>
@@ -1166,7 +1171,7 @@ private theorem denseCompileRangeCBiPredV_eval (ops : DenseZModOps p)
     (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) (pred : DenseCBiPred p)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (h : denseCompileRangeCBiPredV facts keys bi mult = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   unfold denseCompileRangeCBiPredV at h
   cases hmv : bi.multiplicity.constValue? with
   | none => simp [hmv] at h
@@ -1198,7 +1203,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
     (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) (pred : DenseCBiPred p)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (h : denseCompileByteCBiPredV facts keys bi mult = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   unfold denseCompileByteCBiPredV at h
   cases hspec : facts.byteXorSpec bi.busId with
   | none => simp [hspec] at h
@@ -1233,7 +1238,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
                 subst pred
                 have hiff := (denseByteXorSpec_decode_iff bs facts spec bi hspec op o1 o2
                   result hdec env).1 (hopeval.trans hxor)
-                exact denseBytePred_eval ops isZero hz bs keys pt bi mult o1 o2 result io1 io2
+                exact denseBytePred_eval ops isZero hz facts keys pt bi mult o1 o2 result io1 io2
                   iresult spec.bound .xor hm ho1 ho2 hresult (by
                     simpa [DenseBytePredKind.Holds] using hiff)
               · simp only [hxor, if_false] at h
@@ -1243,7 +1248,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
                   subst pred
                   have hiff := (denseByteXorSpec_decode_iff bs facts spec bi hspec op o1 o2
                     result hdec env).2 (hopeval.trans hpair)
-                  exact denseBytePred_eval ops isZero hz bs keys pt bi mult o1 o2 result io1 io2
+                  exact denseBytePred_eval ops isZero hz facts keys pt bi mult o1 o2 result io1 io2
                     iresult spec.bound .pair hm ho1 ho2 hresult (by
                       simpa [DenseBytePredKind.Holds] using hiff)
                 · simp only [hpair, if_false] at h
@@ -1256,7 +1261,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
                       subst pred
                       have hiff := (denseByteBoolSound_decode_iff bs facts spec bi hspec op o1 o2
                         result hdec env).1 orOp hor (hopeval.trans hopOr)
-                      exact denseBytePred_eval ops isZero hz bs keys pt bi mult o1 o2 result io1
+                      exact denseBytePred_eval ops isZero hz facts keys pt bi mult o1 o2 result io1
                         io2 iresult spec.bound .or hm ho1 ho2 hresult (by
                           simpa [DenseBytePredKind.Holds] using hiff)
                     · simp only [hopOr, if_false] at h
@@ -1269,7 +1274,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
                           subst pred
                           have hiff := (denseByteBoolSound_decode_iff bs facts spec bi hspec op o1
                             o2 result hdec env).2 andOp hand (hopeval.trans hopAnd)
-                          exact denseBytePred_eval ops isZero hz bs keys pt bi mult o1 o2 result
+                          exact denseBytePred_eval ops isZero hz facts keys pt bi mult o1 o2 result
                             io1 io2 iresult spec.bound .and hm ho1 ho2 hresult (by
                               simpa [DenseBytePredKind.Holds] using hiff)
                         · simp [hopAnd] at h
@@ -1284,7 +1289,7 @@ private theorem denseCompileByteCBiPredV_eval (ops : DenseZModOps p)
                         subst pred
                         have hiff := (denseByteBoolSound_decode_iff bs facts spec bi hspec op o1 o2
                           result hdec env).2 andOp hand (hopeval.trans hopAnd)
-                        exact denseBytePred_eval ops isZero hz bs keys pt bi mult o1 o2 result io1
+                        exact denseBytePred_eval ops isZero hz facts keys pt bi mult o1 o2 result io1
                           io2 iresult spec.bound .and hm ho1 ho2 hresult (by
                             simpa [DenseBytePredKind.Holds] using hiff)
                       · simp [hopAnd] at h
@@ -1295,7 +1300,7 @@ private theorem denseCompileOtherCBiPredV_eval (ops : DenseZModOps p)
     (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) (pred : DenseCBiPred p)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (h : denseCompileOtherCBiPredV facts keys bi mult = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   unfold denseCompileOtherCBiPredV at h
   cases hrange : denseCompileRangeCBiPredV facts keys bi mult with
   | some rangePred =>
@@ -1316,7 +1321,7 @@ private theorem denseCompileOtherCBiPredV_eval (ops : DenseZModOps p)
       | some payload =>
         simp only [hpayload, Option.map_some, Option.some.injEq] at h
         subst pred
-        exact denseFallbackPred_eval ops isZero hz bs keys pt bi mult payload hm hpayload
+        exact denseFallbackPred_eval ops isZero hz facts keys pt bi mult payload hm hpayload
 
 private theorem denseCompilePairCBiPredV_eval (ops : DenseZModOps p)
     (isZero : ZMod p → Bool) (hz : ∀ v, isZero v = decide (v = 0))
@@ -1325,7 +1330,7 @@ private theorem denseCompilePairCBiPredV_eval (ops : DenseZModOps p)
     (pred : DenseCBiPred p) (hpay : bi.payload = [x, width])
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (h : denseCompilePairCBiPredV facts keys bi mult x width = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   unfold denseCompilePairCBiPredV at h
   cases hx : denseCompileE keys x with
   | none =>
@@ -1378,7 +1383,7 @@ private theorem denseCompilePayloadCBiPredV_eval (ops : DenseZModOps p)
     (pred : DenseCBiPred p) (hpay : bi.payload = payload)
     (hm : denseCompileE keys bi.multiplicity = some mult)
     (h : denseCompilePayloadCBiPredV facts keys bi mult payload = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   cases payload with
   | nil =>
     exact denseCompileOtherCBiPredV_eval ops isZero hz bs facts keys pt bi mult pred hm h
@@ -1396,10 +1401,10 @@ private theorem denseCompilePayloadCBiPredV_eval (ops : DenseZModOps p)
 
 /-- The two `.always` claims agree on evaluated messages: a bus that never violates, or one checked
     for arity only at `bi`'s arity (`denseBIEval` maps the payload, so the arity is preserved). -/
-private theorem denseBiAlwaysOk_violates {bs : BusSemantics p} (facts : BusFacts p bs)
+private theorem denseBiAlwaysOk_accepts {bs : BusSemantics p} (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (env : VarId → ZMod p)
     (h : denseBiAlwaysOk facts bi = true) :
-    bs.violatesConstraint (denseBIEval bi env) = false := by
+    bs.accepts (denseBIEval bi env) := by
   unfold denseBiAlwaysOk at h
   rcases Bool.or_eq_true _ _ |>.mp h with hnever | harity
   · exact facts.neverViolates_sound _ hnever
@@ -1410,16 +1415,16 @@ private theorem denseCompileCBiPredV_eval (ops : DenseZModOps p)
     (bs : BusSemantics p) (facts : BusFacts p bs) (keys : List VarId) (pt : List (ZMod p))
     (bi : BusInteraction (DenseExpr p)) (pred : DenseCBiPred p)
     (h : denseCompileCBiPredV facts keys bi = some pred) :
-    denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
+    denseCBiPredEvalV ops isZero facts pt pred = denseBiObligationV facts bi keys pt := by
   unfold denseCompileCBiPredV at h
   by_cases hnever : denseBiAlwaysOk facts bi = true
   · simp only [hnever, if_true, Option.some.injEq] at h
     subst pred
-    have hnv := denseBiAlwaysOk_violates facts bi (denseEnvOfKeysV keys pt) hnever
+    have hnv := denseBiAlwaysOk_accepts facts bi (denseEnvOfKeysV keys pt) hnever
     unfold denseCBiPredEvalV denseBiObligationV
     change true = (if decide ((denseBIEval bi (denseEnvOfKeysV keys pt)).multiplicity = 0)
-      then true else !bs.violatesConstraint (denseBIEval bi (denseEnvOfKeysV keys pt)))
-    rw [hnv]
+      then true else facts.acceptsDec (denseBIEval bi (denseEnvOfKeysV keys pt)))
+    rw [(facts.acceptsDec_iff _).mpr hnv]
     simp
   · have hneverFalse : denseBiAlwaysOk facts bi = false := Bool.eq_false_of_not_eq_true hnever
     simp only [hneverFalse, Bool.false_eq_true, if_false] at h
@@ -1435,8 +1440,8 @@ private theorem denseCompileCBiPredsV_all (ops : DenseZModOps p)
     (bs : BusSemantics p) (facts : BusFacts p bs) (keys : List VarId) (pt : List (ZMod p)) :
     ∀ (bis : List (BusInteraction (DenseExpr p))) (preds : List (DenseCBiPred p)),
       denseCompileCBiPredsV facts keys bis = some preds →
-      preds.all (denseCBiPredEvalV ops isZero bs pt) =
-        bis.all (fun bi => denseBiObligationV bs bi keys pt) := by
+      preds.all (denseCBiPredEvalV ops isZero facts pt) =
+        bis.all (fun bi => denseBiObligationV facts bi keys pt) := by
   intro bis
   induction bis with
   | nil =>
@@ -1464,7 +1469,7 @@ theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (ces : List (IExpr p)) (preds : List (DenseCBiPred p)) (pt : List (ZMod p))
     (hce : denseCompileEs keys es = some ces)
     (hcb : denseCompileCBiPredsV facts keys bis = some preds) :
-    denseSurvivesAllCWV ops isZero bs ces preds pt = denseSurvivesAllMV bs es bis keys pt := by
+    denseSurvivesAllCWV ops isZero facts ces preds pt = denseSurvivesAllMV facts es bis keys pt := by
   unfold denseSurvivesAllCWV denseSurvivesAllMV
   congr 1
   · exact denseCompileEs_allV ops isZero hz keys pt es ces hce
@@ -1473,7 +1478,7 @@ theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
 theorem denseCompiledSurvV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (es : List (DenseExpr p)) (bis : List (BusInteraction (DenseExpr p)))
     (keys : List VarId) (pt : List (ZMod p)) :
-    (denseCompiledSurvV bs facts es bis keys).run pt = denseSurvivesAllMV bs es bis keys pt := by
+    (denseCompiledSurvV bs facts es bis keys).run pt = denseSurvivesAllMV facts es bis keys pt := by
   unfold denseCompiledSurvV
   cases hce : denseCompileEs keys es with
   | none => rfl
@@ -1482,19 +1487,20 @@ theorem denseCompiledSurvV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     | none => rfl
     | some preds =>
       change denseSurvivesAllCWV denseZModOps (fun v => decide (v = denseZModOps.zero))
-          bs ces preds pt = denseSurvivesAllMV bs es bis keys pt
+          facts ces preds pt = denseSurvivesAllMV facts es bis keys pt
       exact denseSurvivesAllCWV_eq denseZModOps _ (fun _ => rfl)
         bs facts es bis keys ces preds pt hce hcb
 
 /-- The restriction of a satisfying `denv` survives the covered-item predicate (value-only). -/
-theorem denseSurvivesAllMV_restriction (bs : BusSemantics p) (es : List (DenseExpr p))
+theorem denseSurvivesAllMV_restriction {bs : BusSemantics p} (facts : BusFacts p bs)
+    (es : List (DenseExpr p))
     (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (denv : VarId → ZMod p)
     (hes0 : ∀ e ∈ es, e.eval denv = 0)
     (hbi0 : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false)
+      bs.accepts (denseBIEval bi denv))
     (hesk : ∀ e ∈ es, ∀ i ∈ e.vars, i ∈ keys)
     (hbik : ∀ bi ∈ bis, ∀ i ∈ denseBIVars bi, i ∈ keys) :
-    denseSurvivesAllMV bs es bis keys (keys.map denv) = true := by
+    denseSurvivesAllMV facts es bis keys (keys.map denv) = true := by
   unfold denseSurvivesAllMV
   rw [Bool.and_eq_true]
   constructor
@@ -1511,11 +1517,11 @@ theorem denseSurvivesAllMV_restriction (bs : BusSemantics p) (es : List (DenseEx
     unfold denseBiObligationV
     change (if decide ((denseBIEval bi (denseEnvOfKeysV keys (keys.map denv))).multiplicity = 0)
       then true
-      else !bs.violatesConstraint (denseBIEval bi (denseEnvOfKeysV keys (keys.map denv)))) = true
+      else facts.acceptsDec (denseBIEval bi (denseEnvOfKeysV keys (keys.map denv)))) = true
     rw [hbe]
     by_cases hm : (denseBIEval bi denv).multiplicity = 0
     · simp [hm]
-    · simp [hm, hbi0 bi hbi hm]
+    · simp [hm, (facts.acceptsDec_iff _).mpr (hbi0 bi hbi hm)]
 
 /-- The restriction survives the compiled survivor predicate (value-only). -/
 theorem denseCompiledSurvV_restriction (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -1523,12 +1529,12 @@ theorem denseCompiledSurvV_restriction (bs : BusSemantics p) (facts : BusFacts p
     (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (denv : VarId → ZMod p)
     (hes0 : ∀ e ∈ es, e.eval denv = 0)
     (hbi0 : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false)
+      bs.accepts (denseBIEval bi denv))
     (hesk : ∀ e ∈ es, ∀ i ∈ e.vars, i ∈ keys)
     (hbik : ∀ bi ∈ bis, ∀ i ∈ denseBIVars bi, i ∈ keys) :
     (denseCompiledSurvV bs facts es bis keys).run (keys.map denv) = true := by
   rw [denseCompiledSurvV_eq]
-  exact denseSurvivesAllMV_restriction bs es bis keys denv hes0 hbi0 hesk hbik
+  exact denseSurvivesAllMV_restriction facts es bis keys denv hes0 hbi0 hesk hbik
 
 /-! ## `forcedOver` entailment (value-only) -/
 
@@ -1791,7 +1797,7 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     (hes : ∀ e ∈ (denseGatherConstraintsV fidx xs).active,
       e.eval denv = 0 ∧ ∀ i ∈ e.vars, i ∈ xs)
     (hbis : ∀ bi ∈ (denseGatherBusesV fidx xs).interactions,
-      ((denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false)
+      ((denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv))
         ∧ ∀ i ∈ denseBIVars bi, i ∈ xs) :
     ∀ f ∈ denseForcedOverV bs facts T fidx xs, denv f.1 = f.2 := by
   unfold denseForcedOverV denseForcedPreflightV

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DropPasses.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DropPasses.lean
@@ -266,19 +266,19 @@ theorem denseConstMessage?_sound (bi : BusInteraction (DenseExpr p))
 /-- Drops tautological lookups (`denseIsTautoLookup`). -/
 def denseTautoBusDropPass : DenseVerifiedPassW p :=
   DenseVerifiedPassW.of
-    (fun bs _ d => d.filterBus (fun bi => !denseIsTautoLookup bs bi))
+    (fun bs facts d => d.filterBus (fun bi => !denseIsTautoLookup bs facts bi))
     (fun _ _ _ => [])
     (fun _ _ _ _ hcov => DenseConstraintSystem.filterBus_covered hcov)
     (fun _ _ _ _ _ => by intro x hx; simp at hx)
-    (fun reg bs _ d _ => by
+    (fun reg bs facts d _ => by
       refine DensePassCorrect.denseFilterBusEntailed d bs reg.isInput
-        (fun bi => !denseIsTautoLookup bs bi) ?_ ?_
+        (fun bi => !denseIsTautoLookup bs facts bi) ?_ ?_
       · intro bi _ hkf
-        have htauto : denseIsTautoLookup bs bi = true := by simpa using hkf
+        have htauto : denseIsTautoLookup bs facts bi = true := by simpa using hkf
         simp only [denseIsTautoLookup, Bool.and_eq_true] at htauto
         simpa using htauto.1
       · intro bi _ hkf denv _ _
-        have htauto : denseIsTautoLookup bs bi = true := by simpa using hkf
+        have htauto : denseIsTautoLookup bs facts bi = true := by simpa using hkf
         simp only [denseIsTautoLookup, Bool.and_eq_true] at htauto
         have hmsg := htauto.2
         cases hcm : denseConstMessage? bi with
@@ -286,6 +286,6 @@ def denseTautoBusDropPass : DenseVerifiedPassW p :=
         | some msg =>
           rw [hcm] at hmsg
           rw [denseConstMessage?_sound bi msg hcm denv]
-          simpa using hmsg)
+          exact (facts.acceptsDec_iff msg).mp (by simpa using hmsg))
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
@@ -83,7 +83,7 @@ theorem DensePassCorrect.denseFilterBusEntailed (d : DenseConstraintSystem p) (b
     (hok : ∀ bi ∈ d.busInteractions, keep bi = false → ∀ denv,
       (d.filterBus keep).satisfies bs denv →
       (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     DensePassCorrect isInput d (d.filterBus keep) [] bs := by
   have hiff : ∀ denv, (d.filterBus keep).satisfies bs denv ↔ d.satisfies bs denv := by
     intro denv
@@ -199,7 +199,7 @@ structure DenseCheckRule (p : ℕ) (bs : BusSemantics p) where
   stateless : ∀ bi e, recognize bi = some e → bs.isStateful bi.busId = false
   vars : ∀ bi e, recognize bi = some e → ∀ z ∈ e.vars, z ∈ denseBIVars bi
   violates_iff : ∀ bi e, recognize bi = some e → ∀ denv : VarId → ZMod p,
-    (bs.violatesConstraint (denseBIEval bi denv) = false ↔ e.eval denv = 0)
+    (bs.accepts (denseBIEval bi denv) ↔ e.eval denv = 0)
 
 /-- Every emitted constraint comes from some recognizer firing on some listed interaction. -/
 theorem denseGroupEmit_mem {recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p))}

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
@@ -77,9 +77,9 @@ theorem denseFuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
     (denv : VarId → ZMod p)
     (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0)
     (hobX : (denseBIEval biX denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval biX denv) = false)
+      bs.accepts (denseBIEval biX denv))
     (hobY : (denseBIEval biY denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval biY denv) = false) :
+      bs.accepts (denseBIEval biY denv)) :
     denv vy = denv vx := by
   unfold denseFuCheck at h
   cases hd : denseFuPairData? bs facts domIdx biX biY x with
@@ -133,9 +133,9 @@ theorem denseFuCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                       biX.multiplicity.constValue?_sound mx hmx denv
                     have hmYe : (denseBIEval biY denv).multiplicity = my :=
                       biY.multiplicity.constValue?_sound my hmy denv
-                    have hviolX : bs.violatesConstraint (denseBIEval biX denv) = false :=
+                    have hviolX : bs.accepts (denseBIEval biX denv) :=
                       hobX (by rw [hmXe]; exact hmx0)
-                    have hviolY : bs.violatesConstraint (denseBIEval biY denv) = false :=
+                    have hviolY : bs.accepts (denseBIEval biY denv) :=
                       hobY (by rw [hmYe]; exact hmy0)
                     have hgetX : (denseBIEval biX denv).payload[0]? = some (OX.eval denv) := by
                       show (biX.payload.map (fun e => e.eval denv))[0]? = _

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FxSubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FxSubst.lean
@@ -81,9 +81,9 @@ theorem denseFxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
     (denv : VarId → ZMod p)
     (hdom : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c.eval denv = 0)
     (hobX : (denseBIEval biX denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval biX denv) = false)
+      bs.accepts (denseBIEval biX denv))
     (hobY : (denseBIEval biY denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval biY denv) = false) :
+      bs.accepts (denseBIEval biY denv)) :
     denv vy = E.eval denv := by
   unfold denseFxCheck at h
   cases hd : denseFuPairData? bs facts domIdx biX biY x with
@@ -138,9 +138,9 @@ theorem denseFxCheck_sound [Fact p.Prime] (bs : BusSemantics p) (facts : BusFact
                       biX.multiplicity.constValue?_sound mx hmx denv
                     have hmYe : (denseBIEval biY denv).multiplicity = my :=
                       biY.multiplicity.constValue?_sound my hmy denv
-                    have hviolX : bs.violatesConstraint (denseBIEval biX denv) = false :=
+                    have hviolX : bs.accepts (denseBIEval biX denv) :=
                       hobX (by rw [hmXe]; exact hmx0)
-                    have hviolY : bs.violatesConstraint (denseBIEval biY denv) = false :=
+                    have hviolY : bs.accepts (denseBIEval biY denv) :=
                       hobY (by rw [hmYe]; exact hmy0)
                     have hgetX : (denseBIEval biX denv).payload[0]? = some (OX.eval denv) := by
                       show (biX.payload.map (fun e => e.eval denv))[0]? = _

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
@@ -577,7 +577,7 @@ theorem dense_collapse_correct [Fact p.Prime] (isInput : VarId → Bool)
   refine ⟨hsound, ?_, ?_, ?_⟩
   · -- Invariant preservation.
     intro hcsInv denv hsatOut bi hbiOut
-    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.breaksInvariant (denseBIEval bi denv) = false
+    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi denv)
     rw [← hbe denv bi (hob ▸ hbiOut)]
     exact hcsInv (reasg denv (denv invId)) (hcssat denv hsatOut) bi (hob ▸ hbiOut)
   · -- No new powdr-ID (input) column.

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IdentitySubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IdentitySubst.lean
@@ -75,7 +75,7 @@ theorem denseIdentityPairAt_spec {bs : BusSemantics p} (facts : BusFacts p bs)
 theorem denseIdentityPairAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) (rv o1v : VarId)
     (h : denseIdentityPairAt facts bi = some (rv, o1v)) (denv : VarId → ZMod p)
-    (hviol : bs.violatesConstraint (denseBIEval bi denv) = false) : denv rv = denv o1v := by
+    (hviol : bs.accepts (denseBIEval bi denv)) : denv rv = denv o1v := by
   obtain ⟨spec, oop, o1, o2, hspec, _, hoop, hdec, hoo⟩ :=
     denseIdentityPairAt_spec facts bi rv o1v h
   have hdecEv : spec.decode (denseBIEval bi denv).payload
@@ -183,7 +183,7 @@ theorem denseIdentityMap_forced {bs : BusSemantics p} (facts : BusFacts p bs)
     ∀ a b, (denseIdentityMap facts d)[a]? = some b → denv a = denv b := by
   intro a b hab
   obtain ⟨bi, hbi, hpair⟩ := denseIdentityMap_mem facts d a b hab
-  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := by
+  have hviol : bs.accepts (denseBIEval bi denv) := by
     refine hsat.2 bi hbi ?_
     obtain ⟨_, _, _, _, _, hmc, _, _, _⟩ := denseIdentityPairAt_spec facts bi a b hpair
     show (bi.multiplicity.eval denv) ≠ 0

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IntervalForce.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IntervalForce.lean
@@ -343,7 +343,7 @@ theorem denseBoundIdxBuild_witnessed {bs : BusSemantics p} (facts : BusFacts p b
 theorem denseBoundIdxBuild_lookup_sound {bs : BusSemantics p} (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (denv : VarId → ZMod p)
     (hbus : ∀ bi ∈ d.busInteractions, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ v B, (denseBoundIdxBuild bs facts d.busInteractions)[v]? = some B → (denv v).val < B := by
   intro v B h
   obtain ⟨bi, hbi, hib⟩ := denseBoundIdxBuild_witnessed facts d.busInteractions v B h
@@ -355,7 +355,7 @@ theorem denseInteractionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs
     (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p)
     (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
     (hviol : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     ∀ s ∈ denseInteractionSeeds bs facts bnd bi, s.eval denv = 0 := by
   intro s hs
   unfold denseInteractionSeeds at hs
@@ -379,7 +379,7 @@ theorem denseInteractionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs
         simp only [hpe, hsb] at hsi
         have hmeval : (denseBIEval bi denv).multiplicity = mval :=
           bi.multiplicity.constValue?_sound mval hmc denv
-        have hv : bs.violatesConstraint (denseBIEval bi denv) = false := by
+        have hv : bs.accepts (denseBIEval bi denv) := by
           apply hviol
           rw [hmeval]
           exact hmz

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
@@ -34,7 +34,7 @@ theorem denseByteCheckOperands?_accepted (bs : BusSemantics p) (facts : BusFacts
     (bi : BusInteraction (DenseExpr p)) (ops : List (DenseExpr p))
     (h : denseByteCheckOperands? bs facts bi = some ops) (denv : VarId → ZMod p)
     (hops : ∀ e ∈ ops, (e.eval denv).val < 256) :
-    bs.violatesConstraint (denseBIEval bi denv) = false := by
+    bs.accepts (denseBIEval bi denv) := by
   unfold denseByteCheckOperands? at h
   cases hc : denseByteShape? denseCmpFolded bs facts bi with
   | none => rw [hc] at h; exact absurd h (by simp)
@@ -77,7 +77,7 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
       -- every justification-base interaction survives the filter, so `hsat` accepts it
       have hbusbase : ∀ bi' ∈ denseByteDropBase bs facts d,
           (denseBIEval bi' denv).multiplicity ≠ 0 →
-          bs.violatesConstraint (denseBIEval bi' denv) = false := by
+          bs.accepts (denseBIEval bi' denv) := by
         intro bi' hbi' hmult
         have hnone : denseByteCheckOperands? bs facts bi' = none := by
           have h := (List.mem_filter.1 hbi').2

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -734,7 +734,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
         have h1 := hsat'.1 _ hmem
         rw [hA c hc] at h1; exact h1
       · exact hdrop c hc (by simpa using hk)
-    · show (denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false
+    · show (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)
       have hmem : { bi with multiplicity := grw bi.multiplicity, payload := bi.payload.map grw }
           ∈ (d.busInteractions.map (fun bi =>
             { bi with multiplicity := grw bi.multiplicity, payload := bi.payload.map grw })) :=
@@ -754,7 +754,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
     have hd := hsatd denv denv' hA hB hdrop hsat'
     obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi'
     show (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv').multiplicity ≠ 0 →
-      bs.breaksInvariant (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv') = false
+      bs.maintainsInvariants (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv')
     rw [hB bi0 hbi0]
     exact hinv denv hd bi0 hbi0
   · -- Completeness with derivations.
@@ -768,7 +768,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
       · exact hnew c h
     · obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
       show (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv').multiplicity ≠ 0 →
-        bs.violatesConstraint (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv') = false
+        bs.accepts (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv')
       rw [hB bi0 hbi0]
       exact hsat.2 bi0 hbi0
     · rw [hside denv denv' hB]; exact BusState.equiv_refl _

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
@@ -128,7 +128,7 @@ theorem denseScaledSlotBound_sound [Fact p.Prime] (bs : BusSemantics p) (facts :
     (B : Nat) (h : denseScaledSlotBound bs facts domCs bi x = some B) (denv : VarId → ZMod p)
     (hdom : ∀ c ∈ domCs, c.eval denv = 0)
     (hob : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     (denv x).val < B := by
   unfold denseScaledSlotBound at h
   cases hmv : bi.multiplicity.constValue? with
@@ -155,7 +155,7 @@ theorem denseScaledSlotBound_sound [Fact p.Prime] (bs : BusSemantics p) (facts :
           obtain ⟨hunit, hcover, _hcap⟩ := hcond
           have hmeval : (denseBIEval bi denv).multiplicity = mval :=
             bi.multiplicity.constValue?_sound mval hmv denv
-          have hviol : bs.violatesConstraint (denseBIEval bi denv) = false :=
+          have hviol : bs.accepts (denseBIEval bi denv) :=
             hob (by rw [hmeval]; exact hmz)
           have hget : (denseBIEval bi denv).payload[slot]? = some (O.eval denv) := by
             show (bi.payload.map (fun e => e.eval denv))[slot]? = _
@@ -228,7 +228,7 @@ theorem denseFindVarBound_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (DenseExpr p))) (x : VarId) (bound : Nat)
     (h : denseFindVarBound bs facts bis x = some bound) (denv : VarId → ZMod p)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) : (denv x).val < bound := by
+      bs.accepts (denseBIEval bi denv)) : (denv x).val < bound := by
   induction bis with
   | nil => exact absurd h (by simp [denseFindVarBound])
   | cons bi rest ih =>
@@ -250,7 +250,7 @@ theorem denseAnyVarBound_sound [Fact p.Prime] (bs : BusSemantics p) (facts : Bus
     (denv : VarId → ZMod p)
     (hdom : ∀ c ∈ domCs, c.eval denv = 0)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) : (denv x).val < B := by
+      bs.accepts (denseBIEval bi denv)) : (denv x).val < B := by
   unfold denseAnyVarBound at h
   cases hfb : denseFindVarBound bs facts bis x with
   | some B' =>
@@ -274,7 +274,7 @@ theorem denseRpCheckPair_sound [Fact p.Prime] (bs : BusSemantics p)
     (hdom : ∀ c ∈ domCs, c.eval denv = 0)
     (hcXe : cX.eval denv = 0) (hcYe : cY.eval denv = 0)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.violatesConstraint (denseBIEval bi denv) = false) :
+      bs.accepts (denseBIEval bi denv)) :
     denv x = denv y := by
   unfold denseRpCheckPair at h
   cases hxt : denseTwoRootOf? cX x with

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SeqzCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SeqzCollapse.lean
@@ -190,7 +190,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
       (denseSeqzClusterBus r.busId r.m3 r.m2 r.m1 r.m0 r.dv spec) w = true)
     (habyteAll : ∀ (denv : VarId → ZMod p),
       (∀ bi ∈ (denseSeqzCollapsedSystem d r invId spec).busInteractions,
-        (denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false) →
+        (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)) →
       ∀ a ∈ ([r.a0, r.a1, r.a2, r.a3] : List VarId), (denv a).val < 256)
     (hnodup : ([r.R, r.a0, r.a1, r.a2, r.a3, r.m3, r.m2, r.m1, r.m0, r.dv] : List VarId).Nodup)
     (hinv_fresh : invId ∉ d.occ) (hinv_id : isInput invId = false)
@@ -392,7 +392,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
           rw [hgframeE c (fun w hw => hpureC w hw c hc hccl)]
           exact hsatOut.1 c hcout
       · by_cases hbe : bi = busE
-        · show (denseBIEval bi g).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi g) = false
+        · show (denseBIEval bi g).multiplicity ≠ 0 → bs.accepts (denseBIEval bi g)
           rw [hbe, hbusEval]
           intro hmult
           exact SeqzCollapse.bus_accepts_byte_zero facts r.busId spec hspec hbound (-1 + vd)
@@ -400,7 +400,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
         · have hbout : bi ∈ out.busInteractions := by
             rw [houtdef, denseSeqzCollapsedSystem, ← hbusEdef]
             exact List.mem_filter.2 ⟨hbi, by simpa using hbe⟩
-          show (denseBIEval bi g).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi g) = false
+          show (denseBIEval bi g).multiplicity ≠ 0 → bs.accepts (denseBIEval bi g)
           rw [hgframeBus bi hbi hbe]
           exact hsatOut.2 bi hbout
     have hseSound : d.sideEffects bs g = d.sideEffects bs env := by
@@ -453,7 +453,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
     exact BusState.equiv_refl _
   · -- invariant preservation
     intro hdInv env hsatOut bi hbiOut
-    show (denseBIEval bi env).multiplicity ≠ 0 → bs.breaksInvariant (denseBIEval bi env) = false
+    show (denseBIEval bi env).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi env)
     obtain ⟨g, hgcs, hgfr, _⟩ := hReconstruct env hsatOut
     have hbicsmem : bi ∈ d.busInteractions := by
       have := hbiOut; rw [houtdef, denseSeqzCollapsedSystem] at this
@@ -483,7 +483,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
       (denseClusterEval_iff r.m3 r.m2 r.m1 r.m0 r.dv r.R r.a3 r.a2 r.a1 r.a0 r.K env).mp
         (fun c hc => hsat.1 c (hclMem c hc))
     have hbusOutEnv : ∀ bi ∈ (denseSeqzCollapsedSystem d r invId spec).busInteractions,
-        (denseBIEval bi env).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi env) = false := by
+        (denseBIEval bi env).multiplicity ≠ 0 → bs.accepts (denseBIEval bi env) := by
       intro bi hbi hm
       rw [denseSeqzCollapsedSystem] at hbi
       exact hsat.2 bi (List.mem_of_mem_filter hbi) hm
@@ -536,7 +536,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
             rw [mul_right_comm, inv_mul_cancel₀ hS0, one_mul]; ring
     · have hbics : bi ∈ d.busInteractions := by
         rw [houtdef, denseSeqzCollapsedSystem] at hbi; exact List.mem_of_mem_filter hbi
-      show (denseBIEval bi envC).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi envC) = false
+      show (denseBIEval bi envC).multiplicity ≠ 0 → bs.accepts (denseBIEval bi envC)
       rw [hbeC bi hbics]; exact hsat.2 bi hbics
     · -- admissibility preserved
       show bs.admissible ((out.busInteractions.map (fun bi => denseBIEval bi envC)).filter
@@ -678,7 +678,7 @@ theorem dense_seqzCollapse_bundle (reg : VarRegistry) (d : DenseConstraintSystem
   -- byte bounds on the limbs for any output-satisfying assignment, via `denseBuild_sound`
   have habyteAll : ∀ (denv : VarId → ZMod p),
       (∀ bi ∈ (denseSeqzCollapsedSystem d r (reg.register (denseSeqzInvVar reg r)).2 spec).busInteractions,
-        (denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false) →
+        (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)) →
       ∀ a ∈ ([r.a0, r.a1, r.a2, r.a3] : List VarId), (denv a).val < 256 := by
     intro denv hnv a ha
     have hb := hboundsB a ha

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
@@ -27,7 +27,7 @@ theorem denseAsBytePair_eq (bs : BusSemantics p) (facts : BusFacts p bs)
 /-- The obligation predicate appearing in dense `satisfies`. -/
 private def denseP (bs : BusSemantics p) (denv : VarId → ZMod p)
     (bi : BusInteraction (DenseExpr p)) : Prop :=
-  (denseBIEval bi denv).multiplicity ≠ 0 → bs.violatesConstraint (denseBIEval bi denv) = false
+  (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)
 
 private theorem filter_cons_append {α : Type} (q : α → Bool) (x : α) (ys : List α) :
     ([x].filter q) ++ ys.filter q = (x :: ys).filter q := by
@@ -45,19 +45,19 @@ private theorem denseSplitOne_P (bs : BusSemantics p) (facts : BusFacts p bs)
     obtain ⟨rfl, hspec⟩ := denseAsBytePair_eq bs facts bi busId spec a b hab
     simp only [List.mem_cons, List.not_mem_nil, or_false, forall_eq_or_imp, forall_eq]
     have hsaP : denseP bs denv (denseMkByteCheck spec busId a) ↔
-        bs.violatesConstraint (denseBIEval (denseMkByteCheck spec busId a) denv) = false := by
+        bs.accepts (denseBIEval (denseMkByteCheck spec busId a) denv) := by
       unfold denseP
       have hmul : (denseBIEval (denseMkByteCheck spec busId a) denv).multiplicity = 1 := by
         rw [denseMkByteCheck_eval]
       exact ⟨fun h => h (by rw [hmul]; exact hp1), fun h _ => h⟩
     have hsbP : denseP bs denv (denseMkByteCheck spec busId b) ↔
-        bs.violatesConstraint (denseBIEval (denseMkByteCheck spec busId b) denv) = false := by
+        bs.accepts (denseBIEval (denseMkByteCheck spec busId b) denv) := by
       unfold denseP
       have hmul : (denseBIEval (denseMkByteCheck spec busId b) denv).multiplicity = 1 := by
         rw [denseMkByteCheck_eval]
       exact ⟨fun h => h (by rw [hmul]; exact hp1), fun h _ => h⟩
     have hpairP : denseP bs denv (denseMkBytePair spec busId a b) ↔
-        bs.violatesConstraint (denseBIEval (denseMkBytePair spec busId a b) denv) = false := by
+        bs.accepts (denseBIEval (denseMkBytePair spec busId a b) denv) := by
       unfold denseP
       have hmul : (denseBIEval (denseMkBytePair spec busId a b) denv).multiplicity = 1 := by
         rw [denseMkBytePair_eval]
@@ -174,7 +174,7 @@ private theorem denseSplitOne_vars (bs : BusSemantics p) (facts : BusFacts p bs)
 private theorem denseSplitOne_breaksInvariant (bs : BusSemantics p) (facts : BusFacts p bs)
     (bi b : BusInteraction (DenseExpr p)) (hb : b ∈ denseSplitOne bs facts bi)
     (denv : VarId → ZMod p) :
-    (b = bi) ∨ bs.breaksInvariant (denseBIEval b denv) = false := by
+    (b = bi) ∨ bs.maintainsInvariants (denseBIEval b denv) := by
   cases hab : denseAsBytePair bs facts bi with
   | none => simp only [denseSplitOne, hab, List.mem_singleton] at hb; exact Or.inl hb
   | some t =>
@@ -246,7 +246,7 @@ private theorem denseSplitBytePair_correct_aux (isInput : VarId → Bool) (bs : 
   · intro hgi denv hsat bi hbi
     rw [hbus, List.mem_flatMap] at hbi
     obtain ⟨orig, horig, hbimem⟩ := hbi
-    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.breaksInvariant (denseBIEval bi denv) = false
+    show (denseBIEval bi denv).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi denv)
     intro hne
     rcases denseSplitOne_breaksInvariant bs facts orig bi hbimem denv with heq | hbrk
     · rw [heq]; exact hgi denv ((hsatiff denv).2 hsat) orig horig (heq ▸ hne)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SubsumedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SubsumedCheck.lean
@@ -26,7 +26,7 @@ def SubsumedRecognizerSound (bs : BusSemantics p)
   ∀ bi x B, f bi = some (x, B) →
     bs.isStateful bi.busId = false ∧
     ∀ denv : VarId → ZMod p, (denv x).val < B →
-      bs.violatesConstraint (denseBIEval bi denv) = false
+      bs.accepts (denseBIEval bi denv)
 
 /-- Every dropped interaction is a recognised check whose variable is already bounded `< B` by the
     retained base, so it is accepted under every assignment satisfying the filtered system. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/TupleRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/TupleRange.lean
@@ -64,18 +64,18 @@ theorem denseTupleKey (bs : BusSemantics p) (facts : BusFacts p bs)
     (htr : facts.tupleRangeBus trBus = some (s1, s2))
     (hs1 : s1 = 256) (b : ZMod p) (hble : b.val ≤ 17) (hs2 : 2 ^ b.val = s2)
     (x y : DenseExpr p) :
-    ∀ denv, bs.violatesConstraint (denseBIEval (denseTupleCheck trBus x y) denv) = false ↔
-      bs.violatesConstraint (denseBIEval (denseMkByteCheck spec bcBus x) denv) = false ∧
-        bs.violatesConstraint (denseBIEval (denseRangeCheck1 vrBus y (.const b)) denv) = false := by
+    ∀ denv, bs.accepts (denseBIEval (denseTupleCheck trBus x y) denv) ↔
+      bs.accepts (denseBIEval (denseMkByteCheck spec bcBus x) denv) ∧
+        bs.accepts (denseBIEval (denseRangeCheck1 vrBus y (.const b)) denv) := by
   intro denv
   obtain ⟨-, -, htriff⟩ := facts.tupleRangeBus_sound trBus s1 s2 htr
   obtain ⟨-, hvriff⟩ := facts.varRangeBus_sound vrBus hvr
   rw [denseTupleCheck_eval, denseRangeCheck1_eval,
     denseMkByteCheck_accepted bs facts spec bcBus hspec x denv, hbound]
   rw [htriff (x.eval denv) (y.eval denv) 1]
-  have hB : bs.violatesConstraint
-      { busId := vrBus, multiplicity := 1,
-        payload := [y.eval denv, (DenseExpr.const b).eval denv] } = false ↔
+  have hB : bs.accepts
+        { busId := vrBus, multiplicity := 1,
+          payload := [y.eval denv, (DenseExpr.const b).eval denv] } ↔
       (b.val ≤ 17 ∧ (y.eval denv).val < 2 ^ b.val) :=
     hvriff (y.eval denv) b 1
   rw [hB, hs1, ← hs2]

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/XorEqExtract.lean
@@ -48,7 +48,7 @@ theorem denseXorEq?_eval (bs : BusSemantics p) (facts : BusFacts p bs) (d : Dens
     (h1ne : (1 : ZMod p) ≠ 0) (h : denseXorEq? bs facts bi = some c) (hbi : bi ∈ d.busInteractions)
     (hsat : d.satisfies bs denv) : c.eval denv = 0 := by
   obtain ⟨spec, o1, o2, r, hspec, hmult, hdec, hcase⟩ := denseXorEq?_spec bs facts bi c h
-  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := by
+  have hviol : bs.accepts (denseBIEval bi denv) := by
     refine hsat.2 bi hbi ?_
     show (bi.multiplicity.eval denv) ≠ 0
     rw [hmult]; simpa using h1ne
@@ -126,7 +126,7 @@ theorem denseBoolEq?_eval (bs : BusSemantics p) (facts : BusFacts p bs) (d : Den
     (h1ne : (1 : ZMod p) ≠ 0) (h : denseBoolEq? bs facts bi = some c) (hbi : bi ∈ d.busInteractions)
     (hsat : d.satisfies bs denv) : c.eval denv = 0 := by
   obtain ⟨spec, op, o1, o2, r, hspec, hmult, hdec, hcase⟩ := denseBoolEq?_spec bs facts bi c h
-  have hviol : bs.violatesConstraint (denseBIEval bi denv) = false := by
+  have hviol : bs.accepts (denseBIEval bi denv) := by
     refine hsat.2 bi hbi ?_
     show (bi.multiplicity.eval denv) ≠ 0
     rw [hmult]; simpa using h1ne

--- a/ApcOptimizer/Implementation/OptimizerPasses/SeqzCollapseCore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SeqzCollapseCore.lean
@@ -300,8 +300,7 @@ theorem seqz_reconstruct [Fact p.Prime] (hp : 1024 ≤ p)
 theorem bus_accepts_byte_zero {bs : BusSemantics p} (facts : BusFacts p bs) (busId : Nat)
     (spec : ByteXorSpec p) (hspec : facts.byteXorSpec busId = some spec) (hbound : spec.bound = 256)
     (x mult : ZMod p) (hx : x.val < 256) :
-    bs.violatesConstraint
-      { busId := busId, multiplicity := mult, payload := spec.encode spec.pairOp x 0 0 } = false := by
+    bs.accepts { busId := busId, multiplicity := mult, payload := spec.encode spec.pairOp x 0 0 } := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound busId spec hspec
   have hdec : spec.decode (spec.encode spec.pairOp x 0 0) = some (spec.pairOp, x, 0, 0) :=
     spec.decode_encode _ _ _ _
@@ -312,8 +311,7 @@ theorem bus_accepts_byte_zero {bs : BusSemantics p} (facts : BusFacts p bs) (bus
 theorem bus_byte_of_accepts {bs : BusSemantics p} (facts : BusFacts p bs) (busId : Nat)
     (spec : ByteXorSpec p) (hspec : facts.byteXorSpec busId = some spec) (hbound : spec.bound = 256)
     (x mult : ZMod p)
-    (h : bs.violatesConstraint
-      { busId := busId, multiplicity := mult, payload := spec.encode spec.pairOp x 0 0 } = false) :
+    (h : bs.accepts { busId := busId, multiplicity := mult, payload := spec.encode spec.pairOp x 0 0 }) :
     x.val < 256 := by
   obtain ⟨_, _, hsound⟩ := facts.byteXorSpec_sound busId spec hspec
   have hdec : spec.decode (spec.encode spec.pairOp x 0 0) = some (spec.pairOp, x, 0, 0) :=

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -10,13 +10,134 @@ set_option autoImplicit false
 The `BusFacts` instance for `sp1BusSemantics` (see `ApcOptimizer/Implementation/BusFacts.lean` for
 the design). The memory discipline is direction-parametric (`MemoryBusShape.direction`), so SP1's
 reverse memory convention (`setNewMult = -1`) and its execution bridge (`setNewMult = 1`) reuse the
-same machinery. Every claim is proven against the concrete `violates`, so none needs auditing.
+same machinery. Every claim is proven against the audited `accepts`/`maintainsInvariants`, so none needs auditing.
 Parameterized by the bus map (defaulting to `defaultBusMap`).
 -/
 
 namespace ApcOptimizer.SP1
 
 variable {p : ℕ}
+
+/-! ## Deciding the semantics
+
+The audited `accepts`/`maintainsInvariants` are `Prop`s, so a pass cannot evaluate them. `violates`
+and `breaksInvariant` below are the `Bool` decision procedures the pipeline actually runs, each
+proven equivalent to its audited counterpart; the `@[simp]` interface lemmas let the Bool-shaped
+helper proofs in this file stand as written. -/
+
+private def isByteB (x : ZMod p) : Bool := decide (x.val < 256)
+private def is16BitB (x : ZMod p) : Bool := decide (x.val < 2 ^ 16)
+
+private theorem isByteB_iff (x : ZMod p) : isByteB x = true ↔ isByte x := by
+  simp [isByteB, isByte]
+
+private theorem is16BitB_iff (x : ZMod p) : is16BitB x = true ↔ is16Bit x := by
+  simp [is16BitB, is16Bit]
+
+private theorem all_is16BitB_iff (v : Vector (ZMod p) 4) :
+    v.all is16BitB = true ↔ ∀ d ∈ v, is16Bit d := by
+  rw [Vector.all_eq_true_iff_forall_mem]
+  simp only [is16BitB_iff]
+
+private theorem forall_is16BitB_iff (v : Vector (ZMod p) 4) :
+    (∀ (i : Nat) (h : i < 4), is16BitB v[i] = true) ↔ ∀ d ∈ v, is16Bit d :=
+  Vector.all_eq_true.symm.trans (all_is16BitB_iff v)
+
+/-- Bool decision procedure for `accepts` (`violates_eq_false_iff`). -/
+private def violates (busMap : Nat → Option Sp1BusType) (msg : BusInteraction (ZMod p)) : Bool :=
+  match busMap msg.busId, msg.payload with
+  | some .pcLookup, args => !decide (args.length = 16)
+  | some .instructionFetch, args => !decide (args.length = 22)
+  | some .pageProt, args => !decide (args.length = 6)
+  | some .byteLookup, [op, a, b, c] =>
+    match op.val with
+    | 0 => !(isByteB b && isByteB c && decide (a.val = Nat.land b.val c.val))
+    | 1 => !(isByteB b && isByteB c && decide (a.val = Nat.lor b.val c.val))
+    | 2 => !(isByteB b && isByteB c && decide (a.val = Nat.xor b.val c.val))
+    | 3 => !(isByteB b && isByteB c && decide (a.val = 0))
+    | 4 => !(isByteB b && isByteB c && decide (a.val = if b.val < c.val then 1 else 0))
+    | 5 => !(isByteB b && decide (c.val = 0) && decide (a.val = b.val >>> 7))
+    | 6 => !(decide (b.val ≤ 16) && decide (c.val = 0) && decide (a.val < 2 ^ b.val))
+    | _ => true
+  | some .byteLookup, _ => true
+  | some .executionBridge, _ => false
+  | some .memory, payload =>
+    match memoryPayload? payload with
+    | some f => decide (msg.multiplicity = 1) && !(f.data.all is16BitB)
+    | none => false
+  | none, _ => true
+
+/-- Bool decision procedure for `maintainsInvariants` (`breaksInvariant_eq_false_iff`). -/
+private def breaksInvariant (busMap : Nat → Option Sp1BusType)
+    (msg : BusInteraction (ZMod p)) : Bool :=
+  match busMap msg.busId with
+  | some .pcLookup | some .byteLookup | some .instructionFetch | some .pageProt =>
+    !decide (msg.multiplicity = 1)
+  | some .executionBridge =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
+  | some .memory =>
+    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
+    (match memoryPayload? msg.payload with
+      | some f => !(f.data.all is16BitB)
+      | none => false)
+  | none => true
+
+private theorem violates_eq_false_iff (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) : violates busMap m = false ↔ accepts busMap m := by
+  obtain ⟨bid, mult, payload⟩ := m
+  unfold violates accepts
+  cases hb : busMap bid with
+  | none => simp
+  | some t =>
+    cases t with
+    | executionBridge => simp
+    | pcLookup => simp
+    | instructionFetch => simp
+    | pageProt => simp
+    | byteLookup =>
+        rcases payload with _ | ⟨op, _ | ⟨a, _ | ⟨b, _ | ⟨c, _ | ⟨w, rest⟩⟩⟩⟩⟩ <;> try simp
+        rcases op.val with _ | _ | _ | _ | _ | _ | _ | n <;>
+          simp [isByteB_iff, and_assoc]
+    | memory =>
+        cases hp : memoryPayload? payload with
+        | none => simp [hp]
+        | some f => simp [hp, forall_is16BitB_iff, imp_iff_not_or]
+
+private theorem breaksInvariant_eq_false_iff (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) :
+    breaksInvariant busMap m = false ↔ maintainsInvariants busMap m := by
+  obtain ⟨bid, mult, payload⟩ := m
+  unfold breaksInvariant maintainsInvariants
+  cases hb : busMap bid with
+  | none => simp
+  | some t =>
+    cases t with
+    | pcLookup => simp
+    | byteLookup => simp
+    | instructionFetch => simp
+    | pageProt => simp
+    | executionBridge => simp [or_iff_not_imp_left]
+    | memory =>
+        cases hp : memoryPayload? payload with
+        | none => simp [or_iff_not_imp_left]
+        | some f => simp [forall_is16BitB_iff, or_iff_not_imp_left]
+
+/-- `accepts` is decidable, via the Bool procedure above; `BusFacts.trivial` needs this. -/
+instance instDecidableSp1Accepts (busMap : Nat → Option Sp1BusType) :
+    DecidablePred (sp1BusSemantics p busMap).accepts := fun m =>
+  decidable_of_iff (violates busMap m = false) (violates_eq_false_iff busMap m)
+
+/-- The `BusFacts` interface speaks the audited `accepts`; the lemmas here speak `violates`. -/
+@[simp] private theorem sp1_accepts_iff (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) :
+    (sp1BusSemantics p busMap).accepts m ↔ violates busMap m = false :=
+  (violates_eq_false_iff busMap m).symm
+
+@[simp] private theorem sp1_maintains_iff (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) :
+    (sp1BusSemantics p busMap).maintainsInvariants m ↔ breaksInvariant busMap m = false :=
+  (breaksInvariant_eq_false_iff busMap m).symm
+
 
 private def neverViolatesImpl (busMap : Nat → Option Sp1BusType) (busId : Nat) : Bool :=
   match busMap busId with
@@ -98,7 +219,7 @@ private theorem byte_operands (busMap : Nat → Option Sp1BusType)
   · refine ⟨op, a, b, c, rfl, ?_, ?_⟩ <;>
       (split at hok <;>
         first
-          | (simp only [isByte, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq] at hok
+          | (simp only [isByteB, Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq] at hok
              obtain ⟨⟨hb, hc⟩, _⟩ := hok
              omega)
           | simp_all)
@@ -136,27 +257,27 @@ private theorem byte_result_lt256 (busMap : Nat → Option Sp1BusType)
   rcases (show op.val = 0 ∨ op.val = 1 ∨ op.val = 2 ∨ op.val = 3 ∨ op.val = 4 ∨ op.val = 5 by omega)
     with h | h | h | h | h | h
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨⟨hb, _⟩, ha⟩ := hok
     rw [ha]; exact lt_of_le_of_lt Nat.and_le_left hb
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨⟨hb, hc⟩, ha⟩ := hok
     rw [ha]; exact Nat.or_lt_two_pow (n := 8) hb hc
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨⟨hb, hc⟩, ha⟩ := hok
     rw [ha]; exact Nat.xor_lt_two_pow (n := 8) hb hc
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨_, ha⟩ := hok
     rw [ha]; omega
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨_, ha⟩ := hok
     rw [ha]; split <;> omega
   · rw [h] at hok
-    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByte] at hok
+    simp only [Bool.not_eq_false', Bool.and_eq_true, decide_eq_true_eq, isByteB] at hok
     obtain ⟨⟨hb, _⟩, ha⟩ := hok
     rw [ha, Nat.shiftRight_eq_div_pow]
     have h128 : (2 : ℕ) ^ 7 = 128 := rfl
@@ -248,7 +369,8 @@ theorem sp1ByteEncode_mem {α : Type} (op o1 o2 r x : α)
 /-- An execution-bridge message never violates. -/
 private theorem execBridge_ok (busMap : Nat → Option Sp1BusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .executionBridge) :
-    violates busMap m = false := by
+    (sp1BusSemantics p busMap).accepts m := by
+  rw [sp1_accepts_iff]
   unfold violates
   rw [hbus]
 
@@ -303,7 +425,8 @@ private theorem memShapeOf_memory_setNewMult {p : ℕ} (busMap : Nat → Option 
 /-- A memory message that is not a `getPrevious` (multiplicity ≠ 1) never violates. -/
 private theorem memory_nonGetPrev_ok (busMap : Nat → Option Sp1BusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
-    (hm : m.multiplicity ≠ 1) : violates busMap m = false := by
+    (hm : m.multiplicity ≠ 1) : (sp1BusSemantics p busMap).accepts m := by
+  rw [sp1_accepts_iff]
   obtain ⟨bid, mult, payload⟩ := m
   simp only at hbus hm
   unfold violates
@@ -316,7 +439,8 @@ private theorem memory_getPrev_ok (busMap : Nat → Option Sp1BusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
     (hm : m.multiplicity = 1)
     (hslots : ∀ slot ∈ [5, 6, 7, 8], ∀ x : ZMod p, m.payload[slot]? = some x → x.val < 2 ^ 16) :
-    violates busMap m = false := by
+    (sp1BusSemantics p busMap).accepts m := by
+  rw [sp1_accepts_iff]
   obtain ⟨bid, mult, payload⟩ := m
   simp only at hbus hm hslots
   unfold violates
@@ -327,7 +451,7 @@ private theorem memory_getPrev_ok (busMap : Nat → Option Sp1BusType)
   have h1 : d1.val < 65536 := hslots 6 (by simp) d1 rfl
   have h2 : d2.val < 65536 := hslots 7 (by simp) d2 rfl
   have h3 : d3.val < 65536 := hslots 8 (by simp) d3 rfl
-  simp [memoryPayload?, is16Bit, hm, h0, h1, h2, h3]
+  simp [memoryPayload?, is16BitB, hm, h0, h1, h2, h3]
 
 /-- The four data limbs (slots 5–8) of an accepted memory `getPrevious` (multiplicity `1`, ≥9-slot
     record) are 16-bit (converse of `memory_getPrev_ok`). -/
@@ -342,12 +466,13 @@ private theorem memory_read_data (busMap : Nat → Option Sp1BusType)
   rw [hbus, hm] at hok
   rcases hs with rfl | rfl | rfl | rfl <;>
     (rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
-      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp_all [memoryPayload?, is16Bit, List.all_cons, List.all_nil])
+      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp_all [memoryPayload?, is16BitB, List.all_cons, List.all_nil])
 
 /-- A memory `setNew` (multiplicity -1) never violates. -/
 private theorem memory_setNew_ok [NeZero p] (busMap : Nat → Option Sp1BusType)
     (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .memory)
-    (hm : m.multiplicity = -1) : violates busMap m = false := by
+    (hm : m.multiplicity = -1) : (sp1BusSemantics p busMap).accepts m := by
+  rw [sp1_accepts_iff]
   by_cases hc : (1 : ZMod p) = -1
   · -- `p ∣ 2`: every value is `< 2 ≤ 2^16`, so the 16-bit test never fails.
     have hadd : (1 : ZMod p) + 1 = 0 := (congrArg (· + 1) hc).trans (neg_add_cancel 1)
@@ -362,18 +487,24 @@ private theorem memory_setNew_ok [NeZero p] (busMap : Nat → Option Sp1BusType)
     unfold violates
     rw [hbus]
     rcases payload with _ | ⟨c0, _ | ⟨c1, _ | ⟨a0, _ | ⟨a1, _ | ⟨a2, _ | ⟨d0, _ | ⟨d1, _ | ⟨d2,
-      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [memoryPayload?, is16Bit, h16]
-  · exact memory_nonGetPrev_ok busMap m hbus (by rw [hm]; exact fun h => hc h.symm)
+      _ | ⟨d3, rest⟩⟩⟩⟩⟩⟩⟩⟩⟩ <;> simp [memoryPayload?, is16BitB, h16]
+  · exact (sp1_accepts_iff busMap m).mp
+      (memory_nonGetPrev_ok busMap m hbus (by rw [hm]; exact fun h => hc h.symm))
 
 /-- The proven facts about `sp1BusSemantics`, for any bus map. -/
 def sp1Facts (p : ℕ) [NeZero p]
     (busMap : Nat → Option Sp1BusType := defaultBusMap) :
     BusFacts p (sp1BusSemantics p busMap) :=
   { BusFacts.trivial (sp1BusSemantics p busMap) with
+    acceptsDec := fun m => !violates busMap m
+    acceptsDec_iff := by
+      intro m
+      rw [Bool.not_eq_true']
+      exact violates_eq_false_iff busMap m
     slotBound := fun busId mult pattern slot => slotBoundImpl busMap busId mult pattern slot
     slotBound_sound := by
       intro m pattern slot bound x hfact hmatch hok hget
-      have hok' : violates busMap m = false := hok
+      have hok' : violates busMap m = false := (sp1_accepts_iff busMap m).mp hok
       unfold slotBoundImpl at hfact
       split at hfact
       · rename_i hbus
@@ -451,7 +582,7 @@ def sp1Facts (p : ℕ) [NeZero p]
     slotFun := slotFunImpl busMap
     slotFun_sound := by
       intro m pattern outSlot f z hfact hmatch hok hget
-      have hok' : violates busMap m = false := hok
+      have hok' : violates busMap m = false := (sp1_accepts_iff busMap m).mp hok
       unfold slotFunImpl at hfact
       split at hfact
       · rename_i op w1 w2 w3 hbus
@@ -486,9 +617,13 @@ def sp1Facts (p : ℕ) [NeZero p]
       intro m h
       unfold neverViolatesArityImpl at h
       split at h
-      · rename_i hbus; exact pcLookup_ok busMap m hbus (by simpa using h)
-      · rename_i hbus; exact instructionFetch_ok busMap m hbus (by simpa using h)
-      · rename_i hbus; exact pageProt_ok busMap m hbus (by simpa using h)
+      · rename_i hbus
+        exact (sp1_accepts_iff busMap m).mpr (pcLookup_ok busMap m hbus (by simpa using h))
+      · rename_i hbus
+        exact (sp1_accepts_iff busMap m).mpr
+          (instructionFetch_ok busMap m hbus (by simpa using h))
+      · rename_i hbus
+        exact (sp1_accepts_iff busMap m).mpr (pageProt_ok busMap m hbus (by simpa using h))
       · exact absurd h (by simp)
     zeroCell := zeroCellImpl busMap
     zeroCell_sound := by
@@ -645,6 +780,7 @@ def sp1Facts (p : ℕ) [NeZero p]
         · show (match busMap busId with | some t => t.isStateful | none => false) = false
           rw [hbus]; rfl
         · intro pl
+          rw [sp1_maintains_iff]
           show breaksInvariant busMap { busId := busId, multiplicity := 1, payload := pl } = false
           unfold breaksInvariant; rw [hbus]; simp
         · intro pl op o1 o2 r mult hdec
@@ -653,16 +789,18 @@ def sp1Facts (p : ℕ) [NeZero p]
           refine ⟨fun hxor => ?_, fun hpair => ?_⟩
           · have hop2 : op = 2 := hxor
             subst hop2
+            rw [sp1_accepts_iff]
             show violates busMap { busId := busId, multiplicity := mult, payload := [2, r, o1, o2] }
                 = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.xor o1.val o2.val
             unfold violates; rw [hbus]
-            simp [hp2, isByte, and_assoc]
+            simp [hp2, isByteB, and_assoc]
           · have hop3 : op = 3 := hpair
             subst hop3
+            rw [sp1_accepts_iff]
             show violates busMap { busId := busId, multiplicity := mult, payload := [3, r, o1, o2] }
                 = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r = 0
             unfold violates; rw [hbus]
-            simp [hp3, isByte, ZMod.val_eq_zero, and_assoc]
+            simp [hp3, isByteB, ZMod.val_eq_zero, and_assoc]
       · rw [if_neg hp] at hspec; exact absurd hspec (by simp)
     -- SP1's byte bus also carries OR (op 1, `a = b | c`) and AND (op 0, `a = b & c`), declared as
     -- `orOp`/`andOp`.
@@ -685,16 +823,18 @@ def sp1Facts (p : ℕ) [NeZero p]
         refine ⟨fun oop hor hopeq => ?_, fun aop hand hopeq => ?_⟩
         · obtain rfl : oop = 1 := by simpa using hor.symm
           subst hopeq
+          rw [sp1_accepts_iff]
           show violates busMap { busId := busId, multiplicity := mult, payload := [1, r, o1, o2] }
               = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.lor o1.val o2.val
           unfold violates; rw [hbus]
-          simp [hp1, isByte, and_assoc]
+          simp [hp1, isByteB, and_assoc]
         · obtain rfl : aop = 0 := by simpa using hand.symm
           subst hopeq
+          rw [sp1_accepts_iff]
           show violates busMap { busId := busId, multiplicity := mult, payload := [0, r, o1, o2] }
               = false ↔ o1.val < 256 ∧ o2.val < 256 ∧ r.val = Nat.land o1.val o2.val
           unfold violates; rw [hbus]
-          simp [hp0, isByte, and_assoc]
+          simp [hp0, isByteB, and_assoc]
       · rw [if_neg hp] at hspec; exact absurd hspec (by simp)
     -- SP1's op-6 (`Range`) byte-bus check `[6, a, w, 0]` (w ≤ 16) is a pure range check on `a`.
     rangeCheckAt := fun busId pattern => rangeCheckAtImpl busMap busId pattern
@@ -719,12 +859,13 @@ def sp1Facts (p : ℕ) [NeZero p]
           have hq3 : q3 = c := by
             have := hmatch.2 3 c (by simp); rw [hpe] at this; simpa using this
           rw [hq0, hq2, hq3] at hpe
-          have hbreak : breaksInvariant busMap m = false := by
+          have hbreak : (sp1BusSemantics p busMap).maintainsInvariants m := by
+            rw [sp1_maintains_iff]
             unfold breaksInvariant; simp [hmbus, hmult]
           refine ⟨hbreak, fun x hx => ?_⟩
           have hxq : q1 = x := by rw [hpe] at hx; simpa using hx
           rw [← hxq]
-          exact byte_op6_iff busMap m hmbus op q1 w c hpe hop hw hc
+          exact (sp1_accepts_iff busMap m).trans (byte_op6_iff busMap m hmbus op q1 w c hpe hop hw hc)
       · exact absurd hfact (by simp) }
 
 end ApcOptimizer.SP1

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -59,7 +59,7 @@ def OpenVmBusType.isStateful : OpenVmBusType → Bool
   | .tupleRangeChecker _ _ => false
 
 /-- Whether a field element is a byte (`0 ≤ x < 256`). -/
-def isByte (x : ZMod p) : Bool := decide (x.val < 256)
+def isByte (x : ZMod p) : Prop := x.val < 256
 
 /-- The named fields of an OpenVM memory payload,
     `(address_space, pointer, data… (4 limbs), timestamp)`. -/
@@ -79,11 +79,12 @@ def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
 
 /-- Whether the address space is one whose words OpenVM byte-range-checks: registers (`1`) or main
     memory (`2`). -/
-def MemoryPayload.isByteChecked (f : MemoryPayload p) : Bool :=
-  f.addressSpace.val == 1 || f.addressSpace.val == 2
+def MemoryPayload.isByteChecked (f : MemoryPayload p) : Prop :=
+  f.addressSpace.val = 1 ∨ f.addressSpace.val = 2
 
-/-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
-def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
+/-- Whether the bus's receiving chip accepts this message: it contradicts no entry of the bus's
+    lookup table. -/
+def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId, msg.payload with
   -- ISSUE:
   -- The PC lookup is a bit special: We would have to know the program to
@@ -97,67 +98,65 @@ def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
   -- optimized circuit does not contain any PC lookups (they can always
   -- be removed in practice).
   -- [1] https://github.com/powdr-labs/powdr/blob/f94a24f19249af67efbea92ff9c3db6e3e50e7fd/autoprecompiles/src/symbolic_machine_generator.rs#L185-L192
-  | some .pcLookup, args => !decide (args.length = 9)
+  | some .pcLookup, args => args.length = 9
 
   | some .bitwiseLookup, [x, y, z, op] =>
     match op.val with
-    -- Op 0: range check x and y to be bytes, z must be 0.
-    | 0 => !(isByte x && isByte y && decide (z.val = 0))
-    -- Op 1: range check x and y to be bytes, z must be x ^ y.
-    | 1 => !(isByte x && isByte y && decide (z.val = Nat.xor x.val y.val))
-    -- Other ops are invalid.
-    | _ => true
+    -- Op 0 range-checks `x` and `y` to be bytes and forces `z = 0`.
+    | 0 => isByte x ∧ isByte y ∧ z.val = 0
+    -- Op 1 also fixes `z = x ^ y`.
+    | 1 => isByte x ∧ isByte y ∧ z.val = Nat.xor x.val y.val
+    -- No other op is in the table.
+    | _ => False
 
   | some .variableRangeChecker, [x, bits] =>
-    -- Check that x < 2^bits, and that the number of bits requested is one the checker
-    -- supports: OpenVM's variable range checker rejects any lookup of more than 17 bits.
+    -- `x < 2^bits`, at a width the checker supports: OpenVM's variable range checker rejects any
+    -- lookup of more than 17 bits.
     -- TODO: The maximum number of bits is configurable, but the default is 17 and the
     -- OpenVM chips assume that it is at least 17, so we're being conservative here.
-    !(decide (bits.val ≤ 17) && decide (x.val < 2 ^ bits.val))
+    bits.val ≤ 17 ∧ x.val < 2 ^ bits.val
 
-  | some (.tupleRangeChecker s1 s2), [x, y] =>
-    -- Range check that x < s1 and y < s2.
-    !(decide (x.val < s1) && decide (y.val < s2))
+  | some (.tupleRangeChecker s1 s2), [x, y] => x.val < s1 ∧ y.val < s2
 
-  -- For lookups, reject if the number of arguments is not as expected.
-  | some .bitwiseLookup, _ => true
-  | some .variableRangeChecker, _ => true
-  | some (.tupleRangeChecker _ _), _ => true
+  -- For lookups, an unexpected number of arguments is in no table.
+  | some .bitwiseLookup, _ => False
+  | some .variableRangeChecker, _ => False
+  | some (.tupleRangeChecker _ _), _ => False
 
-  -- Stateful buses.
-  | some .executionBridge, _ => false
+  -- Stateful buses have no table to contradict.
+  | some .executionBridge, _ => True
 
   -- In OpenVM, the invariant is that only range-checked values are sent to
   -- the register & memory address spaces.
   | some .memory, payload =>
     match memoryPayload? payload with
-    | some f => decide (msg.multiplicity = -1) && f.isByteChecked && !(f.data.all isByte)
-    | none => false
+    | some f => msg.multiplicity = -1 → f.isByteChecked → ∀ d ∈ f.data, isByte d
+    | none => True
 
   -- Invalid bus ID. Won't have a matching receive.
-  | none, _ => true
+  | none, _ => False
 
-/-- Whether a message breaks an invariant on which soundness depends. Only meaningful for an
-    *active* message — the multiplicity tests below reject `0`, and callers guard on it. -/
-def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
+/-- Whether a message maintains the invariants on which soundness depends. Only meaningful for an
+    *active* message — no multiplicity condition below holds at `0`, and callers guard on it. -/
+def maintainsInvariants (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).
   | some .pcLookup | some .variableRangeChecker | some .bitwiseLookup
   | some (.tupleRangeChecker _ _) =>
-    !decide (msg.multiplicity = 1)
+    msg.multiplicity = 1
   -- The execution bridge is stateful: it is sent (1) or received (-1).
   | some .executionBridge =>
-    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
+    msg.multiplicity = 1 ∨ msg.multiplicity = -1
   -- Memory is stateful (multiplicity 1 or -1), and additionally maintains the invariant
   -- that data limbs written to the register / main-memory address spaces (1 and 2) are
   -- byte-range.
   | some .memory =>
-    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
-    (match memoryPayload? msg.payload with
-      | some f => bif f.isByteChecked then !(f.data.all isByte) else false
-      | none => false)
+    (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ∧
+      (match memoryPayload? msg.payload with
+        | some f => f.isByteChecked → ∀ d ∈ f.data, isByte d
+        | none => True)
   -- Circuits should not send messages to an unknown bus.
-  | none => true
+  | none => False
 
 /-- Assume that x0 always returns 0. This should be enforced globally by all OpenVM chips. -/
 def x0ReturnsZero (busMap : BusMap) (msgs : List (BusInteraction (ZMod p))) : Prop :=
@@ -186,8 +185,8 @@ def openVmBusSemantics (p : ℕ) (busMap : BusMap := defaultBusMap) :
     match busMap busId with
     | some t => t.isStateful
     | none => false
-  violatesConstraint := violates busMap
-  breaksInvariant := breaksInvariant busMap
+  accepts := accepts busMap
+  maintainsInvariants := maintainsInvariants busMap
   admissible msgs :=
     (∀ (busId : Nat) (shape : MemoryBusShape), memShapeOf busMap busId = some shape →
       admissibleMemoryBus shape (msgs.filter (fun m => m.busId = busId)))

--- a/ApcOptimizer/OpenVmSemantics.lean
+++ b/ApcOptimizer/OpenVmSemantics.lean
@@ -82,8 +82,7 @@ def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
 def MemoryPayload.isByteChecked (f : MemoryPayload p) : Prop :=
   f.addressSpace.val = 1 ∨ f.addressSpace.val = 2
 
-/-- Whether the bus's receiving chip accepts this message: it contradicts no entry of the bus's
-    lookup table. -/
+/-- For lookups, whether the message is in the lookup table. -/
 def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId, msg.payload with
   -- ISSUE:
@@ -136,8 +135,8 @@ def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => False
 
-/-- Whether a message maintains the invariants on which soundness depends. Only meaningful for an
-    *active* message — no multiplicity condition below holds at `0`, and callers guard on it. -/
+/-- Whether a message maintains the invariants on which soundness depends. Only called
+   for messages with nonzero multiplicity. -/
 def maintainsInvariants (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).

--- a/ApcOptimizer/Optimizer.lean
+++ b/ApcOptimizer/Optimizer.lean
@@ -21,7 +21,7 @@ variable {p : ℕ}
 
 /-- Optimizer which does not use any bus facts. Works with any VM, but is less effective. Returns
     the optimized system together with the `Derivations` for its newly-introduced columns. -/
-def simpleOptimizer (bs : BusSemantics p) (b : DegreeBound) :
+def simpleOptimizer (bs : BusSemantics p) [DecidablePred bs.accepts] (b : DegreeBound) :
     Circuit p → Circuit p × Derivations p :=
   optimizerWithBusFacts b (BusFacts.trivial bs)
 
@@ -53,7 +53,8 @@ theorem optimizerWithBusFacts_maintainsCorrectness (bs : BusSemantics p) (b : De
   ⟨fun cs => optimizerWithBusFacts_correct b facts cs,
    fun cs => optimizerWithBusFacts_respectsDegree b facts cs⟩
 
-theorem simpleOptimizer_maintainsCorrectness (bs : BusSemantics p) (b : DegreeBound) :
+theorem simpleOptimizer_maintainsCorrectness (bs : BusSemantics p) [DecidablePred bs.accepts]
+    (b : DegreeBound) :
     Optimizer.isCorrect (simpleOptimizer bs b) bs b :=
   optimizerWithBusFacts_maintainsCorrectness bs b (BusFacts.trivial bs)
 

--- a/ApcOptimizer/Sp1Semantics.lean
+++ b/ApcOptimizer/Sp1Semantics.lean
@@ -79,8 +79,7 @@ def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
       some { clk := #v[c0, c1], address := #v[a0, a1, a2], data := #v[d0, d1, d2, d3] }
   | _ => none
 
-/-- Whether the bus's receiving chip accepts this message: it contradicts no entry of the bus's
-    lookup table. -/
+/-- For lookups, whether the message is in the lookup table. -/
 def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId, msg.payload with
   -- As for OpenVM's PC lookup, we only check the arity of these lookups: the input circuit has
@@ -122,8 +121,8 @@ def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   -- Invalid bus ID. Won't have a matching receive.
   | none, _ => False
 
-/-- Whether a message maintains the invariants on which soundness depends. Only meaningful for an
-    *active* message — no multiplicity condition below holds at `0`, and callers guard on it. -/
+/-- Whether a message maintains the invariants on which soundness depends. Only called
+    for messages with nonzero multiplicity. -/
 def maintainsInvariants (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).

--- a/ApcOptimizer/Sp1Semantics.lean
+++ b/ApcOptimizer/Sp1Semantics.lean
@@ -58,10 +58,10 @@ def Sp1BusType.isStateful : Sp1BusType → Bool
   | .pageProt => false
 
 /-- Whether a field element is a byte (`0 ≤ x < 256`). -/
-def isByte (x : ZMod p) : Bool := decide (x.val < 256)
+def isByte (x : ZMod p) : Prop := x.val < 256
 
 /-- Whether a field element is a 16-bit limb (`0 ≤ x < 2^16`). -/
-def is16Bit (x : ZMod p) : Bool := decide (x.val < 2 ^ 16)
+def is16Bit (x : ZMod p) : Prop := x.val < 2 ^ 16
 
 /-- The named fields of an SP1 memory payload,
     `(clk… (2 fields), address… (3 limbs), data… (4 × 16-bit limbs))`. -/
@@ -79,67 +79,68 @@ def memoryPayload? : List (ZMod p) → Option (MemoryPayload p)
       some { clk := #v[c0, c1], address := #v[a0, a1, a2], data := #v[d0, d1, d2, d3] }
   | _ => none
 
-/-- Whether a message conflicts with the lookup table of the bus it is sent on. -/
-def violates (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
+/-- Whether the bus's receiving chip accepts this message: it contradicts no entry of the bus's
+    lookup table. -/
+def accepts (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId, msg.payload with
   -- As for OpenVM's PC lookup, we only check the arity of these lookups: the input circuit has
   -- already fixed the looked-up fields to constants, so the optimizer cannot change them.
-  | some .pcLookup, args => !decide (args.length = 16)
-  | some .instructionFetch, args => !decide (args.length = 22)
-  | some .pageProt, args => !decide (args.length = 6)
+  | some .pcLookup, args => args.length = 16
+  | some .instructionFetch, args => args.length = 22
+  | some .pageProt, args => args.length = 6
 
   | some .byteLookup, [op, a, b, c] =>
     match op.val with
-    -- AND: range check b, c to be bytes; a must be b & c.
-    | 0 => !(isByte b && isByte c && decide (a.val = Nat.land b.val c.val))
-    -- OR: a must be b | c.
-    | 1 => !(isByte b && isByte c && decide (a.val = Nat.lor b.val c.val))
-    -- XOR: a must be b ^ c.
-    | 2 => !(isByte b && isByte c && decide (a.val = Nat.xor b.val c.val))
-    -- U8Range: range check b, c to be bytes; a must be 0.
-    | 3 => !(isByte b && isByte c && decide (a.val = 0))
-    -- LTU: a must be 1 if b < c, else 0.
-    | 4 => !(isByte b && isByte c && decide (a.val = if b.val < c.val then 1 else 0))
-    -- MSB: a must be the top bit of the byte b, and c must be 0.
-    | 5 => !(isByte b && decide (c.val = 0) && decide (a.val = b.val >>> 7))
-    -- Range: check that a < 2^b, that c = 0, and that b ≤ 16 (the largest width the table holds).
-    | 6 => !(decide (b.val ≤ 16) && decide (c.val = 0) && decide (a.val < 2 ^ b.val))
-    -- Other ops are invalid.
-    | _ => true
-  | some .byteLookup, _ => true
+    -- AND: `b`, `c` are bytes and `a = b & c`.
+    | 0 => isByte b ∧ isByte c ∧ a.val = Nat.land b.val c.val
+    -- OR: `a = b | c`.
+    | 1 => isByte b ∧ isByte c ∧ a.val = Nat.lor b.val c.val
+    -- XOR: `a = b ^ c`.
+    | 2 => isByte b ∧ isByte c ∧ a.val = Nat.xor b.val c.val
+    -- U8Range: `b`, `c` are bytes and `a = 0`.
+    | 3 => isByte b ∧ isByte c ∧ a.val = 0
+    -- LTU: `a` is 1 if `b < c`, else 0.
+    | 4 => isByte b ∧ isByte c ∧ a.val = if b.val < c.val then 1 else 0
+    -- MSB: `a` is the top bit of the byte `b`, and `c = 0`.
+    | 5 => isByte b ∧ c.val = 0 ∧ a.val = b.val >>> 7
+    -- Range: `a < 2^b` with `c = 0` and `b ≤ 16` (the largest width the table holds).
+    | 6 => b.val ≤ 16 ∧ c.val = 0 ∧ a.val < 2 ^ b.val
+    -- No other op is in the table.
+    | _ => False
+  | some .byteLookup, _ => False
 
-  -- Stateful buses.
-  | some .executionBridge, _ => false
+  -- Stateful buses have no table to contradict.
+  | some .executionBridge, _ => True
 
   -- In SP1, the invariant is that memory data limbs are 16-bit range-checked. A *send*
   -- (multiplicity 1) reads the previous record, so its data must be 16-bit.
   | some .memory, payload =>
     match memoryPayload? payload with
-    | some f => decide (msg.multiplicity = 1) && !(f.data.all is16Bit)
-    | none => false
+    | some f => msg.multiplicity = 1 → ∀ d ∈ f.data, is16Bit d
+    | none => True
 
   -- Invalid bus ID. Won't have a matching receive.
-  | none, _ => true
+  | none, _ => False
 
-/-- Whether a message breaks an invariant on which soundness depends. Only called for
-    message with nonzero multiplicity. -/
-def breaksInvariant (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Bool :=
+/-- Whether a message maintains the invariants on which soundness depends. Only meaningful for an
+    *active* message — no multiplicity condition below holds at `0`, and callers guard on it. -/
+def maintainsInvariants (busMap : BusMap) (msg : BusInteraction (ZMod p)) : Prop :=
   match busMap msg.busId with
   -- Lookups are only ever sent (multiplicity 1).
   | some .pcLookup | some .byteLookup | some .instructionFetch | some .pageProt =>
-    !decide (msg.multiplicity = 1)
+    msg.multiplicity = 1
   -- The execution bridge is stateful: it is sent (1) or received (-1).
   | some .executionBridge =>
-    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1)
+    msg.multiplicity = 1 ∨ msg.multiplicity = -1
   -- Memory is stateful (multiplicity 1 or -1), and additionally maintains the invariant that its
   -- data limbs are 16-bit range.
   | some .memory =>
-    !decide (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ||
-    (match memoryPayload? msg.payload with
-      | some f => !(f.data.all is16Bit)
-      | none => false)
+    (msg.multiplicity = 1 ∨ msg.multiplicity = -1) ∧
+      (match memoryPayload? msg.payload with
+        | some f => ∀ d ∈ f.data, is16Bit d
+        | none => True)
   -- Circuits should not send messages to an unknown bus.
-  | none => true
+  | none => False
 
 /-- Assume that reading register `x0` (address `0`) always returns `0`. This should be enforced
     globally by all SP1 chips. -/
@@ -173,8 +174,8 @@ def sp1BusSemantics (p : ℕ) (busMap : BusMap := defaultBusMap) :
     match busMap busId with
     | some t => t.isStateful
     | none => false
-  violatesConstraint := violates busMap
-  breaksInvariant := breaksInvariant busMap
+  accepts := accepts busMap
+  maintainsInvariants := maintainsInvariants busMap
   -- The memory discipline, per declared bus. On SP1 *memory* the `setNew` multiplicity is `-1`
   -- (`direction := .sendThenReceive`); on the *execution bridge* it is `1` (`.receiveThenSend`, which
   -- sends the next CPU state). Either way `admissibleMemoryBus` pairs each `setNew` with the next

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -134,16 +134,13 @@ structure BusSemantics (p : ℕ) where
       sending it violates no constraint in *another* chip.
       A message that is *not* accepted is, for example, one contradicting a
       lookup table entry.
-      Only consulted for *active* messages: `Circuit.satisfies` guards on
-      `multiplicity ≠ 0`, so the value at multiplicity `0` is never used. -/
+      Only consulted for messages with nonzero multiplicity. -/
   accepts (busInteractionMessage : BusInteraction (ZMod p)) : Prop
   /-- Whether sending this bus interaction message maintains the invariants on
       which soundness of the system depends.
       For example, a memory bus might have the invariant that all sent values
       must be in a certain range.
-      Only consulted for *active* messages: `Circuit.guaranteesInvariants`
-      guards on `multiplicity ≠ 0`, so the value at multiplicity `0` is never
-      used. -/
+      Only consulted for messages with nonzero multiplicity. -/
   maintainsInvariants (busInteractionMessage : BusInteraction (ZMod p)) : Prop
   /-- A property on *stateful* bus messages with nonzero multiplicity.
       Completeness is only required for assignments whose stateful messages

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -130,18 +130,21 @@ structure BusSemantics (p : ℕ) where
   /-- Whether the bus of the given ID changes the state of the VM.
       Stateless bus interactions are typically lookups. -/
   isStateful (busId : Nat) : Bool
-  /-- Whether sending this bus interaction message violates a constraint in
-      *another* chip.
-      An example of this is sending a message that conflicts with a lookup
-      table entry.
-      Only consulted for messages with nonzero multiplicity. -/
-  violatesConstraint (busInteractionMessage : BusInteraction (ZMod p)) : Bool
-  /-- Whether sending this bus interaction message breaks an invariant on which
-      soundness of the system depends.
+  /-- Whether the receiving chip accepts this bus interaction message, i.e.
+      sending it violates no constraint in *another* chip.
+      A message that is *not* accepted is, for example, one contradicting a
+      lookup table entry.
+      Only consulted for *active* messages: `Circuit.satisfies` guards on
+      `multiplicity ≠ 0`, so the value at multiplicity `0` is never used. -/
+  accepts (busInteractionMessage : BusInteraction (ZMod p)) : Prop
+  /-- Whether sending this bus interaction message maintains the invariants on
+      which soundness of the system depends.
       For example, a memory bus might have the invariant that all sent values
       must be in a certain range.
-      Only consulted for messages with nonzero multiplicity. -/
-  breaksInvariant (busInteractionMessage : BusInteraction (ZMod p)) : Bool
+      Only consulted for *active* messages: `Circuit.guaranteesInvariants`
+      guards on `multiplicity ≠ 0`, so the value at multiplicity `0` is never
+      used. -/
+  maintainsInvariants (busInteractionMessage : BusInteraction (ZMod p)) : Prop
   /-- A property on *stateful* bus messages with nonzero multiplicity.
       Completeness is only required for assignments whose stateful messages
       are `admissible`.
@@ -257,14 +260,14 @@ def Circuit.admissible (circuit : Circuit p) (busSemantics : BusSemantics p)
 
 -- ANCHOR: satisfies
 /-- Whether a circuit is satisfied under a given assignment and bus semantics,
-    i.e., whether it satisfies all algebraic constraints and does not violate
-    any bus constraints. -/
+    i.e., whether it satisfies all algebraic constraints and every active bus
+    interaction message is accepted. -/
 def Circuit.satisfies (circuit : Circuit p) (busSemantics : BusSemantics p)
     (assignment : Variable → ZMod p) : Prop :=
   (∀ c ∈ circuit.algebraicConstraints, c.eval assignment = 0) ∧
   (∀ bi ∈ circuit.busInteractions,
     let message := bi.eval assignment
-    message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false)
+    message.multiplicity ≠ 0 → busSemantics.accepts message)
 -- ANCHOR_END: satisfies
 
 -- ANCHOR: guaranteesInvariants
@@ -275,7 +278,7 @@ def Circuit.guaranteesInvariants (circuit : Circuit p)
   ∀ assignment, circuit.satisfies busSemantics assignment →
     ∀ bi ∈ circuit.busInteractions,
       let message := bi.eval assignment
-      message.multiplicity ≠ 0 → busSemantics.breaksInvariant message = false
+      message.multiplicity ≠ 0 → busSemantics.maintainsInvariants message
 -- ANCHOR_END: guaranteesInvariants
 
 -- ANCHOR: isSoundReplacementOf

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -131,18 +131,18 @@ A {deftech}_circuit_ is simply a collection of algebraic constraints and symboli
 
 {docstring Circuit}
 
-A circuit is satisfied under an assignment when all algebraic constraints evaluate to zero and no bus interaction message violates the bus semantics:
+A circuit is satisfied under an assignment when all algebraic constraints evaluate to zero and every bus interaction message is accepted by the bus semantics:
 
 ```anchor satisfies
 /-- Whether a circuit is satisfied under a given assignment and bus semantics,
-    i.e., whether it satisfies all algebraic constraints and does not violate
-    any bus constraints. -/
+    i.e., whether it satisfies all algebraic constraints and every active bus
+    interaction message is accepted. -/
 def Circuit.satisfies (circuit : Circuit p) (busSemantics : BusSemantics p)
     (assignment : Variable → ZMod p) : Prop :=
   (∀ c ∈ circuit.algebraicConstraints, c.eval assignment = 0) ∧
   (∀ bi ∈ circuit.busInteractions,
     let message := bi.eval assignment
-    message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false)
+    message.multiplicity ≠ 0 → busSemantics.accepts message)
 ```
 
 # Bus Semantics
@@ -168,7 +168,7 @@ def Circuit.sideEffects (circuit : Circuit p) (busSemantics : BusSemantics p)
       ((m.busId, m.payload), m.multiplicity))
 ```
 
-Second, we define that a circuit _guarantees invariants_ if, under any satisfying assignment, no bus interaction breaks an invariant of the bus semantics.
+Second, we define that a circuit _guarantees invariants_ if, under any satisfying assignment, every bus interaction maintains the invariants of the bus semantics.
 
 ```anchor guaranteesInvariants
 /-- Whether a circuit guarantees that all invariants are maintained under a
@@ -178,7 +178,7 @@ def Circuit.guaranteesInvariants (circuit : Circuit p)
   ∀ assignment, circuit.satisfies busSemantics assignment →
     ∀ bi ∈ circuit.busInteractions,
       let message := bi.eval assignment
-      message.multiplicity ≠ 0 → busSemantics.breaksInvariant message = false
+      message.multiplicity ≠ 0 → busSemantics.maintainsInvariants message
 ```
 
 Finally, we formalize what it means for an optimized circuit to be a sound replacement for an original circuit:


### PR DESCRIPTION
Third of four PRs from a readability review of the bus-semantics spec.

> **Stacked on #241** (base is `claude/spec-hygiene`, not `main`) — it builds on
> the `MemoryPayload` projection introduced there, which both `accepts` arms use.
> Review #241 first; the diff here is against it.

## The problem

`BusSemantics.violatesConstraint` and `breaksInvariant` were `Bool`-valued, and
inside `Spec.lean` they were used *only* in `Prop` position — so every use read
through a double negation:

```lean
message.multiplicity ≠ 0 → busSemantics.violatesConstraint message = false
```

The `Bool` was there because the optimizer evaluates these at run time. But that
is the implementation's need, not the spec's, and this repo already has the place
for it: `BusFacts` exists to hand passes proof-backed knowledge about a
`BusSemantics` at zero audit cost.

## What changed in the audited surface

Both fields become Props, framed positively:

```lean
message.multiplicity ≠ 0 → busSemantics.accepts message
```

and both VM semantics are restated to match. This is where most of the
readability comes from — every arm now reads as the table entry it describes,
instead of the negation of a Bool conjunction. OpenVM's bitwise lookup, before
and after:

```lean
-- before
| 0 => !(isByte x && isByte y && decide (z.val = 0))
| 1 => !(isByte x && isByte y && decide (z.val = Nat.xor x.val y.val))
| _ => true
-- after
| 0 => isByte x ∧ isByte y ∧ z.val = 0
| 1 => isByte x ∧ isByte y ∧ z.val = Nat.xor x.val y.val
| _ => False
```

`isByte`, `is16Bit` and `MemoryPayload.isByteChecked` are Props too, so no `decide`
survives in either semantics file.

## Where the Bool went

`BusFacts` gains the decision procedure:

```lean
acceptsDec : BusInteraction (ZMod p) → Bool
acceptsDec_iff : ∀ m, acceptsDec m = true ↔ bs.accepts m
```

It is a **full** decision procedure, not merely sound. I first tried
`→ Option Bool` (so `BusFacts.trivial` needed nothing), but that does not work:
`Proofs/DomainBatch.lean` proves the compiled fast-path predicates *equal* to the
fallback obligation, and those equalities need both directions. A sound-only
oracle would have made the compiled predicates disagree with the fallback.

`OpenVmFacts`/`Sp1Facts` carry the Bool `violates`/`breaksInvariant` — the exact
definitions this PR removes from the audited files — as that procedure, each
proven equivalent to its audited counterpart (`violates_eq_false_iff`,
`breaksInvariant_eq_false_iff`). `@[simp]` interface lemmas mean the existing
Bool-shaped helper proofs in those files stand as written, which is why the diff
there is small relative to their size.

## The one audited signature change

`BusFacts.trivial` now needs `[DecidablePred bs.accepts]`, which propagates to
`simpleOptimizer` and `simpleOptimizer_maintainsCorrectness`. That reads as
honest to me — the fact-free optimizer can only run against a semantics it can
evaluate — but it is a change to an audited statement, so flagging it explicitly
rather than burying it. `openVmOptimizer` and `sp1Optimizer` are unaffected
(their facts supply `acceptsDec` directly).

## Pass-framework consequence

Five passes that queried the semantics at run time now take a `BusFacts`
argument where they previously took only a `BusSemantics`: `denseIsTautoLookup`,
`denseConnBad`/`denseDropCheck`/`denseDropGuarded`/`denseDisconnectedF`,
`denseCBiPredEvalV`/`denseBiObligationV`/`denseSurvivesAll{CWV,MV}`.

## Effectiveness

Unchanged, by construction: `acceptsDec` for both VMs is `!violates busMap m` —
bit-for-bit the Bool those passes computed before. Local sweep of the top 8
`openvm-eth` cases: variables 4.629x, bus interactions 3.705x, constraints
11.672x (vs powdr 3.974x / 3.567x / 4.914x). The CI effectiveness bench will
give the per-case comparison against `main`.

## Verification

- `lake build` — clean, no errors, **no warnings** (2554 jobs)
- `lake build docs` — clean; the `satisfies` and `guaranteesInvariants` anchors
  and their surrounding prose are updated in lockstep
- `Scripts/check-proof-integrity.sh` — passes; the correctness theorems still
  rest only on `propext`, `Classical.choice`, `Quot.sound`, and no theorem is
  orphaned
- `lake exe apc-optimizer run` on a benchmark case — degree bound ok in and out

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKMeZM6XGPcv89SyzvYcUf)_