### PR TITLE
spec: make BusState a net-multiplicity function, so side effects compare by equality

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -223,9 +223,11 @@ theorem Circuit.admissible_congr {cs : Circuit p} {bs : BusSemantics p}
 theorem Circuit.sideEffects_congr {cs : Circuit p} {bs : BusSemantics p}
     {f g : Variable → ZMod p} (h : ∀ x ∈ cs.vars, f x = g x) :
     cs.sideEffects bs f = cs.sideEffects bs g := by
+  have hmap : cs.busInteractions.map (fun bi => bi.eval f)
+      = cs.busInteractions.map (fun bi => bi.eval g) :=
+    List.map_congr_left (fun bi hbi => Circuit.busEval_congr h hbi)
   unfold Circuit.sideEffects
-  refine List.map_congr_left (fun bi hbi => ?_)
-  simp only [Circuit.busEval_congr h (List.mem_of_mem_filter hbi)]
+  rw [hmap]
 
 theorem Derivations.methodFor_map_same (vs : List Variable)
     (f : Variable → ComputationMethod p) (v : Variable) :
@@ -329,7 +331,7 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
   refine ⟨(Circuit.satisfies_congr hagree).mpr hsat',
     (Circuit.admissible_congr hagree).mpr hadm', ?_⟩
   · have hse' : cs.sideEffects bs env
