### PR TITLE
perf(domainBatch): compile arity-only bus lookups to `.always` (7.1x on its worst-share APC)

### DIFF
--- a/ApcOptimizer/Implementation/BusFacts.lean
+++ b/ApcOptimizer/Implementation/BusFacts.lean
@@ -94,6 +94,12 @@ structure BusFacts (p : ℕ) (bs : BusSemantics p) where
   neverViolates_sound :
     ∀ (m : BusInteraction (ZMod p)),
       neverViolates m.busId = true → bs.violatesConstraint m = false
+  /-- Buses whose only table obligation is the payload arity: a message of the declared arity never
+      violates, whatever its values (both VMs' instruction-table lookups are of this shape). -/
+  neverViolatesArity : (busId : Nat) → (arity : Nat) → Bool
+  neverViolatesArity_sound :
+    ∀ (m : BusInteraction (ZMod p)),
+      neverViolatesArity m.busId m.payload.length = true → bs.violatesConstraint m = false
   /-- Last-write-wins shape declared for a bus, or `none` (see `ApcOptimizer/MemoryBus.lean`). -/
   memShape : (busId : Nat) → Option MemoryBusShape
   /-- Table obligations of a memory-style stateful bus, for pair cancellation:
@@ -242,6 +248,8 @@ def BusFacts.trivial (bs : BusSemantics p) : BusFacts p bs where
   slotFun_sound := by intro _ _ _ _ _ h; exact absurd h (by simp)
   neverViolates _ := false
   neverViolates_sound := by intro _ h; exact absurd h (by simp)
+  neverViolatesArity _ _ := false
+  neverViolatesArity_sound := by intro _ h; exact absurd h (by simp)
   recvByteSlots _ _ := none
   recvByteSlots_sound := by intro _ _ h; exact absurd h (by simp)
   memShape _ := none

--- a/ApcOptimizer/Implementation/OpenVmFacts.lean
+++ b/ApcOptimizer/Implementation/OpenVmFacts.lean
@@ -61,6 +61,13 @@ private def neverViolatesImpl (busMap : Nat → Option OpenVmBusType) (busId : N
   -- address spaces 1/2 (see `recvByteSlots`), and pcLookup rejects payloads of length ≠ 9.
   | _ => false
 
+/-- The PC lookup is checked for arity only, so a 9-field message never violates. -/
+private def neverViolatesArityImpl (busMap : Nat → Option OpenVmBusType) (busId : Nat)
+    (arity : Nat) : Bool :=
+  match busMap busId with
+  | some .pcLookup => arity == 9
+  | _ => false
+
 /-- Byte-slot obligation for a memory-style pair cancellation, conditioned on the receive's
     constant pattern (bound `256`, OpenVM limbs are bytes). A memory `getPrevious` whose
     address-space slot (slot 0) is a constant ∉ {1,2} carries no obligation (`some ([], 256)`),
@@ -150,6 +157,15 @@ private theorem execBridge_ok (busMap : Nat → Option OpenVmBusType)
     violates busMap m = false := by
   unfold violates
   rw [hbus]
+
+/-- A PC lookup with the expected nine fields never violates (`violates` checks its arity only). -/
+private theorem pcLookup_ok (busMap : Nat → Option OpenVmBusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .pcLookup)
+    (harity : m.payload.length = 9) :
+    violates busMap m = false := by
+  unfold violates
+  rw [hbus]
+  simp [harity]
 
 /-- The data limbs of an accepted (non-violating) memory *receive* from address space 1 or 2
     are bytes. -/
@@ -462,6 +478,13 @@ def openVmFacts (p : ℕ) [NeZero p]
     unfold neverViolatesImpl at h
     split at h
     · rename_i hbus; exact execBridge_ok busMap m hbus
+    · exact absurd h (by simp)
+  neverViolatesArity := neverViolatesArityImpl busMap
+  neverViolatesArity_sound := by
+    intro m h
+    unfold neverViolatesArityImpl at h
+    split at h
+    · rename_i hbus; exact pcLookup_ok busMap m hbus (by simpa using h)
     · exact absurd h (by simp)
   recvByteSlots := recvByteSlotsImpl busMap
   recvByteSlots_sound := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -138,9 +138,17 @@ def denseCompilePayloadCBiPredV {bs : BusSemantics p} (facts : BusFacts p bs)
   | [x, width] => denseCompilePairCBiPredV facts keys bi mult x width
   | _ => denseCompileOtherCBiPredV facts keys bi mult
 
+/-- An interaction whose obligation is discharged for every point: a bus that never violates, or one
+    checked for arity only (the VMs' instruction-table lookups) at its declared arity. Compiling
+    these to `.always` keeps the opaque `bs.violatesConstraint` — a payload list and a message record
+    per enumerated point — out of the scan. -/
+def denseBiAlwaysOk {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
+  facts.neverViolates bi.busId || facts.neverViolatesArity bi.busId bi.payload.length
+
 def denseCompileCBiPredV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : List VarId)
     (bi : BusInteraction (DenseExpr p)) : Option (DenseCBiPred p) :=
-  if facts.neverViolates bi.busId then some .always
+  if denseBiAlwaysOk facts bi then some .always
   else
     match denseCompileE keys bi.multiplicity with
     | none => none

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -1394,6 +1394,17 @@ private theorem denseCompilePayloadCBiPredV_eval (ops : DenseZModOps p)
       | cons third tail =>
         exact denseCompileOtherCBiPredV_eval ops isZero hz bs facts keys pt bi mult pred hm h
 
+/-- The two `.always` claims agree on evaluated messages: a bus that never violates, or one checked
+    for arity only at `bi`'s arity (`denseBIEval` maps the payload, so the arity is preserved). -/
+private theorem denseBiAlwaysOk_violates {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (env : VarId → ZMod p)
+    (h : denseBiAlwaysOk facts bi = true) :
+    bs.violatesConstraint (denseBIEval bi env) = false := by
+  unfold denseBiAlwaysOk at h
+  rcases Bool.or_eq_true _ _ |>.mp h with hnever | harity
+  · exact facts.neverViolates_sound _ hnever
+  · exact facts.neverViolatesArity_sound _ (by simpa [denseBIEval] using harity)
+
 private theorem denseCompileCBiPredV_eval (ops : DenseZModOps p)
     (isZero : ZMod p → Bool) (hz : ∀ v, isZero v = decide (v = 0))
     (bs : BusSemantics p) (facts : BusFacts p bs) (keys : List VarId) (pt : List (ZMod p))
@@ -1401,16 +1412,16 @@ private theorem denseCompileCBiPredV_eval (ops : DenseZModOps p)
     (h : denseCompileCBiPredV facts keys bi = some pred) :
     denseCBiPredEvalV ops isZero bs pt pred = denseBiObligationV bs bi keys pt := by
   unfold denseCompileCBiPredV at h
-  by_cases hnever : facts.neverViolates bi.busId = true
+  by_cases hnever : denseBiAlwaysOk facts bi = true
   · simp only [hnever, if_true, Option.some.injEq] at h
     subst pred
-    have hnv := facts.neverViolates_sound (denseBIEval bi (denseEnvOfKeysV keys pt)) hnever
+    have hnv := denseBiAlwaysOk_violates facts bi (denseEnvOfKeysV keys pt) hnever
     unfold denseCBiPredEvalV denseBiObligationV
     change true = (if decide ((denseBIEval bi (denseEnvOfKeysV keys pt)).multiplicity = 0)
       then true else !bs.violatesConstraint (denseBIEval bi (denseEnvOfKeysV keys pt)))
     rw [hnv]
     simp
-  · have hneverFalse : facts.neverViolates bi.busId = false := Bool.eq_false_of_not_eq_true hnever
+  · have hneverFalse : denseBiAlwaysOk facts bi = false := Bool.eq_false_of_not_eq_true hnever
     simp only [hneverFalse, Bool.false_eq_true, if_false] at h
     cases hm : denseCompileE keys bi.multiplicity with
     | none => simp [hm] at h

--- a/ApcOptimizer/Implementation/Sp1Facts.lean
+++ b/ApcOptimizer/Implementation/Sp1Facts.lean
@@ -23,6 +23,16 @@ private def neverViolatesImpl (busMap : Nat → Option Sp1BusType) (busId : Nat)
   | some .executionBridge => true
   | _ => false
 
+/-- The instruction-table lookups are checked for arity only, so a message of the declared arity
+    never violates. -/
+private def neverViolatesArityImpl (busMap : Nat → Option Sp1BusType) (busId : Nat)
+    (arity : Nat) : Bool :=
+  match busMap busId with
+  | some .pcLookup => arity == 16
+  | some .instructionFetch => arity == 22
+  | some .pageProt => arity == 6
+  | _ => false
+
 private def slotFunImpl (busMap : Nat → Option Sp1BusType) (busId : Nat)
     (pattern : List (Option (ZMod p))) (outSlot : Nat) :
     Option (List (ZMod p) → ZMod p) :=
@@ -242,6 +252,33 @@ private theorem execBridge_ok (busMap : Nat → Option Sp1BusType)
   unfold violates
   rw [hbus]
 
+/-- A PC lookup with its sixteen fields never violates (`violates` checks its arity only). -/
+private theorem pcLookup_ok (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .pcLookup)
+    (harity : m.payload.length = 16) :
+    violates busMap m = false := by
+  unfold violates
+  rw [hbus]
+  simp [harity]
+
+/-- An instruction fetch with its twenty-two fields never violates (arity-only check). -/
+private theorem instructionFetch_ok (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .instructionFetch)
+    (harity : m.payload.length = 22) :
+    violates busMap m = false := by
+  unfold violates
+  rw [hbus]
+  simp [harity]
+
+/-- A page-protection lookup with its six fields never violates (arity-only check). -/
+private theorem pageProt_ok (busMap : Nat → Option Sp1BusType)
+    (m : BusInteraction (ZMod p)) (hbus : busMap m.busId = some .pageProt)
+    (harity : m.payload.length = 6) :
+    violates busMap m = false := by
+  unfold violates
+  rw [hbus]
+  simp [harity]
+
 /-- A bus with a declared last-write-wins shape (memory or execution bridge) is stateful. -/
 theorem sp1_isStateful_of_memShape {p : ℕ} (busMap : Nat → Option Sp1BusType)
     (busId : Nat) (shape : MemoryBusShape) (h : memShapeOf busMap busId = some shape) :
@@ -443,6 +480,15 @@ def sp1Facts (p : ℕ) [NeZero p]
       unfold neverViolatesImpl at h
       split at h
       · rename_i hbus; exact execBridge_ok busMap m hbus
+      · exact absurd h (by simp)
+    neverViolatesArity := neverViolatesArityImpl busMap
+    neverViolatesArity_sound := by
+      intro m h
+      unfold neverViolatesArityImpl at h
+      split at h
+      · rename_i hbus; exact pcLookup_ok busMap m hbus (by simpa using h)
+      · rename_i hbus; exact instructionFetch_ok busMap m hbus (by simpa using h)
+      · rename_i hbus; exact pageProt_ok busMap m hbus (by simpa using h)
       · exact absurd h (by simp)
     zeroCell := zeroCellImpl busMap
     zeroCell_sound := by

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -220,10 +220,13 @@ constant evaluation or exact `BusFacts` and extracts constant domains directly. 
 anchor buckets as arrays and summarizes inactive variable-free constraints once, so targets no
 longer materialize candidate lists or walk the same inactive tail. Entry 131 advances range domains
 in `ZMod` instead of recasting each element and compiles exact range/byte bus facts into scalar,
-allocation-free checks, with the opaque evaluator retained as fallback. Remaining:
-`constraintRedundant` full-box scans (they pay once to save per-target work), the list-shaped point
-and candidate-mask scanner, and hot-variable bucket capping (not byte-identical — the gates read
-`esFull`).
+allocation-free checks, with the opaque evaluator retained as fallback. Entry 152 compiles
+arity-only lookups (OpenVM `pcLookup`, SP1 `pcLookup`/`instructionFetch`/`pageProt`) to `.always`
+via a new `neverViolatesArity` fact, taking the opaque per-point `violatesConstraint` out of the
+scan. Remaining: `constraintRedundant` full-box scans (measured 2.5–5.6 % of the pass — they pay
+once to save per-target work), the list-shaped point and candidate-mask scanner (inside the 0.8–3.8 %
+box-loop phase on the big cases), and hot-variable bucket capping (not byte-identical — the gates
+read `esFull`). **The pass's remaining cost is not here — see R13.**
 
 **R3. domainFold/reencode: fuse the duplicate whole-system scans; retire the 8192 raw-count
 index gate**  ·  mostly **done (entries 105/107/109/145)**:
@@ -459,6 +462,63 @@ the per-variable bucket maps (`DenseCovIndex.buckets`, `denseVarBucket`, `denseT
 be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide but mechanical;
 worth a prototype on one index first.
 
+**R13. domainBatch is per-target *setup*-bound, not enumeration-bound** (measured 2026-07-28, LBR
+profiles over five OpenVM cases + SP1 keccak; entry 152). Phase shares of in-pass samples:
+
+| phase | sha256 apc_001 | keccak | SP1 keccak | eth apc_071 | wasm apc_005 |
+|---|---:|---:|---:|---:|---:|
+| per-target bus classification (`denseCompileCBiPredsV`) | **56.1** | **40.5** | 34.4 | 2.3 | 0.3 |
+| opaque `.fallback` per point (`violatesConstraint`) | 14.0 | 18.0 | 17.9 | 1.7 | **63.2** |
+| bus-sourced table build (`denseInteractionBound`) | 15.1 | 19.5 | 16.4 | 11.7 | 7.9 |
+| byte-operand coset build (`denseByteOperandDomain`) | ~0 | 0.4 | **21.3** | ~0 | ~0 |
+| box-loop machinery (`rangeFoldFrom`, mask) | 3.8 | 3.0 | 1.3 | **20.8** | 2.2 |
+| gathers + preflight | 6.2 | 1.9 | 0.6 | 1.1 | 0.2 |
+
+Pass-only cost classes on sha256: 32.5 % closure-apply + 25 % refcount — `BusFacts` closure calls and
+the allocation traffic of their results. The `.fallback` row is **done (entry 152)**. Open, in order:
+
+   - **(a) Hoist the target-independent bus classification.** `denseCompiledSurvV` runs
+     `denseCompileCBiPredV facts keys bi` per gathered interaction *per target*, and everything it
+     does except `denseCompileE keys <slot>` depends on `bi` alone (`neverViolates`, `varRangeBus`,
+     `tupleRangeBus`, `byteXorSpec`, `spec.decode`, `rangeCheckAt` + its pattern, `constValue?`).
+     Inside that phase the keys-dependent `denseCompileEs` is only 11 %; the rest is
+     `lean_apply_1` (57 %) + `lean_dec_ref_cold` (27 %). Two tiers: a per-`busId` fact-answer cache
+     threaded as a *value* (entry 143's lesson — never a closure in a thunk payload), with a
+     `denseVarBucket_mem`-shaped membership lemma, ~60–100 lines and ≈ 45 % of the phase; or the
+     complete version, a keys-free `DenseBiPredShape` stored in `DenseBusPlan` (built once per
+     invocation) plus `denseCompileShape keys mult shape = denseCompileCBiPredV facts keys bi`, whose
+     hypothesis discharges through the existing `denseGatherBusesV_plan_mem`, ~200–350 lines.
+     Expect pass ≈ 0.55× on sha256/keccak.
+   - **(b) One constant pattern per interaction.** `denseInteractionBound` rebuilds
+     `bi.payload.map DenseExpr.constValue?` per *queried variable*, and `denseAddBusVars` /
+     `denseBiInformative` compute the same bound twice per variable. `denseInteractionBoundPat`
+     (`BusPairCancelWits.lean:26`) is the hoisted twin already. The same specialized map is 6 % of the
+     whole sha256 run, called from `denseFindVarBound` (intervalForce, 36.6 % of its calls),
+     `denseAddVars`, `denseBoolCheck?`, `denseFormBoundAt`, `denseInteractionSeeds` — so the general
+     fix is a per-invocation prepared-interaction record (pattern + constant multiplicity) shared
+     across passes, in the `DenseAddrPre` mould. Heed entry 148: prepare only what a profile shows
+     rebuilt.
+   - **(c) Fuse or lazify the byte-operand coset** — 21.3 % of the pass on SP1 keccak (entry 151's own
+     residual, now measured; the only live hit of the "dictionary rebuilt inside a loop" C sweep).
+     `((List.range bound).map cast).map (fun z => (z - b) * a⁻¹)` is two passes plus a 256-element
+     intermediate per affine byte operand; best form is a `FiniteDomain` arm carrying `(bound, a, b)`
+     so `foldElts` advances in the field and the coset is never materialized.
+   - **(d) Prefix-pruned / component-split enumeration**, the only lever left on the big-box OpenVM
+     cases (`apc_071`: 74.7 % of in-pass samples under `rangeFoldFrom`). Test each compiled item as
+     soon as its last variable is fixed (failing prefixes prune the suffix box), and split the
+     gathered items into connected components over `xs` so `∏ |domᵢ|` becomes `Σ` per component (the
+     unsat case must still force every key to 0). Both keep the survivor set, so the final mask is
+     unchanged — but keep the `maxEnumWork`/`boxSize` gates on the *full* product or effectiveness
+     moves. ~250–400 lines; **measure first** with a box-shape/point counter (entry 151 built one):
+     if the wide boxes are single-variable, neither pays.
+   - **(e) Cheap micros.** `BusMap` is an assoc-list lookup closure (`toBusMap`) queried per point and
+     per fact call — 1–2 % of the run, and substituting an array-backed lookup at the `Main.lean` /
+     `Ffi.lean` boundary needs **no proof** (every theorem is ∀ busMap). `DenseForcedScanV.work` (the
+     parallel chunk budget) models `boxSize × items` only, but per-target cost has a large
+     boxSize-independent term — adding it rebalances chunks with zero proof (order preserved).
+     Preflight's `T.doms xs` is 6.8 % on sha256, all `Std.HashMap VarId` probes: the R12 array-indexed
+     prototype belongs here first.
+
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
 - **Whole-system content-hash gating of passes across cycles**: catches ~0 % — the fixpoint only
@@ -533,9 +593,11 @@ worth a prototype on one index first.
   full-system gated rewrite (`denseReencodeOutFast` — the state's `useCs` buckets + `foldCs` cover
   exactly the positions the gate can fire on; needs a positions-driven twin with the state
   invariant threaded, ~200-400 lines).
-- **domainBatch cycle 0 (26–28 s for 2.6k vars)**: gathers are bucket-served already; the cost is
-  hot-variable buckets × many candidate groups. Maybe gate groups on a cheap upper bound of the
-  gather size, or dedupe overlapping groups before gathering.
+- ~~**domainBatch cycle 0 (26–28 s for 2.6k vars)**: the cost is hot-variable buckets × many
+  candidate groups; gate groups on a gather-size bound or dedupe overlapping groups~~ **wrong,
+  measured (entry 152)**: gathers are 4.6 % of the pass at sha scale and target dedup 0.4 %; the
+  per-target cost that follows them is the survivor *compile* (56 %), not the gather or the scan.
+  See R13.
 - **flagFold cycle 0 (24 s, zero effect)**: NOT the domain lookups (bucketing them changed
   nothing). Suspect `denseFuCandidates`' per-interaction `O.vars.eraseDups × splitAt` on large
   first-slot payloads, or the per-matched-pair box evaluation in `denseFuPairData?`. Sample the
@@ -549,10 +611,11 @@ remains for a next pass:
 - **Two-variable deep scans** (cycle 4 had ~108 of them, boxes up to 65536 = ~256×256): entry 151's
   coset shrink is single-var-operand; if BOTH operands of a byte/tuple interaction are affine in
   distinct vars, each var could still get a coset, shrinking the 2-D box. Verify how many 2-var deep
-  scans survive after entry 151 (re-run the point counter) before implementing.
-- **Fuse the coset build**: `denseByteOperandDomain` currently materializes `((range bound).map cast).map
-  (fun z => (z-b)/a)` — two passes + a 256-elt intermediate, per byte operand per interaction (~2292×)
-  per cycle. A single fused map (or a `.range`+affine `FiniteDomain` variant carrying `(a,b)` lazily)
-  avoids the intermediate. Low risk, modest constant.
-- **Skip byte-domain work when it can't shrink**: only build the coset when the operand's current table
-  domain exceeds `bound` (otherwise `insertEntry` discards it anyway). Cheap guard, saves allocations.
+  scans survive after entry 151 (re-run the point counter) before implementing — the same counter
+  R13(d) needs.
+- **Fuse the coset build** — now measured at **21.3 % of the pass on SP1 keccak** (entry 152), the top
+  SP1 item; see R13(c) for the preferred lazy-`FiniteDomain` form.
+- ~~**Skip byte-domain work when it can't shrink**~~ **done**: `denseAddByteVarDoms` builds the coset
+  only when `spec.bound < d0.size`.
+- Post-entry-151 the SP1 pass profile matches OpenVM's: box scans are 1.3 % and the cost has moved to
+  the per-target classification and the coset build (R13).

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5255,3 +5255,52 @@ OpenVM eth. `lake build` clean (no warnings); `check-proof-integrity` passes (ax
 propext/Classical.choice/Quot.sound only). General: any byte/range-bounded finite-domain circuit
 benefits; the coset handles the affine-operand case OpenVM's bare-operand range domains miss.
 **Worked: yes (domainBatch ~4x, output byte-identical; committed).**
+
+### 152. Runtime: arity-only bus lookups compile to `.always` (domainBatch 7.1x on its worst-share APC)
+BISECTED FIRST (the #219/#151 lesson), and the ideas.md guess was again wrong: domainBatch is **no
+longer enumeration-bound**. LBR profiles (`perf --call-graph lbr` + the phase/cost-class/caller scripts)
+over five OpenVM cases and SP1 keccak put the pass's budget in *per-target and per-invocation setup*:
+per-target bus **classification** (`denseCompileCBiPredsV`, all of it target-independent) is 56.1 % of
+in-pass samples on sha256 apc_001, 40.5 % on keccak, 34.4 % on SP1 keccak; the opaque `.fallback` arm
+(`bs.violatesConstraint` per enumerated point) is 63.2 % on wasm-eth apc_005, 18 % keccak, 14 % sha256;
+`rangeFoldFrom` (the box loop entry 151 shrank) is 0.8 % on sha256 and 74.7 % only on openvm-eth
+apc_071. Pass-only cost classes on sha256: 32.5 % closure-apply + 25 % refcount — the budget is
+`BusFacts` closure calls and the allocation traffic of their results, not arithmetic.
+THIS ENTRY takes the cheapest of the resulting levers. Both VMs have buses whose table obligation is
+*only* the payload arity (`OpenVM.violates`: `some .pcLookup, args => !decide (args.length = 9)`; SP1
+`pcLookup` 16, `instructionFetch` 22, `pageProt` 6). None can be in `facts.neverViolates` (busId-only,
+and they *do* violate at the wrong arity), so each one compiled to `.fallback` and every point paid
+9–22 `IExpr` evals + a fresh payload list + a fresh message record + an assoc-list `busMap` lookup
+(`OpenVM_violates` was 49 % of the `ZMod.commRing` rebuilds and 45 % of `lean_dec_ref_cold` callers on
+apc_005). Fix: one new `BusFacts` field `neverViolatesArity : busId → arity → Bool` with soundness
+`∀ m, neverViolatesArity m.busId m.payload.length = true → violatesConstraint m = false`, instantiated
+per VM, and `denseBiAlwaysOk` = `neverViolates busId || neverViolatesArity busId payload.length`
+gating the existing `.always` arm of `denseCompileCBiPredV`. Proof: three arity lemmas mirroring
+`execBridge_ok` (`unfold violates; rw [hbus]; simp [harity]`) plus `denseBiAlwaysOk_violates`
+(`denseBIEval` maps the payload, so the arity survives); the 9-line `.always` `_eval` case is reused
+unchanged. All under `Implementation/` — audited surface untouched.
+OUTPUT IDENTITY: the fact is proven, so these interactions never rejected a point and the survivor
+sets (hence every forced constant) are unchanged. `denseBiInformative` / `denseBiDomainRedundantV` are
+deliberately **not** extended — recognizing these buses as uninformative or domain-redundant would
+skip whole scans, which is an effectiveness change, not a runtime one (left as a follow-up to argue
+separately).
+NUMBERS (this 20-core box, interleaved best-of-3 per case, `profile`; domainBatch ms, then case total):
+wasm-eth apc_005 **248 → 35 (0.14x)**, total 397 → 183 (0.46x); keccak apc_001 1428 → 1310 (0.92x),
+total 12967 → 12830; openvm-eth apc_071 573 → 550 (0.96x); wasm-eth apc_063 1593 → 1567 (0.98x);
+sha256 apc_001 (single shot, the pass runs parallel there) 19108 → 17964 (0.94x), total 176070 →
+175627; SP1 keccak 1136 → 1000 (0.88x), SP1 rsp apc_030 201 → 149 (0.74x), rsp apc_024 173 → 130
+(0.75x). No collateral movement in any other pass column. Note the sha256 win (0.94x) is smaller than
+its 14 % `violates` sample share predicts: the pass fans out at ≥ 8192 constraints, so its `perf`
+share is CPU and only ~1/3 of it is wall.
+VERIFIED: `opt-export` **byte-identical** on OpenVM keccak / wasm-eth apc_005 / openvm-eth apc_071 and
+SP1 keccak / rsp apc_001; keccak `run` counts identical (2021 / 186 / 1748); `lake build` clean, no
+warnings; `check-proof-integrity` passes (axioms propext/Classical.choice/Quot.sound only).
+NEXT LEVERS from the same attribution, in order: (a) hoist the target-independent bus classification
+into the per-invocation `DenseBusPlan` (56 % of the pass on sha256; a per-`busId` fact cache is the
+cheap half, a per-interaction shape the complete one); (b) compute each interaction's
+`payload.map constValue?` pattern once instead of per queried variable (15–19 % of the pass, and the
+same specialized map is 6 % of the whole sha256 run across intervalForce/rootPairUnify); (c) fuse or
+lazify `denseByteOperandDomain`'s coset build (21.3 % of the pass on SP1 keccak, ~0 on OpenVM);
+(d) prefix-pruned / component-split enumeration for the big-box OpenVM cases, gated on a box-shape
+counter first.
+**Worked: yes (domainBatch 0.14x on its worst-share APC, output byte-identical; draft PR).**


### PR DESCRIPTION
## What

Both VM semantics have buses whose table obligation is **only the payload arity** — OpenVM's
`pcLookup` (`violates`: `some .pcLookup, args => !decide (args.length = 9)`) and SP1's `pcLookup` (16),
`instructionFetch` (22) and `pageProt` (6). None of them can be in `facts.neverViolates`, which is
busId-only and would be unsound at the wrong arity, so `domainBatch` compiled every such interaction
to `.fallback` and each enumerated point paid the opaque `bs.violatesConstraint`: 9–22 `IExpr`
evaluations, a fresh payload list, a fresh message record and an assoc-list `busMap` lookup.

This adds one `BusFacts` field

```lean
neverViolatesArity : (busId : Nat) → (arity : Nat) → Bool
neverViolatesArity_sound :
  ∀ m, neverViolatesArity m.busId m.payload.length = true → bs.violatesConstraint m = false
```

instantiated for both VMs, and gates `denseCompileCBiPredV`'s existing `.always` arm on
`denseBiAlwaysOk = neverViolates busId || neverViolatesArity busId payload.length`. Everything is
under `Implementation/` — the audited surface is untouched, and the new proofs are three arity lemmas
in the shape of `execBridge_ok` plus `denseBiAlwaysOk_violates`; the `.always` `_eval` case is reused
unchanged.

## Why this and not something else

Profiled first (`perf --call-graph lbr` + the `OptimizingRuntime.md` phase / cost-class / caller
scripts) over five OpenVM cases and SP1 keccak. `domainBatch` is **no longer enumeration-bound**:

| phase (% of in-pass samples) | sha256 apc_001 | keccak | SP1 keccak | eth apc_071 | wasm apc_005 |
|---|---:|---:|---:|---:|---:|
| per-target bus classification | 56.1 | 40.5 | 34.4 | 2.3 | 0.3 |
| **opaque `.fallback` per point** | **14.0** | **18.0** | **17.9** | 1.7 | **63.2** |
| bus-sourced table build | 15.1 | 19.5 | 16.4 | 11.7 | 7.9 |
| byte-operand coset build | ~0 | 0.4 | 21.3 | ~0 | ~0 |
| box-loop machinery | 3.8 | 3.0 | 1.3 | 20.8 | 2.2 |

Pass-only cost classes on sha256 are 32.5 % closure-apply + 25 % refcount — the budget is `BusFacts`
closure calls and the allocation traffic of their results. This PR takes the `.fallback` row, the
cheapest of the levers; the rest are recorded in `ideas.md` R13 (entry 152 in `log.md`).

## Numbers

Interleaved best-of-3 per case on a quiet 20-core box, `profile`, `domainBatch` ms → case total ms:

| case | domainBatch | total |
|---|---|---|
| `wasm-eth/apc_005_pc0x2E9C48` (worst share) | **248 → 35 (0.14×)** | 397 → 183 (0.46×) |
| `keccak/apc_001_pckeccak` | 1428 → 1310 (0.92×) | 12967 → 12830 |
| `openvm-eth/apc_071_pc0x3783a8` | 573 → 550 (0.96×) | 1294 → 1271 |
| `wasm-eth/apc_063_pc0x078B60` | 1593 → 1567 (0.98×) | 13510 → 13465 |
| SP1 `keccak/apc_001` | 1136 → 1000 (0.88×) | 6972 → 6832 |
| SP1 `rsp/apc_030` | 201 → 149 (0.74×) | 889 → 836 |
| SP1 `rsp/apc_024` | 173 → 130 (0.75×) | 708 → 668 |
| `sha256/apc_001_pcsha256` (worst absolute, single shot) | 19108 → 17964 (0.94×) | 176070 → 175627 |

No other pass column moves. The sha256 win is smaller than its 14 % sample share predicts because the
pass fans out at ≥ 8192 constraints, so that share is CPU and only ~1/3 of it is wall.

## Effectiveness: unchanged, by construction

The fact is proven, so these interactions never rejected an enumerated point; the survivor sets, and
therefore every forced constant, are identical. Verified locally: `opt-export` output is
**byte-identical** on OpenVM keccak / wasm-eth apc_005 / openvm-eth apc_071 and SP1 keccak / rsp
apc_001, and keccak `run` counts are unchanged (2021 / 186 / 1748).

`denseBiInformative` and `denseBiDomainRedundantV` are deliberately *not* extended with the new fact:
treating these buses as uninformative or domain-redundant would skip whole enumerations, which is an
effectiveness change to argue separately, not a runtime one.

## Checks

- `lake build` clean, no warnings.
- `Scripts/check-proof-integrity.sh` passes (axioms: `propext`, `Classical.choice`, `Quot.sound`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
