### PR TITLE
perf(busPairCancel): decide the shield by a descending early-exit scan (0.33x on sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
@@ -10,9 +10,10 @@ the pass. For a candidate whose address slots are all constants, a message can o
 region tests if it is on the same bus and either shares the candidate's constant address key or
 has a non-constant key: every other position is refuted by the bus-id or constant-disequality arm
 and contributes the identity to the scan fold. `DenseKeyIdx` buckets each bus's positions by
-constant address key (plus a `sym` list for non-constant keys), so the sparse scans below visit
-only the same-key and symbolic positions. `Proofs/BusPairCancelKeyIdx.lean` proves the builder
-sound and packages the sparse results back into the full-region forms (`denseRegionTests`). -/
+constant address key (plus a `sym` list for non-constant keys, and both as arrays), so the scans
+below visit only the same-key and symbolic positions — and the shield stops at the first position
+that decides it. `Proofs/BusPairCancelKeyIdx.lean` proves the builder sound and packages the scan
+results back into the full-region forms (`denseRegionTests`). -/
 
 namespace ApcOptimizer.Dense
 
@@ -35,6 +36,10 @@ def denseKeyHash (k : List (ZMod p)) : UInt64 :=
 structure DenseKeyIdx (p : ℕ) where
   byKey : Std.HashMap UInt64 (List Nat)
   sym : List Nat
+  /-- `byKey`/`sym` as ascending arrays: the runtime walks these (`denseLiveAllGated`,
+      `denseShieldEarly`) instead of materializing a filtered list per candidate. -/
+  byKeyA : Std.HashMap UInt64 (Array Nat)
+  symA : Array Nat
 
 /-- Insert one position (front of its bucket; the builder folds positions descending). -/
 def denseKeyIdxAdd (shape : MemoryBusShape) (busId : Nat)
@@ -53,35 +58,78 @@ def denseKeyIdxAdd (shape : MemoryBusShape) (busId : Nat)
 
 def denseKeyIdxBuild (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) : DenseKeyIdx p :=
-  (List.range arr.size).foldr (denseKeyIdxAdd shape busId arr) ⟨∅, []⟩
+  let idx := (List.range arr.size).foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], ∅, #[]⟩
+  { idx with byKeyA := idx.byKey.map (fun _ l => l.toArray), symA := idx.sym.toArray }
 
-def denseMergeAsc : List Nat → List Nat → List Nat
-  | [], ys => ys
-  | xs, [] => xs
-  | x :: xs, y :: ys =>
-    if x ≤ y then x :: denseMergeAsc xs (y :: ys) else y :: denseMergeAsc (x :: xs) ys
-  termination_by xs ys => xs.length + ys.length
+/-! ## The index scans
 
-/-! ## The sparse scans -/
+The mid test walks the index arrays with a window gate; the shield walks them **descending with an
+early exit**, since its verdict is decided by the topmost visited live position `q` with
+`¬P q ∨ Q q` (`ok = P q`, `true` when there is none — `denseShieldScanSegP_true_of`), so the
+positions below the last provable receive are never tested. Both walks re-check the position window
+at every entry, so the index needs no range search. -/
 
