### PR TITLE
perf(domainBatch): resolve the bus classification once per interaction (CPU 0.55x, wall flat — negative result)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -364,13 +364,43 @@ structure DenseConstraintPlan (p : ℕ) where
   vars : List VarId
   active : Bool
 
-/-- A bus interaction and the target-planning data reused by every enumeration. -/
+/-- Direct relation implemented by a compiled byte-bus predicate. -/
+inductive DenseBytePredKind where
+  | xor
+  | pair
+  | or
+  | and
+
+/-- The classification of an interaction that is neither `.always` nor a two-slot range/tuple check:
+    the range-check and byte-relation decodings, and the payload the opaque fallback compiles. -/
+structure DenseBiOtherShape (p : ℕ) where
+  busId : Nat
+  /-- `rangeCheckAt`'s value slot expression and bound (cf. `denseCompileRangeCBiPredV`). -/
+  range : Option (DenseExpr p × Nat)
+  /-- Decoded byte relation: operands, result, bound, relation (cf. `denseCompileByteCBiPredV`). -/
+  byte : Option (DenseExpr p × DenseExpr p × DenseExpr p × Nat × DenseBytePredKind)
+  payload : List (DenseExpr p)
+
+/-- An interaction's compilation plan with every `BusFacts` query already resolved. The two-slot
+    shapes carry no fallback data: a slot that does not compile against the target's keys cannot
+    happen for a gathered item (its variables are all keys), and `denseCompileShapeV` re-derives that
+    arm from `facts` rather than paying for it on every range check. -/
+inductive DenseBiPredShape (p : ℕ) where
+  | always
+  | varRange (x width : DenseExpr p) (constBound : Option Nat)
+  | tupleRange (x y : DenseExpr p) (boundX boundY : Nat)
+  | other (o : DenseBiOtherShape p)
+
+/-- A bus interaction and the target-planning data reused by every enumeration. `predShape` is the
+    keys-free half of the survivor-predicate compilation, so a target only compiles slots (see
+    `denseClassifyBi`); it is meaningful only for `usable` plans, the only ones a gather keeps. -/
 structure DenseBusPlan (p : ℕ) where
   interaction : BusInteraction (DenseExpr p)
   vars : List VarId
   usable : Bool
   informative : Bool
   domainRedundant : Bool
+  predShape : DenseBiPredShape p
 
 /-- Compact anchor buckets used by the read-only per-target gathers. -/
 structure DenseArrayCovIndex where

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -32,13 +32,6 @@ def denseIExprEvalWithV (ops : DenseZModOps p) (pt : List (ZMod p)) :
   | .add a b => ops.add (denseIExprEvalWithV ops pt a) (denseIExprEvalWithV ops pt b)
   | .mul a b => ops.mul (denseIExprEvalWithV ops pt a) (denseIExprEvalWithV ops pt b)
 
-/-- Direct relation implemented by a compiled byte-bus predicate. -/
-inductive DenseBytePredKind where
-  | xor
-  | pair
-  | or
-  | and
-
 def DenseBytePredKind.Holds (kind : DenseBytePredKind) (a b r : ZMod p) : Prop :=
   match kind with
   | .xor => r.val = Nat.xor a.val b.val
@@ -162,6 +155,137 @@ def denseCompileCBiPredsV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : 
     | some pred, some preds => some (pred :: preds)
     | _, _ => none
 
