### PR TITLE
perf(reencode): rewrite the bus side of an accept by position (reencode 0.74x on sha256/apc_001)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1421,6 +1421,295 @@ theorem denseCheckReencodeVS_sound {w : DenseReencodeWork p}
   rw [hcontains] at this
   exact Bool.noConfusion this
 
+/-! ### The bus-side index invariant
+
+`denseWorkOut` rewrites the bus list only at the positions it is handed, so it needs those positions
+to cover everywhere `denseBIRewriteGate` could fire. `DenseBusIdxOk` is what supplies that: the
+`useBis` buckets list every position by each of its variables, and `foldBis` lists every position
+carrying a variable-free composite node. Both hold at the seed by construction and are maintained by
+the state update, which folds over the very list the splice consumed. -/
+
+/-- Insert-folding into a set never loses a member. -/
+theorem denseNatFold_mono (l : List Nat) :
+    ∀ (s : Std.HashSet Nat) (v : Nat), s.contains v = true →
+      (l.foldl (·.insert ·) s).contains v = true := by
+  intro s v
+  induction l generalizing s with
+  | nil => intro h; exact h
+  | cons a rest ih => intro h; exact ih _ (by simp [Std.HashSet.contains_insert, h])
+
+/-- A member of the folded list ends up in the set. -/
+theorem denseNatFold_mem (l : List Nat) :
+    ∀ (s : Std.HashSet Nat) (v : Nat), v ∈ l → (l.foldl (·.insert ·) s).contains v = true := by
+  intro s v
+  induction l generalizing s with
+  | nil => intro h; simp at h
+  | cons a rest ih =>
+      intro h
+      rcases List.mem_cons.1 h with rfl | h
+      · exact denseNatFold_mono rest _ v (by simp [Std.HashSet.contains_insert])
+      · exact ih _ h
+
+/-- `denseBuild_complete` in the `getElem?` form the invariant uses. -/
+theorem denseBuild_complete' {α : Type} (varsOf : α → List VarId) (items : List α) (i : Nat)
+    (a : α) (hi : items[i]? = some a) (v : VarId) (hv : v ∈ varsOf a) :
+    i ∈ (denseCovBuild varsOf items).buckets.getD v [] := by
+  obtain ⟨hlt, hget⟩ := List.getElem?_eq_some_iff.1 hi
+  subst hget
+  exact denseBuild_complete varsOf items i hlt v hv
+
+/-- The seed's fold-position scan lists every interaction carrying a variable-free composite node. -/
+theorem denseFoldBisSeed_complete (bis : List (BusInteraction (DenseExpr p))) :
+    ∀ (n : Nat) (s : Std.HashSet Nat) (k : Nat) (bi : BusInteraction (DenseExpr p)),
+      bis[k]? = some bi → denseBiHasFold bi = true →
+      ((bis.zipIdx n).foldl
+        (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s) s).contains (n + k) = true := by
+  have hmono : ∀ (l : List (BusInteraction (DenseExpr p) × Nat)) (s : Std.HashSet Nat) (j : Nat),
+      s.contains j = true →
+      (l.foldl (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s) s).contains j = true := by
+    intro l
+    induction l with
+    | nil => intro s j h; exact h
+    | cons a rest ih =>
+        intro s j h
+        refine ih _ j ?_
+        by_cases hf : denseBiHasFold a.1 = true
+        · simp [hf, Std.HashSet.contains_insert, h]
+        · simp [hf, h]
+  intro n s k bi
+  induction bis generalizing n s k with
+  | nil => intro h; simp at h
+  | cons a rest ih =>
+      intro hk hfold
+      cases k with
+      | zero =>
+          simp only [List.getElem?_cons_zero, Option.some.injEq] at hk
+          subst hk
+          simp only [List.zipIdx_cons, List.foldl_cons]
+          refine hmono _ _ _ ?_
+          simp [hfold, Std.HashSet.contains_insert]
+      | succ k =>
+          simp only [List.getElem?_cons_succ] at hk
+          simp only [List.zipIdx_cons, List.foldl_cons]
+          have := ih (n + 1) (if denseBiHasFold a then s.insert n else s) k hk hfold
+          have heq : n + 1 + k = n + (k + 1) := by omega
+          rwa [heq] at this
+
+/-- Every position of the system whose interaction is listed by its variables, and every position
+    carrying a variable-free composite node. -/
+def DenseBusIdxOk (state : DenseReencodeCacheState p) (w : DenseReencodeWork p) : Prop :=
+  (∀ (i : Nat) (bi : BusInteraction (DenseExpr p)), w.bis[i]? = some bi →
+      ∀ v ∈ denseBIVars bi, i ∈ state.useBis.buckets.getD v [])
+  ∧ (∀ (i : Nat) (bi : BusInteraction (DenseExpr p)), w.bis[i]? = some bi →
+      denseBiHasFold bi = true → state.foldBis.get.contains i = true)
+
+/-- The position list the step builds. -/
+def denseBusPosList (state : DenseReencodeCacheState p) (xs : List VarId) : List Nat :=
+  ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).toList.mergeSort (· ≤ ·)
+
+theorem denseBusPosList_sorted (state : DenseReencodeCacheState p) (xs : List VarId) :
+    (denseBusPosList state xs).Pairwise (· ≤ ·) :=
+  List.pairwise_mergeSort' (fun a b => a ≤ b) _
+
+/-- The invariant makes the position list complete for the gate. -/
+theorem denseBusPosList_cover {state : DenseReencodeCacheState p} {w : DenseReencodeWork p}
+    (xs : List VarId) (hidx : DenseBusIdxOk state w) :
+    ∀ k bi, w.bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ denseBusPosList state xs := by
+  intro k bi hk hf
+  have hset : ((denseCandidates state.useBis xs).foldl (·.insert ·)
+      state.foldBis.get).contains k = true := by
+    have hvar : ∀ (e : DenseExpr p), e.sharesVarIn xs = true → (∀ v ∈ e.vars, v ∈ denseBIVars bi) →
+        ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).contains k = true := by
+      intro e he hsub
+      obtain ⟨v, hv, hvxs⟩ := denseSharesVarIn_exists he
+      exact denseNatFold_mem _ _ k
+        (denseMem_candidates state.useBis xs v k hvxs (hidx.1 k bi hk v (hsub v hv)))
+    have hfold : denseBiHasFold bi = true →
+        ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).contains k = true :=
+      fun h => denseNatFold_mono _ _ k (hidx.2 k bi hk h)
+    simp only [denseBiGateFires, Bool.or_eq_true, List.any_eq_true] at hf
+    rcases hf with (hm | hm) | ⟨e, he, hee⟩
+    · exact hvar bi.multiplicity hm (fun v hv => by
+        simp only [denseBIVars, List.mem_append]; exact Or.inl hv)
+    · exact hfold (by simp [denseBiHasFold, hm])
+    · rcases hee with h | h
+      · exact hvar e h (fun v hv => by
+          simp only [denseBIVars, List.mem_append, List.mem_flatMap]
+          exact Or.inr ⟨e, he, hv⟩)
+      · exact hfold (by
+          simp only [denseBiHasFold, Bool.or_eq_true, List.any_eq_true]
+          exact Or.inr ⟨e, he, h⟩)
+  rw [denseBusPosList, List.mem_mergeSort]
+  simpa [Std.HashSet.mem_toList] using hset
+
+/-- Bucket inserts never lose a member. -/
+theorem denseBucketFold_mono (vs : List VarId) (i : Nat) :
+    ∀ (m : Std.HashMap VarId (List Nat)) (v : VarId) (k : Nat), k ∈ m.getD v [] →
+      k ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD v [] := by
+  intro m v k
+  induction vs generalizing m with
+  | nil => intro h; exact h
+  | cons a rest ih =>
+      intro h
+      refine ih _ ?_
+      by_cases hva : v = a
+      · subst hva
+        rw [Std.HashMap.getD_insert_self]
+        exact List.mem_cons_of_mem _ h
+      · have hne : (m.insert a (i :: m.getD a [])).getD v [] = m.getD v [] := by
+          rw [Std.HashMap.getD_insert]
+          rw [if_neg (show ¬((a == v) = true) by simpa using Ne.symm hva)]
+        rw [hne]; exact h
+
+/-- A variable of the inserted list gets the position. -/
+theorem denseBucketFold_mem (vs : List VarId) (i : Nat) :
+    ∀ (m : Std.HashMap VarId (List Nat)) (v : VarId), v ∈ vs →
+      i ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD v [] := by
+  intro m v
+  induction vs generalizing m with
+  | nil => intro h; simp at h
+  | cons a rest ih =>
+      intro h
+      rcases List.mem_cons.1 h with rfl | h
+      · refine denseBucketFold_mono rest i _ _ i ?_
+        rw [Std.HashMap.getD_insert_self]
+        exact List.mem_cons_self ..
+      · exact ih _ h
+
+/-- Positions the fold does not visit keep their fold-set membership. -/
+theorem denseBusIdxFold_keep_of_not_mem (arrB : Array (BusInteraction (DenseExpr p))) :
+    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat), i ∉ ps →
+      acc.2.contains i = true → (denseBusIdxFold arrB ps acc).2.contains i = true := by
+  intro ps
+  induction ps with
+  | nil => intro acc i _ h; rw [denseBusIdxFold]; exact h
+  | cons j rest ih =>
+      intro acc i hni h
+      have hij : i ≠ j := fun hh => hni (hh ▸ List.mem_cons_self ..)
+      rw [denseBusIdxFold]
+      split
+      · refine ih _ i (fun hmem => hni (List.mem_cons_of_mem _ hmem)) ?_
+        show (if denseBiHasFold _ then acc.2.insert j else acc.2.erase j).contains i = true
+        split
+        · simp [Std.HashSet.contains_insert, h]
+        · simp [Std.HashSet.contains_erase, h, Ne.symm hij]
+      · exact ih _ i (fun hmem => hni (List.mem_cons_of_mem _ hmem)) h
+
+/-- A position whose interaction carries a fold node keeps its membership through the fold: every
+    visit to it re-inserts it, since the decision is a function of the (unchanging) content. -/
+theorem denseBusIdxFold_keep_of_hasFold (arrB : Array (BusInteraction (DenseExpr p))) :
+    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat) (h : i < arrB.size),
+      denseBiHasFold arrB[i] = true → acc.2.contains i = true →
+      (denseBusIdxFold arrB ps acc).2.contains i = true := by
+  intro ps
+  induction ps with
+  | nil => intro acc i _ _ h; rw [denseBusIdxFold]; exact h
+  | cons j rest ih =>
+      intro acc i hlt hfold h
+      rw [denseBusIdxFold]
+      split
+      · refine ih _ i hlt hfold ?_
+        show (if denseBiHasFold _ then acc.2.insert j else acc.2.erase j).contains i = true
+        by_cases hij : i = j
+        · subst hij; rw [if_pos hfold]; simp [Std.HashSet.contains_insert]
+        · split
+          · simp [Std.HashSet.contains_insert, h]
+          · simp [Std.HashSet.contains_erase, h, Ne.symm hij]
+      · exact ih _ i hlt hfold h
+
+/-- Visited in-range positions get their interaction's variables into the buckets. -/
+theorem denseBusIdxFold_buckets (arrB : Array (BusInteraction (DenseExpr p))) :
+    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat),
+      (∀ v k, k ∈ acc.1.buckets.getD v [] →
+        k ∈ (denseBusIdxFold arrB ps acc).1.buckets.getD v [])
+      ∧ (∀ i, i ∈ ps → ∀ (h : i < arrB.size), ∀ v ∈ denseBIVars arrB[i],
+          i ∈ (denseBusIdxFold arrB ps acc).1.buckets.getD v []) := by
+  intro ps
+  induction ps with
+  | nil =>
+      intro acc
+      exact ⟨fun v k h => by rw [denseBusIdxFold]; exact h, fun i h => absurd h (by simp)⟩
+  | cons j rest ih =>
+      intro acc
+      rw [denseBusIdxFold]
+      split
+      · next hj =>
+        obtain ⟨ih1, ih2⟩ := ih (⟨(HashedDedup.hashedDedup (hash ·)
+            (denseBIVars arrB[j])).foldl (fun m v => m.insert v (j :: m.getD v [])) acc.1.buckets,
+            acc.1.varless⟩,
+          if denseBiHasFold arrB[j] then acc.2.insert j else acc.2.erase j)
+        refine ⟨fun v k h => ih1 v k (denseBucketFold_mono _ _ _ v k h), ?_⟩
+        intro i hi h v hv
+        rcases List.mem_cons.1 hi with rfl | hi
+        · refine ih1 v i (denseBucketFold_mem _ _ _ v ?_)
+          rw [HashedDedup.hashedDedup_eq]
+          exact List.mem_dedup.2 (by simpa using hv)
+        · exact ih2 i hi h v hv
+      · next hj =>
+        obtain ⟨ih1, ih2⟩ := ih acc
+        refine ⟨ih1, ?_⟩
+        intro i hi h v hv
+        rcases List.mem_cons.1 hi with rfl | hi
+        · exact absurd h hj
+        · exact ih2 i hi h v hv
+
+/-- A visited in-range position carrying a fold node ends up in the fold set. -/
+theorem denseBusIdxFold_mem_of_hasFold (arrB : Array (BusInteraction (DenseExpr p))) :
+    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat) (h : i < arrB.size),
+      i ∈ ps → denseBiHasFold arrB[i] = true →
+      (denseBusIdxFold arrB ps acc).2.contains i = true := by
+  intro ps
+  induction ps with
+  | nil => intro _ i _ hi _; exact absurd hi (by simp)
+  | cons j rest ih =>
+      intro acc i hlt hi hfold
+      rcases List.mem_cons.1 hi with rfl | hi
+      · rw [denseBusIdxFold, dif_pos hlt]
+        refine denseBusIdxFold_keep_of_hasFold arrB rest _ i hlt hfold ?_
+        show (if denseBiHasFold arrB[i] then acc.2.insert i else acc.2.erase i).contains i = true
+        rw [if_pos hfold]
+        simp [Std.HashSet.contains_insert]
+      · rw [denseBusIdxFold]
+        split
+        · exact ih _ i hlt hi hfold
+        · exact ih _ i hlt hi hfold
+
+/-- The index invariant survives an accept: the update folds over the positions the rewrite visited,
+    recording the new interactions' variables, and every other position kept its content. -/
+theorem denseBusIdxOk_update {state : DenseReencodeCacheState p} {w w' : DenseReencodeWork p}
+    {xs bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
+    (hidx : DenseBusIdxOk state w)
+    (hnew : ∀ i bi, w'.bis[i]? = some bi → i ∉ denseBusPosList state xs →
+      w.bis[i]? = some bi) :
+    DenseBusIdxOk
+      (denseReencodeStateUpdate state (denseBusPosList state xs) w'.bis xs bits hm) w' := by
+  set ps := denseBusPosList state xs with hps
+  have hproj : (denseReencodeStateUpdate state ps w'.bis xs bits hm).useBis
+      = (denseBusIdxFold w'.bis.toArray ps (state.useBis, state.foldBis.get)).1 := rfl
+  have hprojF : (denseReencodeStateUpdate state ps w'.bis xs bits hm).foldBis.get
+      = (denseBusIdxFold w'.bis.toArray ps (state.useBis, state.foldBis.get)).2 := rfl
+  obtain ⟨hb1, hb2⟩ :=
+    denseBusIdxFold_buckets w'.bis.toArray ps (state.useBis, state.foldBis.get)
+  constructor
+  · intro i bi hi v hv
+    obtain ⟨hlt', hget⟩ := List.getElem?_eq_some_iff.1 hi
+    have hlt : i < w'.bis.toArray.size := by simpa using hlt'
+    have hidx' : w'.bis.toArray[i] = bi := by simpa using hget
+    rw [hproj]
+    by_cases hmem : i ∈ ps
+    · exact hb2 i hmem hlt v (by rw [hidx']; exact hv)
+    · exact hb1 v i (hidx.1 i bi (hnew i bi hi hmem) v hv)
+  · intro i bi hi hfold
+    obtain ⟨hlt', hget⟩ := List.getElem?_eq_some_iff.1 hi
+    have hlt : i < w'.bis.toArray.size := by simpa using hlt'
+    have hidx' : w'.bis.toArray[i] = bi := by simpa using hget
+    rw [hprojF]
+    by_cases hmem : i ∈ ps
+    · exact denseBusIdxFold_mem_of_hasFold w'.bis.toArray ps _ i hlt hmem
+        (by rw [hidx']; exact hfold)
+    · exact denseBusIdxFold_keep_of_not_mem w'.bis.toArray ps _ i hmem
+        (hidx.2 i bi (hnew i bi hi hmem) hfold)
+
 set_option maxHeartbeats 1000000 in
 theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
     (reg : VarRegistry) (w : DenseReencodeWork p) (state : DenseReencodeCacheState p)
@@ -1428,7 +1717,8 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
     (hcov : (denseWorkView w).CoveredBy reg)
     (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
     (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hvs : DenseWorkVarsOk state.varSet w) :
+    (hvs : DenseWorkVarsOk state.varSet w)
+    (hidxB : DenseBusIdxOk state w) :
     reg.Extends (denseWorkStep b reg w state xs freshBase).1
     ∧ (∀ i, (denseWorkStep b reg w state xs freshBase).1.isInput i = reg.isInput i)
     ∧ (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1).CoveredBy
@@ -1459,10 +1749,15 @@ theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
   have hview : denseWorkView ro.1
       = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
           (fun c => !denseIsZero c) := by
-    have h := denseWorkOut_view b (denseWorkEnsureBounded w) xs bits hm
+    have h := denseWorkOut_view (usePosB := denseBusPosList state1 xs)
+        b (denseWorkEnsureBounded w) xs bits hm
       (denseWorkEnsureBounded_posOk hpos)
       (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
       (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
+      (denseBusPosList_sorted state1 xs)
+      (by
+        intro k bi hk hf
+        exact denseBusPosList_cover xs hidxB k bi (by rwa [denseWorkEnsureBounded_bis] at hk) hf)
     rwa [denseWorkEnsureBounded_view] at h
   have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
   have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
@@ -1520,7 +1815,8 @@ theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReenco
     (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String)
     (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
     (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hvs : DenseWorkVarsOk state.varSet w) :
+    (hvs : DenseWorkVarsOk state.varSet w)
+    (hidxB : DenseBusIdxOk state w) :
     ((denseWorkStep b reg w state xs freshBase).2.1.bounded = true →
       DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
         (denseWorkStep b reg w state xs freshBase).2.1.lastFold
@@ -1528,13 +1824,15 @@ theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReenco
     ∧ DenseWorkBoolsOk (denseWorkStep b reg w state xs freshBase).2.1.bitSet
         (denseWorkStep b reg w state xs freshBase).2.1.bools
     ∧ DenseWorkVarsOk (denseWorkStep b reg w state xs freshBase).2.2.2.varSet
+        (denseWorkStep b reg w state xs freshBase).2.1
+    ∧ DenseBusIdxOk (denseWorkStep b reg w state xs freshBase).2.2.2
         (denseWorkStep b reg w state xs freshBase).2.1 := by
   fun_cases denseWorkStep b reg w state xs freshBase
-  all_goals try exact ⟨hpos, hbools, hvs⟩
+  all_goals try exact ⟨hpos, hbools, hvs, hidxB⟩
   rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
   have hxsB' : ∀ x ∈ xs, w.bitSet.contains x = false := by simpa using hbit
   have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
-  refine ⟨?_, ?_, ?_⟩
+  refine ⟨?_, ?_, ?_, ?_⟩
   · intro _
     show DenseWorkPosOk _ _ _
     rw [densePosOk_from0]
@@ -1561,10 +1859,16 @@ theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReenco
     have hview : denseWorkView ro.1
         = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
             (fun c => !denseIsZero c) := by
-      have h := denseWorkOut_view b (denseWorkEnsureBounded w) xs bits hm
+      have h := denseWorkOut_view (usePosB := denseBusPosList state1 xs)
+          b (denseWorkEnsureBounded w) xs bits hm
         (denseWorkEnsureBounded_posOk hpos)
         (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
         (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
+        (denseBusPosList_sorted state1 xs)
+        (by
+          intro k bi hk hf
+          exact denseBusPosList_cover (w := w) xs hidxB k bi
+            (by rwa [denseWorkEnsureBounded_bis] at hk) hf)
       rwa [denseWorkEnsureBounded_view] at h
     intro v hv
     show (bits.foldl (·.insert ·) state.varSet).contains v = true
@@ -1573,6 +1877,24 @@ theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReenco
         (denseFilterConstraints_occ_sub _ _ v hv) with h | h
     · exact denseBitSetFold_mono bits state.varSet v (hvs v h)
     · exact denseBitSetFold_mem bits state.varSet v h
+  · -- the bus index invariant survives an accept
+    have hcov : ∀ k bi, (denseWorkEnsureBounded w).bis[k]? = some bi →
+        denseBiGateFires xs bi = true → k ∈ denseBusPosList state1 xs := by
+      intro k bi hk hf
+      exact denseBusPosList_cover (w := w) xs hidxB k bi
+        (by rwa [denseWorkEnsureBounded_bis] at hk) hf
+    have hnew : ∀ i bi, ro.1.bis[i]? = some bi → i ∉ denseBusPosList state1 xs →
+        w.bis[i]? = some bi := by
+      intro i bi hi hni
+      have hro : ro.1.bis = (denseGateBisPos b.busInteractions xs bits (denseGroupSubst xs hm)
+          (denseAssignments (denseBitBox bits)) (denseBusPosList state1 xs) 0
+          (denseWorkEnsureBounded w).bis [] true).1 := rfl
+      rw [hro] at hi
+      have := denseGateBisPos_untouched b.busInteractions xs bits (denseGroupSubst xs hm)
+        (denseAssignments (denseBitBox bits)) (denseBusPosList state1 xs)
+        (denseWorkEnsureBounded w).bis (denseBusPosList_sorted state1 xs) hcov i bi hi hni
+      rwa [denseWorkEnsureBounded_bis] at this
+    exact denseBusIdxOk_update hidxB hnew
 
 set_option maxHeartbeats 1000000 in
 theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantics p) :
@@ -1582,6 +1904,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       (w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) →
       DenseWorkBoolsOk w.bitSet w.bools →
       DenseWorkVarsOk state.varSet w →
+      DenseBusIdxOk state w →
       reg.Extends (denseWorkLoop b targets idx reg w state nc nb).1
       ∧ (∀ i, (denseWorkLoop b targets idx reg w state nc nb).1.isInput i = reg.isInput i)
       ∧ (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1).CoveredBy
@@ -1594,7 +1917,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
   intro targets
   induction targets with
   | nil =>
-      intro idx reg w state nc nb hcov _ _ _
+      intro idx reg w state nc nb hcov _ _ _ _
       show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i)
         ∧ (denseWorkView w).CoveredBy reg
         ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
@@ -1603,16 +1926,16 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
         (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput (denseWorkView w) bs⟩
   | cons xs rest ih =>
-      intro idx reg w state nc nb hcov hpos hbools hvs
+      intro idx reg w state nc nb hcov hpos hbools hvs hidxB
       simp only [denseWorkLoop]
       rcases hstep : denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
           with ⟨reg1, w1, derivs1, state1⟩
       have hsp := denseWorkStep_correct b reg w state xs s!"rnc{nc}_{nb}_{idx}" bs hcov hpos hbools
-        hvs
-      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools hvs
+        hvs hidxB
+      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools hvs hidxB
       simp only [hstep] at hsp hinv
       obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
-      obtain ⟨hi_pos, hi_bools, hi_vs⟩ := hinv
+      obtain ⟨hi_pos, hi_bools, hi_vs, hi_idxB⟩ := hinv
       rcases hrec : denseWorkLoop b rest (idx + 1) reg1 w1 state1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
@@ -1620,7 +1943,7 @@ theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantic
       have hih := ih (idx + 1) reg1 w1 state1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
           (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
-          hs_cov hi_pos hi_bools hi_vs
+          hs_cov hi_pos hi_bools hi_vs hi_idxB
       simp only [hrec] at hih
       obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
       refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
@@ -1668,6 +1991,8 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
         arrBis := d.busInteractions.toArray
         foldCs := d.algebraicConstraints.zipIdx.foldl
           (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        foldBis := Thunk.mk (fun _ => d.busInteractions.zipIdx.foldl
+          (fun s bi => if denseBiHasFold bi.1 then s.insert bi.2 else s) ∅)
         liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
         bisN := d.busInteractions.length
         dWithin := false } with hst
@@ -1678,10 +2003,22 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
       rw [hst]
       show (Std.HashSet.ofList d.occ).contains v = true
       simpa [Std.HashSet.contains_ofList, List.contains_iff_mem] using hd
+    have hseedIdxB : DenseBusIdxOk st (denseWorkSeed d) := by
+      constructor
+      · intro i bi hi v hv
+        rw [hst]
+        show i ∈ (denseCovBuild denseBIVars d.busInteractions).buckets.getD v []
+        exact denseBuild_complete' denseBIVars d.busInteractions i bi (by simpa using hi) v hv
+      · intro i bi hi hfold
+        rw [hst]
+        show ((d.busInteractions.zipIdx).foldl
+          (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s)
+          (∅ : Std.HashSet Nat)).contains i = true
+        simpa using denseFoldBisSeed_complete d.busInteractions 0 ∅ i bi (by simpa using hi) hfold
     obtain ⟨he, _, hc, hd, hcorr⟩ :=
       denseWorkLoop_correct b bs targets 0 reg (denseWorkSeed d) st
         (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
-        hseedCov hseedPos hseedBools hseedVars
+        hseedCov hseedPos hseedBools hseedVars hseedIdxB
     refine ⟨he, hc, hd, ?_⟩
     -- the seed drops trivially-true constraints, itself a verified step
     have hpre : DensePassCorrect

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -582,47 +582,6 @@ theorem denseBIGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId →
   unfold denseBIGateDeg denseBIRewriteGate
   split <;> rfl
 
-/-- The bus side of the fused gate: an interaction none of whose expressions can change is kept
-    as-is, and only the ones it rewrites are measured against the degree bound. -/
-def denseGateBisGo (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) :
-    List (BusInteraction (DenseExpr p)) → List (BusInteraction (DenseExpr p)) → Bool →
-      List (BusInteraction (DenseExpr p)) × Bool
-  | [], acc, ok => (acc.reverse, ok)
-  | bi :: rest, acc, ok =>
-      if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
-          || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
-        let bi' : BusInteraction (DenseExpr p) :=
-          { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
-                    payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
-        denseGateBisGo dmax xs bits σfn patts rest (bi' :: acc)
-          (ok && (decide (bi'.multiplicity.degree ≤ dmax) &&
-            bi'.payload.all (fun e => decide (e.degree ≤ dmax))))
-      else denseGateBisGo dmax xs bits σfn patts rest (bi :: acc) ok
-
-theorem denseGateBisGo_eq (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) :
-    ∀ (l acc : List (BusInteraction (DenseExpr p))) (ok : Bool),
-      denseGateBisGo dmax xs bits σfn patts l acc ok
-        = (acc.reverse ++ l.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1),
-           ok && l.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) := by
-  intro l
-  induction l with
-  | nil => intro acc ok; simp [denseGateBisGo]
-  | cons bi rest ih =>
-      intro acc ok
-      rw [denseGateBisGo]
-      split
-      · next h =>
-          rw [ih]
-          simp only [List.map_cons, List.all_cons, denseBIGateDeg, if_pos h,
-            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append, Bool.and_assoc]
-      · next h =>
-          rw [ih]
-          simp only [List.map_cons, List.all_cons, denseBIGateDeg, if_neg h,
-            List.reverse_cons, List.append_assoc, List.cons_append, List.nil_append,
-            Bool.true_and]
-
 /-- Two lists' `all` agree when the predicates agree pointwise on the members. -/
 theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
     (h : ∀ x ∈ l, f x = g x) : l.all f = l.all g := by
@@ -631,6 +590,153 @@ theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
   | cons x rest ih =>
       rw [List.all_cons, List.all_cons, h x List.mem_cons_self,
         ih (fun y hy => h y (List.mem_cons_of_mem x hy))]
+
+/-- Whether any expression of the interaction carries a variable-free composite node. Independent of
+    the group, so it is a property of the interaction and does not need re-deriving per accept. -/
+def denseBiHasFold (bi : BusInteraction (DenseExpr p)) : Bool :=
+  bi.multiplicity.hasConstFoldableNode || bi.payload.any (fun e => e.hasConstFoldableNode)
+
+/-- Whether the group rewrite can change the interaction: it touches a group variable, or it carries
+    a variable-free composite node the rewrite would fold. `denseBIRewriteGate` and
+    `denseBIGateDeg` are the identity when this is `false` (`denseBIGateDeg_of_not_fires`). -/
+def denseBiGateFires (xs : List VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode ||
+    bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode)
+
+/-- The bus side of an accept, driven by an ascending position list instead of by a gate test at
+    every interaction: `denseBIRewriteGate` is the identity wherever the gate cannot fire
+    (`denseBIRewriteGate_eq` + `denseGroupRewrite_eq_self`), and the positions where it can are the
+    `useBis` bucket candidates for `xs` together with the interactions carrying a variable-free
+    composite node. Once the positions run out the remaining suffix is shared untouched, which is
+    what makes this `O(prefix + candidates)` rather than `O(system)` tree walks. -/
+def denseGateBisPos (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
+    (patts : List (List (VarId × ZMod p))) :
+    List Nat → Nat → List (BusInteraction (DenseExpr p)) →
+      List (BusInteraction (DenseExpr p)) → Bool →
+      List (BusInteraction (DenseExpr p)) × Bool
+  | _, _, [], acc, ok => (acc.reverse, ok)
+  | [], _, rest, acc, ok => (acc.reverse ++ rest, ok)
+  | j :: ps, i, bi :: rest, acc, ok =>
+      if j < i then denseGateBisPos dmax xs bits σfn patts ps i (bi :: rest) acc ok
+      else if j == i then
+        let r := denseBIGateDeg dmax xs bits σfn patts bi
+        denseGateBisPos dmax xs bits σfn patts ps (i + 1) rest (r.1 :: acc) (ok && r.2)
+      else denseGateBisPos dmax xs bits σfn patts (j :: ps) (i + 1) rest (bi :: acc) ok
+
+/-- The gate leaves an interaction it cannot fire on completely alone. -/
+theorem denseBIGateDeg_of_not_fires (dmax : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
+    {bi : BusInteraction (DenseExpr p)} (h : denseBiGateFires xs bi = false) :
+    denseBIGateDeg dmax xs bits σfn patts bi = (bi, true) := by
+  unfold denseBIGateDeg
+  rw [if_neg (by simpa [denseBiGateFires] using h)]
+
+/-- The position-driven bus rewrite equals the dense one, provided every position the gate can fire
+    on is listed. Extra and out-of-range positions are harmless (each visited position is re-tested by
+    `denseBIGateDeg`); the listed positions must be ascending, which is what lets the scan share the
+    suffix once they run out. -/
+theorem denseGateBisPos_eq (dmax : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) :
+    ∀ (bis : List (BusInteraction (DenseExpr p))) (ps : List Nat) (i : Nat)
+      (acc : List (BusInteraction (DenseExpr p))) (ok : Bool),
+      ps.Pairwise (· ≤ ·) →
+      (∀ k bi, bis[k]? = some bi → denseBiGateFires xs bi = true → (i + k) ∈ ps) →
+      denseGateBisPos dmax xs bits σfn patts ps i bis acc ok
+        = (acc.reverse ++ bis.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1),
+           ok && bis.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) := by
+  -- `gid l` : the gate is the identity on every item of `l`
+  have gid : ∀ (l : List (BusInteraction (DenseExpr p))),
+      (∀ bi ∈ l, denseBiGateFires xs bi = false) →
+      l.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1) = l ∧
+      (l.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) = true := by
+    intro l hl
+    constructor
+    · have h := List.map_congr_left (l := l)
+        (f := fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1) (g := id)
+        (fun bi hbi => by
+          simp [denseBIGateDeg_of_not_fires dmax xs bits σfn patts (hl bi hbi)])
+      rwa [List.map_id] at h
+    · rw [List.all_eq_true]
+      intro bi hbi
+      simp only [denseBIGateDeg_of_not_fires dmax xs bits σfn patts (hl bi hbi)]
+  intro bis
+  induction bis with
+  | nil =>
+      intro ps i acc ok _ _
+      cases ps <;> simp [denseGateBisPos]
+  | cons bi rest ih =>
+      intro ps i acc ok hsorted hcov
+      induction ps with
+      | nil =>
+          have hl : ∀ bi' ∈ bi :: rest, denseBiGateFires xs bi' = false := by
+            intro bi' hbi'
+            cases hf : denseBiGateFires xs bi' with
+            | false => rfl
+            | true =>
+                obtain ⟨k, hk⟩ := List.mem_iff_getElem?.1 hbi'
+                exact absurd (hcov k bi' hk hf) (by simp)
+          obtain ⟨hmap, hall⟩ := gid (bi :: rest) hl
+          simp only [denseGateBisPos, hmap, hall, Bool.and_true]
+      | cons j ps' ihps =>
+          have hsorted' : ps'.Pairwise (· ≤ ·) :=
+            List.Pairwise.sublist (List.sublist_cons_self j ps') hsorted
+          rcases Nat.lt_trichotomy j i with hji | hji | hji
+          · -- a position already passed: drop it and keep the same items
+            rw [denseGateBisPos, if_pos hji]
+            refine ihps hsorted' ?_
+            intro k bi' hk hf
+            rcases List.mem_cons.1 (hcov k bi' hk hf) with h | h
+            · omega
+            · exact h
+          · -- the current position: rewrite this item
+            rw [denseGateBisPos, if_neg (by omega), if_pos (show (j == i) = true by simp [hji])]
+            rw [ih ps' (i + 1) _ _ hsorted' ?_]
+            · simp [Bool.and_assoc]
+            · intro k bi' hk hf
+              have h1 := hcov (k + 1) bi' (by simpa using hk) hf
+              rcases List.mem_cons.1 h1 with h | h
+              · omega
+              · have : i + 1 + k = i + (k + 1) := by omega
+                rwa [this]
+          · -- the next listed position is later: this item cannot fire
+            have hni : denseBiGateFires xs bi = false := by
+              cases hf : denseBiGateFires xs bi with
+              | false => rfl
+              | true =>
+                  have h0 := hcov 0 bi (by simp) hf
+                  rcases List.mem_cons.1 (by simpa using h0) with h | h
+                  · omega
+                  · have := (List.pairwise_cons.1 hsorted).1 i h
+                    omega
+            rw [denseGateBisPos, if_neg (by omega),
+              if_neg (show ¬ ((j == i) = true) by simp; omega)]
+            rw [ih (j :: ps') (i + 1) _ _ hsorted ?_]
+            · simp [denseBIGateDeg_of_not_fires dmax xs bits σfn patts hni]
+            · intro k bi' hk hf
+              have h1 := hcov (k + 1) bi' (by simpa using hk) hf
+              have : i + 1 + k = i + (k + 1) := by omega
+              rwa [this]
+
+/-- A position the rewrite did not visit keeps its interaction. -/
+theorem denseGateBisPos_untouched (dmax : Nat) (xs bits : List VarId)
+    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
+    (ps : List Nat) (bis : List (BusInteraction (DenseExpr p)))
+    (hsorted : ps.Pairwise (· ≤ ·))
+    (hcov : ∀ k bi, bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ ps) :
+    ∀ i bi, ((denseGateBisPos dmax xs bits σfn patts ps 0 bis [] true).1)[i]? = some bi →
+      i ∉ ps → bis[i]? = some bi := by
+  intro i bi hi hni
+  rw [denseGateBisPos_eq dmax xs bits σfn patts bis ps 0 [] true hsorted
+    (by simpa using hcov)] at hi
+  simp only [List.reverse_nil, List.nil_append, List.getElem?_map,
+    Option.map_eq_some_iff] at hi
+  obtain ⟨bi0, hbi0, hgate⟩ := hi
+  have hfires : denseBiGateFires xs bi0 = false := by
+    cases hf : denseBiGateFires xs bi0 with
+    | false => rfl
+    | true => exact absurd (hcov i bi0 hbi0 hf) hni
+  rw [denseBIGateDeg_of_not_fires dmax xs bits σfn patts hfires] at hgate
+  rw [hbi0, ← hgate]
 
 /-! ## Deferred materialisation: the loop's working system
 
@@ -1150,30 +1256,45 @@ theorem denseBoolConstraints_not_zero (bits : List VarId) :
 
 
 /-- One accept on the working system: splice the constraints, gate the bus interactions (reusing the
-    fused traversal of `denseGateBisGo`), and accumulate the booleanity constraints. Assumes the
+    position-driven `denseGateBisPos`), and accumulate the booleanity constraints. Assumes the
     position bound is computed — `denseWorkStep` calls `denseWorkEnsureBounded` first. -/
-def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List VarId)
+def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (usePosB : List Nat)
+    (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeWork p × Bool :=
   let σfn := denseGroupSubst xs hm
   let patts := denseAssignments (denseBitBox bits)
   let mp := denseWorkMaxPos w.lastPos w.lastFold xs
   let rc := denseWorkSpliceCs b.identities xs bits σfn patts mp 0 w.cs [] w.lastPos w.lastFold true
-  let rb := denseGateBisGo b.busInteractions xs bits σfn patts w.bis [] true
+  let rb := denseGateBisPos b.busInteractions xs bits σfn patts usePosB 0 w.bis [] true
   let newBools := bits.map (denseBoolConstraint (p := p))
   ({ cs := rc.1, bis := rb.1, bools := w.bools ++ newBools,
      bitSet := bits.foldl (·.insert ·) w.bitSet,
      lastPos := rc.2.1, lastFold := rc.2.2.1, bounded := true },
    (rc.2.2.2 && newBools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
 
-/-- An accept on the working system is `denseReencodeOut` on the view, followed by dropping the
-    placeholders — and dropping those is itself a verified transformation
-    (`DensePassCorrect.denseFilterConstraintsEntailed`), so both halves reuse existing correctness. -/
-theorem denseWorkOut_view (b : DegreeBound) (w : DenseReencodeWork p) (xs bits : List VarId)
+/-- **Unproven on this branch (measurement).** The real statement adds the completeness side
+    condition that makes the position-driven bus rewrite agree with `denseReencodeOut`:
+
+    `hcomplete : ∀ i bi, w.bis[i]? = some bi →
+       (bi.multiplicity.sharesVarIn xs = true ∨ bi.multiplicity.hasConstFoldableNode = true ∨
+        bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) = true) → i ∈ usePosB`
+
+    plus `usePosB` ascending. The `useBis` buckets are complete by construction and `foldBis` tracks
+    the fold positions, so a superset is fine and every visited position is re-tested by
+    `denseBIGateDeg`. Given that, the bus half of the old proof goes through with
+    `denseBIRewriteGate_eq` + `denseGroupRewrite_eq_self` supplying the identity at every unvisited
+    position and at the shared suffix — structurally the same argument
+    `denseTombify_id_of_untouched` already makes on the constraint side, which is why this shape was
+    chosen over the array-backed one. The constraint half of this lemma is untouched. -/
+theorem denseWorkOut_view (b : DegreeBound) (w : DenseReencodeWork p) {usePosB : List Nat}
+    (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p))
     (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
     (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false) :
-    denseWorkView (denseWorkOut b w xs bits hm).1
+    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false)
+    (hsortedB : usePosB.Pairwise (· ≤ ·))
+    (hcoverB : ∀ k bi, w.bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ usePosB) :
+    denseWorkView (denseWorkOut b w usePosB xs bits hm).1
       = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
           (fun c => !denseIsZero c) := by
   obtain ⟨hbcov, hbmap, hbz⟩ := denseWorkBools_filter_covered (bools := w.bools) bits
@@ -1187,14 +1308,16 @@ theorem denseWorkOut_view (b : DegreeBound) (w : DenseReencodeWork p) (xs bits :
       (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs)
       w.cs 0 [] w.lastPos w.lastFold true (denseWorkBounded_of_posOk hpos)
     simpa using this
-  have hbus : (denseGateBisGo b.busInteractions xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) w.bis [] true).1
+  have hbus : (denseGateBisPos b.busInteractions xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) usePosB 0 w.bis [] true).1
       = w.bis.map (fun bi => { bi with
           multiplicity := denseGroupRewrite xs bits (denseGroupSubst xs hm)
             (denseAssignments (denseBitBox bits)) bi.multiplicity,
           payload := bi.payload.map (denseGroupRewrite xs bits (denseGroupSubst xs hm)
             (denseAssignments (denseBitBox bits))) }) := by
-    rw [denseGateBisGo_eq]
+    rw [denseGateBisPos_eq b.busInteractions xs bits (denseGroupSubst xs hm)
+      (denseAssignments (denseBitBox bits)) w.bis usePosB 0 [] true hsortedB
+      (by simpa using hcoverB)]
     simp only [List.reverse_nil, List.nil_append]
     exact List.map_congr_left (fun bi _ => by
       rw [denseBIGateDeg_fst, denseBIRewriteGate_eq])
@@ -1559,6 +1682,11 @@ structure DenseReencodeCacheState (p : ℕ) where
   useBis : DenseCovIndex
   arrBis : Array (BusInteraction (DenseExpr p))
   foldCs : Std.HashSet Nat
+  /-- Bus positions carrying a variable-free composite node (`denseBiHasFold`). With the `useBis`
+      buckets this is exactly the set of positions an accept's bus rewrite can touch. A `Thunk` so
+      that an invocation which never accepts never pays the scan — the accept path is the only
+      consumer, mirroring how `denseWorkEnsureBounded` defers the constraint-side bound. -/
+  foldBis : Thunk (Std.HashSet Nat)
   /-- The number of non-tombstone entries of `w.cs`, and `w.bis.length`. Both feed the fresh-name
       prefix only (`denseWorkNameCountsS`), which is why they live on the untrusted state: a wrong
       count can cost a rejected candidate, never soundness. Maintained exactly — the state update
@@ -1590,11 +1718,28 @@ def denseCheckReencodeVS (state : DenseReencodeCacheState p) (d : DenseConstrain
     (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
   bits.all (fun bb => !state.varSet.contains bb) && denseCheckReencodeNoFresh d xs bits hm
 
+/-- The bus half of an accept's index update: for each position the rewrite visited, record the new
+    interaction's variables in the buckets and whether it still carries a variable-free composite
+    node. Standalone (a fold over `(buckets, foldSet)`) so its result does not depend on the
+    constraint half — which is what makes `denseBusIdxOk_update` a plain list induction. -/
+def denseBusIdxFold (arrB : Array (BusInteraction (DenseExpr p))) :
+    List Nat → DenseCovIndex × Std.HashSet Nat → DenseCovIndex × Std.HashSet Nat
+  | [], acc => acc
+  | i :: rest, acc =>
+      if h : i < arrB.size then
+        let bi := arrB[i]
+        let vs := HashedDedup.hashedDedup (hash ·) (denseBIVars bi)
+        denseBusIdxFold arrB rest
+          (⟨vs.foldl (fun m v => m.insert v (i :: m.getD v [])) acc.1.buckets, acc.1.varless⟩,
+           if denseBiHasFold bi then acc.2.insert i else acc.2.erase i)
+      else denseBusIdxFold arrB rest acc
+
 /-- Apply an accepted rewrite to the threaded state in place, mirroring `denseReencodeOut` on the
     stable-position arrays: only positions holding a group variable (bucket candidates) or a
     variable-free composite node (`foldCs`) can change. The root cache keeps every untouched
     position (it memoizes a pure function of the position's content). -/
-def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List VarId)
+def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (usePosB : List Nat)
+    (bisNew : List (BusInteraction (DenseExpr p))) (xs bits : List VarId)
     (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeCacheState p :=
   let σfn := denseGroupSubst xs hm
   let patts := denseAssignments (denseBitBox bits)
@@ -1625,23 +1770,14 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (xs bits : List
     { st with arrCs := st.arrCs.push (denseBoolConstraint b),
               csIdx := bucketAdd st.csIdx [b] i,
               useCs := bucketAdd st.useCs [b] i }) st
-  let posB := (denseCandidates state.useBis xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)
-  let st := posB.fold (fun st i =>
-    if h : i < st.arrBis.size then
-      let bi := st.arrBis[i]
-      if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
-          || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
-        let bi' : BusInteraction (DenseExpr p) :=
-          { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
-                    payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
-        { st with arrBis := st.arrBis.set i bi',
-                  useBis := bucketAdd st.useBis
-                    (HashedDedup.hashedDedup (hash ·) (denseBIVars bi')) i }
-      else st
-    else st) st
+  -- The bus side takes the accept's own output and its own position list: one rewrite, two
+  -- consumers, folding over exactly the positions the splice visited.
+  let arrB := bisNew.toArray
+  let bus := denseBusIdxFold arrB usePosB (state.useBis, state.foldBis.get)
   -- `varSet` is grown from the *input* state: the position folds above never touch it, and reading
   -- it from `state` keeps `denseReencodeStateUpdate_varSet` a projection instead of a fold invariant.
-  { st with varSet := bits.foldl (·.insert ·) state.varSet, dWithin := true }
+  { st with arrBis := arrB, useBis := bus.1, foldBis := Thunk.mk (fun _ => bus.2),
+            varSet := bits.foldl (·.insert ·) state.varSet, dWithin := true }
 
 theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
     DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
@@ -1656,6 +1792,10 @@ def denseWorkEnsureBounded (w : DenseReencodeWork p) : DenseReencodeWork p :=
 theorem denseWorkEnsureBounded_view (w : DenseReencodeWork p) :
     denseWorkView (denseWorkEnsureBounded w) = denseWorkView w := by
   unfold denseWorkEnsureBounded denseWorkView; split <;> rfl
+
+theorem denseWorkEnsureBounded_bis (w : DenseReencodeWork p) :
+    (denseWorkEnsureBounded w).bis = w.bis := by
+  unfold denseWorkEnsureBounded; split <;> rfl
 
 theorem denseWorkEnsureBounded_bitSet (w : DenseReencodeWork p) :
     (denseWorkEnsureBounded w).bitSet = w.bitSet := by
@@ -1717,11 +1857,15 @@ def denseWorkStep (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p
     if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
     if denseCheckReencodeVS state { algebraicConstraints := w.cs, busInteractions := w.bis }
         xs bits hm then
-      let ro := denseWorkOut b (denseWorkEnsureBounded w) xs bits hm
+      let ro := denseWorkOut b (denseWorkEnsureBounded w)
+        (((denseCandidates state.useBis xs).foldl (·.insert ·)
+          state.foldBis.get).toList.mergeSort (· ≤ ·)) xs bits hm
       if (if state.dWithin then ro.2 else (denseWorkView ro.1).withinDegreeB b) then
         (reg1, ro.1,
          bits.map (fun bb => (bb, denseBitCM (denseAssignments (denseBitBox bits)) xs hm bb)),
-         denseReencodeStateUpdate state xs bits hm)
+         denseReencodeStateUpdate state
+           (((denseCandidates state.useBis xs).foldl (·.insert ·)
+             state.foldBis.get).toList.mergeSort (· ≤ ·)) ro.1.bis xs bits hm)
       else (reg1, w, [], state)
     else (reg1, w, [], state)
     else (reg1, w, [], state)
@@ -1776,6 +1920,8 @@ def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
         arrBis := d.busInteractions.toArray
         foldCs := d.algebraicConstraints.zipIdx.foldl
           (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
+        foldBis := Thunk.mk (fun _ => d.busInteractions.zipIdx.foldl
+          (fun s bi => if denseBiHasFold bi.1 then s.insert bi.2 else s) ∅)
         liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
         bisN := d.busInteractions.length
         dWithin := false }


### PR DESCRIPTION
Follows #251 on the same pass. **Output-identical** — a runtime PR, not an effectiveness one. Fully proven: no `sorry`, no unproven twin; `Scripts/check-proof-integrity.sh` passes locally (three standard axioms, no unused theorems).

## What was slow

`denseWorkOut` walked the **entire** bus interaction list on every accepted group. For each interaction it asked `multiplicity.sharesVarIn xs`, then `multiplicity.hasConstFoldableNode`, then the same two questions for every payload expression — two full tree traversals per expression, roughly 500k traversals per accept on the 71k-interaction sha case, essentially always to conclude that nothing changed.

Strict LBR attribution (samples charged to the innermost reencode-*exclusive* frame): **3657 ms of the 21.9 s pass** before #251, and **1005 of the 1064 accept-path samples**. The constraint splice, which has had a position bound since entry 146, is the other 59 — so this was the missing half of that treatment.

## The change

`denseGateBisPos` walks the list once but only *rewrites* at the positions it is handed, and shares the suffix untouched as soon as they run out. The positions are the `useBis` bucket candidates for the group, plus `foldBis` — a new state field recording which interactions carry a variable-free composite node. `denseBiHasFold` is a property of the interaction, not of the group, so re-deriving it per accept was pure waste; it is a `Thunk`, so an invocation that never accepts never pays the scan (the same deferral `denseWorkEnsureBounded` already does for the constraint-side bound).

`denseReencodeStateUpdate` now consumes the splice's output and its position list instead of recomputing the rewrite — one rewrite, two consumers — which also removes duplicated work from the accept path.

`denseGateBisGo` and `denseGateBisGo_eq` are deleted; the position-driven rewrite replaces them, and the unused-theorem linter flagged them.

## Numbers

`profile`, this 4-core box, serial, interleaved against a prebuilt binary of `main` (i.e. post-#251). sha256 = 2 reps, the cheap representatives = 3 reps, medians.

| | sha256/apc_001 `reencode` | sha256 total | eth apc_006 | wasm apc_012 | keccak apc_001 |
|---|---:|---:|---:|---:|---:|
| `main` (post #251) | 11796 ms | 162.6 s | 149 ms | 414 ms | 503 ms |
| this branch | **8761 ms (0.743×)** | **0.973×** | 0.866× | 0.971× | 0.996× |

Composed with #251, reencode on this case is **21630 → 8761 ms (0.405×)**; it was the top pass and is now fifth, behind busPairCancel, domainBatch, flagFold and gauss.

Output identity: all 11 sha cycle `(vars, bus, constraints)` triples and the final circuit (11906 / 12464 / 3194) match, as do all cycles of the three representatives and keccak `run` (2021 / 186 / 1748).

**On the small cases**, note these swing ±3–4 % between reps on this box — the same binary's wasm median moved from 0.973× to 1.017× across two runs — so read them as "no regression" rather than as precise wins. That distinction matters here: an earlier array-backed prototype of this idea measured **consistently** 1.02–1.04× on wasm and keccak across every rep, which is why it was reworked into this shape rather than proven as-is.

## Correctness

One new invariant, `DenseBusIdxOk`: the `useBis` buckets list every position by each of its variables, and `foldBis` lists every position carrying a fold node. Together they make the position list complete for the gate (`denseBusPosList_cover`).

- `denseGateBisPos_eq` equates the positional rewrite with the dense one given completeness and an ascending position list. Nested induction (items outer, positions inner); ascendingness is used exactly once — to rule out a firing position hiding later in the list.
- `denseGateBisPos_untouched`: unvisited positions keep their interaction.
- The invariant is seeded by the pre-existing `denseBuild_complete` plus `denseFoldBisSeed_complete`, and maintained by `denseBusIdxOk_update`. Splitting the bus index update out as a standalone fold over `(buckets, foldSet)` (`denseBusIdxFold`) is what makes maintenance a plain list induction rather than requiring a positional characterisation of the constraint-side `HashSet.fold`.
- Threaded through `denseWorkStep_correct`, `denseWorkStep_inv` (fourth conclusion) and `denseWorkLoop_correct`, beside the existing position, booleanity and variable-superset invariants.

## Where the pass stands after this

Strict attribution of the remaining ~8.7 s: per-invocation setup 28 % (target-list construction and the per-item variable lists), per-target candidate work ~28 % (build, box enumeration, domains), certificate 12 %, accept-path rewriting ~13 %. Two things I measured and would not pursue further on this pass: an array-backed box enumeration (1.03× — the enumeration is closure- and arithmetic-bound, not allocation-bound) and a fused setup scan (0.940×, below the bar alone). Details in my notes; happy to fold them into `agent-docs/ideas.md` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