-/-- `denseLiveAllSegP` restricted to a position list. -/
-def denseLiveAllSparse {α : Type} (preArr : Array α) (alive : Array Bool)
-    (P : α → Bool) : List Nat → Bool
-  | [] => true
-  | pos :: rest =>
-    (if alive[pos]?.getD false then (preArr[pos]?).elim true P else true)
-      && denseLiveAllSparse preArr alive P rest
+/-- `P` at every live entry of `a` (indices `[0, n)`) whose position lies in `[lo, hi)`. -/
+def denseLiveAllGated {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (a : Array Nat) (lo hi : Nat) : Nat → Bool
+  | 0 => true
+  | n + 1 =>
+    (match a[n]? with
+     | some pos =>
+       if decide (lo ≤ pos) && decide (pos < hi) && alive[pos]?.getD false then
+         (preArr[pos]?).elim true P
+       else true
+     | none => true)
+      && denseLiveAllGated P preArr alive a lo hi n
 
-/-- `denseShieldScanSegP` restricted to a position list. -/
-def denseShieldScanSparse {α : Type} (P Q : α → Bool) (preArr : Array α)
-    (alive : Array Bool) : List Nat → Bool × Bool
-  | [] => (false, true)
-  | pos :: rest =>
-    let r := denseShieldScanSparse P Q preArr alive rest
-    if alive[pos]?.getD false then
-      match preArr[pos]? with
-      | some m0 => (r.1 || Q m0, r.2 && (P m0 || r.1))
-      | none => r
-    else r
+/-- One descending step of the shield: `some v` when position `pos` decides it (`v = P pos`), `none`
+    when `pos` is outside the window, dead, or refuted without being a provable receive. -/
+@[inline] def denseShieldDecide {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (bound pos : Nat) : Option Bool :=
+  if decide (pos < bound) && alive[pos]?.getD false then
+    match preArr[pos]? with
+    | some m =>
+      match P m with
+      | false => some false
+      | true => if Q m then some true else none
+    | none => none
+  else none
+
+/-- Descending early-exit shield over the entries of the two ascending arrays below `bound`: the
+    larger of the two current tails is tested first, so entries are visited in descending position
+    order and the walk stops at the topmost deciding one. `fuel` bounds the walk (`nb + ns`). -/
+def denseShieldEarly {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (b s : Array Nat) (bound : Nat) : Nat → Nat → Nat → Bool
+  | 0, _, _ => true
+  | fuel + 1, nb, ns =>
+    match (if 0 < nb then b[nb - 1]? else none), (if 0 < ns then s[ns - 1]? else none) with
+    | none, none => true
+    | some pb, none =>
+      match denseShieldDecide P Q preArr alive bound pb with
+      | some v => v
+      | none => denseShieldEarly P Q preArr alive b s bound fuel (nb - 1) ns
+    | none, some ps =>
+      match denseShieldDecide P Q preArr alive bound ps with
+      | some v => v
+      | none => denseShieldEarly P Q preArr alive b s bound fuel nb (ns - 1)
+    | some pb, some ps =>
+      if ps ≤ pb then
+        match denseShieldDecide P Q preArr alive bound pb with
+        | some v => v
+        | none => denseShieldEarly P Q preArr alive b s bound fuel (nb - 1) ns
+      else
+        match denseShieldDecide P Q preArr alive bound ps with
+        | some v => v
+        | none => denseShieldEarly P Q preArr alive b s bound fuel nb (ns - 1)
+
+/-- Descending early-exit shield over the whole segment `[0, n)` — the symbolic-key fallback, which
+    has no index to walk. -/
+def denseShieldEarlySeg {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (bound : Nat) : Nat → Bool
+  | 0 => true
+  | n + 1 =>
+    match denseShieldDecide P Q preArr alive bound n with
+    | some v => v
+    | none => denseShieldEarlySeg P Q preArr alive bound n
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
@@ -92,42 +92,6 @@ theorem denseAddrKeyOf_ne_constsNeq (shape : MemoryBusShape)
     (hne : kS ≠ km) : denseAddrConstsNeq shape S m = true :=
   denseKeyFold_ne_any S m shape.addressFields kS km hS hm hne
 
-/-- Two constant keys that differ refute the constant address-equality test. -/
-theorem denseAddrKeyOf_ne_constsEq (shape : MemoryBusShape)
-    (S m : BusInteraction (DenseExpr p)) (kS km : List (ZMod p))
-    (hS : denseAddrKeyOf shape S = some kS) (hm : denseAddrKeyOf shape m = some km)
-    (hne : kS ≠ km) : denseAddrConstsEq shape S m = false := by
-  have hneq := denseAddrKeyOf_ne_constsNeq shape S m kS km hS hm hne
-  unfold denseAddrConstsNeq at hneq
-  unfold denseAddrConstsEq
-  rw [List.any_eq_true] at hneq
-  obtain ⟨slot, hslot, hval⟩ := hneq
-  rw [List.all_eq_false]
-  refine ⟨slot, hslot, ?_⟩
-  cases hpS : S.payload[slot]? with
-  | none => simp [hpS] at hval
-  | some e =>
-    cases hpm : m.payload[slot]? with
-    | none => simp [hpS, hpm] at hval
-    | some e' =>
-      simp only [hpS, hpm] at hval
-      cases hcS : e.constValue? with
-      | none => simp [hcS] at hval
-      | some c =>
-        cases hcm : e'.constValue? with
-        | none => simp [hcS, hcm] at hval
-        | some c' =>
-          simp only [hcS, hcm, decide_eq_true_eq] at hval
-          have hee : e ≠ e' := fun h => hval (by
-            rw [h] at hcS
-            exact Option.some.inj (hcS.symm.trans hcm))
-          intro hcontra
-          rw [Bool.or_eq_true] at hcontra
-          rcases hcontra with h1 | h2
-          · exact hee (of_decide_eq_true h1)
-          · simp only [hcS, hcm, decide_eq_true_eq] at h2
-            exact hval h2
-
 /-- A cross-bus message is mid-refuted. -/
 theorem denseMidRefuted_of_crossBus (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseAddrCerts p)) (busId : Nat) (S m : BusInteraction (DenseExpr p))
@@ -144,23 +108,6 @@ theorem denseMidRefuted_of_keyNe (ops : DenseZModOps p) (shape : MemoryBusShape)
     denseMidRefuted ops shape T busId S m = true := by
   unfold denseMidRefuted
   rw [denseAddrKeyOf_ne_constsNeq shape S m kS km hS hm hne]
-  simp
-
-/-- A cross-bus message is not a provable receive. -/
-theorem denseProvRecv_of_crossBus (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
-    (S m : BusInteraction (DenseExpr p)) (h : m.busId ≠ busId) :
-    denseProvRecv ops shape busId S m = false := by
-  unfold denseProvRecv
-  rw [decide_eq_false h]
-  simp
-
-/-- A same-bus message with a different constant key is not a provable receive. -/
-theorem denseProvRecv_of_keyNe (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
-    (S m : BusInteraction (DenseExpr p)) (kS km : List (ZMod p))
-    (hS : denseAddrKeyOf shape S = some kS) (hm : denseAddrKeyOf shape m = some km)
-    (hne : kS ≠ km) : denseProvRecv ops shape busId S m = false := by
-  unfold denseProvRecv
-  rw [denseAddrKeyOf_ne_constsEq shape S m kS km hS hm hne]
   simp
 
 /-- Skipped positions are pre-refuted (the shield's `P` test): `densePreRefuted` contains
@@ -196,7 +143,7 @@ structure DenseKeyIdx.Sound (shape : MemoryBusShape) (busId : Nat)
 theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) :
     ∀ (ps : List Nat), ps.Pairwise (· < ·) →
-      (let idx := ps.foldr (denseKeyIdxAdd shape busId arr) ⟨∅, []⟩
+      (let idx := ps.foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], ∅, #[]⟩
        (∀ pos m k, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
           denseAddrKeyOf shape m = some k → pos ∈ idx.byKey.getD (denseKeyHash k) []) ∧
        (∀ pos m, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
@@ -216,7 +163,7 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
       have hqlt : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hps).1 r hr
       obtain ⟨ck, cs, sk, ss, mk, ms⟩ := ih (List.pairwise_cons.mp hps).2
       simp only [List.foldr_cons]
-      set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, []⟩ : DenseKeyIdx p) with hidx
+      set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, [], ∅, #[]⟩ : DenseKeyIdx p) with hidx
       unfold denseKeyIdxAdd
       cases hq : arr[q]? with
       | none =>
@@ -341,165 +288,388 @@ theorem denseKeyIdxBuild_sound (shape : MemoryBusShape) (busId : Nat)
     fun h pos hpos => (mk h pos hpos).2,
     fun pos hpos => (ms pos hpos).2⟩
 
-/-! ## Ascending merge -/
+/-! ## The array-driven scans are sound
 
-theorem denseMergeAsc_mem : ∀ (xs ys : List Nat) (q : Nat),
-    q ∈ denseMergeAsc xs ys ↔ q ∈ xs ∨ q ∈ ys
-  | [], ys, q => by simp [denseMergeAsc]
-  | x :: xs, [], q => by simp [denseMergeAsc]
-  | x :: xs, y :: ys, q => by
-      unfold denseMergeAsc
-      split
-      · simp only [List.mem_cons, denseMergeAsc_mem xs (y :: ys) q]
-        tauto
-      · simp only [List.mem_cons, denseMergeAsc_mem (x :: xs) ys q]
-        tauto
-  termination_by xs ys => xs.length + ys.length
+`denseRegionTests` no longer materializes a position list per candidate: the mid test walks the index
+arrays with a window gate (`denseLiveAllGated`) and the shield walks them descending with an early
+exit (`denseShieldEarly`). Two semantic lemmas turn what those walks establish into the full-region
+forms `denseMkDropResult` consumes — per-position facts give the mid `all`
+(`denseLiveAllSegP_true_of`), and per-position facts plus the position the shield stopped at give the
+shield fold (`denseShieldScanSegP_true_of`). -/
 
-theorem denseMergeAsc_pairwise : ∀ (xs ys : List Nat),
-    xs.Pairwise (· < ·) → ys.Pairwise (· < ·) → (∀ x ∈ xs, x ∉ ys) →
-    (denseMergeAsc xs ys).Pairwise (· < ·)
-  | [], ys, _, hys, _ => by simpa [denseMergeAsc] using hys
-  | x :: xs, [], hxs, _, _ => by simpa [denseMergeAsc] using hxs
-  | x :: xs, y :: ys, hxs, hys, hdisj => by
-      unfold denseMergeAsc
-      obtain ⟨hxlt, hxs'⟩ := List.pairwise_cons.mp hxs
-      obtain ⟨hylt, hys'⟩ := List.pairwise_cons.mp hys
-      split
-      · rename_i hxy
-        refine List.pairwise_cons.mpr ⟨?_, ?_⟩
-        · intro q hq
-          rcases (denseMergeAsc_mem xs (y :: ys) q).mp hq with h | h
-          · exact hxlt q h
-          · rcases List.mem_cons.mp h with rfl | h
-            · exact Nat.lt_of_le_of_ne hxy (fun hc =>
-                hdisj x (List.mem_cons_self ..) (hc ▸ List.mem_cons_self ..))
-            · exact Nat.lt_of_le_of_lt hxy (hylt q h)
-        · exact denseMergeAsc_pairwise xs (y :: ys) hxs' hys
-            (fun z hz => hdisj z (List.mem_cons_of_mem _ hz))
-      · rename_i hxy
-        have hyx : y < x := Nat.lt_of_not_le hxy
-        refine List.pairwise_cons.mpr ⟨?_, ?_⟩
-        · intro q hq
-          rcases (denseMergeAsc_mem (x :: xs) ys q).mp hq with h | h
-          · rcases List.mem_cons.mp h with rfl | h
-            · exact hyx
-            · exact Nat.lt_trans hyx (hxlt q h)
-          · exact hylt q h
-        · exact denseMergeAsc_pairwise (x :: xs) ys hxs hys'
-            (fun z hz hzys => hdisj z hz (List.mem_cons_of_mem _ hzys))
-  termination_by xs ys => xs.length + ys.length
+/-- Per-position refutations give the segment `all`. -/
+theorem denseLiveAllSegP_true_of {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (lo0 N : Nat)
+    (h : ∀ q, lo0 ≤ q → q < N → alive[q]?.getD false = true →
+      ∀ m, preArr[q]? = some m → P m = true) :
+    ∀ (n lo : Nat), lo0 ≤ lo → lo + n ≤ N → denseLiveAllSegP preArr alive P lo n = true := by
+  intro n
+  induction n with
+  | zero => intro lo _ _; rfl
+  | succ n ih =>
+    intro lo hlo hle
+    rw [denseLiveAllSegP, Bool.and_eq_true]
+    refine ⟨?_, ih (lo + 1) (by omega) (by omega)⟩
+    cases halive : alive[lo]?.getD false with
+    | false => rw [if_neg (by simp)]
+    | true =>
+      rw [if_pos rfl]
+      cases hm : preArr[lo]? with
+      | none => rfl
+      | some m => exact h lo hlo (by omega) halive m hm
 
-/-! ## The sparse scans decide the full-range scans -/
-
-/-- The shield scan: skipped positions have `P` true (pre-refuted) and `Q` false (not a
-    provable receive), which is the fold's identity step. -/
-theorem denseShieldScanSparse_eq {α : Type} (P Q : α → Bool) (preArr : Array α)
-    (alive : Array Bool) :
-    ∀ (n lo : Nat) (vs : List Nat), vs.Pairwise (· < ·) →
-      (∀ q ∈ vs, lo ≤ q ∧ q < lo + n) →
-      (∀ q, lo ≤ q → q < lo + n → q ∉ vs → ∀ m, preArr[q]? = some m →
-        alive[q]?.getD false = true → P m = true ∧ Q m = false) →
-      denseShieldScanSparse P Q preArr alive vs = denseShieldScanSegP P Q preArr alive lo n := by
+/-- The shield fold over `[lo, lo + n)` holds when every live position is refuted except possibly
+    below a witness position `q0` that is itself a live provable receive. The `.1` conclusion (the
+    fold's "a provable receive occurs later" flag) is what carries the witness leftwards. -/
+theorem denseShieldScanSegP_true_aux {α : Type} (P Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) (q0 : Option Nat) (N : Nat)
+    (hq0 : ∀ q ∈ q0, ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
+      P m = true ∧ Q m = true)
+    (hab : ∀ q, q < N → (∀ r ∈ q0, r < q) → alive[q]?.getD false = true →
+      ∀ m, preArr[q]? = some m → P m = true) :
+    ∀ (n lo : Nat), lo + n ≤ N → (∀ r ∈ q0, r < lo + n) →
+      (denseShieldScanSegP P Q preArr alive lo n).2 = true ∧
+        ∀ r ∈ q0, lo ≤ r → (denseShieldScanSegP P Q preArr alive lo n).1 = true := by
   intro n
   induction n with
   | zero =>
-      intro lo vs _ hbound _
-      cases vs with
-      | nil => rfl
-      | cons q rest => exact absurd (hbound q (List.mem_cons_self ..)) (by omega)
+    intro lo _ hlt
+    exact ⟨rfl, fun r hr hle => by have := hlt r hr; omega⟩
   | succ n ih =>
-      intro lo vs hsort hbound hskip
-      have hstepid : (lo ∉ vs) → ∀ (r : Bool × Bool),
-          (if alive[lo]?.getD false then
-            match preArr[lo]? with
-            | some m0 => (r.1 || Q m0, r.2 && (P m0 || r.1))
-            | none => r
-          else r) = r := by
-        intro hnot r
-        cases halive : alive[lo]?.getD false with
-        | false => simp
-        | true =>
-            rw [if_pos rfl]
-            cases hm : preArr[lo]? with
-            | none => rfl
-            | some m =>
-                obtain ⟨hP, hQ⟩ := hskip lo (Nat.le_refl _) (by omega) hnot m hm halive
-                simp [hP, hQ]
-      cases vs with
-      | nil =>
-          rw [denseShieldScanSegP]
-          rw [← ih (lo + 1) [] (by simp) (by simp)
-            (fun q hq1 hq2 _ => hskip q (by omega) (by omega) (by simp))]
-          exact (hstepid (by simp) _).symm
-      | cons q rest =>
-          by_cases hq : q = lo
-          · subst hq
-            rw [denseShieldScanSparse, denseShieldScanSegP]
-            have hrest : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hsort).1 r hr
-            rw [ih (q + 1) rest (List.pairwise_cons.mp hsort).2
-              (fun r hr => ⟨hrest r hr, by have := (hbound r (List.mem_cons_of_mem _ hr)).2; omega⟩)
-              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega)
-                (by
-                  intro hmem
-                  rcases List.mem_cons.mp hmem with rfl | hmem
-                  · omega
-                  · exact hnot hmem) m hm halive)]
-            rfl
-          · have hlonot : lo ∉ (q :: rest) := by
-              intro hmem
-              rcases List.mem_cons.mp hmem with rfl | hmem
-              · exact hq rfl
-              · have := (List.pairwise_cons.mp hsort).1 lo hmem
-                have := (hbound q (List.mem_cons_self ..)).1
+    intro lo hle hlt
+    obtain ⟨ih2, ih1⟩ := ih (lo + 1) (by omega) (fun r hr => by have := hlt r hr; omega)
+    rw [denseShieldScanSegP]
+    cases halive : alive[lo]?.getD false with
+    | false =>
+      rw [if_neg (by simp)]
+      refine ⟨ih2, fun r hr hler => ?_⟩
+      rcases Nat.lt_or_ge lo r with h | h
+      · exact ih1 r hr (by omega)
+      · have hrl : r = lo := by omega
+        obtain ⟨m, hal, _, _, _⟩ := hq0 r hr
+        rw [hrl, halive] at hal
+        exact absurd hal (by simp)
+    | true =>
+      rw [if_pos rfl]
+      cases hm : preArr[lo]? with
+      | none =>
+        refine ⟨ih2, fun r hr hler => ?_⟩
+        rcases Nat.lt_or_ge lo r with h | h
+        · exact ih1 r hr (by omega)
+        · have hrl : r = lo := by omega
+          obtain ⟨m, _, hme, _, _⟩ := hq0 r hr
+          rw [hrl, hm] at hme
+          exact absurd hme (by simp)
+      | some m0 =>
+        have hflag : ∀ r ∈ q0, lo ≤ r →
+            ((denseShieldScanSegP P Q preArr alive (lo + 1) n).1 || Q m0) = true := by
+          intro r hr hler
+          rcases Nat.lt_or_ge lo r with h | h
+          · rw [ih1 r hr (by omega)]; rfl
+          · have hrl : r = lo := by omega
+            obtain ⟨m, _, hme, _, hQm⟩ := hq0 r hr
+            rw [hrl, hm] at hme
+            obtain rfl := Option.some.inj hme
+            rw [hQm, Bool.or_true]
+        refine ⟨?_, hflag⟩
+        dsimp only
+        rw [ih2, Bool.true_and]
+        by_cases hup : ∃ r ∈ q0, lo < r
+        · obtain ⟨r, hr, hlt0⟩ := hup
+          rw [ih1 r hr (by omega), Bool.or_true]
+        · have hPm : P m0 = true := by
+            cases hq0e : q0 with
+            | none =>
+              exact hab lo (by omega) (by intro r hr; rw [hq0e] at hr; exact absurd hr (by simp))
+                halive m0 hm
+            | some q =>
+              by_cases hqlo : q = lo
+              · obtain ⟨m, _, hme, hPm, _⟩ := hq0 q (by rw [hq0e]; exact rfl)
+                rw [hqlo, hm] at hme
+                obtain rfl := Option.some.inj hme
+                exact hPm
+              · refine hab lo (by omega) (fun r hr => ?_) halive m0 hm
+                rw [hq0e] at hr
+                have hrq : q = r := by simpa using hr
+                have hnlt : ¬ lo < q := fun hc => hup ⟨q, by rw [hq0e]; exact rfl, hc⟩
                 omega
-            rw [denseShieldScanSegP]
-            rw [← ih (lo + 1) (q :: rest) hsort (fun r hr => by
-                obtain ⟨h1, h2⟩ := hbound r hr
-                have hrne : r ≠ lo := fun hrl => hlonot (hrl ▸ hr)
-                exact ⟨by omega, by omega⟩)
-              (fun r hr1 hr2 hnot m hm halive => hskip r (by omega) (by omega) hnot m hm halive)]
-            exact (hstepid hlonot _).symm
+          rw [hPm, Bool.true_or]
 
-/-- An all-scan is a shield scan with no receives: `Q ≡ false` keeps the receive accumulator at
-    `false`, leaving exactly the conjunction in the second component. -/
-theorem denseShieldScanSparse_const_false {α : Type} (P : α → Bool) (preArr : Array α)
-    (alive : Array Bool) :
-    ∀ vs : List Nat, denseShieldScanSparse P (fun _ => false) preArr alive vs
-      = (false, denseLiveAllSparse preArr alive P vs)
-  | [] => rfl
-  | pos :: rest => by
-      rw [denseShieldScanSparse, denseLiveAllSparse,
-        denseShieldScanSparse_const_false P preArr alive rest]
-      cases halive : alive[pos]?.getD false
-      · simp
-      · cases hm : preArr[pos]? <;> simp [Option.elim, Bool.and_comm]
+/-- The witness form of the shield fold over `[0, n)`. -/
+theorem denseShieldScanSegP_true_of {α : Type} (P Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) (q0 : Option Nat) (n : Nat)
+    (hq0 : ∀ q ∈ q0, ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
+      P m = true ∧ Q m = true)
+    (hab : ∀ q, q < n → (∀ r ∈ q0, r < q) → alive[q]?.getD false = true →
+      ∀ m, preArr[q]? = some m → P m = true)
+    (hlt : ∀ r ∈ q0, r < n) :
+    (denseShieldScanSegP P Q preArr alive 0 n).2 = true :=
+  (denseShieldScanSegP_true_aux P Q preArr alive q0 n hq0 hab n 0 (by omega)
+    (fun r hr => by simpa using hlt r hr)).1
 
-theorem denseShieldScanSegP_const_false {α : Type} (P : α → Bool) (preArr : Array α)
-    (alive : Array Bool) :
-    ∀ (lo n : Nat), denseShieldScanSegP P (fun _ => false) preArr alive lo n
-      = (false, denseLiveAllSegP preArr alive P lo n) := by
-  intro lo n
-  induction n generalizing lo with
-  | zero => rfl
+/-! ### What the array walks establish -/
+
+/-- Entries of an ascending array compare like their indices. -/
+theorem denseArrEntry_le {a : Array Nat} (ha : a.toList.Pairwise (· < ·)) {k t q x : Nat}
+    (hkt : k ≤ t) (hk : a[k]? = some q) (ht : a[t]? = some x) : q ≤ x := by
+  rcases Nat.eq_or_lt_of_le hkt with rfl | hlt
+  · rw [hk] at ht; exact Nat.le_of_eq (Option.some.inj ht)
+  · have hks : k < a.size := by
+      by_contra hc
+      rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hk
+      exact absurd hk (by simp)
+    have hts : t < a.size := by
+      by_contra hc
+      rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at ht
+      exact absurd ht (by simp)
+    have hkl : k < a.toList.length := by simpa using hks
+    have htl : t < a.toList.length := by simpa using hts
+    have hkv : a.toList[k] = q := by
+      have h := Array.getElem?_toList (xs := a) (i := k)
+      rw [hk, List.getElem?_eq_getElem hkl] at h
+      exact Option.some.inj h
+    have htv : a.toList[t] = x := by
+      have h := Array.getElem?_toList (xs := a) (i := t)
+      rw [ht, List.getElem?_eq_getElem htl] at h
+      exact Option.some.inj h
+    have hpw := List.pairwise_iff_getElem.mp ha k t hkl htl hlt
+    rw [hkv, htv] at hpw
+    exact Nat.le_of_lt hpw
+
+/-- A decided descending step: the position is in the window, live, and a provable receive whose
+    `P` value is the verdict. -/
+theorem denseShieldDecide_some {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    {bound pos : Nat} {v : Bool} (h : denseShieldDecide P Q preArr alive bound pos = some v) :
+    pos < bound ∧ ∃ m, alive[pos]?.getD false = true ∧ preArr[pos]? = some m ∧ P m = v ∧
+      (v = true → Q m = true) := by
+  unfold denseShieldDecide at h
+  split at h
+  · rename_i hgate
+    rw [Bool.and_eq_true, decide_eq_true_eq] at hgate
+    split at h
+    · rename_i m hme
+      split at h
+      · rename_i hP
+        obtain rfl := Option.some.inj h
+        exact ⟨hgate.1, m, hgate.2, hme, hP, fun hv => absurd hv (by simp)⟩
+      · rename_i hP
+        split at h
+        · rename_i hQ
+          obtain rfl := Option.some.inj h
+          exact ⟨hgate.1, m, hgate.2, hme, hP, fun _ => hQ⟩
+        · exact absurd h (by simp)
+    · exact absurd h (by simp)
+  · exact absurd h (by simp)
+
+/-- An undecided descending step: an in-window live position with a prepared record is `P`-refuted. -/
+theorem denseShieldDecide_none {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    {bound pos : Nat} (h : denseShieldDecide P Q preArr alive bound pos = none) :
+    pos < bound → alive[pos]?.getD false = true → ∀ m, preArr[pos]? = some m → P m = true := by
+  intro hlt hal m hme
+  by_contra hP
+  have hPf : P m = false := by simpa using hP
+  simp [denseShieldDecide, hme, hal, hlt, hPf] at h
+
+/-- The descending early-exit shield over one segment: the position it stopped at is a live in-window
+    provable receive, and every live in-window position above it is refuted. -/
+theorem denseShieldEarlySeg_sound {α : Type} (P Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) (bound : Nat) :
+    ∀ (n : Nat), denseShieldEarlySeg P Q preArr alive bound n = true →
+      ∃ q0 : Option Nat,
+        (∀ q ∈ q0, q < bound ∧ ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
+          P m = true ∧ Q m = true) ∧
+        (∀ q, q < n → (∀ r ∈ q0, r < q) → q < bound → alive[q]?.getD false = true →
+          ∀ m, preArr[q]? = some m → P m = true) := by
+  intro n
+  induction n with
+  | zero => exact fun _ => ⟨none, by simp, fun q hq => absurd hq (by omega)⟩
   | succ n ih =>
-      rw [denseShieldScanSegP, denseLiveAllSegP, ih (lo + 1)]
-      cases halive : alive[lo]?.getD false
-      · simp
-      · cases hm : preArr[lo]? <;> simp [Option.elim, Bool.and_comm]
+    intro hw
+    rw [denseShieldEarlySeg] at hw
+    cases hd : denseShieldDecide P Q preArr alive bound n with
+    | some v =>
+      rw [hd] at hw
+      obtain rfl : v = true := hw
+      obtain ⟨hlt, m, hal, hme, hPm, hQm⟩ := denseShieldDecide_some P Q preArr alive hd
+      refine ⟨some n, ?_, ?_⟩
+      · intro q hq
+        obtain rfl : n = q := by simpa using hq
+        exact ⟨hlt, m, hal, hme, hPm, hQm rfl⟩
+      · intro q hq hgt _ _ _ _
+        have := hgt n (by simp)
+        omega
+    | none =>
+      rw [hd] at hw
+      obtain ⟨q0, hq0, habove⟩ := ih hw
+      refine ⟨q0, hq0, fun q hq hgt hqb hal m hme => ?_⟩
+      rcases Nat.lt_or_ge q n with h | h
+      · exact habove q h hgt hqb hal m hme
+      · obtain rfl : q = n := by omega
+        exact denseShieldDecide_none P Q preArr alive hd hqb hal m hme
 
-/-- A visited-position list that covers every non-refuted live position decides the full range
-    scan: skipped positions contribute the identity (`P` holds on them). -/
-theorem denseLiveAllSparse_eq {α : Type} (preArr : Array α) (alive : Array Bool) (P : α → Bool)
-    (n lo : Nat) (vs : List Nat) (hsort : vs.Pairwise (· < ·))
-    (hbound : ∀ q ∈ vs, lo ≤ q ∧ q < lo + n)
-    (hskip : ∀ q, lo ≤ q → q < lo + n → q ∉ vs → ∀ m, preArr[q]? = some m →
-      alive[q]?.getD false = true → P m = true) :
-    denseLiveAllSparse preArr alive P vs = denseLiveAllSegP preArr alive P lo n := by
-  have h := denseShieldScanSparse_eq P (fun _ => false) preArr alive n lo vs hsort hbound
-    (fun q h1 h2 h3 m hm ha => ⟨hskip q h1 h2 h3 m hm ha, rfl⟩)
-  rw [denseShieldScanSparse_const_false, denseShieldScanSegP_const_false, Prod.mk.injEq] at h
-  exact h.2
+/-- The descending early-exit shield over the two index arrays: same conclusion, with the "above the
+    witness" facts restricted to the arrays' entries (every other position is refuted by the
+    key-index argument at the use site). -/
+theorem denseShieldEarly_sound {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (b s : Array Nat) (bound : Nat)
+    (hbs : b.toList.Pairwise (· < ·)) (hss : s.toList.Pairwise (· < ·)) :
+    ∀ (fuel nb ns : Nat), nb + ns ≤ fuel → nb ≤ b.size → ns ≤ s.size →
+      denseShieldEarly P Q preArr alive b s bound fuel nb ns = true →
+      ∃ q0 : Option Nat,
+        (∀ q ∈ q0, q < bound ∧ ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
+          P m = true ∧ Q m = true) ∧
+        (∀ k q, k < nb → b[k]? = some q → (∀ r ∈ q0, r < q) → q < bound →
+          alive[q]?.getD false = true → ∀ m, preArr[q]? = some m → P m = true) ∧
+        (∀ k q, k < ns → s[k]? = some q → (∀ r ∈ q0, r < q) → q < bound →
+          alive[q]?.getD false = true → ∀ m, preArr[q]? = some m → P m = true) := by
+  intro fuel
+  induction fuel with
+  | zero =>
+    intro nb ns hf _ _ _
+    exact ⟨none, by simp, fun k q hk => absurd hk (by omega), fun k q hk => absurd hk (by omega)⟩
+  | succ fuel ih =>
+    intro nb ns hf hnb hns hw
+    -- one shared step, instantiated by each of the four tail shapes
+    have key : ∀ (pos nb' ns' : Nat), nb' + ns' + 1 = nb + ns → nb' ≤ b.size → ns' ≤ s.size →
+        (∀ k q, k < nb → b[k]? = some q → q ≤ pos) →
+        (∀ k q, k < ns → s[k]? = some q → q ≤ pos) →
+        (∀ k q, k < nb → b[k]? = some q → k < nb' ∨ q = pos) →
+        (∀ k q, k < ns → s[k]? = some q → k < ns' ∨ q = pos) →
+        (match denseShieldDecide P Q preArr alive bound pos with
+         | some v => v
+         | none => denseShieldEarly P Q preArr alive b s bound fuel nb' ns') = true →
+        ∃ q0 : Option Nat,
+          (∀ q ∈ q0, q < bound ∧ ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
+            P m = true ∧ Q m = true) ∧
+          (∀ k q, k < nb → b[k]? = some q → (∀ r ∈ q0, r < q) → q < bound →
+            alive[q]?.getD false = true → ∀ m, preArr[q]? = some m → P m = true) ∧
+          (∀ k q, k < ns → s[k]? = some q → (∀ r ∈ q0, r < q) → q < bound →
+            alive[q]?.getD false = true → ∀ m, preArr[q]? = some m → P m = true) := by
+      intro pos nb' ns' hcount hnb' hns' hleb hles hdropb hdrops hstep
+      cases hd : denseShieldDecide P Q preArr alive bound pos with
+      | some v =>
+        rw [hd] at hstep
+        obtain rfl : v = true := hstep
+        obtain ⟨hlt, m, hal, hme, hPm, hQm⟩ := denseShieldDecide_some P Q preArr alive hd
+        refine ⟨some pos, ?_, ?_, ?_⟩
+        · intro q hq
+          obtain rfl : pos = q := by simpa using hq
+          exact ⟨hlt, m, hal, hme, hPm, hQm rfl⟩
+        · intro k q hk hkq hgt _ _ _ _
+          have h1 := hleb k q hk hkq
+          have h2 := hgt pos (by simp)
+          omega
+        · intro k q hk hkq hgt _ _ _ _
+          have h1 := hles k q hk hkq
+          have h2 := hgt pos (by simp)
+          omega
+      | none =>
+        rw [hd] at hstep
+        obtain ⟨q0, hq0, habB, habS⟩ := ih nb' ns' (by omega) hnb' hns' hstep
+        refine ⟨q0, hq0, ?_, ?_⟩
+        · intro k q hk hkq hgt hqb hal m hme
+          rcases hdropb k q hk hkq with h | rfl
+          · exact habB k q h hkq hgt hqb hal m hme
+          · exact denseShieldDecide_none P Q preArr alive hd hqb hal m hme
+        · intro k q hk hkq hgt hqb hal m hme
+          rcases hdrops k q hk hkq with h | rfl
+          · exact habS k q h hkq hgt hqb hal m hme
+          · exact denseShieldDecide_none P Q preArr alive hd hqb hal m hme
+    rw [denseShieldEarly] at hw
+    rcases Nat.eq_zero_or_pos nb with rfl | hnbp
+    · rcases Nat.eq_zero_or_pos ns with rfl | hnsp
+      · exact ⟨none, by simp, fun k q hk => absurd hk (by omega), fun k q hk => absurd hk (by omega)⟩
+      · obtain ⟨ps, hps⟩ : ∃ ps, s[ns - 1]? = some ps :=
+          ⟨s[ns - 1]'(by omega), Array.getElem?_eq_getElem (by omega)⟩
+        rw [if_neg (by omega), if_pos hnsp, hps] at hw
+        dsimp only at hw
+        exact key ps 0 (ns - 1) (by omega) (by omega) (by omega)
+          (fun k q hk => absurd hk (by omega))
+          (fun k q hk hkq => denseArrEntry_le hss (by omega) hkq hps)
+          (fun k q hk => absurd hk (by omega))
+          (fun k q hk hkq => by
+            rcases Nat.lt_or_ge k (ns - 1) with h | h
+            · exact Or.inl h
+            · obtain rfl : k = ns - 1 := by omega
+              exact Or.inr (Option.some.inj (hkq.symm.trans hps))) hw
+    · obtain ⟨pb, hpb⟩ : ∃ pb, b[nb - 1]? = some pb :=
+        ⟨b[nb - 1]'(by omega), Array.getElem?_eq_getElem (by omega)⟩
+      rcases Nat.eq_zero_or_pos ns with rfl | hnsp
+      · rw [if_pos hnbp, hpb, if_neg (by omega)] at hw
+        exact key pb (nb - 1) 0 (by omega) (by omega) (by omega)
+          (fun k q hk hkq => denseArrEntry_le hbs (by omega) hkq hpb)
+          (fun k q hk => absurd hk (by omega))
+          (fun k q hk hkq => by
+            rcases Nat.lt_or_ge k (nb - 1) with h | h
+            · exact Or.inl h
+            · obtain rfl : k = nb - 1 := by omega
+              exact Or.inr (Option.some.inj (hkq.symm.trans hpb)))
+          (fun k q hk => absurd hk (by omega)) hw
+      · obtain ⟨ps, hps⟩ : ∃ ps, s[ns - 1]? = some ps :=
+          ⟨s[ns - 1]'(by omega), Array.getElem?_eq_getElem (by omega)⟩
+        rw [if_pos hnbp, hpb, if_pos hnsp, hps] at hw
+        dsimp only at hw
+        by_cases hle : ps ≤ pb
+        · rw [if_pos hle] at hw
+          exact key pb (nb - 1) ns (by omega) (by omega) hns
+            (fun k q hk hkq => denseArrEntry_le hbs (by omega) hkq hpb)
+            (fun k q hk hkq => Nat.le_trans (denseArrEntry_le hss (by omega) hkq hps) hle)
+            (fun k q hk hkq => by
+              rcases Nat.lt_or_ge k (nb - 1) with h | h
+              · exact Or.inl h
+              · obtain rfl : k = nb - 1 := by omega
+                exact Or.inr (Option.some.inj (hkq.symm.trans hpb)))
+            (fun k q hk _ => Or.inl hk) hw
+        · rw [if_neg hle] at hw
+          exact key ps nb (ns - 1) (by omega) hnb (by omega)
+            (fun k q hk hkq => Nat.le_of_lt (Nat.lt_of_le_of_lt
+              (denseArrEntry_le hbs (by omega) hkq hpb) (by omega)))
+            (fun k q hk hkq => denseArrEntry_le hss (by omega) hkq hps)
+            (fun k q hk _ => Or.inl hk)
+            (fun k q hk hkq => by
+              rcases Nat.lt_or_ge k (ns - 1) with h | h
+              · exact Or.inl h
+              · obtain rfl : k = ns - 1 := by omega
+                exact Or.inr (Option.some.inj (hkq.symm.trans hps))) hw
+
+/-- The gated window walk: every live entry of the array inside the window is refuted. -/
+theorem denseLiveAllGated_sound {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
+    (a : Array Nat) (lo hi : Nat) :
+    ∀ (n : Nat), denseLiveAllGated P preArr alive a lo hi n = true →
+      ∀ k q, k < n → a[k]? = some q → lo ≤ q → q < hi → alive[q]?.getD false = true →
+        ∀ m, preArr[q]? = some m → P m = true := by
+  intro n
+  induction n with
+  | zero => intro _ k q hk; exact absurd hk (by omega)
+  | succ n ih =>
+    intro hw k q hk hkq hlo hhi hal m hme
+    rw [denseLiveAllGated, Bool.and_eq_true] at hw
+    rcases Nat.lt_or_ge k n with h | h
+    · exact ih hw.2 k q h hkq hlo hhi hal m hme
+    · obtain rfl : k = n := by omega
+      have h1 := hw.1
+      rw [hkq] at h1
+      dsimp only at h1
+      rw [if_pos (by rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq,
+        decide_eq_true_eq]; exact ⟨⟨hlo, hhi⟩, hal⟩), hme] at h1
+      exact h1
+
+/-- The index's arrays are the list buckets, entry for entry. -/
+theorem denseKeyIdxBuild_byKeyA_getD (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (h : UInt64) :
+    (denseKeyIdxBuild shape busId arr).byKeyA.getD h #[]
+      = ((denseKeyIdxBuild shape busId arr).byKey.getD h []).toArray := by
+  have hmap : (denseKeyIdxBuild shape busId arr).byKeyA
+      = (denseKeyIdxBuild shape busId arr).byKey.map (fun _ l => l.toArray) := rfl
+  rw [hmap, Std.HashMap.getD_eq_getD_getElem?, Std.HashMap.getD_eq_getD_getElem?,
+    Std.HashMap.getElem?_map]
+  cases hm : (denseKeyIdxBuild shape busId arr).byKey[h]? with
+  | none => simp
+  | some l => simp
+
+theorem denseKeyIdxBuild_symA (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    (denseKeyIdxBuild shape busId arr).symA = (denseKeyIdxBuild shape busId arr).sym.toArray := rfl
 
 /-! ## The combined region test
 
@@ -523,7 +693,7 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
       (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
         denseMidRefuted ops shape T busId S m0 = true) ∧
       denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true } :=
-  -- converting a full-region result to the consumed forms (shared by both paths)
+  -- the mid `all` and the shield fold, converted to the forms `denseMkDropResult` consumes
   have hmidOf : denseLiveAllSegP preArr alive
       (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true →
       ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
@@ -551,133 +721,126 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
       funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
     rw [hP, hQ, denseShieldScanW_eq] at hshieldA
     exact hshieldA
+  -- the prepared record at a position is the prepared record of the interaction there
+  have hentry : ∀ q m0, arr[q]? = some m0 →
+      preArr[q]? = some (denseAddrPrep shape T.get.tworoot m0) := by
+    intro q m0 hq
+    rw [hpre, Array.getElem?_map, hq]
+    rfl
+  have hentry' : ∀ q m, preArr[q]? = some m →
+      ∃ m0, arr[q]? = some m0 ∧ m = denseAddrPrep shape T.get.tworoot m0 := by
+    intro q m hm
+    rw [hpre, Array.getElem?_map] at hm
+    cases hq : arr[q]? with
+    | none => rw [hq] at hm; exact absurd hm (by simp)
+    | some m0 => rw [hq] at hm; exact ⟨m0, hq, (Option.some.inj hm).symm⟩
   match hkS : denseAddrKeyOf shape S with
   | none =>
       ⟨denseLiveAllSegP preArr alive
             (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1)
-          && (denseShieldScanSegP
+          && denseShieldEarlySeg
             (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
             (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive 0 i).2, by
+            preArr alive i i, by
         intro hb
         rw [Bool.and_eq_true] at hb
-        exact ⟨hmidOf hb.1, hshieldOf hb.2⟩⟩
+        obtain ⟨q0, hq0, habove⟩ := denseShieldEarlySeg_sound
+          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS) preArr alive i i hb.2
+        refine ⟨hmidOf hb.1, hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
+          (fun q hq => (hq0 q hq).2)
+          (fun q hqi hgt hal m hme => habove q hqi hgt hqi hal m hme)
+          (fun r hr => (hq0 r hr).1))⟩⟩
   | some kS =>
-      let bucket := kIdx.byKey.getD (denseKeyHash kS) []
-      let visMid := denseMergeAsc
-        (bucket.filter (fun q => decide (i + 1 ≤ q) && decide (q < j)))
-        (kIdx.sym.filter (fun q => decide (i + 1 ≤ q) && decide (q < j)))
-      let visShield := denseMergeAsc
-        (bucket.filter (fun q => decide (q < i)))
-        (kIdx.sym.filter (fun q => decide (q < i)))
-      have hsound := hkIdx ▸ denseKeyIdxBuild_sound shape busId arr
-      -- bucket/sym disjointness (a position's key cannot be both constant and not)
-      have hdisj : ∀ q, q ∈ bucket → q ∈ kIdx.sym → False := by
-        intro q hqb hqs
-        obtain ⟨m, k, hm, _, hk, _⟩ := hsound.mem_key _ q hqb
-        obtain ⟨m', hm', _, hk'⟩ := hsound.mem_sym q hqs
-        rw [hm] at hm'
-        obtain rfl := Option.some.inj hm'
-        rw [hk] at hk'
-        exact absurd hk' (by simp)
-      -- a skipped in-range position is refuted: cross-bus, or constant key ≠ kS
-      have hskipP : ∀ (inRange : Nat → Prop) (vs : List Nat),
-          (∀ q, q ∈ bucket → inRange q → q ∈ vs) →
-          (∀ q, q ∈ kIdx.sym → inRange q → q ∈ vs) →
-          ∀ q, inRange q → q ∉ vs → ∀ m, arr[q]? = some m →
-            denseMidRefuted ops shape T busId S m = true ∧
-            denseProvRecv ops shape busId S m = false := by
-        intro inRange vs hbk hsy q hqr hqnot m hm
-        by_cases hbus : m.busId = busId
-        · cases hkm : denseAddrKeyOf shape m with
-          | none =>
-              exact absurd (hsy q (hsound.complete_sym q m hm hbus hkm) hqr) hqnot
-          | some km =>
-              by_cases hkeq : km = kS
-              · subst hkeq
-                exact absurd (hbk q (hsound.complete_key q m km hm hbus hkm) hqr) hqnot
-              · refine ⟨denseMidRefuted_of_keyNe ops shape T busId S m kS km hkS hkm
-                  (fun h => hkeq (h.symm)) , ?_⟩
-                exact denseProvRecv_of_keyNe ops shape busId S m kS km hkS hkm
-                  (fun h => hkeq h.symm)
-        · exact ⟨denseMidRefuted_of_crossBus ops shape T busId S m hbus,
-            denseProvRecv_of_crossBus ops shape busId S m hbus⟩
-      ⟨denseLiveAllSparse preArr alive
-            (denseMidRefutedP ops T.get.nonzero busId preS) visMid
-          && (denseShieldScanSparse
+      ⟨(denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
+              (kIdx.byKeyA.getD (denseKeyHash kS) #[]) (i + 1) j
+              (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size
+            && denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
+              kIdx.symA (i + 1) j kIdx.symA.size)
+          && denseShieldEarly
             (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
             (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive visShield).2, by
+            preArr alive (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i
+            ((kIdx.byKeyA.getD (denseKeyHash kS) #[]).size + kIdx.symA.size)
+            (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size kIdx.symA.size, by
         intro hb
-        rw [Bool.and_eq_true] at hb
-        obtain ⟨hmidB, hshieldA⟩ := hb
-        have hbucketSorted : bucket.Pairwise (· < ·) := hsound.sorted_key _
-        have hsymSorted : kIdx.sym.Pairwise (· < ·) := hsound.sorted_sym
+        rw [Bool.and_eq_true, Bool.and_eq_true] at hb
+        obtain ⟨⟨hmidB, hmidS⟩, hshieldB⟩ := hb
+        have hsound := hkIdx ▸ denseKeyIdxBuild_sound shape busId arr
+        -- the arrays are the buckets
+        have hbA : kIdx.byKeyA.getD (denseKeyHash kS) #[]
+            = (kIdx.byKey.getD (denseKeyHash kS) []).toArray := by
+          rw [hkIdx]; exact denseKeyIdxBuild_byKeyA_getD shape busId arr _
+        have hsA : kIdx.symA = kIdx.sym.toArray := by
+          rw [hkIdx]; exact denseKeyIdxBuild_symA shape busId arr
+        -- a list membership is an in-bounds array entry
+        have hidxB : ∀ q, q ∈ kIdx.byKey.getD (denseKeyHash kS) [] →
+            ∃ k, k < (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size ∧
+              (kIdx.byKeyA.getD (denseKeyHash kS) #[])[k]? = some q := by
+          intro q hq
+          obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp hq
+          have hkA : (kIdx.byKeyA.getD (denseKeyHash kS) #[])[k]? = some q := by
+            rw [hbA, List.getElem?_toArray]; exact hk
+          refine ⟨k, ?_, hkA⟩
+          by_contra hc
+          rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hkA
+          exact absurd hkA (by simp)
+        have hidxS : ∀ q, q ∈ kIdx.sym →
+            ∃ k, k < kIdx.symA.size ∧ kIdx.symA[k]? = some q := by
+          intro q hq
+          obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp hq
+          have hkA : kIdx.symA[k]? = some q := by
+            rw [hsA, List.getElem?_toArray]; exact hk
+          refine ⟨k, ?_, hkA⟩
+          by_contra hc
+          rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hkA
+          exact absurd hkA (by simp)
+        -- every position is a bucket entry, a symbolic entry, or refuted by its key
+        have hclass : ∀ q m0, arr[q]? = some m0 →
+            q ∈ kIdx.byKey.getD (denseKeyHash kS) [] ∨ q ∈ kIdx.sym ∨
+              denseMidRefuted ops shape T busId S m0 = true := by
+          intro q m0 hq
+          by_cases hbus : m0.busId = busId
+          · cases hkm : denseAddrKeyOf shape m0 with
+            | none => exact Or.inr (Or.inl (hsound.complete_sym q m0 hq hbus hkm))
+            | some km =>
+                by_cases hkeq : km = kS
+                · exact Or.inl (hkeq ▸ hsound.complete_key q m0 km hq hbus hkm)
+                · exact Or.inr (Or.inr (denseMidRefuted_of_keyNe ops shape T busId S m0 kS km hkS
+                    hkm (fun h => hkeq h.symm)))
+          · exact Or.inr (Or.inr (denseMidRefuted_of_crossBus ops shape T busId S m0 hbus))
         -- the mid region
-        have hmid : denseLiveAllSegP preArr alive
-            (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true := by
-          rw [← denseLiveAllSparse_eq preArr alive
-            (denseMidRefutedP ops T.get.nonzero busId preS) (j - i - 1) (i + 1) visMid
-            (denseMergeAsc_pairwise _ _ (hbucketSorted.filter _) (hsymSorted.filter _)
-              (fun x hx hx' => hdisj x (List.mem_of_mem_filter hx) (List.mem_of_mem_filter hx')))
-            (fun q hq => by
-              rcases (denseMergeAsc_mem _ _ q).mp hq with h | h <;>
-              · have := List.of_mem_filter h
-                simp only [Bool.and_eq_true, decide_eq_true_eq] at this
-                omega)
-            (fun q hq1 hq2 hqnot m hm halive => by
-              rw [hpre, Array.getElem?_map] at hm
-              cases harr : arr[q]? with
-              | none => rw [harr] at hm; exact absurd hm (by simp)
-              | some m0 =>
-                  rw [harr] at hm
-                  obtain rfl := Option.some.inj hm
-                  have href := (hskipP (fun q => i + 1 ≤ q ∧ q < j) visMid
-                    (fun q hqb hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inl
-                      (List.mem_filter.mpr ⟨hqb, by
-                        simp only [Bool.and_eq_true, decide_eq_true_eq]; omega⟩)))
-                    (fun q hqs hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inr
-                      (List.mem_filter.mpr ⟨hqs, by
-                        simp only [Bool.and_eq_true, decide_eq_true_eq]; omega⟩)))
-                    q ⟨hq1, by omega⟩ hqnot m0 harr).1
-                  rw [hpreS, denseMidRefutedP_eq]
-                  exact href)]
-          exact hmidB
+        have hmidPos : ∀ q, i + 1 ≤ q → q < j → alive[q]?.getD false = true →
+            ∀ m, preArr[q]? = some m →
+              denseMidRefutedP ops T.get.nonzero busId preS m = true := by
+          intro q hq1 hq2 hal m hme
+          obtain ⟨m0, hq, rfl⟩ := hentry' q m hme
+          rcases hclass q m0 hq with hin | hin | href
+          · obtain ⟨k, hklt, hkq⟩ := hidxB q hin
+            exact denseLiveAllGated_sound _ preArr alive _ (i + 1) j _ hmidB k q hklt hkq hq1 hq2
+              hal _ hme
+          · obtain ⟨k, hklt, hkq⟩ := hidxS q hin
+            exact denseLiveAllGated_sound _ preArr alive _ (i + 1) j _ hmidS k q hklt hkq hq1 hq2
+              hal _ hme
+          · rw [hpreS, denseMidRefutedP_eq]; exact href
         -- the shield region
-        have hshield : (denseShieldScanSegP
-            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive 0 i).2 = true := by
-          rw [← denseShieldScanSparse_eq
-            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive i 0 visShield
-            (denseMergeAsc_pairwise _ _ (hbucketSorted.filter _) (hsymSorted.filter _)
-              (fun x hx hx' => hdisj x (List.mem_of_mem_filter hx) (List.mem_of_mem_filter hx')))
-            (fun q hq => by
-              rcases (denseMergeAsc_mem _ _ q).mp hq with h | h <;>
-              · have := List.of_mem_filter h
-                simp only [decide_eq_true_eq] at this
-                omega)
-            (fun q hq1 hq2 hqnot m hm halive => by
-              rw [hpre, Array.getElem?_map] at hm
-              cases harr : arr[q]? with
-              | none => rw [harr] at hm; exact absurd hm (by simp)
-              | some m0 =>
-                  rw [harr] at hm
-                  obtain rfl := Option.some.inj hm
-                  have href := hskipP (fun q => q < i) visShield
-                    (fun q hqb hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inl
-                      (List.mem_filter.mpr ⟨hqb, by simp only [decide_eq_true_eq]; omega⟩)))
-                    (fun q hqs hqr => (denseMergeAsc_mem _ _ q).mpr (Or.inr
-                      (List.mem_filter.mpr ⟨hqs, by simp only [decide_eq_true_eq]; omega⟩)))
-                    q (by omega) hqnot m0 harr
-                  constructor
-                  · rw [hpreS, densePreRefutedP_eq]
-                    exact densePreRefuted_of_midRefuted ops shape T busId S m0 href.1
-                  · rw [hpreS, denseProvRecvP_eq]
-                    exact href.2)]
-          exact hshieldA
-        exact ⟨hmidOf hmid, hshieldOf hshield⟩⟩
-
+        obtain ⟨q0, hq0, habB, habS⟩ := denseShieldEarly_sound
+          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS) preArr alive
+          (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i
+          (by rw [hbA, List.toList_toArray]; exact hsound.sorted_key _)
+          (by rw [hsA, List.toList_toArray]; exact hsound.sorted_sym)
+          _ _ _ (by omega) (le_refl _) (le_refl _) hshieldB
+        refine ⟨hmidOf (denseLiveAllSegP_true_of _ preArr alive (i + 1) j hmidPos (j - i - 1)
+            (i + 1) (le_refl _) (by omega)), ?_⟩
+        refine hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
+          (fun q hq => (hq0 q hq).2) (fun q hqi hgt hal m hme => ?_) (fun r hr => (hq0 r hr).1))
+        obtain ⟨m0, hq, rfl⟩ := hentry' q m hme
+        rcases hclass q m0 hq with hin | hin | href
+        · obtain ⟨k, hklt, hkq⟩ := hidxB q hin
+          exact habB k q hklt hkq hgt hqi hal _ hme
+        · obtain ⟨k, hklt, hkq⟩ := hidxS q hin
+          exact habS k q hklt hkq hgt hqi hal _ hme
+        · rw [hpreS, densePreRefutedP_eq]
+          exact densePreRefuted_of_midRefuted ops shape T busId S m0 href⟩
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -410,16 +410,24 @@ reencode's per-target *gating* work is also independent between accepts, but the
 if their serial remainder grows relative to the rest. busPairCancel/busUnify are inherently
 sequential scans (window state).
 
-**R8. busPairCancel residual quadratics** (formerly part of R1). Design (a) — array-segment
-twins of `liveArr`+`shieldScan`/`List.all` (`denseLiveAllSeg`/`denseShieldScanSeg` with `…_eq`
-lemmas) — is **done (#210)**: sha256_big busPairCancel 107 → 89.5 s, and entry 143 took the
-justification's domain scans out (89.5 → 50 s). The remaining 50 s is the O(live²) certificate work
-itself — `denseShieldScanSeg` is ~4 % of whole-run CPU: `shieldOk` still evaluates
-`densePreRefuted` over the whole live prefix per candidate send, and `midRefuted` over the
-between-region. Design (b) stands: the busUnify entry-111 treatment — `shieldOk` left-folds
-to a single per-address-key `pending` bit, maintainable across one sweep — but the pass's
-tombstone-and-restart structure (drops invalidate prefix state: removing a consumed receive
-un-shields earlier messages) forces a recompute-on-drop scheme, bounded by #drops × O(B).
+**R8. busPairCancel residual quadratics** (formerly part of R1) · **done (entries 141/143/148/153)**.
+Design (a), array-segment twins of `liveArr`+`shieldScan`, landed in #210 (sha256_big 107 → 89.5 s);
+entry 143 took the justification's domain scans out (89.5 → 50 s); entry 148's sparse same-key index
+cut the region scans to the same-key + symbolic positions (0.54× on the big case). **Entry 153 closes
+the O(live²) certificate work itself**: the shield fold is decided by the *topmost* visited live
+position `q` with `¬P q ∨ Q q` (`ok = P q`), so a descending early-exit walk over the index arrays
+computes the same boolean while touching only the positions above the last provable receive —
+28.6 M → 0.86 M positions on sha256 `apc_001`, pass 19.3 → 6.4 s (0.33×), output byte-identical.
+Design (b) (a maintained per-address-key `pending` bit with recompute-on-drop) is therefore
+**retired**: the early exit gets the same asymptotics with no cross-candidate state, no drop
+invalidation, and a value-identical transformation of the existing fold.
+   **What is left in the pass (6.4 s on sha256 `apc_001`, measured post-153)**, in order:
+   the surviving certificate evaluations — `denseAddrNonzeroNeqP` is allocation- and
+   `ZMod`-dictionary-bound (R9; `denseIsZeroLin` derives the whole `CommRing` chain *before* testing
+   `terms.isEmpty`, and `denseDiffSumP` rebuilds it per subset, 4 subsets per compared pair on a
+   two-slot address); the per-invocation index builds (`denseRecvIndexAll`, `denseKeyIdxBuild`,
+   `denseBuildBoundIdx`/`FormIdx`, 5.4 % of the pre-153 pass); the per-drop `alive` copy (below);
+   and `denseInteractionBound`'s per-variable pattern rebuild (R13b).
 
 **R9a (done, entry 144).** `DenseTwoRootMap.addVars` re-linearized a product's factors per
 variable; `addVarsFast` + `@[csimp] addVars_eq_fast` hoists them. The `@[csimp]` twin is the
@@ -572,15 +580,26 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
   effectiveness hides single-case regressions that the lexicographic merge rule forbids.
 - **Runtime is a de-facto merge criterion**: build per-invocation indexes once; keep expensive
   arms out of hot per-query paths; put once-suffices passes in the coda.
+- **Count the change before proving it.** Entry 153 validated a fold reformulation with a throwaway
+  `dbg_trace` probe that ran the proposed function *next to* the real one on every candidate of the
+  worst case: identical verdict on 14 433/14 433 and a 33× drop in visited positions, both known
+  before a line of proof. A counter probe is cheaper than a prototype and strictly more informative
+  than a sample share.
+- **Re-attribute after every landing; a pass's residual moves.** Entry 148's closing note put
+  busPairCancel's remaining cost in "per-drop `alive` copies, `denseCheckCancel`, `denseFirstMatchAt`";
+  measured in entry 153 those are 2.1 %, ~0 % and ~0 % — the cost had never left the region scans, it
+  had only moved from "every prefix position" to "every same-key-or-symbolic prefix position".
 - **Check open PRs / recent `claude/*` branches for duplicates before implementing.**
 
 ## Runtime ideas (2026-07-27 session, entry 148)
 
-- **Per-drop `alive` copies in busPairCancel**: with the region scans now sparse, the heavy-drop
-  cycle's residual includes `(alive.setIfInBounds iP false).setIfInBounds jP false` copying the
-  71k-entry array per drop (alive is shared by the scan closures). ~12k drops ≈ 1.7 GB of copies.
-  A persistent-friendly representation (e.g. a `Std.HashSet Nat` of tombstones consulted alongside
-  a stable array, or batching drops per findCancel sweep) could cut most of it.
+- **Per-drop `alive` copies in busPairCancel**: **measured (entry 153) at 2.1 % of the pass**
+  (~410 ms of 19.3 s on sha256 `apc_001`), 97 % of it `lean_copy_expand_array` — the array is still
+  referenced by the loop frame, so the first `setIfInBounds` copies all 71 402 entries (≈ 8 GB of
+  memcpy over 14 418 drops). Below the land bar on its own; bundle it with a bigger change. Cheap
+  forms: a `ByteArray` (1 byte per entry, 8× less copying) or handing both tombstone positions to
+  `denseCancelLoop`, which owns the array uniquely. **Do not** switch to a `Std.HashSet Nat` of
+  tombstones: liveness is *read* tens of millions of times per invocation.
 - **busUnify same-key mid verification**: `denseCheckPair` re-verifies each candidate's whole mid
   window (`mid.all`). The same constant-key argument as entry 148 applies: mid messages with a
   different constant key are refuted by the ConstsNeq arm. Needs the window's positions (the sweep

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -540,10 +540,18 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
   indexes are the pattern.
 - **Feeding whole regions into per-query justification arms**: 63 s/case for −3 interactions
   (entry 102). Use a position index or nothing.
-- CI notes (updated 2026-07-24): the effectiveness-matrix runtime row swung **+51 % → +15 % on
+- CI notes (updated 2026-07-29): the effectiveness-matrix runtime row swung **+51 % → +15 % on
   identical code** for openvm-eth while its own per-pass table showed ≤1.04× — treat the wall row
   as ±50 % noise on the small parallel sets and read the per-pass table instead; the serial
-  `Runtime Bench` workflow (dispatch-only, openvm sets only) is the real A/B. This container has
+  `Runtime Bench` workflow (dispatch-only, openvm sets only) is the real A/B. **Entry 153 re-confirmed
+  this quantitatively**: the row read wasm-eth +20 %, SP1 rsp +67 %, openvm-eth +5 % for a change that
+  the serial `Runtime Bench` on the same runner put at **0.99× total / 0.83× on the pass**, and that a
+  local serial interleaved re-run of all three sets (300 cases) put at **0.951× wall / 0.570× on the
+  pass**, with every case ≥ 50 ms of pass time improving. The row's per-case outliers are 8–80 ms
+  cases carrying 0–5 ms of the pass: on SP1 rsp, 28 cases came out >5 % slower and 30 >5 % faster.
+  `benchmark.py` runs cases with `--jobs = cpu_count`; the runtime it prints is scheduling, not work.
+  Peak RSS is worth one check when the row moves (entry 153: 241.7 → 228.1 MB on wasm-eth apc_012),
+  since memory pressure is the one mechanism that *would* make a parallel-only regression real. This container has
   ±15 % run-to-run variance; keccak numbers above were taken serially, and the per-cycle keccak
   run was inflated ~30 % by a concurrent gdb sampler — compare shapes, not absolutes, and let CI
   arbitrate.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5364,7 +5364,9 @@ memcpy over 14 418 drops) and `denseInteractionBound`'s per-variable pattern reb
 CI FOLLOW-UP: the effectiveness matrix's runtime row reported wasm-eth +20 %, SP1 rsp +67 %,
 openvm-eth +5 % (keccak −4 %, sha256 −6 %, SP1 keccak −7 %) — the parallel-harness artifact, measured
 twice. CI's serial `Runtime Bench` on the same runner: openvm-eth total **0.99×**, busPairCancel
-**0.83×**, every other pass 1.00× ± noise. Local serial interleaved re-run of the three flagged sets
+**0.83×**, every other pass 1.00× ± noise; SP1 rsp (100 cases, once the serial bench could reach SP1
+at all — the `<vm>:<set>` selector, PR #254) total **0.95×**, busPairCancel **0.77×**, slowest five
+cases 0.86–0.97×. Local serial interleaved re-run of the three flagged sets
 (300 cases, one process at a time): wall **118967 → 113145 ms (0.951×)**, busPairCancel
 **12749 → 7263 ms (0.570×)** — SP1/rsp 0.982× wall / 0.762× pass, openvm-eth 0.990× / 0.819×,
 wasm-eth 0.926× / 0.507×; all 23 cases with ≥ 50 ms of pass time improve (0.16×–0.97×), and the row's

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5361,4 +5361,15 @@ RESIDUAL for the next pass at this: the surviving 0.86 M certificate evaluations
 builds the whole `CommRing` chain before testing `terms.isEmpty`), the per-invocation index builds
 (5.4 % of the old pass), the per-drop `alive` array copy (2.1 %, all `lean_copy_expand_array`, ~8 GB of
 memcpy over 14 418 drops) and `denseInteractionBound`'s per-variable pattern rebuild (R13b).
-**Worked: yes (busPairCancel 0.33× on its worst case, −8.1 % end-to-end, output byte-identical; draft PR).**
+CI FOLLOW-UP: the effectiveness matrix's runtime row reported wasm-eth +20 %, SP1 rsp +67 %,
+openvm-eth +5 % (keccak −4 %, sha256 −6 %, SP1 keccak −7 %) — the parallel-harness artifact, measured
+twice. CI's serial `Runtime Bench` on the same runner: openvm-eth total **0.99×**, busPairCancel
+**0.83×**, every other pass 1.00× ± noise. Local serial interleaved re-run of the three flagged sets
+(300 cases, one process at a time): wall **118967 → 113145 ms (0.951×)**, busPairCancel
+**12749 → 7263 ms (0.570×)** — SP1/rsp 0.982× wall / 0.762× pass, openvm-eth 0.990× / 0.819×,
+wasm-eth 0.926× / 0.507×; all 23 cases with ≥ 50 ms of pass time improve (0.16×–0.97×), and the row's
+outliers are 8–80 ms cases carrying 0–5 ms of the pass (rsp: 28 cases >5 % slower, 30 >5 % faster).
+Peak RSS checked because the index is now stored as both lists and arrays, i.e. the one mechanism that
+could make a parallel-only regression real: wasm-eth apc_012 241.7 → 228.1 MB, openvm-eth apc_005
+111.8 → 112.4 MB.
+**Worked: yes (busPairCancel 0.33× on its worst case, corpus 0.570× on the pass, output byte-identical; draft PR #253).**

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5304,3 +5304,61 @@ lazify `denseByteOperandDomain`'s coset build (21.3 % of the pass on SP1 keccak,
 (d) prefix-pruned / component-split enumeration for the big-box OpenVM cases, gated on a box-shape
 counter first.
 **Worked: yes (domainBatch 0.14x on its worst-share APC, output byte-identical; draft PR).**
+
+### 153. Runtime: busPairCancel's shield scan stops at the first deciding position (0.33x on the pass, sha256)
+TARGETED the top pass of the corpus (`ranked_passes.md`: busPairCancel 31.5 s / 10.8 % of the corpus,
+19.0 s of 171 s on its worst case sha256 `apc_001`). ATTRIBUTED FIRST (LBR + the phase / cost-class /
+caller scripts, every sample required to carry a pass frame): **65 % of the pass is the
+address-disequality certificate chain** — `denseAddrNonzeroNeqP` alone 47.5 % — and 92 % of those
+samples are reached from `denseShieldScanSparse`, the *before-region* scan; another **13.9 %** builds
+the per-candidate `bucket.filter` / `sym.filter` / `denseMergeAsc` lists. Pass-only cost classes:
+31 % refcount, 21 % allocator, 13 % `ZMod` dictionaries, 17 % real logic — the budget is the memory
+traffic of intermediate `DenseLinExpr`s. A throwaway `dbg_trace` counter probe then measured the
+volume: 14 848 candidates reach the region tests, **14 418 are accepted (97 %)**, the shield visits
+**28.6 M positions** (mean 1982, max 8003) and the range filters walk **104 M** list cells, while the
+whole mid region visits 32 k. Two structural reasons: OpenVM's execution bridge has
+`addressFields = []`, so all 8006 bridge messages share **one** key bucket (4002 candidates × mean
+4002 positions = 56 % of all shield work), and hot memory cells have 900–1500-entry buckets plus 1114
+symbolic-address messages that every memory candidate visits. Entry 148's sparse index has an
+unintended consequence: it visits exactly the positions the *cheap* certificate arms cannot refute,
+so every visited position runs the chain to its last and most expensive arm.
+THE FIX is a reformulation of the existing fold, not a new certificate. `denseShieldScanW`'s verdict
+is `∀ k, P l_k ∨ ∃ k' > k, Q l_k'`, so it is decided by the **topmost** visited live position `q` with
+`¬P q ∨ Q q`: `ok = P q` (`true` when there is none). A descending walk with an early exit computes
+the same boolean while touching only the positions above the last provable receive. Measured with the
+same probe *before* writing any proof: **28.6 M → 0.86 M positions (0.030×)**, verdict identical on
+**14 433 / 14 433** candidates (bridge candidates settle in exactly 1 position instead of 4002;
+memory candidates mean 82.5, median 7).
+IMPLEMENTATION (`BusPairCancelKeyIdx.lean`, all under `Implementation/`): `DenseKeyIdx` also carries
+its buckets and `sym` as ascending arrays (`byKeyA` via `Std.HashMap.map`, `symA`); the mid test is a
+gated array walk (`denseLiveAllGated`) and the shield a descending two-array early-exit walk
+(`denseShieldEarly`, plus `denseShieldEarlySeg` for the symbolic-key fallback, which needs no index).
+Both walks re-check the position window at every entry, so **no range search is needed**: a
+binary-searched variant was built and measured first and is only 2 % faster on sha256 (6250 vs
+6388 ms) — not worth the extra correctness argument.
+PROOF: two semantic lemmas replace the whole sparse-list layer, which is deleted (`denseMergeAsc`,
+`denseLiveAllSparse`, `denseShieldScanSparse` and their `_eq` lemmas). `denseLiveAllSegP_true_of`:
+per-position refutations give the segment `all`. `denseShieldScanSegP_true_aux`/`_of`: the shield fold
+holds when every live position is refuted except possibly below a witness position that is itself a
+live provable receive — one induction, carrying the fold's `.1` ("a provable receive occurs later")
+flag leftwards. The walks' soundness (`denseShieldEarly_sound`, `denseShieldEarlySeg_sound`,
+`denseLiveAllGated_sound`) supplies exactly those hypotheses; the per-array `Pairwise (· < ·)` from
+`denseKeyIdxBuild_sound` is what makes "every entry above the stop position was examined" true.
+Positions that are not index entries are refuted by the unchanged `denseMidRefuted_of_keyNe` /
+`_of_crossBus` + `densePreRefuted_of_midRefuted`.
+NUMBERS (this 20-core box, interleaved, `profile`; median of 3 reps for the cheap cases, single shot
+for sha256): sha256 `apc_001` busPairCancel **19276 → 6391 ms (0.332×)**, total 159266 → 146419
+(**0.919×**); wasm-eth `apc_028` **708 → 108 (0.153×)**, total 0.745×; wasm-eth `apc_012`
+2197 → 1186 (0.540×), total 0.945×; keccak `apc_001` 1143 → 469 (0.410×), total 0.952×; openvm-eth
+`apc_100` 146 → 121 (0.829×). No other pass column moves outside noise; `busPairCancelLate` flat
+(250 → 239 ms).
+VERIFIED: `opt-export` **byte-identical** on sha256 apc_001 (5.76 MB export), OpenVM keccak,
+openvm-eth apc_006 / apc_100, wasm-eth apc_012 / apc_028 and SP1 keccak; keccak `run` counts
+identical (2021 / 186 / 1748); `lake build` clean (no warnings); `check-proof-integrity` passes
+(axioms propext / Classical.choice / Quot.sound, no unused theorems).
+RESIDUAL for the next pass at this: the surviving 0.86 M certificate evaluations (the
+`denseAddrNonzeroNeqP` allocation + `ZMod`-dictionary chain — R9 threading is the lever; `denseIsZeroLin`
+builds the whole `CommRing` chain before testing `terms.isEmpty`), the per-invocation index builds
+(5.4 % of the old pass), the per-drop `alive` array copy (2.1 %, all `lean_copy_expand_array`, ~8 GB of
+memcpy over 14 418 drops) and `denseInteractionBound`'s per-variable pattern rebuild (R13b).
+**Worked: yes (busPairCancel 0.33× on its worst case, −8.1 % end-to-end, output byte-identical; draft PR).**


### PR DESCRIPTION
## What

`busPairCancel`'s before-region *shield* was 65 % of the pass, and 92 % of those samples come from the shield scan alone. Its fold asks

```
ok(l) = ∀ k, P l_k ∨ ∃ k' > k, Q l_k'
```

which is decided entirely by the **topmost** visited live position `q` with `¬P q ∨ Q q`: `ok = P q` (`true` when there is none). So a descending walk with an early exit computes the *same boolean* while touching only the positions above the last provable receive.

- `DenseKeyIdx` also carries its buckets and `sym` as ascending arrays (`byKeyA` via `Std.HashMap.map`, `symA`); the lists stay as the proof-side spec.
- the mid test becomes a gated array walk (`denseLiveAllGated`), the shield a descending two-array early-exit walk (`denseShieldEarly`), with `denseShieldEarlySeg` for the symbolic-key fallback (no index needed there).
- both walks re-check the position window at every entry, so **no range search is needed**. A binary-searched variant was built and measured first: only 2 % faster on sha256 (6250 vs 6388 ms), not worth its extra correctness argument.

All under `Implementation/`; the audited surface is untouched.

## Why it is this big

Counted with a throwaway `dbg_trace` probe on `sha256/apc_001` (reverted): 14 848 candidates reach the region tests, 97 % are accepted, and the shield visits **28.6 M positions** (mean 1982). Two reasons: OpenVM's execution bridge has `addressFields = []`, so all 8006 bridge messages share **one** key bucket (4002 candidates × mean 4002 positions = 56 % of all shield work); and hot memory cells have 900–1500-entry buckets plus 1114 symbolic-address messages that every memory candidate visits.

The same probe ran the proposed walk next to the real scan: **28.6 M → 0.86 M positions (0.030×)**, verdict identical on **14 433 / 14 433** candidates — known before a line of proof was written.

## Proof

Two semantic lemmas replace the whole sparse-list layer, which is deleted (`denseMergeAsc`, `denseLiveAllSparse`, `denseShieldScanSparse` and their `_eq` lemmas):

- `denseLiveAllSegP_true_of` — per-position refutations give the segment `all`.
- `denseShieldScanSegP_true_aux` / `_of` — the shield fold holds when every live position is refuted except possibly below a witness position that is itself a live provable receive; one induction, carrying the fold's "a provable receive occurs later" flag leftwards.

`denseShieldEarly_sound` / `denseShieldEarlySeg_sound` / `denseLiveAllGated_sound` supply exactly those hypotheses (the per-array `Pairwise (· < ·)` from `denseKeyIdxBuild_sound` is what makes "every entry above the stop position was examined" true). Positions that are not index entries are refuted by the unchanged `denseMidRefuted_of_keyNe` / `_of_crossBus` + `densePreRefuted_of_midRefuted`.

## Numbers

Interleaved on one quiet 20-core box, median of 3 reps (single shot for sha256); busPairCancel, then the case total:

| case | busPairCancel | ratio | case total | ratio |
|---|---:|---:|---:|---:|
| `sha256/apc_001` (worst absolute) | 19276 → **6391 ms** | **0.332×** | 159266 → 146419 ms | **0.919×** |
| `wasm-eth/apc_028` (worst share) | 708 → **108 ms** | **0.153×** | 2345 → 1748 ms | 0.745× |
| `wasm-eth/apc_012` (near p95) | 2197 → 1186 ms | 0.540× | 16185 → 15297 ms | 0.945× |
| `keccak/apc_001` | 1143 → **469 ms** | **0.410×** | 12628 → 12020 ms | 0.952× |
| `openvm-eth/apc_100` (family tail) | 146 → 121 ms | 0.829× | 2074 → 2042 ms | 0.985× |

No other pass column moves outside run-to-run noise; `busPairCancelLate` is flat (250 → 239 ms).

## Verification

- **Output byte-identical** (`opt-export` + `cmp`): `sha256/apc_001` (5.76 MB export), OpenVM `keccak/apc_001`, `openvm-eth/apc_006`, `openvm-eth/apc_100`, `wasm-eth/apc_012`, `wasm-eth/apc_028`, SP1 `keccak/apc_001`.
- keccak `run` counts identical: 2021 / 186 / 1748.
- `lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` passes (axioms `propext` / `Classical.choice` / `Quot.sound`, no `sorry`, no unused theorems).

Effectiveness should be unchanged everywhere — the transformation is value-preserving — but the CI matrix is the arbiter.

## Residual (for the next pass at this)

The remaining 6.4 s on sha256: the surviving 0.86 M certificate evaluations (`denseAddrNonzeroNeqP` is allocation- and `ZMod`-dictionary-bound — `denseIsZeroLin` derives the whole `CommRing` chain *before* testing `terms.isEmpty`), the per-invocation index builds (5.4 % of the old pass), the per-drop `alive` array copy (2.1 %, ~8 GB of memcpy over 14 418 drops) and `denseInteractionBound`'s per-variable pattern rebuild. Written up in `agent-docs/ideas.md` R8 and log entry 153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)