+/-! ### The keys-free half of the compilation
+
+`denseCompileCBiPredV` queries `facts` and re-decodes the payload for every gathered interaction of
+every target, although only the `denseCompileE keys …` of a few slots depends on the target.
+`denseClassifyBi` resolves the target-independent half once per interaction (in `denseBusPlansV`) and
+`denseCompileBiShapeV` finishes it per target; `denseCompileBiShapeV_eq` (`Proofs/DomainBatch.lean`)
+proves the two compose to `denseCompileCBiPredV`, so the compiled predicate — and the scan — is
+unchanged. -/
+
+def denseClassifyRange {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p × Nat) :=
+  match bi.multiplicity.constValue? with
+  | some mult =>
+    if mult = 1 then
+      match facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+      | some (slot, bound) =>
+        match bi.payload[slot]? with
+        | some value => some (value, bound)
+        | none => none
+      | none => none
+    else none
+  | none => none
+
+/-- The byte relation a constant op selects, or `none` if it selects no recognized relation. The
+    arm order is `denseCompileByteCBiPredV`'s (`denseByteKindOf_eq` bridges the two). -/
+def denseByteKindOf (spec : ByteXorSpec p) (opValue : ZMod p) : Option DenseBytePredKind :=
+  if opValue = spec.xorOp then some .xor
+  else if opValue = spec.pairOp then some .pair
+  else
+    match spec.orOp, spec.andOp with
+    | some orOp, _ =>
+      if opValue = orOp then some .or
+      else match spec.andOp with
+        | some andOp => if opValue = andOp then some .and else none
+        | none => none
+    | none, some andOp => if opValue = andOp then some .and else none
+    | none, none => none
+
+def denseClassifyByte {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) :
+    Option (DenseExpr p × DenseExpr p × DenseExpr p × Nat × DenseBytePredKind) :=
+  match facts.byteXorSpec bi.busId with
+  | none => none
+  | some spec =>
+    match spec.decode bi.payload with
+    | none => none
+    | some (op, o1, o2, result) =>
+      match op.constValue? with
+      | none => none
+      | some opValue =>
+        (denseByteKindOf spec opValue).map (fun kind => (o1, o2, result, spec.bound, kind))
+
+def denseClassifyOther {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : DenseBiOtherShape p :=
+  { busId := bi.busId, range := denseClassifyRange facts bi, byte := denseClassifyByte facts bi,
+    payload := bi.payload }
+
+def denseClassifyBi {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : DenseBiPredShape p :=
+  if denseBiAlwaysOk facts bi then .always
+  else
+    match bi.payload with
+    | [x, width] =>
+      if facts.varRangeBus bi.busId then
+        .varRange x width
+          (match width.constValue? with
+           | some widthValue => if widthValue.val ≤ 17 then some (2 ^ widthValue.val) else none
+           | none => none)
+      else
+        match facts.tupleRangeBus bi.busId with
+        | some (boundX, boundY) => .tupleRange x width boundX boundY
+        | none => .other (denseClassifyOther facts bi)
+    | _ => .other (denseClassifyOther facts bi)
+
+/-- Compile a decoded byte relation's three operand slots. -/
+def denseCompileByteShapeV (keys : List VarId) (mult : IExpr p)
+    (t : DenseExpr p × DenseExpr p × DenseExpr p × Nat × DenseBytePredKind) :
+    Option (DenseCBiPred p) :=
+  match denseCompileE keys t.1, denseCompileE keys t.2.1, denseCompileE keys t.2.2.1 with
+  | some io1, some io2, some iresult => some (.byte mult io1 io2 iresult t.2.2.2.1 t.2.2.2.2)
+  | _, _, _ => none
+
+def denseCompileOtherShapeV (keys : List VarId) (mult : IExpr p) (o : DenseBiOtherShape p) :
+    Option (DenseCBiPred p) :=
+  match o.range.bind (fun vb =>
+      (denseCompileE keys vb.1).map (fun iv => .fixedRange mult iv vb.2)) with
+  | some pred => some pred
+  | none =>
+    match o.byte.bind (denseCompileByteShapeV keys mult) with
+    | some pred => some pred
+    | none => (denseCompileEs keys o.payload).map (fun payload =>
+        .fallback ⟨o.busId, mult, payload⟩)
+
+def denseCompileShapeV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : List VarId)
+    (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) :
+    DenseBiPredShape p → Option (DenseCBiPred p)
+  | .always => some .always
+  | .varRange x width constBound =>
+    match denseCompileE keys x, denseCompileE keys width with
+    | some ix, some iwidth =>
+      match constBound with
+      | some bound => some (.varRangeConst mult ix bound)
+      | none => some (.varRange mult ix iwidth)
+    | _, _ => denseCompileOtherCBiPredV facts keys bi mult
+  | .tupleRange x y boundX boundY =>
+    match denseCompileE keys x, denseCompileE keys y with
+    | some ix, some iy => some (.tupleRange mult ix iy boundX boundY)
+    | _, _ => denseCompileOtherCBiPredV facts keys bi mult
+  | .other o => denseCompileOtherShapeV keys mult o
+
+/-- The per-target half: compile the slots a classified interaction needs against `keys`. -/
+def denseCompileBiShapeV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : List VarId)
+    (bi : BusInteraction (DenseExpr p)) (sh : DenseBiPredShape p) : Option (DenseCBiPred p) :=
+  match sh with
+  | .always => some .always
+  | _ =>
+    match denseCompileE keys bi.multiplicity with
+    | none => none
+    | some mult => denseCompileShapeV facts keys bi mult sh
+
+/-- The gathered interactions and their classifications, walked in lockstep. -/
+def denseCompileShapesV {bs : BusSemantics p} (facts : BusFacts p bs) (keys : List VarId) :
+    List (BusInteraction (DenseExpr p)) → List (DenseBiPredShape p) →
+    Option (List (DenseCBiPred p))
+  | [], _ => some []
+  | bi :: rest, sh :: shs =>
+    match denseCompileBiShapeV facts keys bi sh, denseCompileShapesV facts keys rest shs with
+    | some pred, some preds => some (pred :: preds)
+    | _, _ => none
+  | _ :: _, [] => none
+
 def denseCBiPredEvalV (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     {bs : BusSemantics p} (facts : BusFacts p bs) (pt : List (ZMod p)) : DenseCBiPred p → Bool
   | .always => true
@@ -250,9 +374,10 @@ structure DenseSurvV (p : ℕ) where
     items against `keys` once, hoisting ring ops and the zero test, with the uncompiled fallback if
     compilation fails. Boxed in `DenseSurvV` (see there). -/
 def denseCompiledSurvV (bs : BusSemantics p) (facts : BusFacts p bs) (es : List (DenseExpr p))
-    (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) :
+    (bis : List (BusInteraction (DenseExpr p))) (shapes : List (DenseBiPredShape p))
+    (keys : List VarId) :
     DenseSurvV p :=
-  match denseCompileEs keys es, denseCompileCBiPredsV facts keys bis with
+  match denseCompileEs keys es, denseCompileShapesV facts keys bis shapes with
   | some ces, some cbis =>
     let ops : DenseZModOps p := denseZModOps
     let dec : DecidableEq (ZMod p) := inferInstance
@@ -442,6 +567,8 @@ structure DenseBusGatherV (p : ℕ) where
   informative : Bool
   allDomainRedundant : Bool
   interactions : List (BusInteraction (DenseExpr p))
+  /-- The gathered interactions' classifications, in the same order (`denseCompileShapesV`). -/
+  shapes : List (DenseBiPredShape p)
 
 def denseGatherBusAtV (arr : Array (DenseBusPlan p)) (xs : List VarId)
     (acc : DenseBusGatherV p) (i : Nat) : DenseBusGatherV p :=
@@ -451,7 +578,8 @@ def denseGatherBusAtV (arr : Array (DenseBusPlan p)) (xs : List VarId)
       { count := acc.count + 1,
         informative := acc.informative || plan.informative,
         allDomainRedundant := acc.allDomainRedundant && plan.domainRedundant,
-        interactions := plan.interaction :: acc.interactions }
+        interactions := plan.interaction :: acc.interactions,
+        shapes := plan.predShape :: acc.shapes }
     else acc
   else acc
 