-          ≈ (pipeline b cs bs facts).out.sideEffects bs (Derivations.witgen
+          = (pipeline b cs bs facts).out.sideEffects bs (Derivations.witgen
               ((pipeline b cs bs facts).derivs.forOutput cs.vars
                 (pipeline b cs bs facts).out.vars) env) := by
         rw [Circuit.sideEffects_congr hagree]

--- a/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Basic.lean
@@ -8,17 +8,52 @@ variable {p : ℕ}
 /-! # Optimizer scaffolding
 
 The reusable framework for building the optimizer out of small, individually-proven passes: the
-relation glue (`≈`, `Circuit.implies`/`.reconstructs`), `PassCorrect`, and `VerifiedPass`
+relation glue (`Circuit.implies`/`.reconstructs`), `PassCorrect`, and `VerifiedPass`
 bundling a pass with its own `PassCorrect` proof. -/
 
-theorem BusState.equiv_refl (s : BusState p) : s ≈ s :=
-  fun _ => rfl
+/-! ## Net multiplicity over contribution lists
 
-theorem BusState.equiv_symm {s t : BusState p} (h : s ≈ t) : t ≈ s :=
-  fun message => (h message).symm
+`BusState` is a function (`ApcOptimizer/Spec.lean`), but the pass proofs reason by induction over
+the *list* of per-interaction contributions. `multiplicitySum` is that list view and
+`Circuit.sideEffects_eq` relates it to the spec's definition. -/
 
-theorem BusState.equiv_trans {s t u : BusState p} (h1 : s ≈ t) (h2 : t ≈ u) : s ≈ u :=
-  fun message => (h1 message).trans (h2 message)
+/-- The net multiplicity with which `message` is sent by a list of per-interaction contributions. -/
+def multiplicitySum (message : BusMessage p) (state : List (BusMessage p × ZMod p)) : ZMod p :=
+  match state with
+  | [] => 0
+  | (msg, mult) :: tl =>
+      (if msg = message then mult else 0) + multiplicitySum message tl
+
+/-- The contribution list of a circuit's stateful interactions under `env`. -/
+def Circuit.contributions (circuit : Circuit p) (bs : BusSemantics p)
+    (env : Variable → ZMod p) : List (BusMessage p × ZMod p) :=
+  (circuit.busInteractions.filter (fun bi => bs.isStateful bi.busId)).map
+    (fun bi => let m := bi.eval env; ((m.busId, m.payload), m.multiplicity))
+
+theorem multiplicitySum_map_filter (bs : BusSemantics p) (env : Variable → ZMod p)
+    (message : BusMessage p) (bis : List (BusInteraction (Expression p))) :
+    (((bis.map (fun bi => bi.eval env)).filter
+        (fun m => bs.isStateful m.busId && decide ((m.busId, m.payload) = message))).map
+      (fun m => m.multiplicity)).sum
+      = multiplicitySum message
+          ((bis.filter (fun bi => bs.isStateful bi.busId)).map
+            (fun bi => let m := bi.eval env; ((m.busId, m.payload), m.multiplicity))) := by
+  induction bis with
+  | nil => rfl
+  | cons bi rest ih =>
+      -- `BusInteraction.eval` keeps `busId`, so the two spellings of the statefulness test agree.
+      have hb : bs.isStateful (bi.eval env).busId = bs.isStateful bi.busId := rfl
+      by_cases hstate : bs.isStateful bi.busId = true
+      · by_cases hmsg : ((bi.eval env).busId, (bi.eval env).payload) = message
+        · simp [hb, hstate, hmsg, multiplicitySum, ih]
+        · simp [hb, hstate, hmsg, multiplicitySum, ih]
+      · simp [hb, hstate, ih]
+
+/-- The spec's `sideEffects` is the net multiplicity of the contribution list. -/
+theorem Circuit.sideEffects_eq (cs : Circuit p) (bs : BusSemantics p) (env : Variable → ZMod p)
+    (message : BusMessage p) :
+    cs.sideEffects bs env message = multiplicitySum message (cs.contributions bs env) :=
+  multiplicitySum_map_filter bs env message cs.busInteractions
 
 /-- Soundness half of a replacement: every satisfying assignment of `self` maps to one of `other`
     with the same stateful side effects. The spec's `isSoundReplacementOf` is this plus invariant
@@ -27,7 +62,7 @@ def Circuit.implies (self other : Circuit p) (busSemantics : BusSemantics p) :
     Prop :=
   ∀ env, self.satisfies busSemantics env →
     ∃ env', other.satisfies busSemantics env' ∧
-      self.sideEffects busSemantics env ≈ other.sideEffects busSemantics env'
+      self.sideEffects busSemantics env = other.sideEffects busSemantics env'
 
 /-- Every no-powdr-ID variable of `cs` is computed by `ds`'s method for it, reading only powdr-ID
     variables from `inputVars`. Threaded through passes; the pipeline top uses it to match the
@@ -42,14 +77,14 @@ def Circuit.reconstructs (inputVars : List Variable) (cs : Circuit p)
 
 theorem Circuit.implies_refl (cs : Circuit p) (busSemantics : BusSemantics p) :
     cs.implies cs busSemantics :=
-  fun env hsat => ⟨env, hsat, BusState.equiv_refl _⟩
+  fun env hsat => ⟨env, hsat, rfl⟩
 
 theorem Circuit.implies_trans {a b c : Circuit p} {busSemantics : BusSemantics p}
     (h1 : a.implies b busSemantics) (h2 : b.implies c busSemantics) : a.implies c busSemantics :=
   fun env hsat =>
     let ⟨env', hb, hab⟩ := h1 env hsat
     let ⟨env'', hc, hbc⟩ := h2 env' hb
-    ⟨env'', hc, BusState.equiv_trans hab hbc⟩
+    ⟨env'', hc, (hab.trans hbc)⟩
 
 /-! ## Precomputed primality witness
 
@@ -83,7 +118,7 @@ def PassCorrect (cs out : Circuit p) (dsLocal : Derivations p) (bs : BusSemantic
   (∀ v ∈ out.vars, v.powdrId?.isSome → v ∈ cs.vars) ∧
   (∀ env, cs.admissible bs env → cs.satisfies bs env →
     ∃ env', out.satisfies bs env' ∧ out.admissible bs env' ∧
-      cs.sideEffects bs env ≈ out.sideEffects bs env' ∧
+      cs.sideEffects bs env = out.sideEffects bs env' ∧
       (∀ v, v.powdrId?.isSome → env' v = env v) ∧
       (∀ inputVars, (∀ v ∈ cs.vars, v.powdrId?.isSome → v ∈ inputVars) →
         ∀ dsIn, cs.reconstructs inputVars dsIn env →
@@ -93,7 +128,7 @@ theorem PassCorrect.refl (cs : Circuit p) (bs : BusSemantics p) :
     PassCorrect cs cs [] bs :=
   ⟨cs.implies_refl bs, _root_.id, fun _ hv _ => hv,
    fun env hadm hsat =>
-     ⟨env, hsat, hadm, BusState.equiv_refl _,
+     ⟨env, hsat, hadm, rfl,
        ⟨fun _ _ => rfl, fun _ _ dsIn hrec => by rwa [List.append_nil]⟩⟩⟩
 
 /-- Sequential composition: derivations concatenate, soundness/invariants compose, reconstruction
@@ -107,7 +142,7 @@ theorem PassCorrect.andThen {cs mid out : Circuit p} {bs : BusSemantics p}
     fun v hv hpw => hf3 v (hg3 v hv hpw) hpw, fun env hadm hsat => ?_⟩
   obtain ⟨env1, hs1, ha1, he1, hpw1, hr1⟩ := hf4 env hadm hsat
   obtain ⟨env2, hs2, ha2, he2, hpw2, hr2⟩ := hg4 env1 ha1 hs1
-  refine ⟨env2, hs2, ha2, BusState.equiv_trans he1 he2,
+  refine ⟨env2, hs2, ha2, (he1.trans he2),
     ⟨fun v hpw => by rw [hpw2 v hpw, hpw1 v hpw],
       fun inputVars hpowIn dsIn hrec => ?_⟩⟩
   have hmidIn : ∀ v ∈ mid.vars, v.powdrId?.isSome → v ∈ inputVars :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Bridge.lean
@@ -42,13 +42,15 @@ def denseBIEval (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p) :
     multiplicity := bi.multiplicity.eval denv,
     payload := bi.payload.map (fun e => e.eval denv) }
 
-/-- Dense side effects: the stateful-bus messages sent. -/
+/-- Dense side effects: the net multiplicity each message is sent with by the stateful
+    interactions. -/
 def DenseConstraintSystem.sideEffects (d : DenseConstraintSystem p) (bs : BusSemantics p)
     (denv : VarId → ZMod p) : BusState p :=
-  d.busInteractions.filter (fun bi => bs.isStateful bi.busId)
-    |>.map (fun bi =>
-      let m := denseBIEval bi denv
-      ((m.busId, m.payload), m.multiplicity))
+  fun message => multiplicitySum message
+    (d.busInteractions.filter (fun bi => bs.isStateful bi.busId)
+      |>.map (fun bi =>
+        let m := denseBIEval bi denv
+        ((m.busId, m.payload), m.multiplicity)))
 
 /-- Dense satisfaction: all constraints vanish and every fired bus message is unconstrained. -/
 def DenseConstraintSystem.satisfies (d : DenseConstraintSystem p) (bs : BusSemantics p)
@@ -76,7 +78,7 @@ def DenseConstraintSystem.implies (self other : DenseConstraintSystem p) (bs : B
     Prop :=
   ∀ denv, self.satisfies bs denv →
     ∃ denv', other.satisfies bs denv' ∧
-      self.sideEffects bs denv ≈ other.sideEffects bs denv'
+      self.sideEffects bs denv = other.sideEffects bs denv'
 
 /-! ## `occ` membership helpers -/
 
@@ -149,6 +151,7 @@ theorem DenseConstraintSystem.sideEffects_congr {d : DenseConstraintSystem p} {b
     {denv1 denv2 : VarId → ZMod p} (h : ∀ i ∈ d.occ, denv1 i = denv2 i) :
     d.sideEffects bs denv1 = d.sideEffects bs denv2 := by
   unfold DenseConstraintSystem.sideEffects
+  refine funext (fun message => congrArg (multiplicitySum message) ?_)
   refine List.map_congr_left (fun bi hbi => ?_)
   rw [denseBIEval_congr bi denv1 denv2
     (fun i hi => h i (DenseConstraintSystem.mem_occ_of_bi (List.mem_of_mem_filter hbi) hi))]
@@ -265,7 +268,10 @@ theorem VarRegistry.decodeBI_filter_comm (reg : VarRegistry) (d : DenseConstrain
 theorem VarRegistry.decodeCS_sideEffects (reg : VarRegistry) (d : DenseConstraintSystem p)
     (bs : BusSemantics p) (E : Variable → ZMod p) :
     (reg.decodeCS d).sideEffects bs E = d.sideEffects bs (fun i => E (reg.resolve i)) := by
-  simp only [Circuit.sideEffects, DenseConstraintSystem.sideEffects, VarRegistry.decodeCS]
+  funext message
+  rw [Circuit.sideEffects_eq]
+  simp only [Circuit.contributions, DenseConstraintSystem.sideEffects, VarRegistry.decodeCS]
+  refine congrArg (multiplicitySum message) ?_
   rw [reg.decodeBI_filter_comm d bs, List.map_map]
   refine List.map_congr_left (fun bi _ => ?_)
   simp only [Function.comp_apply, reg.decodeBI_eval]
@@ -381,7 +387,7 @@ def DensePassCorrect (isInput : VarId → Bool) (d out : DenseConstraintSystem p
   (∀ i ∈ out.occ, isInput i = true → i ∈ d.occ) ∧
   (∀ denv, d.admissible bs denv → d.satisfies bs denv →
     ∃ denv', out.satisfies bs denv' ∧ out.admissible bs denv' ∧
-      d.sideEffects bs denv ≈ out.sideEffects bs denv' ∧
+      d.sideEffects bs denv = out.sideEffects bs denv' ∧
       (∀ i, isInput i = true → denv' i = denv i) ∧
       (∀ inputVarIds, (∀ i ∈ d.occ, isInput i = true → i ∈ inputVarIds) →
         DenseOutReconstructs isInput inputVarIds d out dd denv denv'))
@@ -477,9 +483,9 @@ theorem DenseDerivations.methodFor_append (a b : DenseDerivations p) (v : VarId)
 /-- Reflexivity: the identity transform (same system, no new derivations) is correct. -/
 theorem DensePassCorrect.refl (isInput : VarId → Bool) (d : DenseConstraintSystem p)
     (bs : BusSemantics p) : DensePassCorrect isInput d d [] bs := by
-  refine ⟨fun denv hsat => ⟨denv, hsat, BusState.equiv_refl _⟩, _root_.id, fun i hi _ => hi, ?_⟩
+  refine ⟨fun denv hsat => ⟨denv, hsat, rfl⟩, _root_.id, fun i hi _ => hi, ?_⟩
   intro denv hadm hsat
-  refine ⟨denv, hsat, hadm, BusState.equiv_refl _, fun _ _ => rfl, ?_⟩
+  refine ⟨denv, hsat, hadm, rfl, fun _ _ => rfl, ?_⟩
   intro inputVarIds _ i hi _
   exact ⟨hi, rfl⟩
 
@@ -497,7 +503,7 @@ theorem DensePassCorrect.andThen {isInput : VarId → Bool} {d mid out : DenseCo
     intro denv hsat3
     obtain ⟨e1, hsat2, hse23⟩ := hs23 denv hsat3
     obtain ⟨e0, hsat1, hse12⟩ := hs12 e1 hsat2
-    exact ⟨e0, hsat1, BusState.equiv_trans hse23 hse12⟩
+    exact ⟨e0, hsat1, (hse23.trans hse12)⟩
   · -- Invariant preservation.
     intro h; exact hi23 (hi12 h)
   · -- No new powdr-ID column.
@@ -506,7 +512,7 @@ theorem DensePassCorrect.andThen {isInput : VarId → Bool} {d mid out : DenseCo
     intro denv hadm1 hsat1
     obtain ⟨e1, hsat2, hadm2, hse12, hii12, hrec12⟩ := hc12 denv hadm1 hsat1
     obtain ⟨e2, hsat3, hadm3, hse23, hii23, hrec23⟩ := hc23 e1 hadm2 hsat2
-    refine ⟨e2, hsat3, hadm3, BusState.equiv_trans hse12 hse23, ?_, ?_⟩
+    refine ⟨e2, hsat3, hadm3, (hse12.trans hse23), ?_, ?_⟩
     · intro i hii; rw [hii23 i hii, hii12 i hii]
     · -- Reconstruction over `dd1 ++ dd2`.
       intro inputVarIds hcov1
@@ -568,7 +574,7 @@ theorem DensePassCorrect.ofEnvEq {isInput : VarId → Bool} {d out : DenseConstr
     (hsub : ∀ i ∈ out.occ, i ∈ d.occ)
     (hcomp : ∀ denv, d.admissible bs denv → d.satisfies bs denv →
       out.satisfies bs denv ∧ out.admissible bs denv ∧
-        d.sideEffects bs denv ≈ out.sideEffects bs denv) :
+        d.sideEffects bs denv = out.sideEffects bs denv) :
     DensePassCorrect isInput d out [] bs := by
   refine ⟨hsound, hinv, fun i hi _ => hsub i hi, ?_⟩
   intro denv hadm hsat
@@ -627,6 +633,7 @@ theorem DensePassCorrect.ofEvalAgree {isInput : VarId → Bool} {d out : DenseCo
   have hside : ∀ denv, A denv → out.sideEffects bs denv = d.sideEffects bs denv := by
     intro denv hA
     unfold DenseConstraintSystem.sideEffects
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
     rw [houtB, filter_map_busId_comm d.busInteractions
       (fun bi => { bi with multiplicity := gb bi.multiplicity, payload := bi.payload.map gb })
       bs (fun _ => rfl), List.map_map]
@@ -662,7 +669,7 @@ theorem DensePassCorrect.ofEvalAgree {isInput : VarId → Bool} {d out : DenseCo
   · intro denv hsatout
     have hA := hAout denv hsatout
     exact ⟨denv, (hsatIff denv hA).1 hsatout,
-      by rw [hside denv hA]; exact BusState.equiv_refl _⟩
+      by rw [hside denv hA]⟩
   · intro hgi denv hsatout bi' hbi'
     have hA := hAout denv hsatout
     have hsatd := (hsatIff denv hA).1 hsatout
@@ -673,7 +680,7 @@ theorem DensePassCorrect.ofEvalAgree {isInput : VarId → Bool} {d out : DenseCo
   · intro denv hadmd hsatd
     have hA := hAd denv hsatd
     exact ⟨(hsatIff denv hA).2 hsatd, (hadm denv hA).2 hadmd,
-      by rw [hside denv hA]; exact BusState.equiv_refl _⟩
+      by rw [hside denv hA]⟩
 
 /-- `DensePassCorrect` composes (derivations empty on both sides); `PassCorrect.andThen`
     specialised to no derivations. -/
@@ -686,13 +693,13 @@ theorem DensePassCorrect.trans {isInput : VarId → Bool} {d1 d2 d3 : DenseConst
   · intro denv hsat3
     obtain ⟨e1, hsat2, hse23⟩ := hs23 denv hsat3
     obtain ⟨e0, hsat1, hse12⟩ := hs12 e1 hsat2
-    exact ⟨e0, hsat1, BusState.equiv_trans hse23 hse12⟩
+    exact ⟨e0, hsat1, (hse23.trans hse12)⟩
   · intro h; exact hi23 (hi12 h)
   · intro i hi3 hii; exact hv12 i (hv23 i hi3 hii) hii
   · intro denv hadm1 hsat1
     obtain ⟨e1, hsat2, hadm2, hse12, hii12, hrec12⟩ := hc12 denv hadm1 hsat1
     obtain ⟨e2, hsat3, hadm3, hse23, hii23, hrec23⟩ := hc23 e1 hadm2 hsat2
-    refine ⟨e2, hsat3, hadm3, BusState.equiv_trans hse12 hse23, ?_, ?_⟩
+    refine ⟨e2, hsat3, hadm3, (hse12.trans hse23), ?_, ?_⟩
     · intro i hii; rw [hii23 i hii, hii12 i hii]
     · intro inputVarIds hcov1 i hi3 hisF
       have H23 := hrec23 d2.occ (fun j hj _ => hj) i hi3 hisF

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
@@ -15,7 +15,7 @@ variable {p : ℕ}
 /-- The stateful side-effect state of a raw dense interaction list under `denv` (what dense
     `sideEffects` computes). -/
 def denseToBusState (bs : BusSemantics p) (denv : VarId → ZMod p)
-    (L : List (BusInteraction (DenseExpr p))) : BusState p :=
+    (L : List (BusInteraction (DenseExpr p))) : List (BusMessage p × ZMod p) :=
   (L.filter (fun bi => bs.isStateful bi.busId)).map
     (fun bi => let m := denseBIEval bi denv; ((m.busId, m.payload), m.multiplicity))
 
@@ -52,7 +52,8 @@ theorem denseSideEffects_dropPair_equiv (bs : BusSemantics p) (denv : VarId → 
     (hRm : (denseBIEval R denv).multiplicity = -(denseBIEval S denv).multiplicity)
     (hbusEq : (denseBIEval S denv).busId = (denseBIEval R denv).busId)
     (hpay : (denseBIEval S denv).payload = (denseBIEval R denv).payload) :
-    denseToBusState bs denv (A ++ S :: B ++ R :: C) ≈ denseToBusState bs denv (A ++ B ++ C) := by
+    ∀ msg, multiplicitySum msg (denseToBusState bs denv (A ++ S :: B ++ R :: C))
+      = multiplicitySum msg (denseToBusState bs denv (A ++ B ++ C)) := by
   intro msg
   have hstructFull : A ++ S :: B ++ R :: C = (A ++ S :: B) ++ (R :: C) := by
     simp only [List.append_assoc, List.cons_append]
@@ -211,21 +212,23 @@ theorem denseDropPair_correct (isInput : VarId → Bool)
     refine (facts.recvByteSlots_sound busId shape hshape pattern slots bound hslots (denseBIEval R denv)
       (show (denseBIEval R denv).busId = busId from hRbus)).2 (hRmEv denv) (hRmatch denv) hbyteEnv
   have hSE : ∀ denv, (∀ c ∈ d.algebraicConstraints, c.eval denv = 0) →
-      d.sideEffects bs denv ≈ out.sideEffects bs denv := by
+      d.sideEffects bs denv = out.sideEffects bs denv := by
     intro denv hcon
-    have e1 : d.sideEffects bs denv = denseToBusState bs denv (A ++ S :: B ++ R :: C) := by
-      show denseToBusState bs denv d.busInteractions = denseToBusState bs denv (A ++ S :: B ++ R :: C)
-      rw [hsplit]
-    have e2 : out.sideEffects bs denv = denseToBusState bs denv (A ++ B ++ C) := by
-      show denseToBusState bs denv (A ++ B ++ C ++ checks) = denseToBusState bs denv (A ++ B ++ C)
+    have e1 : denseToBusState bs denv d.busInteractions
+        = denseToBusState bs denv (A ++ S :: B ++ R :: C) := by rw [hsplit]
+    have e2 : denseToBusState bs denv (A ++ B ++ C ++ checks)
+        = denseToBusState bs denv (A ++ B ++ C) := by
       rw [denseToBusState_append, denseToBusState_stateless bs denv checks hchecksStateless,
         List.append_nil]
+    refine funext (fun msg => ?_)
+    show multiplicitySum msg (denseToBusState bs denv d.busInteractions)
+      = multiplicitySum msg (denseToBusState bs denv (A ++ B ++ C ++ checks))
     rw [e1, e2]
     exact denseSideEffects_dropPair_equiv bs denv A B C S R hSstate hRstate
       (by rw [hRmEv denv, hSmEv denv])
       (by rw [show (denseBIEval S denv).busId = busId from hSbus,
               show (denseBIEval R denv).busId = busId from hRbus])
-      (hpayEval denv hcon)
+      (hpayEval denv hcon) msg
   have hsat_cs_out : ∀ denv, d.satisfies bs denv → out.satisfies bs denv := by
     intro denv hsat
     refine ⟨hsat.1, ?_⟩
@@ -315,7 +318,7 @@ theorem denseDropPair_correct (isInput : VarId → Bool)
       · exact DenseConstraintSystem.mem_occ_of_bi (hmem_core bi hbi') hibi
       · exact DenseConstraintSystem.mem_occ_of_bi hRmem ((hchecks bi hbi').2.2.2 i hibi)
   exact DensePassCorrect.ofEnvEq
-    (fun denv hsat => ⟨denv, hsat_out_cs denv hsat, BusState.equiv_symm (hSE denv hsat.1)⟩)
+    (fun denv hsat => ⟨denv, hsat_out_cs denv hsat, (hSE denv hsat.1).symm⟩)
     (fun hinv denv hsat bi hbi => by
       rcases List.mem_append.1 (by rw [houtb] at hbi; exact hbi) with hbi' | hbi'
       · exact hinv denv (hsat_out_cs denv hsat) bi (hmem_core bi hbi')

--- a/ApcOptimizer/Implementation/OptimizerPasses/ExprOps.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ExprOps.lean
@@ -163,6 +163,7 @@ theorem DenseConstraintSystem.mapExpr_sideEffects (hg : ∀ (e : DenseExpr p) (d
     (g e).eval denv = e.eval denv) (d : DenseConstraintSystem p) (bs : BusSemantics p)
     (denv : VarId → ZMod p) : (d.mapExpr g).sideEffects bs denv = d.sideEffects bs denv := by
   unfold DenseConstraintSystem.sideEffects
+  refine funext (fun message => congrArg (multiplicitySum message) ?_)
   rw [DenseConstraintSystem.mapExpr_busInteractions,
     filter_map_busId_comm d.busInteractions
       (fun bi => { bi with multiplicity := g bi.multiplicity, payload := bi.payload.map g }) bs
@@ -213,7 +214,6 @@ def denseConstantFoldPass : DenseVerifiedPassW p :=
         intro denv hsat
         refine ⟨denv, (DenseConstraintSystem.mapExpr_satisfies hfe d bs denv).mp hsat, ?_⟩
         rw [DenseConstraintSystem.mapExpr_sideEffects hfe]
-        exact BusState.equiv_refl _
       · -- invariants
         exact fun h => DenseConstraintSystem.mapExpr_guaranteesInvariants hfe h
       · -- no new powdr column
@@ -223,7 +223,6 @@ def denseConstantFoldPass : DenseVerifiedPassW p :=
         refine ⟨denv, (DenseConstraintSystem.mapExpr_satisfies hfe d bs denv).mpr hsat,
           (DenseConstraintSystem.mapExpr_admissible hfe d bs denv).mpr hadm, ?_, fun _ _ => rfl, ?_⟩
         · rw [DenseConstraintSystem.mapExpr_sideEffects hfe]
-          exact BusState.equiv_refl _
         · intro _ _ i hi _
           exact ⟨DenseConstraintSystem.mapExpr_occ_subset DenseExpr.fold_vars d i hi, rfl⟩)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ListSplit.lean
@@ -170,9 +170,9 @@ theorem mem_core_of_ne {α : Type _} {l A B C : List α} {S R x : α}
   simp only [List.mem_append, List.mem_cons] at hx ⊢
   tauto
 
-/-- Net multiplicity (over the representation-independent `BusState p`) is additive over
-    concatenation of bus states. -/
-theorem multiplicitySum_append {p : ℕ} (msg : BusMessage p) (s t : BusState p) :
+/-- Net multiplicity is additive over concatenation of contribution lists. -/
+theorem multiplicitySum_append {p : ℕ} (msg : BusMessage p)
+    (s t : List (BusMessage p × ZMod p)) :
     multiplicitySum msg (s ++ t) = multiplicitySum msg s + multiplicitySum msg t := by
   induction s with
   | nil => simp [multiplicitySum]

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -750,7 +750,6 @@ def denseNormalizePass : DenseVerifiedPassW p :=
         intro denv hsat
         refine ⟨denv, (DenseConstraintSystem.mapExpr_satisfies hfe d bs denv).mp hsat, ?_⟩
         rw [DenseConstraintSystem.mapExpr_sideEffects hfe]
-        exact BusState.equiv_refl _
       · -- invariants
         exact fun h => DenseConstraintSystem.mapExpr_guaranteesInvariants hfe h
       · -- no new powdr column
@@ -761,7 +760,6 @@ def denseNormalizePass : DenseVerifiedPassW p :=
         refine ⟨denv, (DenseConstraintSystem.mapExpr_satisfies hfe d bs denv).mpr hsat,
           (DenseConstraintSystem.mapExpr_admissible hfe d bs denv).mpr hadm, ?_, fun _ _ => rfl, ?_⟩
         · rw [DenseConstraintSystem.mapExpr_sideEffects hfe]
-          exact BusState.equiv_refl _
         · intro _ _ i hi _
           exact ⟨DenseConstraintSystem.mapExpr_occ_subset denseNormalizeFused_fst_vars d i hi, rfl⟩)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BoxRewrite.lean
@@ -252,6 +252,7 @@ theorem DenseConstraintSystem.boxRewrite_denseCorrect [Fact p.Prime]
       (d.boxRewrite b).sideEffects bs denv = d.sideEffects bs denv := by
     intro denv hdom
     unfold DenseConstraintSystem.sideEffects
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
     rw [show (d.boxRewrite b).busInteractions
           = d.busInteractions.map (denseBrBi (denseSingleVarCs d.algebraicConstraints) b) from rfl,
         filter_map_busId_comm d.busInteractions
@@ -278,7 +279,6 @@ theorem DenseConstraintSystem.boxRewrite_denseCorrect [Fact p.Prime]
     intro denv hsat
     refine ⟨denv, (hiff denv).1 hsat, ?_⟩
     rw [hside denv (hdomOut denv hsat)]
-    exact BusState.equiv_refl _
   · -- invariant preservation
     intro hgi denv hsat bi hbi
     obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.1 hbi
@@ -299,7 +299,6 @@ theorem DenseConstraintSystem.boxRewrite_denseCorrect [Fact p.Prime]
     have hdom := hdomIn denv hsat
     refine ⟨(hiff denv).2 hsat, (hadmEq denv hdom).2 hadm, ?_⟩
     rw [hside denv hdom]
-    exact BusState.equiv_refl _
 
 /-! ## The dense box-rewrite pass -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ByteCheckPack.lean
@@ -360,7 +360,8 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
     simp only [List.filter_append, List.filter_cons, hst1, hst2, hstC, Bool.false_eq_true, if_false]
   have hside : ∀ denv, d.sideEffects bs denv = out.sideEffects bs denv := by
     intro denv
-    simp only [DenseConstraintSystem.sideEffects, hfilt]
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
+    simp only [hfilt]
   have hstE1 : ∀ denv, bs.isStateful (denseBIEval D₁ denv).busId = false := fun _ => hst1
   have hstE2 : ∀ denv, bs.isStateful (denseBIEval D₂ denv).busId = false := fun _ => hst2
   have hstEC : ∀ denv, bs.isStateful (denseBIEval C denv).busId = false := fun _ => hstC
@@ -398,11 +399,11 @@ theorem denseMergeStateless2_correct (isInput : VarId → Bool) (d : DenseConstr
       · exact Or.inr ⟨bi, hmem bi (Or.inr (Or.inr h)), hibi⟩
   refine DensePassCorrect.ofEnvEq
     (fun denv hsat => ⟨denv, (hsatiff denv).mpr hsat,
-      by rw [← hside denv]; exact BusState.equiv_refl _⟩)
+      by rw [← hside denv]⟩)
     (fun hgi denv hsat bi hbi => ?_)
     hsub
     (fun denv hadmE hsat => ⟨(hsatiff denv).mp hsat, (hadm denv).mp hadmE,
-      by rw [hside denv]; exact BusState.equiv_refl _⟩)
+      by rw [hside denv]⟩)
   -- invariant preservation: `bi` is in `pre`/`mid`/`post` (defer to `d`) or is `C` (`hbrk`).
   rw [houtb] at hbi
   simp only [List.mem_append, List.mem_cons] at hbi

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CarryBranch.lean
@@ -166,7 +166,7 @@ theorem denseCarryBranchF_correct (pw : PrimeWitness p) (reg : VarRegistry) (bs 
     · -- soundness: the same assignment satisfies the input
       intro denv hsatout
       have hB := hBof denv hsatout.2
-      exact ⟨denv, (hsat_iff denv hB).mpr hsatout, BusState.equiv_refl _⟩
+      exact ⟨denv, (hsat_iff denv hB).mpr hsatout, rfl⟩
     · -- invariant preservation (bus interactions are untouched)
       intro hgi denv hsatout
       have hB := hBof denv hsatout.2
@@ -188,7 +188,7 @@ theorem denseCarryBranchF_correct (pw : PrimeWitness p) (reg : VarRegistry) (bs 
     · -- completeness: same assignment, same side effects, `admissible` untouched
       intro denv hadm hsat
       have hB := hBof denv hsat.2
-      exact ⟨(hsat_iff denv hB).mp hsat, hadm, BusState.equiv_refl _⟩
+      exact ⟨(hsat_iff denv hB).mp hsat, hadm, rfl⟩
   · rw [show denseCarryBranchF pw bs facts d = d from by unfold denseCarryBranchF; rw [if_neg hpB]]
     exact DensePassCorrect.refl reg.isInput d bs
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Dedup.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Dedup.lean
@@ -65,7 +65,8 @@ theorem DenseConstraintSystem.dedup_denseCorrect {isInput : VarId → Bool}
   -- Stateful side effects are unchanged (the stateful sublist is untouched).
   have hside : ∀ denv, (d.dedup bs).sideEffects bs denv = d.sideEffects bs denv := by
     intro denv
-    simp only [DenseConstraintSystem.sideEffects, DenseConstraintSystem.dedup]
+    simp only [DenseConstraintSystem.dedup]
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
     rw [denseDedupStateless_statefulFilter bs [] d.busInteractions]
   -- Admissibility is unchanged (the evaluated active∧stateful message list is untouched).
   have hadm : ∀ denv, (d.dedup bs).admissible bs denv ↔ d.admissible bs denv := by
@@ -84,7 +85,7 @@ theorem DenseConstraintSystem.dedup_denseCorrect {isInput : VarId → Bool}
   refine DensePassCorrect.ofEnvEq ?_ ?_ hsub ?_
   · -- soundness (`out.implies d`): same env, side effects equal
     intro denv hsat
-    exact ⟨denv, (hiff denv).1 hsat, by rw [hside]; exact BusState.equiv_refl _⟩
+    exact ⟨denv, (hiff denv).1 hsat, by rw [hside]⟩
   · -- invariant preservation: kept interactions are a subset of the originals
     intro hgi denv hsat bi hbi
     refine hgi denv ((hiff denv).1 hsat) bi ?_
@@ -92,7 +93,7 @@ theorem DenseConstraintSystem.dedup_denseCorrect {isInput : VarId → Bool}
     exact denseDedupStateless_subset bs [] d.busInteractions bi hbi
   · -- completeness (same env; admissibility/side effects unchanged)
     intro denv hadm' hsat
-    exact ⟨(hiff denv).2 hsat, (hadm denv).2 hadm', by rw [hside]; exact BusState.equiv_refl _⟩
+    exact ⟨(hiff denv).2 hsat, (hadm denv).2 hadm', by rw [hside]⟩
 
 /-- The dense duplicate-removal pass (runs the hash-bucketed `dedupN`). -/
 def denseDedupPass : DenseVerifiedPassW p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
@@ -167,10 +167,11 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
     have hse : ({ algebraicConstraints := d.algebraicConstraints.filter keepCon,
                   busInteractions := d.busInteractions.filter keepBi } :
                   DenseConstraintSystem p).sideEffects bs env = d.sideEffects bs (m env) :=
-      denseSideEffects_drop_eq bs keepBi env (m env) d.busInteractions
-        (fun bi hbi hkf => hBstateless bi hbi hkf)
-        (fun bi hbi hstate => hmeB env bi (hBkeep bi hbi (hstKeep bi hbi hstate)))
-    rw [hse]; exact BusState.equiv_refl _
+      funext (fun message => congrArg (multiplicitySum message)
+        (denseSideEffects_drop_eq bs keepBi env (m env) d.busInteractions
+          (fun bi hbi hkf => hBstateless bi hbi hkf)
+          (fun bi hbi hstate => hmeB env bi (hBkeep bi hbi (hstKeep bi hbi hstate)))))
+    rw [hse]
   · -- invariant preservation
     intro hgi env hsat bi hbi
     show (denseBIEval bi env).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi env)
@@ -202,9 +203,10 @@ theorem DensePassCorrect.denseDropComponent (d : DenseConstraintSystem p) (bs : 
       have hse : ({ algebraicConstraints := d.algebraicConstraints.filter keepCon,
                     busInteractions := d.busInteractions.filter keepBi } :
                     DenseConstraintSystem p).sideEffects bs env = d.sideEffects bs env :=
-        denseSideEffects_drop_eq bs keepBi env env d.busInteractions
-          (fun bi hbi hkf => hBstateless bi hbi hkf) (fun _ _ _ => rfl)
-      rw [hse]; exact BusState.equiv_refl _
+        funext (fun message => congrArg (multiplicitySum message)
+          (denseSideEffects_drop_eq bs keepBi env env d.busInteractions
+            (fun bi hbi hkf => hBstateless bi hbi hkf) (fun _ _ _ => rfl)))
+      rw [hse]
 
 /-! ## The guarded drop -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -82,6 +82,7 @@ theorem DenseConstraintSystem.sideEffects_substF (d : DenseConstraintSystem p)
     (df : VarId → Option (DenseExpr p)) (bs : BusSemantics p) (denv : VarId → ZMod p) :
     (d.substF df).sideEffects bs denv = d.sideEffects bs (denseEnvF df denv) := by
   unfold DenseConstraintSystem.sideEffects DenseConstraintSystem.substF
+  refine funext (fun message => congrArg (multiplicitySum message) ?_)
   rw [show (fun bi : BusInteraction (DenseExpr p) => bs.isStateful bi.busId) =
         (fun bi => bs.isStateful bi.busId) from rfl]
   rw [filter_map_busId_comm d.busInteractions (fun bi => denseBIsubstF bi df) bs (fun _ => rfl),
@@ -130,7 +131,6 @@ theorem DenseConstraintSystem.substF_denseCorrect (d : DenseConstraintSystem p)
     intro denv hsat
     refine ⟨denseEnvF df denv, (d.satisfies_substF df bs denv).1 hsat, ?_⟩
     rw [d.sideEffects_substF df bs denv]
-    exact BusState.equiv_refl _
   · -- invariant preservation
     intro hinv denv hsat bi hbi
     have hsatd : d.satisfies bs (denseEnvF df denv) := (d.satisfies_substF df bs denv).1 hsat
@@ -149,7 +149,7 @@ theorem DenseConstraintSystem.substF_denseCorrect (d : DenseConstraintSystem p)
     refine ⟨denv, ?_, ?_, ?_, fun _ _ => rfl, ?_⟩
     · rw [d.satisfies_substF df bs denv, henv]; exact hsat
     · rw [d.admissible_substF df bs denv, henv]; exact hadm
-    · rw [d.sideEffects_substF df bs denv, henv]; exact BusState.equiv_refl _
+    · rw [d.sideEffects_substF df bs denv, henv]
     · -- reconstruction: no derivations, and out.occ ⊆ d.occ, denv' = denv
       intro inputVarIds _
       unfold DenseOutReconstructs
@@ -2027,11 +2027,11 @@ theorem denseCollectForcedV_entailed (bs : BusSemantics p) (facts : BusFacts p b
 theorem DensePassCorrect_refl (isInput : VarId → Bool) (d : DenseConstraintSystem p)
     (bs : BusSemantics p) : DensePassCorrect isInput d d [] bs := by
   refine ⟨?_, ?_, ?_, ?_⟩
-  · intro denv hsat; exact ⟨denv, hsat, BusState.equiv_refl _⟩
+  · intro denv hsat; exact ⟨denv, hsat, rfl⟩
   · intro hinv; exact hinv
   · intro i hi _; exact hi
   · intro denv hadm hsat
-    refine ⟨denv, hsat, hadm, BusState.equiv_refl _, fun _ _ => rfl, ?_⟩
+    refine ⟨denv, hsat, hadm, rfl, fun _ _ => rfl, ?_⟩
     intro inputVarIds _
     unfold DenseOutReconstructs
     intro i hi _

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DropPasses.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DropPasses.lean
@@ -50,11 +50,11 @@ theorem DensePassCorrect.denseFilterConstraintsEntailed (d : DenseConstraintSyst
     fun _ => rfl
   refine DensePassCorrect.ofEnvEq ?_ ?_ (d.filterConstraints_occ_subset keep) ?_
   · intro denv hsat
-    exact ⟨denv, (hiff denv).1 hsat, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨denv, (hiff denv).1 hsat, by rw [hside denv]⟩
   · intro hinv denv hsat bi hbi
     exact hinv denv ((hiff denv).1 hsat) bi hbi
   · intro denv hadmd hsat
-    exact ⟨(hiff denv).2 hsat, hadmd, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨(hiff denv).2 hsat, hadmd, by rw [hside denv]⟩
 
 /-- The const-zero test is sound (only `const 0` passes it), so a passing dense expression
     evaluates to `0` under every assignment. -/
@@ -80,7 +80,7 @@ def denseTrivialConstraintDropPass : DenseVerifiedPassW p :=
 /-! ## Zero-multiplicity bus removal -/
 
 /-- Dropping bus interactions whose evaluated multiplicity is `0` leaves net multiplicity unchanged
-    (each contributes `0`), so the two bus states are `≈`-equal. -/
+    (each contributes `0`), so the two bus states are `=`-equal. -/
 theorem denseMultiplicitySum_filterBus (bs : BusSemantics p) (denv : VarId → ZMod p)
     (keep : BusInteraction (DenseExpr p) → Bool) (message : BusMessage p)
     (bis : List (BusInteraction (DenseExpr p)))
@@ -172,14 +172,15 @@ theorem DensePassCorrect.denseFilterBusZeroMult (d : DenseConstraintSystem p) (b
       · intro hne; exact absurd (h bi hbimem (by simpa using hk) denv) hne
     · rintro ⟨hc, hb⟩
       exact ⟨hc, fun bi hbimem => hb bi (List.mem_filter.1 hbimem).1⟩
-  have hside : ∀ denv, d.sideEffects bs denv ≈ (d.filterBus keep).sideEffects bs denv := by
-    intro denv message
+  have hside : ∀ denv, d.sideEffects bs denv = (d.filterBus keep).sideEffects bs denv := by
+    intro denv
+    refine funext (fun message => ?_)
     simp only [DenseConstraintSystem.sideEffects, DenseConstraintSystem.filterBus]
     exact denseMultiplicitySum_filterBus bs denv keep message d.busInteractions
       (fun bi hbi hkf => h bi hbi hkf denv)
   refine DensePassCorrect.ofEnvEq ?_ ?_ (d.filterBus_occ_subset keep) ?_
   · intro denv hsat
-    exact ⟨denv, (hiff denv).1 hsat, BusState.equiv_symm (hside denv)⟩
+    exact ⟨denv, (hiff denv).1 hsat, (hside denv).symm⟩
   · intro hinv denv hsat bi hbi
     have hbimem : bi ∈ d.busInteractions :=
       List.mem_of_mem_filter (show bi ∈ d.busInteractions.filter keep from hbi)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
@@ -46,7 +46,7 @@ theorem DensePassCorrect.denseAddConstraints {isInput : VarId → Bool} (d : Den
   refine ⟨?_, ?_, ?_, ?_⟩
   · -- soundness
     intro denv hsat
-    exact ⟨denv, hfwd denv hsat, BusState.equiv_refl _⟩
+    exact ⟨denv, hfwd denv hsat, rfl⟩
   · -- invariant preservation
     intro hgi denv hsat bi hbi
     exact hgi denv (hfwd denv hsat) bi hbi
@@ -59,7 +59,7 @@ theorem DensePassCorrect.denseAddConstraints {isInput : VarId → Bool} (d : Den
       rcases List.mem_append.1 hcm with h | h
       · exact hsat.1 c h
       · exact H denv hadm hsat c h
-    refine ⟨denv, hout_sat, hadm, BusState.equiv_refl _, fun _ _ => rfl, ?_⟩
+    refine ⟨denv, hout_sat, hadm, rfl, fun _ _ => rfl, ?_⟩
     intro inputVarIds _ i hi _
     show i ∈ d.occ ∧ denv i = denv i
     exact ⟨hoccsub i hi, rfl⟩
@@ -121,7 +121,8 @@ theorem DensePassCorrect.denseFilterBusEntailed (d : DenseConstraintSystem p) (b
               List.filter_cons_of_neg (by simp [hst]), hrest]
   have hside : ∀ denv, (d.filterBus keep).sideEffects bs denv = d.sideEffects bs denv := by
     intro denv
-    simp only [DenseConstraintSystem.sideEffects, DenseConstraintSystem.filterBus]
+    simp only [DenseConstraintSystem.filterBus]
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
     rw [hfilter d.busInteractions hstateless]
   have hadmfilter : ∀ (denv : VarId → ZMod p) (bis : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ bis, keep bi = false → bs.isStateful bi.busId = false) →
@@ -154,13 +155,13 @@ theorem DensePassCorrect.denseFilterBusEntailed (d : DenseConstraintSystem p) (b
     rw [hadmfilter denv d.busInteractions hstateless]
   refine DensePassCorrect.ofEnvEq ?_ ?_ (d.filterBus_occ_subset keep) ?_
   · intro denv hsat
-    exact ⟨denv, (hiff denv).1 hsat, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨denv, (hiff denv).1 hsat, by rw [hside denv]⟩
   · intro hinv denv hsat bi hbi
     have hbimem : bi ∈ d.busInteractions :=
       List.mem_of_mem_filter (show bi ∈ d.busInteractions.filter keep from hbi)
     exact hinv denv ((hiff denv).1 hsat) bi hbimem
   · intro denv hadmd hsat
-    exact ⟨(hiff denv).2 hsat, (hadm denv).2 hadmd, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨(hiff denv).2 hsat, (hadm denv).2 hadmd, by rw [hside denv]⟩
 
 /-! ## The append-only pass builder -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
@@ -119,7 +119,7 @@ theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
   refine DensePassCorrect.ofEnvEq ?_ ?_ ?_ ?_
   ·
     intro denv hsat
-    exact ⟨denv, (hiff denv).1 hsat, BusState.equiv_refl _⟩
+    exact ⟨denv, (hiff denv).1 hsat, rfl⟩
   ·
     intro hgi denv hsat bi hbi
     exact hgi denv ((hiff denv).1 hsat) bi hbi
@@ -135,7 +135,7 @@ theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
     · exact DenseConstraintSystem.mem_occ_of_bi hbi hib
   ·
     intro denv hadm hsat
-    exact ⟨(hiff denv).2 hsat, hadm, BusState.equiv_refl _⟩
+    exact ⟨(hiff denv).2 hsat, hadm, rfl⟩
 
 /-- Coverage is preserved: replaced constraints are `const 0` (no variables) or original (covered);
     bus interactions unchanged. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/HintCollapse.lean
@@ -557,10 +557,11 @@ theorem dense_collapse_correct [Fact p.Prime] (isInput : VarId → Bool)
     refine ⟨reasg denv (denv invId), hcssat denv hsat, ?_⟩
     have hse : out.sideEffects bs denv = d.sideEffects bs (reasg denv (denv invId)) := by
       unfold DenseConstraintSystem.sideEffects
+      refine funext (fun message => congrArg (multiplicitySum message) ?_)
       rw [hob]
       refine List.map_congr_left (fun bi hbi => ?_)
       rw [hbe denv bi (List.mem_of_mem_filter hbi)]
-    rw [hse]; exact BusState.equiv_refl _
+    rw [hse]
   have hout_occ : ∀ i ∈ out.occ, i = invId ∨ i ∈ d.occ := by
     intro i hi
     rw [hcMemOcc] at hi
@@ -634,10 +635,11 @@ theorem dense_collapse_correct [Fact p.Prime] (isInput : VarId → Bool)
     · -- side effects equivalent
       have hse : d.sideEffects bs denv = out.sideEffects bs envC := by
         unfold DenseConstraintSystem.sideEffects
+        refine funext (fun message => congrArg (multiplicitySum message) ?_)
         rw [hob]
         refine List.map_congr_left (fun bi hbi => ?_)
         rw [hbeC bi (List.mem_of_mem_filter hbi)]
-      rw [hse]; exact BusState.equiv_refl _
+      rw [hse]
     · -- input columns preserved
       intro i hisT
       have hne : i ≠ invId := by intro heq; rw [heq, hinv_id] at hisT; exact absurd hisT (by simp)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/MonicScale.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/MonicScale.lean
@@ -138,11 +138,11 @@ theorem denseMonicScaleF_correct (bs : BusSemantics p) (isInput : VarId → Bool
     · exact Or.inr hbus
   refine DensePassCorrect.ofEnvEq ?_ ?_ hsub ?_
   · intro denv hsatout
-    exact ⟨denv, (hsatiff denv).1 hsatout, BusState.equiv_refl _⟩
+    exact ⟨denv, (hsatiff denv).1 hsatout, rfl⟩
   · intro hinv denv hsatout bi hbi
     exact hinv denv ((hsatiff denv).1 hsatout) bi hbi
   · intro denv hadm hsat
-    exact ⟨(hsatiff denv).2 hsat, hadm, BusState.equiv_refl _⟩
+    exact ⟨(hsatiff denv).2 hsat, hadm, rfl⟩
 
 /-- The dense monic-scaling pass. -/
 def denseMonicScalePass : DenseVerifiedPassW p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -689,6 +689,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
             { bi with multiplicity := grw bi.multiplicity, payload := bi.payload.map grw }) }
         bs denv' = d.sideEffects bs denv := by
     intro denv denv' hB
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
     show ((d.busInteractions.map (fun bi =>
         { bi with multiplicity := grw bi.multiplicity, payload := bi.payload.map grw })).filter
         (fun bi => bs.isStateful bi.busId)).map _ = _
@@ -747,7 +748,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
     intro denv' hsat'
     obtain ⟨denv, hA, hB, hdrop⟩ := hbwd denv' hsat'
     refine ⟨denv, hsatd denv denv' hA hB hdrop hsat', ?_⟩
-    rw [hside denv denv' hB]; exact BusState.equiv_refl _
+    rw [hside denv denv' hB]
   · -- Invariant preservation.
     intro hinv denv' hsat' bi' hbi'
     obtain ⟨denv, hA, hB, hdrop⟩ := hbwd denv' hsat'
@@ -771,7 +772,7 @@ theorem DenseConstraintSystem.reencode_correct_D (d out : DenseConstraintSystem 
         bs.accepts (denseBIEval { bi0 with multiplicity := grw bi0.multiplicity, payload := bi0.payload.map grw } denv')
       rw [hB bi0 hbi0]
       exact hsat.2 bi0 hbi0
-    · rw [hside denv denv' hB]; exact BusState.equiv_refl _
+    · rw [hside denv denv' hB]
 
 /-- The method list built for the fresh bits supplies `g w` for a bit `w`, nothing otherwise. -/
 theorem DenseDerivations.methodFor_map (bits : List VarId) (g : VarId → DenseComputationMethod p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SeqzCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SeqzCollapse.lean
@@ -303,7 +303,8 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
       denseSeqzEM1, denseSeqzE0, DenseExpr.eval]
   have hside : ∀ (denv : VarId → ZMod p), out.sideEffects bs denv = d.sideEffects bs denv := by
     intro denv
-    simp only [houtdef, denseSeqzCollapsedSystem, DenseConstraintSystem.sideEffects, ← hbusEdef]
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
+    simp only [houtdef, denseSeqzCollapsedSystem, ← hbusEdef]
     rw [filter_filter_drop (fun bi => decide (bi ≠ busE)) (fun bi => bs.isStateful bi.busId)
       d.busInteractions (fun bi _ hkf => by
         have hbe : bi = busE := by simpa using hkf
@@ -404,7 +405,7 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
           rw [hgframeBus bi hbi hbe]
           exact hsatOut.2 bi hbout
     have hseSound : d.sideEffects bs g = d.sideEffects bs env := by
-      simp only [DenseConstraintSystem.sideEffects]
+      refine funext (fun message => congrArg (multiplicitySum message) ?_)
       apply List.map_congr_left
       intro bi hbi
       have hbimem : bi ∈ d.busInteractions := List.mem_of_mem_filter hbi
@@ -450,7 +451,6 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
     obtain ⟨g, hgcs, _, hse⟩ := hReconstruct env hsatOut
     refine ⟨g, hgcs, ?_⟩
     rw [hse, ← hside env]
-    exact BusState.equiv_refl _
   · -- invariant preservation
     intro hdInv env hsatOut bi hbiOut
     show (denseBIEval bi env).multiplicity ≠ 0 → bs.maintainsInvariants (denseBIEval bi env)
@@ -558,9 +558,9 @@ theorem dense_seqzCollapse_correct [Fact p.Prime] (isInput : VarId → Bool)
     · -- side effects match
       have hseC : out.sideEffects bs envC = d.sideEffects bs env := by
         rw [hside envC]
-        simp only [DenseConstraintSystem.sideEffects]
+        refine funext (fun message => congrArg (multiplicitySum message) ?_)
         exact List.map_congr_left (fun bi hbi => by rw [hbeC bi (List.mem_of_mem_filter hbi)])
-      rw [hseC]; exact BusState.equiv_refl _
+      rw [hseC]
     · -- input columns keep their values
       intro i hisT
       exact Function.update_of_ne (fun h => by rw [h, hinv_id] at hisT; exact absurd hisT (by simp))

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/SplitBytePair.lean
@@ -223,7 +223,8 @@ private theorem denseSplitBytePair_correct_aux (isInput : VarId → Bool) (bs : 
       exact ⟨hc, (forall_denseP_flatMap bs facts hp1 d.busInteractions denv).1 hb⟩
   have hside : ∀ denv, d.sideEffects bs denv = out.sideEffects bs denv := by
     intro denv
-    simp only [DenseConstraintSystem.sideEffects, hbus]
+    refine funext (fun message => congrArg (multiplicitySum message) ?_)
+    simp only [hbus]
     rw [filter_stateful_flatMap bs facts d.busInteractions]
   have hadm : ∀ denv, d.admissible bs denv ↔ out.admissible bs denv := by
     intro denv
@@ -242,7 +243,7 @@ private theorem denseSplitBytePair_correct_aux (isInput : VarId → Bool) (bs : 
       exact Or.inr (List.mem_flatMap.2 ⟨orig, horig, denseSplitOne_vars bs facts orig bi hbimem hib⟩)
   refine DensePassCorrect.ofEnvEq ?_ ?_ hsub ?_
   · intro denv hsat
-    exact ⟨denv, (hsatiff denv).2 hsat, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨denv, (hsatiff denv).2 hsat, by rw [hside denv]⟩
   · intro hgi denv hsat bi hbi
     rw [hbus, List.mem_flatMap] at hbi
     obtain ⟨orig, horig, hbimem⟩ := hbi
@@ -252,7 +253,7 @@ private theorem denseSplitBytePair_correct_aux (isInput : VarId → Bool) (bs : 
     · rw [heq]; exact hgi denv ((hsatiff denv).2 hsat) orig horig (heq ▸ hne)
     · exact hbrk
   · intro denv hadmE hsat
-    exact ⟨(hsatiff denv).1 hsat, (hadm denv).1 hadmE, by rw [hside denv]; exact BusState.equiv_refl _⟩
+    exact ⟨(hsatiff denv).1 hsat, (hadm denv).1 hadmE, by rw [hside denv]⟩
 
 /-- Coverage is preserved by the split. -/
 theorem denseSplitBytePairF_covered (reg : VarRegistry) (bs : BusSemantics p) (facts : BusFacts p bs)

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -153,21 +153,11 @@ structure BusSemantics (p : ℕ) where
 /-- A concrete bus interaction message: which bus, and the tuple sent. -/
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
 
-/-- The effect on the stateful buses: the messages sent, each with a
-    multiplicity. -/
-abbrev BusState (p : ℕ) := List (BusMessage p × ZMod p)
-
-/-- The net multiplicity with which `message` is sent in `state`. -/
-def multiplicitySum (message : BusMessage p) (state : BusState p) : ZMod p :=
-  match state with
-  | [] => 0
-  | (msg, mult) :: tl =>
-      (if msg = message then mult else 0) + multiplicitySum message tl
-
-/-- Two bus states are equal when every message is sent with the same net
-    multiplicity. -/
-instance : HasEquiv (BusState p) :=
-  ⟨fun s t => ∀ message, multiplicitySum message s = multiplicitySum message t⟩
+/-- The effect on the stateful buses: the *net* multiplicity each message is
+    sent with. Two circuit instances have the same effect on the buses exactly
+    when these functions are equal, so side-effect equivalence below is plain
+    equality. -/
+abbrev BusState (p : ℕ) := BusMessage p → ZMod p
 -- ANCHOR_END: busState
 
 --------- Circuit ---------
@@ -188,14 +178,15 @@ def Circuit.vars (circuit : Circuit p) : List Variable :=
       (fun bi => bi.multiplicity.vars ++ bi.payload.flatMap Expression.vars)
 
 -- ANCHOR: sideEffects
-/-- The side effects of a circuit under a given assignment and bus semantics.
-    The side effects are the tuples sent to the *stateful* buses. -/
+/-- The side effects of a circuit under a given assignment and bus semantics:
+    the net multiplicity with which each tuple is sent to a *stateful* bus. -/
 def Circuit.sideEffects (circuit : Circuit p) (busSemantics : BusSemantics p)
     (assignment : Variable → ZMod p) : BusState p :=
-  circuit.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
-    |>.map (fun bi =>
-      let m := bi.eval assignment
-      ((m.busId, m.payload), m.multiplicity))
+  fun message =>
+    ((circuit.busInteractions.map (fun bi => bi.eval assignment)).filter
+      (fun m => busSemantics.isStateful m.busId &&
+        decide ((m.busId, m.payload) = message))).map
+      (fun m => m.multiplicity) |>.sum
 -- ANCHOR_END: sideEffects
 
 --------- Derived variables ---------
@@ -288,7 +279,7 @@ def Circuit.isSoundReplacementOf (optimizedCircuit originalCircuit : Circuit p)
     (busSemantics : BusSemantics p) : Prop :=
   (∀ assignment, optimizedCircuit.satisfies busSemantics assignment →
     ∃ assignment', originalCircuit.satisfies busSemantics assignment' ∧
-      optimizedCircuit.sideEffects busSemantics assignment ≈
+      optimizedCircuit.sideEffects busSemantics assignment =
         originalCircuit.sideEffects busSemantics assignment') ∧
   (originalCircuit.guaranteesInvariants busSemantics →
     optimizedCircuit.guaranteesInvariants busSemantics)
@@ -315,7 +306,7 @@ def Circuit.isCompleteReplacementOf
     let assignment' := Derivations.witgen ds assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
-      originalCircuit.sideEffects busSemantics assignment ≈
+      originalCircuit.sideEffects busSemantics assignment =
         optimizedCircuit.sideEffects busSemantics assignment'
 -- ANCHOR_END: isCompleteReplacementOf
 

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -154,9 +154,7 @@ structure BusSemantics (p : ℕ) where
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
 
 /-- The effect on the stateful buses: the *net* multiplicity each message is
-    sent with. Two circuit instances have the same effect on the buses exactly
-    when these functions are equal, so side-effect equivalence below is plain
-    equality. -/
+    sent with. -/
 abbrev BusState (p : ℕ) := BusMessage p → ZMod p
 -- ANCHOR_END: busState
 
@@ -273,7 +271,7 @@ def Circuit.guaranteesInvariants (circuit : Circuit p)
 /-- Whether an optimized circuit is a sound replacement for an original
     circuit. Informally, for any satisfying assignment of the optimized
     circuit, there exists a corresponding satisfying assignment of the original
-    circuit *with equivalent side effects*. Also, the optimized circuit must
+    circuit *with equal side effects*. Also, the optimized circuit must
     maintain all invariants guaranteed by the original circuit. -/
 def Circuit.isSoundReplacementOf (optimizedCircuit originalCircuit : Circuit p)
     (busSemantics : BusSemantics p) : Prop :=
@@ -298,7 +296,7 @@ def Circuit.isCompleteReplacementOf
   -- variables, and the return derivations.
   ds.cover originalCircuit.vars optimizedCircuit.vars ∧
   -- For any admissible satisfying assignment of the original circuit, the
-  -- optimized circuit is also satisfied and admissible, with equivalent side
+  -- optimized circuit is also satisfied and admissible, with equal side
   -- effects, under the assignment produced by witness generation.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -86,26 +86,16 @@ A circuit (defined below) contains a list of _symbolic bus interactions_ (i.e., 
 
 ## Bus state and equivalent states
 
-The {deftech}_bus state_ of a circuit instance is the _net_ effect it has on the buses. That is, two bus states are considered equivalent if all messages are sent with the same net multiplicity:
+The {deftech}_bus state_ of a circuit instance is the _net_ effect it has on the buses: the net multiplicity each message is sent with. Two circuit instances therefore have the same effect on the buses exactly when their bus states are _equal_ — no separate equivalence relation is needed:
 ```anchor busState
 /-- A concrete bus interaction message: which bus, and the tuple sent. -/
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
 
-/-- The effect on the stateful buses: the messages sent, each with a
-    multiplicity. -/
-abbrev BusState (p : ℕ) := List (BusMessage p × ZMod p)
-
-/-- The net multiplicity with which `message` is sent in `state`. -/
-def multiplicitySum (message : BusMessage p) (state : BusState p) : ZMod p :=
-  match state with
-  | [] => 0
-  | (msg, mult) :: tl =>
-      (if msg = message then mult else 0) + multiplicitySum message tl
-
-/-- Two bus states are equal when every message is sent with the same net
-    multiplicity. -/
-instance : HasEquiv (BusState p) :=
-  ⟨fun s t => ∀ message, multiplicitySum message s = multiplicitySum message t⟩
+/-- The effect on the stateful buses: the *net* multiplicity each message is
+    sent with. Two circuit instances have the same effect on the buses exactly
+    when these functions are equal, so side-effect equivalence below is plain
+    equality. -/
+abbrev BusState (p : ℕ) := BusMessage p → ZMod p
 ```
 
 Buses must _balance globally_: summed over all circuit instances in the entire zkVM execution, the net multiplicity of each message must be zero. This is enforced by the zkVM's proving backend, typically employing a protocol such as logup {citeNum logup}[] {citeNum logupGKR}[].
@@ -160,14 +150,15 @@ Bus semantics capture the _zkVM-specific_ semantics of the buses.
 First, we define the side effects of a circuit under an assignment as the net effect it has on the stateful buses.
 
 ```anchor sideEffects
-/-- The side effects of a circuit under a given assignment and bus semantics.
-    The side effects are the tuples sent to the *stateful* buses. -/
+/-- The side effects of a circuit under a given assignment and bus semantics:
+    the net multiplicity with which each tuple is sent to a *stateful* bus. -/
 def Circuit.sideEffects (circuit : Circuit p) (busSemantics : BusSemantics p)
     (assignment : Variable → ZMod p) : BusState p :=
-  circuit.busInteractions.filter (fun bi => busSemantics.isStateful bi.busId)
-    |>.map (fun bi =>
-      let m := bi.eval assignment
-      ((m.busId, m.payload), m.multiplicity))
+  fun message =>
+    ((circuit.busInteractions.map (fun bi => bi.eval assignment)).filter
+      (fun m => busSemantics.isStateful m.busId &&
+        decide ((m.busId, m.payload) = message))).map
+      (fun m => m.multiplicity) |>.sum
 ```
 
 Second, we define that a circuit _guarantees invariants_ if, under any satisfying assignment, every bus interaction maintains the invariants of the bus semantics.
@@ -195,7 +186,7 @@ def Circuit.isSoundReplacementOf (optimizedCircuit originalCircuit : Circuit p)
     (busSemantics : BusSemantics p) : Prop :=
   (∀ assignment, optimizedCircuit.satisfies busSemantics assignment →
     ∃ assignment', originalCircuit.satisfies busSemantics assignment' ∧
-      optimizedCircuit.sideEffects busSemantics assignment ≈
+      optimizedCircuit.sideEffects busSemantics assignment =
         originalCircuit.sideEffects busSemantics assignment') ∧
   (originalCircuit.guaranteesInvariants busSemantics →
     optimizedCircuit.guaranteesInvariants busSemantics)
@@ -293,7 +284,7 @@ def Circuit.isCompleteReplacementOf
     let assignment' := Derivations.witgen ds assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
-      originalCircuit.sideEffects busSemantics assignment ≈
+      originalCircuit.sideEffects busSemantics assignment =
         optimizedCircuit.sideEffects busSemantics assignment'
 ```
 

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -84,7 +84,7 @@ A {deftech}_bus interaction_ sends a _payload_ tuple to a bus, weighted by a _mu
 
 A circuit (defined below) contains a list of _symbolic bus interactions_ (i.e., `BusInteraction Expression`). For a concrete run of the zkVM, the circuit might be instantiated several times with different variable assignments. Evaluating the symbolic bus interactions under an assignment yields a list of _bus messages_ (i.e., `BusInteraction (ZMod p)`).
 
-## Bus state and equivalent states
+## Bus state
 
 The {deftech}_bus state_ of a circuit instance is the _net_ effect it has on the buses: the net multiplicity each message is sent with. Two circuit instances therefore have the same effect on the buses exactly when their bus states are _equal_ — no separate equivalence relation is needed:
 ```anchor busState
@@ -92,9 +92,7 @@ The {deftech}_bus state_ of a circuit instance is the _net_ effect it has on the
 abbrev BusMessage (p : ℕ) := Nat × List (ZMod p)
 
 /-- The effect on the stateful buses: the *net* multiplicity each message is
-    sent with. Two circuit instances have the same effect on the buses exactly
-    when these functions are equal, so side-effect equivalence below is plain
-    equality. -/
+    sent with. -/
 abbrev BusState (p : ℕ) := BusMessage p → ZMod p
 ```
 
@@ -180,7 +178,7 @@ Finally, we formalize what it means for an optimized circuit to be a sound repla
 /-- Whether an optimized circuit is a sound replacement for an original
     circuit. Informally, for any satisfying assignment of the optimized
     circuit, there exists a corresponding satisfying assignment of the original
-    circuit *with equivalent side effects*. Also, the optimized circuit must
+    circuit *with equal side effects*. Also, the optimized circuit must
     maintain all invariants guaranteed by the original circuit. -/
 def Circuit.isSoundReplacementOf (optimizedCircuit originalCircuit : Circuit p)
     (busSemantics : BusSemantics p) : Prop :=
@@ -261,7 +259,7 @@ def Derivations.witgen (ds : Derivations p)
 
 ## The full completeness property
 
-Putting the pieces together, we define what it means for an optimized circuit to be a _complete_ replacement for an original circuit. Structurally, the returned derivations must contain no unused entries and must cover every output variable from the input variables. Semantically, every admissible satisfying input assignment must produce a satisfying and admissible output assignment with equivalent side effects.
+Putting the pieces together, we define what it means for an optimized circuit to be a _complete_ replacement for an original circuit. Structurally, the returned derivations must contain no unused entries and must cover every output variable from the input variables. Semantically, every admissible satisfying input assignment must produce a satisfying and admissible output assignment with equal side effects.
 
 ```anchor isCompleteReplacementOf
 /-- Whether an optimized circuit is a complete replacement for an original one. -/
@@ -276,7 +274,7 @@ def Circuit.isCompleteReplacementOf
   -- variables, and the return derivations.
   ds.cover originalCircuit.vars optimizedCircuit.vars ∧
   -- For any admissible satisfying assignment of the original circuit, the
-  -- optimized circuit is also satisfied and admissible, with equivalent side
+  -- optimized circuit is also satisfied and admissible, with equal side
   -- effects, under the assignment produced by witness generation.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →


### PR DESCRIPTION
Last of four PRs from a readability review of the bus-semantics spec. The preceding
#241, #242 and #243 are merged. This PR is rebased directly onto `main`, so its
23-file diff contains only the `BusState` change described below.

## The problem

`BusState` was `List (BusMessage p × ZMod p)` — a list of per-interaction
contributions — which needed two further definitions before it was usable:

```lean
abbrev BusState (p : ℕ) := List (BusMessage p × ZMod p)

def multiplicitySum (message : BusMessage p) (state : BusState p) : ZMod p := …

instance : HasEquiv (BusState p) :=
  ⟨fun s t => ∀ message, multiplicitySum message s = multiplicitySum message t⟩
```

Three definitions for one idea. And the `≈` notation *looks* like an equivalence
relation while nothing proves it is one — an auditor has to check reflexivity,
symmetry and transitivity by hand to trust the soundness statement.

## What changed

`BusState` is the net multiplicity itself:

```lean
abbrev BusState (p : ℕ) := BusMessage p → ZMod p
```

`multiplicitySum` and the `HasEquiv` instance leave the audited surface entirely,
and "equivalent side effects" in `isSoundReplacementOf` / `isCompleteReplacementOf`
becomes plain `=`. Reflexivity, symmetry and transitivity are now facts about `Eq`,
so there is nothing left to check.

## Implementation

- `BusState.equiv_refl` / `_symm` / `_trans` are deleted; their 50 call sites use
  `rfl` / `.symm` / `.trans`.
- The pass proofs reason by induction over the contribution list, so that list view
  moves to `Basic.lean` as `multiplicitySum` / `Circuit.contributions`, bridged to
  the spec by `Circuit.sideEffects_eq`. Proofs that manipulated the list now do so
  under `congrArg (multiplicitySum message)`.
- `denseToBusState` returns the contribution list, so its append / cons / stateless
  lemmas hold verbatim; only `denseSideEffects_dropPair_equiv` changes, to the
  net-multiplicity statement it always actually proved.

## What deliberately did not change

`isStateful` stays `Bool`. It is what `sideEffects` filters on, and making it a
`Prop` forces either a `DecidablePred` side condition or a `noncomputable` marker
into the audited spec and everything downstream of it. That is a readability loss,
so it fails the standard this series is applying — the same reason `x0ReturnsZero`
kept its slot indices in #241.

## Effectiveness

Unchanged — this only changes how the side-effect *state* is represented, with no
runtime path touched. Local sweep of the top 8 `openvm-eth` cases gives exactly the
parent commit's numbers: variables 4.629x, bus interactions 3.705x, constraints
11.672x (vs powdr 3.974x / 3.567x / 4.914x).

## Verification

- `lake build` — clean, no errors, **no warnings**
- `lake build docs` — clean; the `busState` and `sideEffects` anchors, the two
  replacement-property anchors, and the surrounding prose are updated in lockstep
- `Scripts/check-proof-integrity.sh` — passes; correctness theorems still rest only
  on `propext`, `Classical.choice`, `Quot.sound`, and no theorem is orphaned