### PR TITLE
perf(reencode): threaded name counts + varSet freshness (reencode 0.54x on sha256/apc_001)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1337,13 +1337,98 @@ theorem denseFilterConstraints_coveredBy {d : DenseConstraintSystem p} {reg : Va
     (d.filterConstraints keep).CoveredBy reg :=
   ⟨fun e he => h.1 e (List.mem_of_mem_filter he), h.2⟩
 
+/-! ### The variable-superset invariant
+
+`denseWorkStep` decides bit freshness from `state.varSet` rather than scanning the system. What
+licenses that is `DenseWorkVarsOk`: every variable occurring in the working system is in `varSet`.
+The seed satisfies it by construction (`varSet = ofList d.occ`), and an accept preserves it because
+the rewritten system's variables are old variables or fresh bits
+(`denseReencodeOut_vars_subset`), and the fresh bits are exactly what the state update inserts. -/
+
+/-- Every variable of the working system is recorded in `vs`. -/
+def DenseWorkVarsOk (vs : Std.HashSet VarId) (w : DenseReencodeWork p) : Prop :=
+  ∀ v ∈ (denseWorkView w).occ, vs.contains v = true
+
+theorem denseIsZero_vars {c : DenseExpr p} (h : denseIsZero c = true) : c.vars = [] := by
+  cases c <;> simp_all [denseIsZero, DenseExpr.vars]
+
+/-- The raw working pieces have no variable the view lacks: the view only drops `.const 0`
+    tombstones, which carry none. -/
+theorem denseWorkRaw_occ_sub (w : DenseReencodeWork p) :
+    ∀ v ∈ ({ algebraicConstraints := w.cs,
+             busInteractions := w.bis } : DenseConstraintSystem p).occ,
+      v ∈ (denseWorkView w).occ := by
+  intro v hv
+  simp only [DenseConstraintSystem.occ, List.mem_append, List.mem_flatMap] at hv
+  rcases hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
+  · have hkeep : (!denseIsZero c) = true := by
+      cases hz : denseIsZero c with
+      | false => rfl
+      | true => rw [denseIsZero_vars hz] at hcv; simp at hcv
+    refine DenseConstraintSystem.mem_occ_of_constraint (c := c) ?_ hcv
+    show c ∈ w.cs.filter (fun c => !denseIsZero c) ++ w.bools
+    exact List.mem_append.2 (Or.inl (List.mem_filter.2 ⟨hc, hkeep⟩))
+  · exact DenseConstraintSystem.mem_occ_of_bi (bi := bi) hbi hbiv
+
+/-- Filtering constraints cannot introduce a variable. -/
+theorem denseFilterConstraints_occ_sub (d : DenseConstraintSystem p)
+    (keep : DenseExpr p → Bool) :
+    ∀ v ∈ (d.filterConstraints keep).occ, v ∈ d.occ := by
+  intro v hv
+  simp only [DenseConstraintSystem.occ, DenseConstraintSystem.filterConstraints,
+    List.mem_append, List.mem_flatMap] at hv
+  rcases hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
+  · exact DenseConstraintSystem.mem_occ_of_constraint (List.mem_of_mem_filter hc) hcv
+  · exact DenseConstraintSystem.mem_occ_of_bi hbi hbiv
+
+/-- Freshness holds for any bit the system does not mention. -/
+theorem denseFreshScan_of_notMemOcc (d : DenseConstraintSystem p) (bits : List VarId)
+    (h : ∀ b ∈ bits, b ∉ d.occ) : denseFreshScan d bits = true := by
+  have hb : ∀ (e : DenseExpr p), (∀ b ∈ bits, b ∉ e.vars) →
+      e.mentionsAny (Std.HashSet.ofList bits) = false := by
+    intro e he
+    exact (DenseExpr.mentionsAny_ofList_false_iff bits e).2 (fun b hbm =>
+      by
+        cases hm : e.mentions b with
+        | false => rfl
+        | true => exact absurd (DenseExpr.mentions_mem_vars hm) (he b hbm))
+  simp only [denseFreshScan, Bool.and_eq_true, List.all_eq_true, Bool.not_eq_true']
+  refine ⟨fun c hc => hb c (fun b hbm hv => h b hbm ?_), fun bi hbi => ⟨hb _ (fun b hbm hv =>
+    h b hbm ?_), fun e he => hb e (fun b hbm hv => h b hbm ?_)⟩⟩
+  · exact DenseConstraintSystem.mem_occ_of_constraint hc hv
+  · exact DenseConstraintSystem.mem_occ_of_bi hbi (by
+      simp only [denseBIVars, List.mem_append]; exact Or.inl hv)
+  · exact DenseConstraintSystem.mem_occ_of_bi hbi (by
+      simp only [denseBIVars, List.mem_append, List.mem_flatMap]
+      exact Or.inr ⟨e, he, hv⟩)
+
+/-- The step's certificate: the `varSet` test plus the remaining conjuncts give the full
+    certificate, on the strength of the invariant. -/
+theorem denseCheckReencodeVS_sound {w : DenseReencodeWork p}
+    {state : DenseReencodeCacheState p} {xs bits : List VarId}
+    {hm : Std.HashMap VarId (DenseExpr p)} (hvs : DenseWorkVarsOk state.varSet w)
+    (h : denseCheckReencodeVS state
+      { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm = true) :
+    denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm
+      = true := by
+  rw [denseCheckReencodeVS, Bool.and_eq_true] at h
+  obtain ⟨hnv, hnf⟩ := h
+  refine denseCheckReencode_of_parts _ xs bits hm hnf (denseFreshScan_of_notMemOcc _ bits ?_)
+  intro b hb hmem
+  have hcontains : state.varSet.contains b = true :=
+    hvs b (denseWorkRaw_occ_sub w b hmem)
+  have := List.all_eq_true.mp hnv b hb
+  rw [hcontains] at this
+  exact Bool.noConfusion this
+
 set_option maxHeartbeats 1000000 in
 theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
     (reg : VarRegistry) (w : DenseReencodeWork p) (state : DenseReencodeCacheState p)
     (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
     (hcov : (denseWorkView w).CoveredBy reg)
     (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
+    (hvs : DenseWorkVarsOk state.varSet w) :
     reg.Extends (denseWorkStep b reg w state xs freshBase).1
     ∧ (∀ i, (denseWorkStep b reg w state xs freshBase).1.isInput i = reg.isInput i)
     ∧ (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1).CoveredBy
@@ -1370,7 +1455,7 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
   have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
   have hchkView : denseCheckReencode (denseWorkView w) xs bits hm = true := by
     rw [denseWorkView_check hm hbools hxsB' hbitsB']
-    exact hD
+    exact denseCheckReencodeVS_sound hvs hD
   have hview : denseWorkView ro.1
       = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
           (fun c => !denseIsZero c) := by
@@ -1434,17 +1519,22 @@ theorem denseBitSetFold_mem (bits : List VarId) :
 theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
     (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String)
     (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools) :
+    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
+    (hvs : DenseWorkVarsOk state.varSet w) :
     ((denseWorkStep b reg w state xs freshBase).2.1.bounded = true →
       DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
         (denseWorkStep b reg w state xs freshBase).2.1.lastFold
         (denseWorkStep b reg w state xs freshBase).2.1.cs)
     ∧ DenseWorkBoolsOk (denseWorkStep b reg w state xs freshBase).2.1.bitSet
-        (denseWorkStep b reg w state xs freshBase).2.1.bools := by
+        (denseWorkStep b reg w state xs freshBase).2.1.bools
+    ∧ DenseWorkVarsOk (denseWorkStep b reg w state xs freshBase).2.2.2.varSet
+        (denseWorkStep b reg w state xs freshBase).2.1 := by
   fun_cases denseWorkStep b reg w state xs freshBase
-  all_goals try exact ⟨hpos, hbools⟩
+  all_goals try exact ⟨hpos, hbools, hvs⟩
   rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
-  refine ⟨?_, ?_⟩
+  have hxsB' : ∀ x ∈ xs, w.bitSet.contains x = false := by simpa using hbit
+  have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
+  refine ⟨?_, ?_, ?_⟩
   · intro _
     show DenseWorkPosOk _ _ _
     rw [densePosOk_from0]
@@ -1462,6 +1552,27 @@ theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReenco
       exact ⟨bb, rfl, denseBitSetFold_mono bits w.bitSet bb hbb⟩
     · obtain ⟨bb, hbb, rfl⟩ := List.mem_map.1 hc
       exact ⟨bb, rfl, denseBitSetFold_mem bits w.bitSet bb hbb⟩
+  · -- the variable superset survives an accept: the rewritten system's variables are old ones or
+    -- fresh bits, and the fresh bits are exactly what the state update inserts
+    have hchkView : denseCheckReencode (denseWorkView w) xs bits hm = true := by
+      rw [denseWorkView_check hm hbools hxsB' hbitsB']
+      exact denseCheckReencodeVS_sound hvs hD
+    have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
+    have hview : denseWorkView ro.1
+        = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
+            (fun c => !denseIsZero c) := by
+      have h := denseWorkOut_view b (denseWorkEnsureBounded w) xs bits hm
+        (denseWorkEnsureBounded_posOk hpos)
+        (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
+        (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
+      rwa [denseWorkEnsureBounded_view] at h
+    intro v hv
+    show (bits.foldl (·.insert ·) state.varSet).contains v = true
+    rw [hview] at hv
+    rcases denseReencodeOut_vars_subset (denseWorkView w) xs bits hm hpolyVars v
+        (denseFilterConstraints_occ_sub _ _ v hv) with h | h
+    · exact denseBitSetFold_mono bits state.varSet v (hvs v h)
+    · exact denseBitSetFold_mem bits state.varSet v h
 
 set_option maxHeartbeats 1000000 in
 theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantics p) :
@@ -1470,6 +1581,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       (denseWorkView w).CoveredBy reg →
       (w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) →
       DenseWorkBoolsOk w.bitSet w.bools →
+      DenseWorkVarsOk state.varSet w →
       reg.Extends (denseWorkLoop b targets idx reg w state nc nb).1
       ∧ (∀ i, (denseWorkLoop b targets idx reg w state nc nb).1.isInput i = reg.isInput i)
       ∧ (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1).CoveredBy
@@ -1482,7 +1594,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
   intro targets
   induction targets with
   | nil =>
-      intro idx reg w state nc nb hcov _ _
+      intro idx reg w state nc nb hcov _ _ _
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i)
         ∧ (denseWorkView w).CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
@@ -1491,15 +1603,16 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
         (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput (denseWorkView w) bs⟩
   | cons xs rest ih =>
-      intro idx reg w state nc nb hcov hpos hbools
+      intro idx reg w state nc nb hcov hpos hbools hvs
       simp only [denseWorkLoop]
       rcases hstep : denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
           with ⟨reg1, w1, derivs1, state1⟩
       have hsp := denseWorkStep_correct b reg w state xs s!"rnc{nc}_{nb}_{idx}" bs hcov hpos hbools
-      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools
+        hvs
+      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools hvs
       simp only [hstep] at hsp hinv
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
-      obtain ⟨hi_pos, hi_bools⟩ := hinv
+      obtain ⟨hi_pos, hi_bools, hi_vs⟩ := hinv
       rcases hrec : denseWorkLoop b rest (idx + 1) reg1 w1 state1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
@@ -1507,7 +1620,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       have hih := ih (idx + 1) reg1 w1 state1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
-          hs_cov hi_pos hi_bools
+          hs_cov hi_pos hi_bools hi_vs
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1558,10 +1671,17 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
         liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
         bisN := d.busInteractions.length
         dWithin := false } with hst
+    have hseedVars : DenseWorkVarsOk st.varSet (denseWorkSeed d) := by
+      intro v hv
+      rw [denseWorkSeed_view] at hv
+      have hd := denseFilterConstraints_occ_sub d (fun c => !denseIsZero c) v hv
+      rw [hst]
+      show (Std.HashSet.ofList d.occ).contains v = true
+      simpa [Std.HashSet.contains_ofList, List.contains_iff_mem] using hd
     obtain ⟨he, _, hc, hd, hcorr⟩ :=
       denseWorkLoop_correct b bs targets 0 reg (denseWorkSeed d) st
         (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
-        hseedCov hseedPos hseedBools
+        hseedCov hseedPos hseedBools hseedVars
     refine ⟨he, hc, hd, ?_⟩
     -- the seed drops trivially-true constraints, itself a verified step
     have hpre : DensePassCorrect

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1501,10 +1501,12 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
       obtain ⟨hi_pos, hi_bools⟩ := hinv
       rcases hrec : denseWorkLoop b rest (idx + 1) reg1 w1 state1
-          (denseWorkNameCounts derivs1 w1 nc nb).1 (denseWorkNameCounts derivs1 w1 nc nb).2
+          (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
+          (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
           with ⟨reg2, w2, derivs2⟩
       have hih := ih (idx + 1) reg1 w1 state1
-          (denseWorkNameCounts derivs1 w1 nc nb).1 (denseWorkNameCounts derivs1 w1 nc nb).2
+          (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
+          (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
           hs_cov hi_pos hi_bools
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
@@ -1553,6 +1555,8 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
         arrBis := d.busInteractions.toArray
         foldCs := d.algebraicConstraints.zipIdx.foldl
           (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
+        bisN := d.busInteractions.length
         dWithin := false } with hst
     obtain ⟨he, _, hc, hd, hcorr⟩ :=
       denseWorkLoop_correct b bs targets 0 reg (denseWorkSeed d) st

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -340,9 +340,10 @@ theorem denseFreshFused_eq (d : DenseConstraintSystem p) (bits : List VarId) :
     exact ⟨fun c hc b hb => (h b hb).1 c hc, fun bi hbi =>
       ⟨fun b hb => ((h b hb).2 bi hbi).1, fun e he b hb => ((h b hb).2 bi hbi).2 e he⟩⟩
 
-/-- `denseCheckReencode` with the covered set shared between the domain and soundness conjuncts
-    and the freshness conjunct decided in one system walk. -/
-def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
+/-- Every conjunct of the certificate except freshness. Split out so `denseWorkStep` can discharge
+    freshness from the threaded variable superset instead of scanning
+    (`denseFreshScan_of_notMemOcc`). -/
+def denseCheckReencodeNoFresh (d : DenseConstraintSystem p) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
   let es := denseCoveredCsOf d xs
   match denseGroupDoms es xs with
@@ -361,16 +362,36 @@ def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
         decide (((DenseExpr.var x).substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ)
           = denseEnvOfFast s x)))) &&
     patts.all (fun aβ => es.all (fun c =>
-      decide ((c.substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ) = 0))) &&
-    (d.algebraicConstraints.all (fun c => !c.mentionsAny (Std.HashSet.ofList bits)) &&
-      d.busInteractions.all (fun bi =>
-        !bi.multiplicity.mentionsAny (Std.HashSet.ofList bits) &&
-        bi.payload.all (fun e => !e.mentionsAny (Std.HashSet.ofList bits))))
+      decide ((c.substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ) = 0)))
+
+/-- The freshness conjunct: no bit occurs anywhere in the system. -/
+def denseFreshScan (d : DenseConstraintSystem p) (bits : List VarId) : Bool :=
+  d.algebraicConstraints.all (fun c => !c.mentionsAny (Std.HashSet.ofList bits)) &&
+    d.busInteractions.all (fun bi =>
+      !bi.multiplicity.mentionsAny (Std.HashSet.ofList bits) &&
+      bi.payload.all (fun e => !e.mentionsAny (Std.HashSet.ofList bits)))
+
+def denseCheckReencodeFast (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+  denseCheckReencodeNoFresh d xs bits hm && denseFreshScan d bits
 
 @[csimp] theorem denseCheckReencode_eq_fast : @denseCheckReencode = @denseCheckReencodeFast := by
   funext q d xs bits hm
-  unfold denseCheckReencode denseCheckReencodeFast
+  unfold denseCheckReencode denseCheckReencodeFast denseCheckReencodeNoFresh denseFreshScan
   simp only [denseFreshFused_eq]
+  split
+  · rfl
+  · simp only [Bool.and_assoc]
+
+/-- The certificate from its two halves. -/
+theorem denseCheckReencode_of_parts (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p))
+    (h1 : denseCheckReencodeNoFresh d xs bits hm = true)
+    (h2 : denseFreshScan d bits = true) : denseCheckReencode d xs bits hm = true := by
+  have h : denseCheckReencode d xs bits hm = denseCheckReencodeFast d xs bits hm := by
+    simp only [denseCheckReencode_eq_fast]
+  rw [h]
+  simp only [denseCheckReencodeFast, h1, h2, Bool.and_self]
 
 /-! ## Derived-variable methods for the fresh bits
 
@@ -1553,6 +1574,22 @@ structure DenseReencodeCacheState (p : ℕ) where
       candidate is ever accepted. -/
   dWithin : Bool
 
+/-! ### Freshness from the state's variable superset
+
+The certificate's freshness conjunct is its only `O(system)` one: it walks every constraint and
+every bus expression to check that no minted bit occurs there (measured at 66.6 % of the
+certificate, ~25 % of the pass, on sha256/apc_001). `state.varSet` starts as
+`Std.HashSet.ofList d.occ` and only ever *gains* the minted bits, so it over-approximates the live
+variables — and `bits.all (fun b => !varSet.contains b)` is therefore an `O(|bits|)` sufficient
+condition for freshness. Being sufficient rather than equivalent, it enters the proof as an
+implication (`denseCheckReencodeVS_sound`), not a `@[csimp]` equality; the invariant that licenses
+it is `DenseWorkVarsOk`, threaded through the step and the loop. -/
+
+/-- The checked certificate with freshness decided from `state.varSet` in `O(|bits|)`. -/
+def denseCheckReencodeVS (state : DenseReencodeCacheState p) (d : DenseConstraintSystem p)
+    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+  bits.all (fun bb => !state.varSet.contains bb) && denseCheckReencodeNoFresh d xs bits hm
+
 /-- Apply an accepted rewrite to the threaded state in place, mirroring `denseReencodeOut` on the
     stable-position arrays: only positions holding a group variable (bucket candidates) or a
     variable-free composite node (`foldCs`) can change. The root cache keeps every untouched
@@ -1602,7 +1639,9 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
                     (HashedDedup.hashedDedup (hash ·) (denseBIVars bi')) i }
       else st
     else st) st
-  { st with varSet := bits.foldl (·.insert ·) st.varSet, dWithin := true }
+  -- `varSet` is grown from the *input* state: the position folds above never touch it, and reading
+  -- it from `state` keeps `denseReencodeStateUpdate_varSet` a projection instead of a fold invariant.
+  { st with varSet := bits.foldl (·.insert ·) state.varSet, dWithin := true }
 
 theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
     DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
@@ -1676,7 +1715,8 @@ def denseWorkStep (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p
     if xs.all (fun x => state.varSet.contains x) then
     if xs.all (fun x => decide (x ∉ bits)) then
     if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
-    if denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm then
+    if denseCheckReencodeVS state { algebraicConstraints := w.cs, busInteractions := w.bis }
+        xs bits hm then
       let ro := denseWorkOut b (denseWorkEnsureBounded w) xs bits hm
       if (if state.dWithin then ro.2 else (denseWorkView ro.1).withinDegreeB b) then
         (reg1, ro.1,

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -647,9 +647,33 @@ def denseIsZero : DenseExpr p → Bool
   | .const n => n == 0
   | _ => false
 
+/-- `denseIsZero` with the field zero as a parameter. The compiler floats the `0`'s whole
+    `ZMod.commRing` chain to the head of `denseIsZero`, *before* the constructor test, so a caller
+    scanning a list pays four dictionary constructions per item; binding the zero in the function
+    that contains the scan hoists it out of the loop. -/
+def denseIsZeroW (zero : ZMod p) : DenseExpr p → Bool
+  | .const n => n == zero
+  | _ => false
+
+theorem denseIsZeroW_zero : denseIsZeroW (0 : ZMod p) = denseIsZero (p := p) := by
+  funext e; cases e <;> rfl
+
 def denseWorkView (w : DenseReencodeWork p) : DenseConstraintSystem p :=
   { algebraicConstraints := w.cs.filter (fun c => !denseIsZero c) ++ w.bools,
     busInteractions := w.bis }
+
+/-- Boxed twin: `zero` must be a parameter of the function *containing* the scan. A `let` at the
+    head of `denseWorkViewFast` is floated back into the `filter` body by the compiler (verified in
+    the generated C), which is the whole cost being removed here. -/
+def denseWorkViewW (zero : ZMod p) (w : DenseReencodeWork p) : DenseConstraintSystem p :=
+  { algebraicConstraints := w.cs.filter (fun c => !denseIsZeroW zero c) ++ w.bools,
+    busInteractions := w.bis }
+
+def denseWorkViewFast (w : DenseReencodeWork p) : DenseConstraintSystem p := denseWorkViewW 0 w
+
+@[csimp] theorem denseWorkView_eq_fast : @denseWorkView = @denseWorkViewFast := by
+  funext p w
+  simp only [denseWorkView, denseWorkViewFast, denseWorkViewW, denseIsZeroW_zero]
 
 /-- One position's new content: the placeholder if the group covers it, else the gated rewrite. -/
 def denseTombify (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
@@ -1514,6 +1538,12 @@ structure DenseReencodeCacheState (p : ℕ) where
   useBis : DenseCovIndex
   arrBis : Array (BusInteraction (DenseExpr p))
   foldCs : Std.HashSet Nat
+  /-- The number of non-tombstone entries of `w.cs`, and `w.bis.length`. Both feed the fresh-name
+      prefix only (`denseWorkNameCountsS`), which is why they live on the untrusted state: a wrong
+      count can cost a rejected candidate, never soundness. Maintained exactly — the state update
+      visits every position an accept can turn into `.const 0`. -/
+  liveCs : Nat
+  bisN : Nat
   /-- Whether `d` is *known* to be within the degree bound — the side condition that makes
       `denseReencodeOutOk`'s fused degree test agree with measuring the rewritten system outright
       (`denseReencodeOutOk_snd`). Starts `false`, so the first candidate to reach the gate measures
@@ -1538,12 +1568,14 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
     if h : i < st.arrCs.size then
       let c := st.arrCs[i]
       if denseCoveredBy xs c then
+        -- covered ⇒ `c.hasVar` ⇒ `c` was not a tombstone, so the live count drops by one
         { st with arrCs := st.arrCs.set i (.const 0), rootCache := st.rootCache.erase i,
-                  foldCs := st.foldCs.erase i }
+                  foldCs := st.foldCs.erase i, liveCs := st.liveCs - 1 }
       else if c.sharesVarIn xs || c.hasConstFoldableNode then
         let c' := denseGroupRewrite xs bits σfn patts c
         let vs := HashedDedup.hashedDedup (hash ·) c'.vars
         { st with
+          liveCs := if denseIsZero c' then st.liveCs - 1 else st.liveCs
           arrCs := st.arrCs.set i c'
           rootCache := st.rootCache.erase i
           csIdx := if vs.length ≤ 8 then bucketAdd st.csIdx vs i else st.csIdx
@@ -1611,6 +1643,14 @@ def denseWorkNameCounts (derivs : DenseDerivations p) (w : DenseReencodeWork p) 
   if derivs.isEmpty then (nc, nb)
   else ((w.cs.filter (fun c => !denseIsZero c)).length + w.bools.length, w.bis.length)
 
+/-- The same counts, served from the threaded state instead of re-walking the whole system on every
+    accept (`state.liveCs` mirrors `(w.cs.filter (!denseIsZero ·)).length`, `state.bisN` is
+    `w.bis.length`, which no accept changes). Names only need to be fresh, and freshness is checked
+    separately, so this is untrusted. -/
+def denseWorkNameCountsS (derivs : DenseDerivations p) (w : DenseReencodeWork p)
+    (state : DenseReencodeCacheState p) (nc nb : Nat) : Nat × Nat :=
+  if derivs.isEmpty then (nc, nb) else (state.liveCs + w.bools.length, state.bisN)
+
 /-- One checked re-encoding step. Mirrors the cached step, with two extra guards — no group variable
     and no freshly minted bit may be a bit minted earlier — which is what keeps the deferred
     booleanity constraints inert for this group (`denseBoolConstraint_inert`). Rejecting a candidate is
@@ -1656,7 +1696,7 @@ def denseWorkLoop (b : DegreeBound) :
   | [], _, reg, w, _, _, _ => (reg, w, [])
   | xs :: rest, idx, reg, w, state, nc, nb =>
     let (reg1, w1, derivs1, state1) := denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
-    let (nc1, nb1) := denseWorkNameCounts derivs1 w1 nc nb
+    let (nc1, nb1) := denseWorkNameCountsS derivs1 w1 state1 nc nb
     let (reg2, w2, derivs2) := denseWorkLoop b rest (idx + 1) reg1 w1 state1 nc1 nb1
     (reg2, w2, derivs1 ++ derivs2)
 
@@ -1696,6 +1736,8 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         arrBis := d.busInteractions.toArray
         foldCs := d.algebraicConstraints.zipIdx.foldl
           (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
+        bisN := d.busInteractions.length
         dWithin := false }
       (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
     (r.1, denseWorkView r.2.1, r.2.2)


### PR DESCRIPTION
Two runtime changes to reencode, measured against `origin/main` @ `875865b`. **Output-identical** — a runtime PR, not an effectiveness one. Fully proven: no `sorry`, no `axiom`, no unproven `@[implemented_by]`; `Scripts/check-proof-integrity.sh` passes locally (three standard axioms, no unused theorems).

## Numbers

`profile`, this 4-core box, serial, interleaved against prebuilt baseline binaries. sha256 = median of 2 reps (baseline spread 0.7 % across four separate runs today); the three cheap representatives = median of 3.

| | sha256/apc_001 `reencode` | sha256 total | eth apc_006 | wasm apc_012 | keccak apc_001 |
|---|---:|---:|---:|---:|---:|
| baseline | 21704 ms | 170.9 s | 195 ms | 405 ms | 494 ms |
| commit 1 alone | 19239 ms (0.877×) | 0.974× | 0.877× | 1.000× | 0.994× |
| **both** | **11711 ms (0.540×)** | **0.937×** | 0.836× (commit 2 alone) | 1.030× | 1.006× |

reencode was the top pass on this case (12.6 % of the run); it is now fifth, behind busPairCancel 19.3 s, domainBatch 17.8 s, flagFold 14.9 s and gauss 13.5 s.

Output identity: all 11 sha cycle `(vars, bus, constraints)` triples and the final circuit (11906 / 12464 / 3194) match the baseline, for each commit and for the pair; keccak `run` is unchanged (2021 / 186 / 1748).

## Where the time was

`perf record -F 299 --call-graph lbr` over the sha `profile` run, samples charged to the innermost reencode phase, restricted to samples that actually carry a reencode frame. Cycle 0 is 78 % of the pass (17.3 s to remove 128 variables), so this is a cycle-0 story: **~55 % of reencode was `O(system)` sweeps run once per accepted group** (~10² accepts against 146 k constraints / 71 k interactions), and the most expensive of them existed to answer *"nothing here changed"*.

| phase | % of pass | this PR |
|---|---:|---|
| `checkReencode` | 37.2 % (66.6 % of it the freshness scan) | commit 2 |
| `workOut/splice` | 17.0 % | untouched |
| `nameCounts/view` | 13.6 % | commit 1 |

A measurement note worth recording: the reference `PHASES` script in `OptimizingRuntime.md` charges a sample to the first matching frame *anywhere* in the stack, so it credited `withinDegree` with 13.4 % of reencode — that is every pass's `guardDegree`. Requiring a reencode frame in the stack drops it to 0.3 %. I have fixed the script in that doc.

## Commit 1 — fresh-name counts from the threaded state

`denseWorkNameCounts` re-walked the whole system on every accept: `(w.cs.filter (!denseIsZero ·)).length + w.bools.length` allocates and frees a 146 k-cell list per accept, and `denseIsZero` builds the entire `ZMod.commRing → … → toMulZeroClass` chain *before* testing the constructor tag (checked in the generated C), so every visited item paid four dictionary constructions. Leaves under that phase: 30.9 % `lean_dec_ref_cold`, 24.8 % the filter loop, 16 % allocator, 6.7 % the dictionary chain.

`DenseReencodeCacheState` now carries `liveCs`/`bisN`. **No new proof obligation**: the counts feed the fresh-name prefix only, freshness is checked separately, and the state is an opaque parameter in every correctness theorem — a wrong count could cost a rejected candidate, never soundness. The state update already visits every position an accept can turn into `.const 0`, so it maintains the count exactly; `w.bis.length` never changes after the seed, since the bus side is mapped, never filtered.

`denseWorkView`'s exit filter gets the boxed-zero treatment as a proven `@[csimp]` twin. `denseWorkViewW` takes the zero as a parameter rather than binding it in a `let`: the compiler floats a `let` at the function head back into the `filter` body, which I verified in the C before and after.

## Commit 2 — freshness from the threaded variable superset

The certificate's freshness conjunct is its only `O(system)` one, and `Std.HashSet.ofList bits` was rebuilt *inside* the per-item lambdas (`insertManyIfNewUnit` per constraint and per interaction, plus a closure per interaction for the payload `all` — again from the C), so it also drove allocator traffic. That is why it delivered more than its 5.5 s attribution predicted (7.6 s): the sample share undercounted it, because the allocator and refcount traffic it causes was charged to those cost classes rather than to the scan.

`state.varSet` is seeded from `ofList d.occ` and only ever gains the minted bits, so it over-approximates the working system's variables and `bits.all (!varSet.contains ·)` is an `O(|bits|)` **sufficient** condition for freshness. Being sufficient rather than equivalent, it enters the proof as an **implication**, not a `@[csimp]` equality — the cheap direction, needing no twin of the step or the loop.

Proof structure:

- the certificate splits into `denseCheckReencodeNoFresh` and `denseFreshScan`, with `denseCheckReencodeFast` their conjunction, so `denseCheckReencode_eq_fast` still discharges the compiled twin and `denseCheckReencode_of_parts` recombines them;
- `DenseWorkVarsOk vs w` — every variable of the working system is in `vs` — holds at the seed by construction and is preserved by an accept, because the rewritten system's variables are old variables or fresh bits (`denseReencodeOut_vars_subset`, which already existed for registry coverage) while the state update inserts exactly those bits (`denseBitSetFold_mono`/`_mem`);
- `denseFreshScan_of_notMemOcc` turns "no bit occurs in `occ`" into the conjunct via the existing `mentionsAny_ofList_false_iff` and `mentions_mem_vars`;
- threaded through `denseWorkStep_correct`, `denseWorkStep_inv` (third conclusion) and `denseWorkLoop_correct`.

`denseReencodeStateUpdate` now grows `varSet` from the input state rather than the folded intermediate — identical at runtime, since the position folds never touch it, but it keeps the projection an `rfl` instead of needing a fold-invariance lemma.

## Not in this PR

A third change — a position-driven bus rewrite on accept, replacing `denseGateBisGo`'s walk of every interaction — measures `reencode 0.401×` when stacked on this PR (8797 ms), but in prototype form it regresses the small cases (wasm 1.04×, keccak 1.02×) and its proof is not written. It stays local until both are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)