@@ -462,7 +590,7 @@ def denseGatherBusArrayV (arr : Array (DenseBusPlan p)) (xs : List VarId)
 def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGatherV p :=
   let acc := xs.foldl (fun acc v =>
     denseGatherBusArrayV fidx.arrBis xs (fidx.bisIdx.buckets.getD v #[]) acc)
-    ⟨0, false, true, []⟩
+    ⟨0, false, true, [], []⟩
   denseGatherBusArrayV fidx.arrBis xs fidx.bisIdx.varless acc
 
 structure DenseForcedScanV (p : ℕ) where
@@ -470,6 +598,7 @@ structure DenseForcedScanV (p : ℕ) where
   doms : List (FiniteDomain p)
   active : List (DenseExpr p)
   interactions : List (BusInteraction (DenseExpr p))
+  shapes : List (DenseBiPredShape p)
   work : Nat
 
 inductive DenseForcedPlanV (p : ℕ) where
@@ -507,13 +636,14 @@ def denseForcedPreflightV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
             doms,
             active := cs.active,
             interactions := bis.interactions,
+            shapes := bis.shapes,
             work := boxSize * (cs.active.length + bis.count + keys.length) })
       else none
     else none
 
 def denseRunForcedScanV (bs : BusSemantics p) (facts : BusFacts p bs)
     (job : DenseForcedScanV p) : List (VarId × ZMod p) :=
-  let survC := denseCompiledSurvV bs facts job.active job.interactions job.keys
+  let survC := denseCompiledSurvV bs facts job.active job.interactions job.shapes job.keys
   match denseScanBoxV survC.run job.doms with
   | none => job.keys.map (fun x => (x, (0 : ZMod p)))
   | some cands =>
@@ -620,7 +750,9 @@ def denseBusPlansV (bs : BusSemantics p) (facts : BusFacts p bs) (T : DenseDomai
       vars := HashedDedup.hashedDedup (hash ·) (denseBIVars bi),
       usable,
       informative := usable && denseBiInformative bs facts bi,
-      domainRedundant := usable && denseBiDomainRedundantV bs facts T bi }
+      domainRedundant := usable && denseBiDomainRedundantV bs facts T bi,
+      -- Only `usable` plans are gathered, so an unusable one needs no classification.
+      predShape := if usable then denseClassifyBi facts bi else .always }
 
 def densePlanTargetsV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
     List (List VarId) :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -1463,6 +1463,177 @@ private theorem denseCompileCBiPredsV_all (ops : DenseZModOps p)
           denseCompileCBiPredV_eval ops isZero hz bs facts keys pt bi pred hb,
           ih restPreds hr]
 
