### PR TITLE
perf(domainBatch): evaluate the work gate during the gather (sha256 0.81x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -511,6 +511,370 @@ def denseForcedPreflightV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
       else none
     else none
 
+/-! ### Work-gated gathers
+
+`boxSize * items ≤ maxEnumWork` is a cap on the gathered item count, and a gather's counts only
+grow, so a target whose count passes the cap has already lost the work gate: the rest of its scan is
+wasted. On the sha256 case that is 39 980 of 66 062 gathers (61 %).
+
+`denseCapStep` bails to `none` at the cap and stays there, `denseForcedPreflightFastV` runs the
+gathers that way, and `denseForcedPreflightV_eq_fast` proves the two agree — so the plan list, and
+therefore the pass, is unchanged. The `@[csimp]` lemma has to sit above the call sites in this
+module, which is why these proofs live here rather than in `Proofs/`. -/
+
+/-- One capped fold step: apply `f`, and give up as soon as the count passes `cap`. `@[specialize]`
+    so the two gathers compile to direct calls rather than paying a closure per scanned position. -/
+@[specialize] def denseCapStep {β : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (acc : Option β) (i : Nat) : Option β :=
+  match acc with
+  | none => none
+  | some a =>
+    let b := f a i
+    if cap < cnt b then none else some b
+
+private theorem denseCapFold_spec {β : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (hmono : ∀ a i, cnt a ≤ cnt (f a i)) :
+    ∀ (ps : List Nat) (a : β), cnt a ≤ cap →
+      match ps.foldl (denseCapStep cnt f cap) (some a) with
+      | some b => ps.foldl f a = b ∧ cnt b ≤ cap
+      | none => cap < cnt (ps.foldl f a) := by
+  have hfoldMono : ∀ (ps : List Nat) (a : β), cnt a ≤ cnt (ps.foldl f a) := by
+    intro ps
+    induction ps with
+    | nil => intro a; exact Nat.le_refl _
+    | cons i rest ih => intro a; exact Nat.le_trans (hmono a i) (ih (f a i))
+  intro ps
+  induction ps with
+  | nil => intro a ha; exact ⟨rfl, ha⟩
+  | cons i rest ih =>
+    intro a ha
+    simp only [List.foldl_cons, denseCapStep]
+    by_cases hcap : cap < cnt (f a i)
+    · simp only [hcap, ↓reduceIte]
+      have : ∀ (qs : List Nat) (b : β), qs.foldl (denseCapStep cnt f cap) none = none := by
+        intro qs
+        induction qs with
+        | nil => intro _; rfl
+        | cons j qs' ihq => intro b; simpa [denseCapStep] using ihq b
+      rw [this rest a]
+      exact Nat.lt_of_lt_of_le hcap (hfoldMono rest (f a i))
+    · simp only [hcap, ↓reduceIte]
+      exact ih (f a i) (Nat.le_of_not_lt hcap)
+
+private theorem denseCapFolds_spec {β γ : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (hmono : ∀ a i, cnt a ≤ cnt (f a i)) (bucket : γ → List Nat) :
+    ∀ (vs : List γ) (a : β), cnt a ≤ cap →
+      match vs.foldl (fun acc v => (bucket v).foldl (denseCapStep cnt f cap) acc) (some a) with
+      | some b => vs.foldl (fun acc v => (bucket v).foldl f acc) a = b ∧ cnt b ≤ cap
+      | none => cap < cnt (vs.foldl (fun acc v => (bucket v).foldl f acc) a) := by
+  have hfoldMono : ∀ (ps : List Nat) (a : β), cnt a ≤ cnt (ps.foldl f a) := by
+    intro ps
+    induction ps with
+    | nil => intro a; exact Nat.le_refl _
+    | cons i rest ih => intro a; exact Nat.le_trans (hmono a i) (ih (f a i))
+  have hfoldsMono : ∀ (vs : List γ) (a : β),
+      cnt a ≤ cnt (vs.foldl (fun acc v => (bucket v).foldl f acc) a) := by
+    intro vs
+    induction vs with
+    | nil => intro a; exact Nat.le_refl _
+    | cons v rest ih =>
+      intro a
+      exact Nat.le_trans (hfoldMono (bucket v) a) (ih ((bucket v).foldl f a))
+  have hnone : ∀ (vs : List γ),
+      vs.foldl (fun acc v => (bucket v).foldl (denseCapStep cnt f cap) acc) none = none := by
+    intro vs
+    induction vs with
+    | nil => rfl
+    | cons v rest ih =>
+      have : ∀ (qs : List Nat), qs.foldl (denseCapStep cnt f cap) none = none := by
+        intro qs
+        induction qs with
+        | nil => rfl
+        | cons j qs' ihq => simpa [denseCapStep] using ihq
+      simpa [this (bucket v)] using ih
+  intro vs
+  induction vs with
+  | nil => intro a ha; exact ⟨rfl, ha⟩
+  | cons v rest ih =>
+    intro a ha
+    simp only [List.foldl_cons]
+    have hb := denseCapFold_spec cnt f cap hmono (bucket v) a ha
+    cases hcase : (bucket v).foldl (denseCapStep cnt f cap) (some a) with
+    | none =>
+      rw [hcase] at hb
+      simp only [hnone rest]
+      exact Nat.lt_of_lt_of_le hb (hfoldsMono rest _)
+    | some b =>
+      rw [hcase] at hb
+      simp only [hb.1]
+      exact ih b hb.2
+
+private theorem denseCapNone_spec {β : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (arr : Array Nat) : arr.foldl (denseCapStep cnt f cap) none = none := by
+  rw [← Array.foldl_toList]
+  induction arr.toList with
+  | nil => rfl
+  | cons j qs ih => simpa [denseCapStep] using ih
+
+private theorem denseCapFoldArr_spec {β : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (hmono : ∀ a i, cnt a ≤ cnt (f a i)) (arr : Array Nat) (a : β) (ha : cnt a ≤ cap) :
+    match arr.foldl (denseCapStep cnt f cap) (some a) with
+    | some b => arr.foldl f a = b ∧ cnt b ≤ cap
+    | none => cap < cnt (arr.foldl f a) := by
+  rw [← Array.foldl_toList, ← Array.foldl_toList]
+  exact denseCapFold_spec cnt f cap hmono arr.toList a ha
+
+private theorem denseCapFoldArr_mono {β : Type} (cnt : β → Nat) (f : β → Nat → β)
+    (hmono : ∀ a i, cnt a ≤ cnt (f a i)) (arr : Array Nat) (a : β) :
+    cnt a ≤ cnt (arr.foldl f a) := by
+  rw [← Array.foldl_toList]
+  induction arr.toList generalizing a with
+  | nil => exact Nat.le_refl _
+  | cons i rest ih => exact Nat.le_trans (hmono a i) (ih (f a i))
+
+private theorem denseCapFoldsArr_spec {β γ : Type} (cnt : β → Nat) (f : β → Nat → β) (cap : Nat)
+    (hmono : ∀ a i, cnt a ≤ cnt (f a i)) (bucket : γ → Array Nat) :
+    ∀ (vs : List γ) (a : β), cnt a ≤ cap →
+      match vs.foldl (fun acc v => (bucket v).foldl (denseCapStep cnt f cap) acc) (some a) with
+      | some b => vs.foldl (fun acc v => (bucket v).foldl f acc) a = b ∧ cnt b ≤ cap
+      | none => cap < cnt (vs.foldl (fun acc v => (bucket v).foldl f acc) a) := by
+  have hfoldsMono : ∀ (vs : List γ) (a : β),
+      cnt a ≤ cnt (vs.foldl (fun acc v => (bucket v).foldl f acc) a) := by
+    intro vs
+    induction vs with
+    | nil => intro a; exact Nat.le_refl _
+    | cons v rest ih =>
+      intro a
+      exact Nat.le_trans (denseCapFoldArr_mono cnt f hmono (bucket v) a) (ih _)
+  have hnoneOuter : ∀ (vs : List γ),
+      vs.foldl (fun acc v => (bucket v).foldl (denseCapStep cnt f cap) acc) none = none := by
+    intro vs
+    induction vs with
+    | nil => rfl
+    | cons v rest ih => simpa [denseCapNone_spec cnt f cap (bucket v)] using ih
+  intro vs
+  induction vs with
+  | nil => intro a ha; exact ⟨rfl, ha⟩
+  | cons v rest ih =>
+    intro a ha
+    simp only [List.foldl_cons]
+    have hb := denseCapFoldArr_spec cnt f cap hmono (bucket v) a ha
+    cases hcase : (bucket v).foldl (denseCapStep cnt f cap) (some a) with
+    | none =>
+      rw [hcase] at hb
+      simp only [hnoneOuter rest]
+      exact Nat.lt_of_lt_of_le hb (hfoldsMono rest _)
+    | some b =>
+      rw [hcase] at hb
+      simp only [hb.1]
+      exact ih b hb.2
+
+private theorem denseGatherConstraintAtV_mono (arr : Array (DenseConstraintPlan p))
+    (xs : List VarId) (a : DenseConstraintGatherV p) (i : Nat) :
+    a.fullCount ≤ (denseGatherConstraintAtV arr xs a i).fullCount := by
+  unfold denseGatherConstraintAtV
+  by_cases h : i < arr.size
+  · by_cases hv : denseVarsInListF xs arr[i].vars = true <;> simp [h, hv]
+  · simp [h]
+
+private theorem denseGatherBusAtV_mono (arr : Array (DenseBusPlan p)) (xs : List VarId)
+    (a : DenseBusGatherV p) (i : Nat) :
+    a.count ≤ (denseGatherBusAtV arr xs a i).count := by
+  unfold denseGatherBusAtV
+  by_cases h : i < arr.size
+  · by_cases hv : (arr[i].usable && denseVarsInListF xs arr[i].vars) = true <;> simp [h, hv]
+  · simp [h]
+
+/-- `denseGatherConstraintsV`, abandoned as soon as the item count passes `cap`. -/
+def denseGatherConstraintsCapV (fidx : DenseForcedIdx p) (xs : List VarId) (cap : Nat) :
+    Option (DenseConstraintGatherV p) :=
+  let step := denseCapStep DenseConstraintGatherV.fullCount
+    (denseGatherConstraintAtV fidx.arrCs xs) cap
+  let acc := xs.foldl (fun acc v => (fidx.csIdx.buckets.getD v #[]).foldl step acc)
+    (if cap < fidx.csIdx.inactiveVarlessCount then none
+     else some ⟨fidx.csIdx.inactiveVarlessCount, []⟩)
+  fidx.csIdx.activeVarless.foldl step acc
+
+/-- `denseGatherBusesV`, abandoned as soon as the item count passes `cap`. -/
+def denseGatherBusesCapV (fidx : DenseForcedIdx p) (xs : List VarId) (cap : Nat) :
+    Option (DenseBusGatherV p) :=
+  let step := denseCapStep DenseBusGatherV.count (denseGatherBusAtV fidx.arrBis xs) cap
+  let acc := xs.foldl (fun acc v => (fidx.bisIdx.buckets.getD v #[]).foldl step acc)
+    (some ⟨0, false, true, []⟩)
+  fidx.bisIdx.varless.foldl step acc
+
+private theorem denseGatherConstraintsCapV_spec (fidx : DenseForcedIdx p) (xs : List VarId)
+    (cap : Nat) :
+    match denseGatherConstraintsCapV fidx xs cap with
+    | some g => denseGatherConstraintsV fidx xs = g ∧ g.fullCount ≤ cap
+    | none => cap < (denseGatherConstraintsV fidx xs).fullCount := by
+  unfold denseGatherConstraintsCapV denseGatherConstraintsV denseGatherConstraintArrayV
+  have hmono := denseGatherConstraintAtV_mono fidx.arrCs xs
+  set f := denseGatherConstraintAtV fidx.arrCs xs with hf
+  set cnt := DenseConstraintGatherV.fullCount (p := p) with hcnt
+  have hfoldsMono : ∀ (vs : List VarId) (a : DenseConstraintGatherV p),
+      cnt a ≤ cnt (vs.foldl (fun acc v => (fidx.csIdx.buckets.getD v #[]).foldl f acc) a) := by
+    intro vs
+    induction vs with
+    | nil => intro a; exact Nat.le_refl _
+    | cons v rest ih =>
+      intro a
+      exact Nat.le_trans (denseCapFoldArr_mono cnt f hmono _ a) (ih _)
+  by_cases hinit : cap < fidx.csIdx.inactiveVarlessCount
+  · have hnoneOuter : ∀ (vs : List VarId),
+        vs.foldl (fun acc v =>
+          (fidx.csIdx.buckets.getD v #[]).foldl (denseCapStep cnt f cap) acc) none = none := by
+      intro vs
+      induction vs with
+      | nil => rfl
+      | cons v rest ih =>
+        simpa [denseCapNone_spec cnt f cap (fidx.csIdx.buckets.getD v #[])] using ih
+    simp only [hinit, ↓reduceIte, hnoneOuter, denseCapNone_spec]
+    refine Nat.lt_of_lt_of_le hinit ?_
+    exact Nat.le_trans (hfoldsMono xs ⟨fidx.csIdx.inactiveVarlessCount, []⟩)
+      (denseCapFoldArr_mono cnt f hmono _ _)
+  · simp only [hinit, ↓reduceIte]
+    have h0 : cnt (⟨fidx.csIdx.inactiveVarlessCount, []⟩ : DenseConstraintGatherV p) ≤ cap :=
+      Nat.le_of_not_lt hinit
+    have houter := denseCapFoldsArr_spec cnt f cap hmono
+      (fun v => fidx.csIdx.buckets.getD v #[]) xs _ h0
+    cases hcase : xs.foldl (fun acc v =>
+        (fidx.csIdx.buckets.getD v #[]).foldl (denseCapStep cnt f cap) acc)
+        (some ⟨fidx.csIdx.inactiveVarlessCount, []⟩) with
+    | none =>
+      rw [hcase] at houter
+      simp only [denseCapNone_spec]
+      exact Nat.lt_of_lt_of_le houter (denseCapFoldArr_mono cnt f hmono _ _)
+    | some b =>
+      rw [hcase] at houter
+      simp only [houter.1]
+      have hfin := denseCapFoldArr_spec cnt f cap hmono fidx.csIdx.activeVarless b houter.2
+      cases hlast : Array.foldl (denseCapStep cnt f cap) (some b) fidx.csIdx.activeVarless with
+      | none => rw [hlast] at hfin; exact hfin
+      | some g => rw [hlast] at hfin; exact hfin
+
+private theorem denseGatherBusesCapV_spec (fidx : DenseForcedIdx p) (xs : List VarId) (cap : Nat) :
+    match denseGatherBusesCapV fidx xs cap with
+    | some g => denseGatherBusesV fidx xs = g ∧ g.count ≤ cap
+    | none => cap < (denseGatherBusesV fidx xs).count := by
+  unfold denseGatherBusesCapV denseGatherBusesV denseGatherBusArrayV
+  have hmono := denseGatherBusAtV_mono fidx.arrBis xs
+  set f := denseGatherBusAtV fidx.arrBis xs with hf
+  set cnt := DenseBusGatherV.count (p := p) with hcnt
+  have houter := denseCapFoldsArr_spec cnt f cap hmono
+    (fun v => fidx.bisIdx.buckets.getD v #[]) xs ⟨0, false, true, []⟩ (Nat.zero_le _)
+  cases hcase : xs.foldl (fun acc v =>
+      (fidx.bisIdx.buckets.getD v #[]).foldl (denseCapStep cnt f cap) acc)
+      (some ⟨0, false, true, []⟩) with
+  | none =>
+    rw [hcase] at houter
+    simp only [hcase, denseCapNone_spec]
+    exact Nat.lt_of_lt_of_le houter
+      (denseCapFoldArr_mono cnt f hmono fidx.bisIdx.varless _)
+  | some b =>
+    rw [hcase] at houter
+    simp only [hcase, houter.1]
+    have hfin := denseCapFoldArr_spec cnt f cap hmono fidx.bisIdx.varless b houter.2
+    cases hlast : Array.foldl (denseCapStep cnt f cap) (some b) fidx.bisIdx.varless with
+    | none => rw [hlast] at hfin; exact hfin
+    | some g => rw [hlast] at hfin; exact hfin
+
+/-- The tail of `denseForcedPreflightV`, shared with its capped twin. -/
+def denseForcedPlanOfV (fdoms : List (VarId × FiniteDomain p)) (boxSize : Nat)
+    (cs : DenseConstraintGatherV p) (bis : DenseBusGatherV p) : Option (DenseForcedPlanV p) :=
+  let informative := cs.fullCount != 0 || bis.informative
+  if informative && boxSize * (cs.fullCount + bis.count) ≤ maxEnumWork then
+    let keys := fdoms.map Prod.fst
+    let doms := fdoms.map Prod.snd
+    if cs.active.isEmpty && bis.allDomainRedundant &&
+        doms.all (fun d => d.size != 0) then
+      some (.done (denseConstantDomainsV fdoms))
+    else
+      some (.scan {
+        keys,
+        doms,
+        active := cs.active,
+        interactions := bis.interactions,
+        work := boxSize * (cs.active.length + bis.count + keys.length) })
+  else none
+
+/-- `denseForcedPreflightV` with the work gate pushed into the gathers
+    (`denseForcedPreflightV_eq_fast`). -/
+def denseForcedPreflightFastV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
+    (xs : List VarId) : Option (DenseForcedPlanV p) :=
+  match T.doms xs with
+  | none => none
+  | some fdoms =>
+    let boxSize := (fdoms.map (fun yd => yd.2.size)).prod
+    if boxSize ≤ maxEnumSize then
+      if boxSize = 0 then
+        -- an empty domain makes the work gate vacuous, so there is no cap to gate on
+        denseForcedPlanOfV fdoms boxSize (denseGatherConstraintsV fidx xs)
+          (denseGatherBusesV fidx xs)
+      else
+        let cap := maxEnumWork / boxSize
+        match denseGatherConstraintsCapV fidx xs cap with
+        | none => none
+        | some cs =>
+          match denseGatherBusesCapV fidx xs (cap - cs.fullCount) with
+          | none => none
+          | some bis => denseForcedPlanOfV fdoms boxSize cs bis
+    else none
+
+@[csimp] theorem denseForcedPreflightV_eq_fast :
+    @denseForcedPreflightV = @denseForcedPreflightFastV := by
+  funext p T fidx xs
+  unfold denseForcedPreflightV denseForcedPreflightFastV
+  cases hdoms : T.doms xs with
+  | none => rfl
+  | some fdoms =>
+    by_cases hbox : (fdoms.map (fun yd => yd.2.size)).prod ≤ maxEnumSize
+    · simp only [hbox, ↓reduceIte]
+      by_cases hzero : (fdoms.map (fun yd => yd.2.size)).prod = 0
+      · simp only [hzero, ↓reduceIte]
+        rfl
+      · simp only [hzero, ↓reduceIte]
+        have hpos : 0 < (fdoms.map (fun yd => yd.2.size)).prod := Nat.pos_of_ne_zero hzero
+        have hcs := denseGatherConstraintsCapV_spec fidx xs
+          (maxEnumWork / (fdoms.map (fun yd => yd.2.size)).prod)
+        cases hc : denseGatherConstraintsCapV fidx xs
+            (maxEnumWork / (fdoms.map (fun yd => yd.2.size)).prod) with
+        | none =>
+          rw [hc] at hcs
+          -- the work gate would have rejected: cap < fullCount means boxSize * fullCount > maxEnumWork
+          have hlt : maxEnumWork < (fdoms.map (fun yd => yd.2.size)).prod *
+              (denseGatherConstraintsV fidx xs).fullCount := by
+            rw [Nat.mul_comm]
+            exact (Nat.div_lt_iff_lt_mul hpos).mp hcs
+          have hgate : ¬ ((fdoms.map (fun yd => yd.2.size)).prod *
+              ((denseGatherConstraintsV fidx xs).fullCount +
+                (denseGatherBusesV fidx xs).count) ≤ maxEnumWork) := by
+            refine Nat.not_le.mpr (Nat.lt_of_lt_of_le hlt ?_)
+            exact Nat.mul_le_mul_left _ (Nat.le_add_right _ _)
+          simp [hgate]
+        | some cs =>
+          rw [hc] at hcs
+          have hbis := denseGatherBusesCapV_spec fidx xs
+            (maxEnumWork / (fdoms.map (fun yd => yd.2.size)).prod - cs.fullCount)
+          cases hb : denseGatherBusesCapV fidx xs
+              (maxEnumWork / (fdoms.map (fun yd => yd.2.size)).prod - cs.fullCount) with
+          | none =>
+            rw [hb] at hbis
+            have hle := hcs.2
+            have hsum : maxEnumWork / (fdoms.map (fun yd => yd.2.size)).prod <
+                cs.fullCount + (denseGatherBusesV fidx xs).count := by omega
+            have hgate : maxEnumWork < (fdoms.map (fun yd => yd.2.size)).prod *
+                (cs.fullCount + (denseGatherBusesV fidx xs).count) := by
+              rw [Nat.mul_comm]
+              exact (Nat.div_lt_iff_lt_mul hpos).mp hsum
+            simp only [hb, hcs.1]
+            simp [Nat.not_le.mpr hgate]
+          | some bis =>
+            rw [hb] at hbis
+            simp only [hb, hcs.1, hbis.1]
+            rfl
+    · simp [hbox]
+
 def denseRunForcedScanV (bs : BusSemantics p) (facts : BusFacts p bs)
     (job : DenseForcedScanV p) : List (VarId × ZMod p) :=
   let survC := denseCompiledSurvV bs facts job.active job.interactions job.keys

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -462,8 +462,30 @@ the per-variable bucket maps (`DenseCovIndex.buckets`, `denseVarBucket`, `denseT
 be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide but mechanical;
 worth a prototype on one index first.
 
-**R13. domainBatch is per-target *setup*-bound, not enumeration-bound** (measured 2026-07-28, LBR
-profiles over five OpenVM cases + SP1 keccak; entry 152). Phase shares of in-pass samples:
+**R13. domainBatch is *serial-prologue*-bound, not enumeration-bound** (entries 152–154). The wall
+breakdown below comes from `IO` timers at the pass's position (`OptimizingRuntime.md`, *Timing phases
+from the profiler*); the `perf` table after it is kept only because it shows how a CPU share misleads
+here. Per-phase **wall** (ms, summed over all cleanup invocations, on `main` before entry 154):
+
+| phase | sha256 apc_001 | keccak | SP1 keccak |
+|---|---:|---:|---:|
+| preflight (gathers + `T.doms` over all targets) | **6032** | ~200 | — |
+| `denseConstraintPlansV` | 1970 | 189 | 31 |
+| `denseAddConstraintDoms` | 1344 | 131 | 21 |
+| `denseBusPlansV` | 1225 | 160 | 96 |
+| target dedup (`denseVarSetKey`) | 904 | — | — |
+| `denseAddBusDoms` | 705 | 128 | 43 |
+| index + targets | 632 | 34 | 8 |
+| `denseAddByteDoms` (coset) | 161 | 18 | **633** |
+| the scans (fan-out; ~1 s of wall on sha256) | 3694 serial | 314 | 154 |
+
+Entry 154 took the preflight — 61 % of sha256's gathers were work-gate rejects, and the gate is now
+evaluated *during* the gather (0.81× on the pass there). Remaining, in order:
+`denseConstraintPlansV`, `denseAddConstraintDoms`'s per-variable re-linearization, the target dedup's
+per-target `mergeSort`, and — SP1 only, but the largest single share anywhere in this pass —
+`denseAddByteDoms`.
+
+The older `perf` view (shares of in-pass samples), kept for the contrast:
 
 | phase | sha256 apc_001 | keccak | SP1 keccak | eth apc_071 | wasm apc_005 |
 |---|---:|---:|---:|---:|---:|

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5304,3 +5304,47 @@ lazify `denseByteOperandDomain`'s coset build (21.3 % of the pass on SP1 keccak,
 (d) prefix-pruned / component-split enumeration for the big-box OpenVM cases, gated on a box-shape
 counter first.
 **Worked: yes (domainBatch 0.14x on its worst-share APC, output byte-identical; draft PR).**
+
+### 154. Runtime: push the work gate into domainBatch's gathers (sha256 domainBatch 0.81x)
+MEASURED FIRST, with **`IO` timers hooked at the pass's position** in the profiler rather than `perf`
+shares — after entry 153 showed a CPU share is not a wall budget. Per-phase wall on sha256 apc_001
+(ms, summed over all cleanup invocations): preflight **6032**, `denseConstraintPlansV` 1970,
+`denseAddConstraintDoms` 1344, `denseBusPlansV` 1225, target dedup 904, `denseAddBusDoms` 705,
+index/targets 632, `denseAddByteDoms` 161, and the scans themselves 3694 serial (~1 s of wall across
+64 chunks). Everything but the scans is serial. The same timers on keccak read prologue 660 /
+fan-out 550, and on SP1 keccak 832 / 154 — and they corrected two `perf` attributions from the same
+runs: the profile had merged the bus-table build with `denseBiInformative` under shared symbols, and
+put SP1's coset build at 21 % of CPU where it is 64 % of that case's pass wall.
+THE FUNNEL (sha256 cycle 0, instrumented): 190 243 unique targets → 122 881 die at `T.doms` (81 ms
+for the whole stage) → 1 300 at the box-size gate → **66 062 reach the gathers, costing 6040 ms** →
+of those **39 980 (61 %) are then dropped by the work gate**, 23 490 need no scan, 2 592 scan. One
+gather averages 91 µs at that system size, and 61 % of them are pure waste.
+THE CHANGE: `boxSize * items ≤ maxEnumWork` is a cap on the item count, and a gather's counts only
+grow, so a target that passes the cap has already lost the gate. `denseCapStep` (`@[specialize]`)
+folds with an `Option` accumulator that goes `none` at the cap and stays there;
+`denseGatherConstraintsCapV` / `denseGatherBusesCapV` use it, and `denseForcedPreflightFastV` runs
+the gathers capped at `maxEnumWork / boxSize` (the bus cap is the remainder after the constraint
+count). `denseForcedPreflightV_eq_fast` (`@[csimp]`) proves the twin equal to the original, so **no
+downstream proof changed at all** — the plan list, the scans and the output are the same by theorem.
+Two generic fold lemmas (`denseCapFold_spec`, `denseCapFoldsArr_spec`) carry the invariant "either
+the capped fold equals the uncapped one and stays under the cap, or the uncapped count exceeds it";
+`boxSize = 0` (an empty domain makes the gate vacuous) falls back to the uncapped gathers. The
+`@[csimp]` lemma has to precede the call sites, so these proofs live in the impl module — same
+placement as `denseEnvOfFast_eq_fast`.
+NUMBERS (interleaved vs `main` 3448080, this 20-core box; domainBatch ms, median of 3, sha256 single
+shot): **sha256 apc_001 18033 → 14576 (0.81x)**, case total 173.6 → 170.5 s; keccak 1328 → 1293
+(0.97x); wasm-eth apc_063 1566 → 1533 (0.98x); openvm-eth apc_071 565 → 564; wasm-eth apc_005 35 → 37
+(a 36 ms pass — the cap's arithmetic is visible there); SP1 keccak 1006 → 1007. No other pass column
+moves. Sizing was done first with `@[implemented_by]` (0.82x on sha256) exactly as
+`OptimizingRuntime.md` says, and the first *proved* version measured only 0.90x until `denseCapStep`
+got `@[specialize]` — the generic fold was paying two closure applications per scanned position (the
+csimp checklist's rule 3, confirmed in the C: the specialized step now calls
+`denseGatherConstraintAtV` directly).
+VERIFIED: `opt-export` byte-identical to main on OpenVM keccak / wasm-eth apc_005 / openvm-eth apc_071
+and SP1 keccak / rsp apc_001; keccak `run` counts 2021 / 186 / 1748; `lake build` clean; the csimp is
+live in the C (the original's only caller is its dead `_boxed` wrapper);
+`check-proof-integrity` passes (propext / Classical.choice / Quot.sound).
+NEXT in the same phase table: `denseConstraintPlansV` (1970 ms) and `denseAddConstraintDoms`'s
+per-variable re-linearization (1344 ms) on sha256; `denseAddByteDoms`'s coset build (633 ms of 986)
+on SP1.
+**Worked: yes (sha256 domainBatch 0.81x, output byte-identical; PR follows).**


### PR DESCRIPTION
## What

`domainBatch` preflights every unique target before the fan-out: `T.doms`, the box-size gate, then
the two gathers, then `boxSize * (cs.fullCount + bis.count) ≤ maxEnumWork`. That last gate needs two
*counts*, but the gathers materialize `active : List (DenseExpr p)` and
`interactions : List (BusInteraction …)` to produce them — and on the sha256 case most of that work
is thrown away.

Instrumented funnel, `sha256/apc_001_pcsha256` cycle 0:

```
190243 unique targets
  ├─ T.doms fails      122881      (whole doms stage: 81 ms)
  ├─ box too big         1300
  └─ reached gather     66062      ← 6040 ms, ~91 µs each
       ├─ work gate rejects  39980   (61 %, then dropped entirely)
       ├─ done (no scan)     23490
       └─ real scans          2592
```

`boxSize * items ≤ maxEnumWork` is a cap on the item count, and a gather's counts only grow, so a
target that passes the cap has already lost the gate. This evaluates it *during* the gather:
`denseCapStep` folds with an `Option` accumulator that goes `none` at the cap and stays there,
`denseGatherConstraintsCapV` / `denseGatherBusesCapV` use it, and `denseForcedPreflightFastV` caps
the constraint gather at `maxEnumWork / boxSize` and the bus gather at the remainder. `boxSize = 0`
makes the gate vacuous, so that case falls back to the uncapped gathers.

## Why nothing downstream changed

`denseForcedPreflightV_eq_fast` (`@[csimp]`) proves the twin equal to the original definition, which
stays the spec — so the plan list, the scans, the forced constants and the pass output are the same
**by theorem**, and not one existing proof was touched. Two generic fold lemmas carry the invariant
*either the capped fold equals the uncapped one and stays under the cap, or the uncapped count
exceeds it*; the preflight equality then closes with `maxEnumWork / boxSize < n → maxEnumWork <
boxSize * n`.

The `@[csimp]` lemma has to precede its call sites, so these proofs sit in the impl module rather
than `Proofs/` — the same placement as `denseEnvOfFast_eq_fast`. Verified live in the generated C:
the original's only remaining caller is its dead `_boxed` wrapper.

## Numbers

Interleaved against `main`, this 20-core box; `domainBatch` ms, median of 3 (sha256 single shot):

| case | main | branch | ratio |
|---|---:|---:|---|
| **`sha256/apc_001_pcsha256`** (worst absolute) | 18033 | 14576 | **0.81×** |
| `keccak/apc_001_pckeccak` | 1328 | 1293 | 0.97× |
| `wasm-eth/apc_063_pc0x078B60` | 1566 | 1533 | 0.98× |
| `openvm-eth/apc_071_pc0x3783a8` | 565 | 564 | 1.00× |
| SP1 `keccak/apc_001` | 1006 | 1007 | 1.00× |
| `wasm-eth/apc_005_pc0x2E9C48` | 35 | 37 | (36 ms pass; the cap arithmetic is visible) |

sha256's case total: 173.6 → 170.5 s. No other pass column moves.

**`@[specialize]` on `denseCapStep` is load-bearing.** The first proved version measured 0.90× on
sha256 because the generic fold paid two closure applications per scanned position; with the
attribute the specialized step calls `denseGatherConstraintAtV` directly and the win matches the
unproven `@[implemented_by]` sizing (0.82×).

## Method

Sized before proving, per `OptimizingRuntime.md`: the phase timings came from `IO` timers hooked at
the pass's position in the profiler (a `perf` share would not have found this — it put the gather at
4.6 % of in-pass samples, where it is 32 % of the pass's wall), and the change itself was measured
first behind `@[implemented_by]`. Both probes were reverted; nothing tooling-related is in this diff.

## Checks

- `lake build` clean, no warnings.
- `Scripts/check-proof-integrity.sh` passes (axioms: `propext`, `Classical.choice`, `Quot.sound`).
- `opt-export` byte-identical to `main` on OpenVM keccak / wasm-eth apc_005 / openvm-eth apc_071 and
  SP1 keccak / rsp apc_001; keccak `run` counts unchanged (2021 / 186 / 1748).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
