### PR TITLE
Improve PDF documentation layout

### DIFF
--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -31,6 +31,8 @@ set_option verso.docstring.allowMissing true
 shortTitle := "apc-optimizer"
 %%%
 
+# Introduction
+
 This document describes `apc-optimizer`{citeNum powdr_apc_compiler}[], a formally verified zkVM circuit optimizer. `apc-optimizer` is a core component in the powdr autoprecompiles{citeNum powdr_autoprecompiles}[] pipeline.
 
 # Background: zkVMs and autoprecompiles

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -46,11 +46,18 @@ build_pdf() {
   mono+='ItalicFont=DejaVuSansMono-Oblique.ttf,BoldItalicFont=DejaVuSansMono-BoldOblique.ttf]'
   MONO="$mono" perl -0pi -e 's{\\setmonofont\{DejaVu Sans Mono\}}{$ENV{MONO}}e' "$TEX/main.tex"
 
-  # Make the short document read as a continuous whole instead of many half-empty pages: chapters
-  # run on within the text rather than each starting a new page (memoir's default), and
-  # `\cleardoublepage` becomes a plain `\clearpage` so the title/ToC/mainmatter breaks don't insert
-  # blank verso pages.
-  perl -0pi -e 's{\\documentclass\{memoir\}}{"\\documentclass{memoir}\n\\renewcommand*{\\clearforchapter}{}\n\\let\\cleardoublepage\\clearpage"}e' "$TEX/main.tex"
+  # Use a screen-friendly one-sided layout with a larger title and a compact text block. Chapters
+  # run on within the text rather than each starting a new page (memoir's default).
+  perl -0pi -e 's{\\documentclass\{memoir\}}{
+    "\\documentclass[oneside]{memoir}\n" .
+    "\\setlrmarginsandblock{28mm}{28mm}{*}\n" .
+    "\\setulmarginsandblock{24mm}{24mm}{*}\n" .
+    "\\checkandfixthelayout\n" .
+    "\\pretitle{\\begin{center}\\sffamily\\bfseries\\fontsize{30pt}{36pt}\\selectfont}\n" .
+    "\\posttitle{\\par\\end{center}\\vskip 1em}\n" .
+    "\\renewcommand*{\\clearforchapter}{}\n" .
+    "\\let\\cleardoublepage\\clearpage"
+  }e' "$TEX/main.tex"
 
   # Stamp the title page with the build date and source commit.
   stamp="Built $(date -u '+%Y-%m-%d %H:%M UTC') · commit $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"


### PR DESCRIPTION
## Summary

- Add an Introduction heading to the documentation.
- Configure the PDF for a screen-friendly one-sided layout with balanced margins.
- Increase the title size and reduce unnecessary page breaks.

## Testing

- Not run (not requested).