+/-! ### The classification splits the compilation
+
+`denseClassifyBi` (per interaction, in `denseBusPlansV`) and `denseCompileBiShapeV` (per target)
+compose to `denseCompileCBiPredV`, so the compiled predicate — hence the scan and the pass output —
+is unchanged. These are purely structural: the semantic `_eval` lemmas above are reused as they are. -/
+
+private theorem denseClassifyRange_eq {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId) (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) :
+    (denseClassifyRange facts bi).bind
+        (fun vb => (denseCompileE keys vb.1).map (fun iv => DenseCBiPred.fixedRange mult iv vb.2))
+      = denseCompileRangeCBiPredV facts keys bi mult := by
+  unfold denseClassifyRange denseCompileRangeCBiPredV
+  cases hm : bi.multiplicity.constValue? with
+  | none => simp
+  | some mval =>
+    by_cases h1 : mval = 1
+    · cases hr : facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+      | none => simp [h1]
+      | some sb =>
+        obtain ⟨slot, bound⟩ := sb
+        cases hp : bi.payload[slot]? with
+        | none => simp [h1, hp]
+        | some value => simp [h1, hp]
+    · simp [h1]
+
+private theorem denseClassifyByte_eq {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId) (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) :
+    (denseClassifyByte facts bi).bind (denseCompileByteShapeV keys mult)
+      = denseCompileByteCBiPredV facts keys bi mult := by
+  unfold denseClassifyByte denseCompileByteCBiPredV denseCompileByteShapeV
+  cases hspec : facts.byteXorSpec bi.busId with
+  | none => simp
+  | some spec =>
+    cases hdec : spec.decode bi.payload with
+    | none => simp [hdec]
+    | some t =>
+      obtain ⟨op, o1, o2, result⟩ := t
+      cases hop : op.constValue? with
+      | none => simp [hdec, hop]
+      | some opValue =>
+        cases h1 : denseCompileE keys o1 with
+        | none =>
+          simp only [hdec, hop, h1]
+          cases hk : denseByteKindOf spec opValue <;> simp [h1]
+        | some io1 =>
+          cases h2 : denseCompileE keys o2 with
+          | none =>
+            simp only [hdec, hop, h1, h2]
+            cases hk : denseByteKindOf spec opValue <;> simp [h1, h2]
+          | some io2 =>
+            cases h3 : denseCompileE keys result with
+            | none =>
+              simp only [hdec, hop, h1, h2, h3]
+              cases hk : denseByteKindOf spec opValue <;> simp [h1, h2, h3]
+            | some iresult =>
+              -- Both sides now branch on the same op comparisons (`denseByteKindOf` mirrors
+              -- `denseCompileByteCBiPredV`'s arm order); reduce them in lockstep.
+              simp only [hdec, hop, h1, h2, h3, denseByteKindOf]
+              by_cases hx : opValue = spec.xorOp
+              · simp only [if_pos hx]; simp [h1, h2, h3]
+              · simp only [if_neg hx]
+                by_cases hpair : opValue = spec.pairOp
+                · simp only [if_pos hpair]; simp [h1, h2, h3]
+                · simp only [if_neg hpair]
+                  cases hor : spec.orOp with
+                  | some orOp =>
+                    by_cases ho : opValue = orOp
+                    · simp only [if_pos ho]; simp [h1, h2, h3]
+                    · simp only [if_neg ho]
+                      cases hand : spec.andOp with
+                      | some andOp =>
+                        by_cases ha : opValue = andOp
+                        · simp only [if_pos ha]; simp [h1, h2, h3]
+                        · simp only [if_neg ha]; simp
+                      | none => simp
+                  | none =>
+                    cases hand : spec.andOp with
+                    | some andOp =>
+                      by_cases ha : opValue = andOp
+                      · simp only [if_pos ha]; simp [h1, h2, h3]
+                      · simp only [if_neg ha]; simp
+                    | none => simp
+
+private theorem denseCompileOtherShapeV_eq {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId) (bi : BusInteraction (DenseExpr p)) (mult : IExpr p) :
+    denseCompileOtherShapeV keys mult (denseClassifyOther facts bi)
+      = denseCompileOtherCBiPredV facts keys bi mult := by
+  unfold denseCompileOtherShapeV denseCompileOtherCBiPredV denseClassifyOther
+  simp only [denseClassifyRange_eq facts keys bi mult, denseClassifyByte_eq facts keys bi mult]
+
+private theorem denseCompileBiShapeV_eq {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId) (bi : BusInteraction (DenseExpr p)) :
+    denseCompileBiShapeV facts keys bi (denseClassifyBi facts bi)
+      = denseCompileCBiPredV facts keys bi := by
+  unfold denseCompileBiShapeV denseClassifyBi denseCompileCBiPredV
+  by_cases halways : denseBiAlwaysOk facts bi = true
+  · simp [halways]
+  · have hfalse : denseBiAlwaysOk facts bi = false := Bool.eq_false_of_not_eq_true halways
+    simp only [hfalse, Bool.false_eq_true, if_false]
+    cases hmult : denseCompileE keys bi.multiplicity with
+    | none =>
+      cases hpay : bi.payload with
+      | nil => simp
+      | cons x rest =>
+        cases rest with
+        | nil => simp
+        | cons width rest' =>
+          cases rest' with
+          | nil =>
+            by_cases hvr : facts.varRangeBus bi.busId = true
+            · simp [hvr]
+            · have hvrf : facts.varRangeBus bi.busId = false := Bool.eq_false_of_not_eq_true hvr
+              cases htr : facts.tupleRangeBus bi.busId with
+              | none => simp [hvrf]
+              | some b => obtain ⟨bx, by'⟩ := b; simp [hvrf]
+          | cons _ _ => simp
+    | some mult =>
+      cases hpay : bi.payload with
+      | nil =>
+        simp only [denseCompilePayloadCBiPredV, denseCompileShapeV]
+        exact denseCompileOtherShapeV_eq facts keys bi mult
+      | cons x rest =>
+        cases rest with
+        | nil =>
+          simp only [denseCompilePayloadCBiPredV, denseCompileShapeV]
+          exact denseCompileOtherShapeV_eq facts keys bi mult
+        | cons width rest' =>
+          cases rest' with
+          | nil =>
+            simp only [denseCompilePayloadCBiPredV, denseCompilePairCBiPredV]
+            by_cases hvr : facts.varRangeBus bi.busId = true
+            · simp only [hvr, if_pos, denseCompileShapeV]
+              cases h1 : denseCompileE keys x with
+              | none => rfl
+              | some ix =>
+                cases h2 : denseCompileE keys width with
+                | none => rfl
+                | some iwidth =>
+                  cases hw : width.constValue? with
+                  | none => simp
+                  | some widthValue => by_cases hle : widthValue.val ≤ 17 <;> simp [hle]
+            · have hvrf : facts.varRangeBus bi.busId = false := Bool.eq_false_of_not_eq_true hvr
+              cases htr : facts.tupleRangeBus bi.busId with
+              | none =>
+                -- both sides are the `other` arm, whether or not the slots compile
+                simp only [hvrf, Bool.false_eq_true, if_false, denseCompileShapeV]
+                rw [denseCompileOtherShapeV_eq facts keys bi mult]
+                cases h1 : denseCompileE keys x with
+                | none => rfl
+                | some ix => cases h2 : denseCompileE keys width with
+                  | none => rfl
+                  | some iwidth => rfl
+              | some b =>
+                obtain ⟨bx, by'⟩ := b
+                simp only [hvrf, Bool.false_eq_true, if_false, denseCompileShapeV]
+          | cons _ _ =>
+            simp only [denseCompilePayloadCBiPredV, denseCompileShapeV]
+            exact denseCompileOtherShapeV_eq facts keys bi mult
+
+private theorem denseCompileShapesV_eq {bs : BusSemantics p} (facts : BusFacts p bs)
+    (keys : List VarId) :
+    ∀ (bis : List (BusInteraction (DenseExpr p))),
+      denseCompileShapesV facts keys bis (bis.map (denseClassifyBi facts))
+        = denseCompileCBiPredsV facts keys bis := by
+  intro bis
+  induction bis with
+  | nil => rfl
+  | cons bi rest ih =>
+    simp only [List.map_cons, denseCompileShapesV, denseCompileCBiPredsV,
+      denseCompileBiShapeV_eq facts keys bi, ih]
+
 theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
     (hz : ∀ v, isZero v = decide (v = 0)) (bs : BusSemantics p) (facts : BusFacts p bs)
     (es : List (DenseExpr p)) (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId)
@@ -1477,9 +1648,12 @@ theorem denseSurvivesAllCWV_eq (ops : DenseZModOps p) (isZero : ZMod p → Bool)
 
 theorem denseCompiledSurvV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (es : List (DenseExpr p)) (bis : List (BusInteraction (DenseExpr p)))
-    (keys : List VarId) (pt : List (ZMod p)) :
-    (denseCompiledSurvV bs facts es bis keys).run pt = denseSurvivesAllMV facts es bis keys pt := by
+    (shapes : List (DenseBiPredShape p)) (keys : List VarId) (pt : List (ZMod p))
+    (hsh : shapes = bis.map (denseClassifyBi facts)) :
+    (denseCompiledSurvV bs facts es bis shapes keys).run pt
+      = denseSurvivesAllMV facts es bis keys pt := by
   unfold denseCompiledSurvV
+  rw [hsh, denseCompileShapesV_eq facts keys bis]
   cases hce : denseCompileEs keys es with
   | none => rfl
   | some ces =>
@@ -1526,14 +1700,16 @@ theorem denseSurvivesAllMV_restriction {bs : BusSemantics p} (facts : BusFacts p
 /-- The restriction survives the compiled survivor predicate (value-only). -/
 theorem denseCompiledSurvV_restriction (bs : BusSemantics p) (facts : BusFacts p bs)
     (es : List (DenseExpr p))
-    (bis : List (BusInteraction (DenseExpr p))) (keys : List VarId) (denv : VarId → ZMod p)
+    (bis : List (BusInteraction (DenseExpr p))) (shapes : List (DenseBiPredShape p))
+    (keys : List VarId) (denv : VarId → ZMod p)
+    (hsh : shapes = bis.map (denseClassifyBi facts))
     (hes0 : ∀ e ∈ es, e.eval denv = 0)
     (hbi0 : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.accepts (denseBIEval bi denv))
     (hesk : ∀ e ∈ es, ∀ i ∈ e.vars, i ∈ keys)
     (hbik : ∀ bi ∈ bis, ∀ i ∈ denseBIVars bi, i ∈ keys) :
-    (denseCompiledSurvV bs facts es bis keys).run (keys.map denv) = true := by
-  rw [denseCompiledSurvV_eq]
+    (denseCompiledSurvV bs facts es bis shapes keys).run (keys.map denv) = true := by
+  rw [denseCompiledSurvV_eq bs facts es bis shapes keys _ hsh]
   exact denseSurvivesAllMV_restriction facts es bis keys denv hes0 hbi0 hesk hbik
 
 /-! ## `forcedOver` entailment (value-only) -/
@@ -1772,7 +1948,7 @@ theorem denseGatherBusesV_interactions_mem (fidx : DenseForcedIdx p) (xs : List 
   rw [denseGatherBusesV] at hbi
   apply denseGatherBusArrayV_interactions_mem fidx.arrBis xs fidx.bisIdx.varless _
     (denseGatherBusBucketsV_interactions_mem fidx.arrBis fidx.bisIdx xs xs
-      ⟨0, false, true, []⟩ (by simp)) bi hbi
+      ⟨0, false, true, [], []⟩ (by simp)) bi hbi
 
 theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (DenseBusPlan p))
     (harr : fidx.arrBis = plans.toArray) (xs : List VarId)
@@ -1789,10 +1965,76 @@ theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (Dens
   exact ⟨plan, hmem, by simpa [plan] using hbi', by simpa [plan] using husable,
     by simpa [plan] using hvars⟩
 
+/-! ### The gathered shapes are the gathered interactions' classifications
+
+`denseBusPlansV` stores each usable plan's classification (`DenseBusPlansClassified`), and the gather
+conses interaction and shape together, so the two lists stay aligned — which is what
+`denseCompiledSurvV_eq` needs. -/
+
+/-- Every usable plan carries the classification of its own interaction. -/
+def DenseBusPlansClassified {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (DenseBusPlan p)) : Prop :=
+  ∀ (i : Nat) (h : i < arr.size),
+    arr[i].usable = true → arr[i].predShape = denseClassifyBi facts arr[i].interaction
+
+theorem denseGatherBusAtV_shapes {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (DenseBusPlan p)) (hcl : DenseBusPlansClassified facts arr)
+    (xs : List VarId) (acc : DenseBusGatherV p) (i : Nat)
+    (hacc : acc.shapes = acc.interactions.map (denseClassifyBi facts)) :
+    (denseGatherBusAtV arr xs acc i).shapes
+      = (denseGatherBusAtV arr xs acc i).interactions.map (denseClassifyBi facts) := by
+  by_cases hi : i < arr.size
+  · by_cases husable : arr[i].usable = true
+    · by_cases hvars : denseVarsInListF xs arr[i].vars = true
+      · simp only [denseGatherBusAtV, hi, ↓reduceDIte, husable, hvars, Bool.and_self,
+          ↓reduceIte, List.map_cons, hacc, hcl i hi husable]
+      · simpa [denseGatherBusAtV, hi, husable, hvars] using hacc
+    · simpa [denseGatherBusAtV, hi, husable] using hacc
+  · simpa [denseGatherBusAtV, hi] using hacc
+
+theorem denseGatherBusArrayV_shapes {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (DenseBusPlan p)) (hcl : DenseBusPlansClassified facts arr)
+    (xs : List VarId) (positions : Array Nat) (acc : DenseBusGatherV p)
+    (hacc : acc.shapes = acc.interactions.map (denseClassifyBi facts)) :
+    (denseGatherBusArrayV arr xs positions acc).shapes
+      = (denseGatherBusArrayV arr xs positions acc).interactions.map (denseClassifyBi facts) := by
+  rw [denseGatherBusArrayV, ← Array.foldl_toList]
+  induction positions.toList generalizing acc with
+  | nil => simpa using hacc
+  | cons i rest ih =>
+      simp only [List.foldl_cons]
+      exact ih (denseGatherBusAtV arr xs acc i)
+        (denseGatherBusAtV_shapes facts arr hcl xs acc i hacc)
+
+theorem denseGatherBusBucketsV_shapes {bs : BusSemantics p} (facts : BusFacts p bs)
+    (arr : Array (DenseBusPlan p)) (hcl : DenseBusPlansClassified facts arr)
+    (idx : DenseArrayCovIndex) (xs vs : List VarId) (acc : DenseBusGatherV p)
+    (hacc : acc.shapes = acc.interactions.map (denseClassifyBi facts)) :
+    (vs.foldl (fun acc v => denseGatherBusArrayV arr xs (idx.buckets.getD v #[]) acc) acc).shapes
+      = (vs.foldl (fun acc v =>
+          denseGatherBusArrayV arr xs (idx.buckets.getD v #[]) acc) acc).interactions.map
+            (denseClassifyBi facts) := by
+  induction vs generalizing acc with
+  | nil => simpa using hacc
+  | cons v rest ih =>
+      simp only [List.foldl_cons]
+      exact ih _ (denseGatherBusArrayV_shapes facts arr hcl xs _ acc hacc)
+
+theorem denseGatherBusesV_shapes {bs : BusSemantics p} (facts : BusFacts p bs)
+    (fidx : DenseForcedIdx p) (hcl : DenseBusPlansClassified facts fidx.arrBis)
+    (xs : List VarId) :
+    (denseGatherBusesV fidx xs).shapes
+      = (denseGatherBusesV fidx xs).interactions.map (denseClassifyBi facts) := by
+  rw [denseGatherBusesV]
+  exact denseGatherBusArrayV_shapes facts fidx.arrBis hcl xs fidx.bisIdx.varless _
+    (denseGatherBusBucketsV_shapes facts fidx.arrBis hcl fidx.bisIdx xs xs
+      ⟨0, false, true, [], []⟩ (by simp))
+
 /-- **Value-only `forcedOver` entailment.** Every forced pair `(x, c)` is entailed by `denv`, given
     the domain table is sound at `denv` and the covered items evaluate/oblige correctly. -/
 theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     (T : DenseDomainTable p) (fidx : DenseForcedIdx p) (xs : List VarId) (denv : VarId → ZMod p)
+    (hcl : DenseBusPlansClassified facts fidx.arrBis)
     (hTs : DenseTableSoundAt denv T)
     (hes : ∀ e ∈ (denseGatherConstraintsV fidx xs).active,
       e.eval denv = 0 ∧ ∀ i ∈ e.vars, i ∈ xs)
@@ -1815,8 +2057,10 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     · have hsurv : (denseCompiledSurvV bs facts
           (denseGatherConstraintsV fidx xs).active
           (denseGatherBusesV fidx xs).interactions
+          (denseGatherBusesV fidx xs).shapes
           (fdoms.map Prod.fst)).run ((fdoms.map Prod.fst).map denv) = true := by
-        apply denseCompiledSurvV_restriction
+        apply denseCompiledSurvV_restriction bs facts _ _ _ _ denv
+          (denseGatherBusesV_shapes facts fidx hcl xs)
         · exact fun e he => (hes e he).1
         · exact fun bi hbi => (hbis bi hbi).1
         · intro e he i hi; rw [hkeys]; exact (hes e he).2 i hi
@@ -1824,6 +2068,7 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
       cases hscan : denseScanBoxV (denseCompiledSurvV bs facts
           (denseGatherConstraintsV fidx xs).active
           (denseGatherBusesV fidx xs).interactions
+          (denseGatherBusesV fidx xs).shapes
           (fdoms.map Prod.fst)).run (fdoms.map Prod.snd) with
       | none =>
           intro f hf
@@ -2072,6 +2317,18 @@ def dbFidx (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSys
     DenseForcedIdx p :=
   denseForcedIdxV (dbConstraintPlans bs facts d) (dbBusPlans bs facts d)
 
+/-- The pass's own plans satisfy the classification invariant: `denseBusPlansV` stores
+    `denseClassifyBi facts bi` on every usable plan. -/
+theorem dbFidx_classified (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) :
+    DenseBusPlansClassified facts (dbFidx bs facts d).arrBis := by
+  intro i hi husable
+  simp only [dbFidx, denseForcedIdxV, dbBusPlans, denseBusPlansV, List.size_toArray,
+    List.length_map] at hi
+  simp only [dbFidx, denseForcedIdxV, dbBusPlans, denseBusPlansV, List.getElem_toArray,
+    List.getElem_map] at husable ⊢
+  simp [husable]
+
 theorem denseDomainBatchσV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     denseDomainBatchσV bs facts d
@@ -2091,7 +2348,7 @@ theorem denseDomainBatchσV_entailed [Fact p.Prime] [NeZero p]
   case hforced =>
     intro xs f hf denv hsat
     refine denseForcedOverV_entails bs facts (dbT bs facts d) (dbFidx bs facts d) xs denv
-      ?_ ?_ ?_ f hf
+      (dbFidx_classified bs facts d) ?_ ?_ ?_ f hf
     · exact dbT_soundAt bs facts d denv hsat
     · intro e he
       obtain ⟨plan, hplan, hpe, hpvars, _⟩ := denseGatherConstraintsV_plan_mem

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -475,9 +475,26 @@ profiles over five OpenVM cases + SP1 keccak; entry 152). Phase shares of in-pas
 | gathers + preflight | 6.2 | 1.9 | 0.6 | 1.1 | 0.2 |
 
 Pass-only cost classes on sha256: 32.5 % closure-apply + 25 % refcount — `BusFacts` closure calls and
-the allocation traffic of their results. The `.fallback` row is **done (entry 152)**. Open, in order:
+the allocation traffic of their results. The `.fallback` row is **done (entry 152)**.
 
-   - **(a) Hoist the target-independent bus classification.** `denseCompiledSurvV` runs
+**Read this table as CPU, not wall.** `domainBatch` fans out into up to 64 chunks at ≥ 8192
+constraints, which is exactly the regime of every compile-heavy case here, so the per-target rows
+(classification, compile, scan) are largely parallel slack: entry 153 removed 45 % of the pass's CPU
+and the wall did not improve (1.00–1.07× across seven cases). The pass's wall is its **serial prologue** — table build, constraint
+plans/redundancy, `denseRootsIn`, targets/index/preflight — which is 65 % of the remaining CPU. Size
+any candidate against the prologue first. Open, in order:
+
+   - ~~**(a) Hoist the target-independent bus classification**~~ · **implemented and measured; wall
+     negative (entry 153)**. The hoist does what it promised — keccak's compile phase 31.3 % → 2.8 %
+     of in-pass samples, pass CPU **0.55×** — but the *wall* did not (sha256 apc_001 1.07×, SP1
+     keccak 1.03×, keccak 1.01×, apc_063/apc_071/apc_005 1.00×), because `domainBatch` fans out at ≥ 8192 constraints and the
+     per-target compile therefore sat in **parallel slack**. **65 % of the pass's remaining CPU is its
+     serial prologue** (table build 31 %, constraint plans 11 %, `denseRootsIn` 10 %,
+     targets/index/preflight ~6 %), and that is what sets the wall. Do not re-propose a per-target
+     optimization for the big cases without first moving the prologue; the code sits on
+     `perf/domainbatch-arity-never-violates` (draft PR) if a core-starved runner ever makes the CPU
+     win convert. The description below is kept for that reason:
+     **(a) Hoist the target-independent bus classification.** `denseCompiledSurvV` runs
      `denseCompileCBiPredV facts keys bi` per gathered interaction *per target*, and everything it
      does except `denseCompileE keys <slot>` depends on `bi` alone (`neverViolates`, `varRangeBus`,
      `tupleRangeBus`, `byteXorSpec`, `spec.decode`, `rangeCheckAt` + its pattern, `constValue?`).
@@ -489,7 +506,9 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      invocation) plus `denseCompileShape keys mult shape = denseCompileCBiPredV facts keys bi`, whose
      hypothesis discharges through the existing `denseGatherBusesV_plan_mem`, ~200–350 lines.
      Expect pass ≈ 0.55× on sha256/keccak.
-   - **(b) One constant pattern per interaction.** `denseInteractionBound` rebuilds
+   - **(b) One constant pattern per interaction** · **now the top lever** (entry 153: the table build
+     is 31 % of the pass and is serial).
+      `denseInteractionBound` rebuilds
      `bi.payload.map DenseExpr.constValue?` per *queried variable*, and `denseAddBusVars` /
      `denseBiInformative` compute the same bound twice per variable. `denseInteractionBoundPat`
      (`BusPairCancelWits.lean:26`) is the hoisted twin already. The same specialized map is 6 % of the
@@ -521,6 +540,10 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
+- **Per-target work in `domainBatch` as a wall-time lever** (entry 153): the pass fans out at ≥ 8192
+  constraints, so per-target phases are parallel slack on every case where they are large. Removing
+  45 % of the pass's CPU (the whole per-target bus classification) left the wall at 1.00–1.07× on seven
+  cases (worst on the biggest case). Optimize the serial prologue instead, or re-measure on a core-starved runner.
 - **Whole-system content-hash gating of passes across cycles**: catches ~0 % — the fixpoint only
   retains cycles that changed something, so some pass always dirties the hash (#146 measurement).
   Only fine-grained dirtiness (R6) reaches the ~61 % no-op invocations.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5304,3 +5304,50 @@ lazify `denseByteOperandDomain`'s coset build (21.3 % of the pass on SP1 keccak,
 (d) prefix-pruned / component-split enumeration for the big-box OpenVM cases, gated on a box-shape
 counter first.
 **Worked: yes (domainBatch 0.14x on its worst-share APC, output byte-identical; draft PR).**
+
+### 153. Runtime: hoist domainBatch's bus classification out of the per-target compile — CPU 0.55x, wall +2% (NEGATIVE on wall)
+Entry 152's attribution named this the top lever: `denseCompileCBiPredV` queries `facts` and re-decodes
+the payload for every gathered interaction of every target, and everything but the
+`denseCompileE keys …` of a few slots depends on `bi` alone — 56.1 % of in-pass samples on sha256
+apc_001, 40.5 % on keccak, 34.4 % on SP1 keccak.
+IMPLEMENTED (byte-identical, and it does remove the work): a keys-free `DenseBiPredShape` +
+`denseClassifyBi` (all fact queries and `spec.decode` resolved once per interaction, stored on the
+already-per-invocation `DenseBusPlan`), a facts-free `denseCompileShapeV`/`denseCompileBiShapeV` per
+target, and `denseCompileBiShapeV_eq : denseCompileBiShapeV facts keys bi (denseClassifyBi facts bi) =
+denseCompileCBiPredV facts keys bi` (structural; every semantic `_eval` lemma is reused untouched).
+The gather carries the shapes next to the interactions and `denseGatherBusesV_shapes` keeps the two
+lists aligned, discharged from `DenseBusPlansClassified` (`denseBusPlansV` stores the classification of
+each usable plan by construction). ~440 lines, all under `Implementation/`.
+MEASURED: the hoist works exactly as designed — on keccak the compile phase drops from **31.3 % to
+2.8 %** of in-pass samples and the pass's whole CPU falls **10310 → 5638 samples (0.55x)** at the same
+sampling frequency. **The wall time does not follow**: interleaved best-of-3 against `main` (3448080,
+after the #243/#245 audited-surface refactors — re-measured on rebase, the pre-rebase reading against
+5ea2665 agreed) on this 20-core box, domainBatch ms, main → this change: **sha256 apc_001 (single shot)
+17994 → 19287 (1.07×, total 175.4 → 175.6 s)**, SP1 keccak 1006 → 1038 (1.03×), SP1 rsp apc_030
+150 → 153, keccak 1350 → 1367 (1.01×), wasm-eth apc_063 1578 → 1583, openvm-eth apc_071 565 → 567,
+wasm-eth apc_005 36 → 36. Wall-neutral to 7 % worse — nowhere near the land bar — while the pass burns
+45 % less CPU.
+WHY (the lesson): every case whose compile share is large fans out — `domainBatch` runs its targets in
+up to 64 parallel chunks at ≥ 8192 constraints — so the per-target compile lived in **parallel slack**,
+and the pass's *wall* is set by its **serial prologue**. After the hoist, 65 % of the pass's remaining
+CPU is that prologue (domain-table build 31 %, constraint plans/redundancy 11 %, `denseRootsIn` 10 %,
+targets/index/preflight ~6 %), which no per-target optimization can touch. The residual +2–5 % is the
+classification now running for every usable interaction per invocation instead of only for gathered
+ones (a first variant that also pre-resolved the range/byte arms for two-slot range checks cost +4 %;
+those arms are now re-derived from `facts` on the never-taken fall-through path instead).
+**Measurement lesson: for a parallel pass, a `perf` CPU share is not a wall budget — check whether the
+phase you are about to optimize is inside the fan-out before sizing the win.** Entry 152 already hinted
+at this (sha256's 14 % `violates` share bought 6 % of wall); here it is decisive.
+STATUS: byte-identical output verified by `opt-export` on OpenVM keccak / wasm-eth apc_005 /
+openvm-eth apc_071 and SP1 keccak / rsp apc_001; `lake build` clean; `check-proof-integrity` passes.
+Draft PR opened so the serial CI `Runtime Bench` (32-core) can arbitrate — the verdict is
+machine-dependent (on a core-starved box the 0.55x CPU should convert to wall), but on this box it is
+**below the land bar and should not merge on these numbers**.
+NEXT: the pass's wall is now the serial prologue. Top lever is the domain-table build — one constant
+pattern (`payload.map constValue?`) and one bound per interaction instead of per queried variable
+(ideas R13(b), 31 % of the pass and shared with intervalForce/rootPairUnify) — then
+`denseConstraintRedundantV` and `denseRootsIn`. Anything per-target (R13(a), (d)) is parallel slack on
+exactly the cases that hurt.
+A measurement slip worth recording: one SP1 sweep was run while the sha256 A/B was still going and
+produced a 7495 ms outlier — the numbers above are all from strictly serial re-runs.
+**Worked: no (CPU 0.55x, wall 0.97–1.04×; kept as a draft PR for CI arbitration, dead end recorded).**


### PR DESCRIPTION
> **Negative result on wall-clock time — do not merge on these numbers.** The change does exactly
> what it was designed to do (the pass burns **45 % less CPU**, its per-target compile phase goes from
> 31.3 % of samples to 2.8 %) and the output is byte-identical, but the **wall time does not improve**
> on this 20-core box: 1.00–1.07× across seven cases, worst on the biggest one. Opened as a draft so the
> serial CI `Runtime Bench` can arbitrate on a different core count, and so the dead end is recorded
> with its code. The finding itself is the deliverable — see *Why the wall did not move*.

## What

`denseCompileCBiPredV` asked `BusFacts` and re-decoded the payload for **every gathered interaction of
every target**, although everything except the `denseCompileE keys …` of two-to-four slots depends on
the interaction alone: `neverViolates` / `neverViolatesArity`, `varRangeBus`, `tupleRangeBus`,
`byteXorSpec` + `spec.decode`, `rangeCheckAt` and its `payload.map constValue?` pattern,
`multiplicity.constValue?`. Attribution (#244's entry 152): that phase was **56.1 %** of in-pass
samples on `sha256/apc_001`, 40.5 % on keccak, 34.4 % on SP1 keccak, and inside it the
keys-dependent `denseCompileEs` was only 11 %.

This splits the compilation in two:

- `denseClassifyBi facts bi : DenseBiPredShape p` — keys-free, run once per interaction in
  `denseBusPlansV` (which already runs once per invocation) and stored on `DenseBusPlan.predShape`.
- `denseCompileShapeV` / `denseCompileBiShapeV` — per target, compiles only the slots.

`denseCompileBiShapeV_eq : denseCompileBiShapeV facts keys bi (denseClassifyBi facts bi) =
denseCompileCBiPredV facts keys bi` makes the two halves provably the original, so every semantic
`_eval` lemma is reused untouched and the compiled predicate, the scan, and the pass output are
unchanged. The gather carries the shapes next to the interactions; `denseGatherBusesV_shapes` keeps the
two lists aligned, discharged from `DenseBusPlansClassified`, which `denseBusPlansV` satisfies by
construction. Two-slot range shapes deliberately store **no** fallback arm: it is unreachable for a
gathered item (its variables are all keys) and is re-derived from `facts`, so a range check pays
nothing for a branch it never takes. All under `Implementation/`; the audited surface is untouched.

## Numbers (interleaved, vs `main` @ 3448080, this 20-core box)

`domainBatch` ms, main → this branch (re-measured after rebasing over #243/#245; the pre-rebase
reading against 5ea2665 agreed):

| case | main | branch | ratio |
|---|---:|---:|---|
| `sha256/apc_001_pcsha256` (worst absolute, 1 shot) | 17994 | 19287 | **1.07×** |
| SP1 `keccak/apc_001` | 1006 | 1038 | 1.03× |
| SP1 `rsp/apc_030` | 150 | 153 | 1.02× |
| `keccak/apc_001_pckeccak` | 1350 | 1367 | 1.01× |
| `wasm-eth/apc_063_pc0x078B60` | 1578 | 1583 | 1.00× |
| `openvm-eth/apc_071_pc0x3783a8` | 565 | 567 | 1.00× |
| `wasm-eth/apc_005_pc0x2E9C48` | 36 | 36 | 1.00× |

Case totals move ≤ 0.2 %. CPU, on the other hand, drops hard: keccak's in-pass samples fall
**10310 → 5638** at the same sampling frequency (**0.55×**), with the compile phase at 2.8 % of the
pass instead of 31.3 %.

## Why the wall did not move

`domainBatch` fans out into up to 64 parallel chunks at ≥ 8192 constraints — which is exactly the
regime of every case whose compile share was large. The per-target compile therefore lived in
**parallel slack**, and the pass's *wall* is set by its **serial prologue**: after the hoist, **65 % of
the pass's remaining CPU** is prologue work (domain-table build 31 %, constraint plans/redundancy 11 %,
`denseRootsIn` 10 %, targets/index/preflight ~6 %), which no per-target optimization can touch. The
residual +1–7 % is the classification now running for every usable interaction per invocation rather
than only for gathered ones.

**Lesson (recorded in `ideas.md` R13 and log entry 153): for a parallel pass a `perf` CPU share is not
a wall budget — check whether the phase sits inside the fan-out before sizing the win.** #244 already
hinted at it (a 14 % CPU share bought 6 % of wall); here it is decisive. The next lever for this pass
is its serial prologue — one constant pattern and one bound per interaction in the domain-table build
(R13(b), 31 % of the pass, shared with `intervalForce`/`rootPairUnify`), then
`denseConstraintRedundantV` and `denseRootsIn`.

## Effectiveness: unchanged, by construction

The compiled predicate is equal by theorem, so survivors and forced constants cannot change.
`opt-export` output verified **byte-identical to `main`** on OpenVM keccak / wasm-eth apc_005 /
openvm-eth apc_071 and SP1 keccak / rsp apc_001, re-checked after the rebase.

## Checks

- `lake build` clean, no warnings.
- `Scripts/check-proof-integrity.sh` passes (axioms: `propext`, `Classical.choice`, `Quot.sound`).

## What I would like from CI

The serial `Runtime Bench` on a 32-core runner, and the effectiveness matrix to confirm the identity.
If the wall stays flat there too, close this and take the prologue instead — the branch is worth
keeping only as the record of a measured dead end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
