### PR TITLE
perf(domainBatch): summarize the variable-free bus tail once per invocation (0.49x on sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -383,12 +383,22 @@ structure DenseConstraintCovIndex where
   inactiveVarlessCount : Nat
   activeVarless : Array Nat
 
+/-- The variable-free usable interactions' contribution to a gather, which is the same for every
+    target: their count, their `informative`/`domainRedundant` folds, and the constant value of
+    their obligations (`constOk`, false as soon as one of them is violated). -/
+structure DenseBusVarlessSummary (p : ℕ) where
+  count : Nat
+  informative : Bool
+  allDomainRedundant : Bool
+  constOk : Bool
+
 /-- The per-target index bundle (plain data; correctness via correspondence). -/
 structure DenseForcedIdx (p : ℕ) where
   csIdx : DenseConstraintCovIndex
   arrCs : Array (DenseConstraintPlan p)
   bisIdx : DenseArrayCovIndex
   arrBis : Array (DenseBusPlan p)
+  busVarless : DenseBusVarlessSummary p
 
 /-- The dense domain-table `doms` list has keys `xs`. -/
 theorem DenseDomainTable.doms_fst (T : DenseDomainTable p) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatchRuntime.lean
@@ -459,11 +459,13 @@ def denseGatherBusArrayV (arr : Array (DenseBusPlan p)) (xs : List VarId)
     (positions : Array Nat) (acc : DenseBusGatherV p) : DenseBusGatherV p :=
   positions.foldl (denseGatherBusAtV arr xs) acc
 
+/-- Seeded from the per-invocation variable-free summary, so the gather walks only the anchor
+    buckets of `xs`; a variable-free plan passes `denseVarsInListF xs []` for every target, so its
+    contribution to all four fields is target-independent (`denseBusVarlessSummaryV`). -/
 def denseGatherBusesV (fidx : DenseForcedIdx p) (xs : List VarId) : DenseBusGatherV p :=
-  let acc := xs.foldl (fun acc v =>
+  xs.foldl (fun acc v =>
     denseGatherBusArrayV fidx.arrBis xs (fidx.bisIdx.buckets.getD v #[]) acc)
-    ⟨0, false, true, []⟩
-  denseGatherBusArrayV fidx.arrBis xs fidx.bisIdx.varless acc
+    ⟨fidx.busVarless.count, fidx.busVarless.informative, fidx.busVarless.allDomainRedundant, []⟩
 
 structure DenseForcedScanV (p : ℕ) where
   keys : List VarId
@@ -471,6 +473,9 @@ structure DenseForcedScanV (p : ℕ) where
   active : List (DenseExpr p)
   interactions : List (BusInteraction (DenseExpr p))
   work : Nat
+  /-- The variable-free interactions' constant verdict (`DenseBusVarlessSummary.constOk`); `false`
+      leaves the box with no survivor, which is what a per-point `false` predicate yields. -/
+  constOk : Bool
 
 inductive DenseForcedPlanV (p : ℕ) where
   | done (forced : List (VarId × ZMod p))
@@ -507,12 +512,15 @@ def denseForcedPreflightV (T : DenseDomainTable p) (fidx : DenseForcedIdx p)
             doms,
             active := cs.active,
             interactions := bis.interactions,
-            work := boxSize * (cs.active.length + bis.count + keys.length) })
+            work := boxSize * (cs.active.length + bis.count + keys.length),
+            constOk := fidx.busVarless.constOk })
       else none
     else none
 
 def denseRunForcedScanV (bs : BusSemantics p) (facts : BusFacts p bs)
     (job : DenseForcedScanV p) : List (VarId × ZMod p) :=
+  if !job.constOk then job.keys.map (fun x => (x, (0 : ZMod p)))
+  else
   let survC := denseCompiledSurvV bs facts job.active job.interactions job.keys
   match denseScanBoxV survC.run job.doms with
   | none => job.keys.map (fun x => (x, (0 : ZMod p)))
@@ -645,12 +653,41 @@ def denseConstraintCovIndexV (cs : List (DenseConstraintPlan p)) : DenseConstrai
     inactiveVarlessCount := summary.1,
     activeVarless := summary.2 }
 
-def denseForcedIdxV (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) :
-    DenseForcedIdx p :=
+/-- One variable-free interaction's verdict: the survivor predicate of the singleton system, on the
+    empty key list and the empty point. A variable-free expression compiles with no `.ix` node, so
+    this is the value the per-target scan would evaluate at every point.
+
+    The `denseBIVars` guard is the re-check-at-use: only a genuinely variable-free interaction may
+    report `false`, which is the direction that forces constants
+    (`denseBusVarlessSummaryV_constOk`, `denseForcedOverV_entails`). -/
+def denseVarlessBiOkV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Bool :=
+  !(denseBIVars bi).isEmpty || (denseCompiledSurvV bs facts [] [bi] []).run []
+
+/-- Fold the variable-free usable interactions once per invocation: their contribution to a gather
+    is the same for every target (`denseGatherBusesV`). -/
+def denseBusVarlessSummaryV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (varless : Array Nat) (arr : Array (DenseBusPlan p)) : DenseBusVarlessSummary p :=
+  varless.foldl (init := ⟨0, false, true, true⟩) fun s i =>
+    if h : i < arr.size then
+      let plan := arr[i]
+      if plan.usable then
+        { count := s.count + 1,
+          informative := s.informative || plan.informative,
+          allDomainRedundant := s.allDomainRedundant && plan.domainRedundant,
+          constOk := s.constOk && denseVarlessBiOkV bs facts plan.interaction }
+      else s
+    else s
+
+def denseForcedIdxV (bs : BusSemantics p) (facts : BusFacts p bs)
+    (cs : List (DenseConstraintPlan p)) (bis : List (DenseBusPlan p)) : DenseForcedIdx p :=
+  let bisIdx := denseFreezeCovIndex (denseAnchorCovBuild (fun bi => bi.vars) bis)
+  let arrBis := bis.toArray
   { csIdx := denseConstraintCovIndexV cs,
     arrCs := cs.toArray,
-    bisIdx := denseFreezeCovIndex (denseAnchorCovBuild (fun bi => bi.vars) bis),
-    arrBis := bis.toArray }
+    bisIdx,
+    arrBis,
+    busVarless := denseBusVarlessSummaryV bs facts bisIdx.varless arrBis }
 
 /-- Is `op` a recognized byte-relation selector for `spec`? Every such op guarantees both operands
     are below `spec.bound` (`BusFacts.byteXorSpec_sound` / `byteBoolSound`). -/
@@ -741,7 +778,7 @@ def denseDomainBatchσV (bs : BusSemantics p) (facts : BusFacts p bs)
   let csPlans := denseConstraintPlansV T d.algebraicConstraints
   let busPlans := denseBusPlansV bs facts T d.busInteractions
   let targets := densePlanTargetsV csPlans busPlans
-  let fidx := denseForcedIdxV csPlans busPlans
+  let fidx := denseForcedIdxV bs facts csPlans busPlans
   -- Fan out only at keccak/SHA scale; below it the sequential fold avoids spawn overhead.
   denseCollectForcedV bs facts T fidx (8192 ≤ d.algebraicConstraints.length) targets ∅
     DenseSolved.empty

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -1770,9 +1770,9 @@ theorem denseGatherBusesV_interactions_mem (fidx : DenseForcedIdx p) (xs : List 
       fidx.arrBis[i].interaction = bi ∧ fidx.arrBis[i].usable = true ∧
         denseVarsInListF xs fidx.arrBis[i].vars = true := by
   rw [denseGatherBusesV] at hbi
-  apply denseGatherBusArrayV_interactions_mem fidx.arrBis xs fidx.bisIdx.varless _
-    (denseGatherBusBucketsV_interactions_mem fidx.arrBis fidx.bisIdx xs xs
-      ⟨0, false, true, []⟩ (by simp)) bi hbi
+  exact denseGatherBusBucketsV_interactions_mem fidx.arrBis fidx.bisIdx xs xs
+    ⟨fidx.busVarless.count, fidx.busVarless.informative, fidx.busVarless.allDomainRedundant, []⟩
+    (by simp) bi hbi
 
 theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (DenseBusPlan p))
     (harr : fidx.arrBis = plans.toArray) (xs : List VarId)
@@ -1789,11 +1789,70 @@ theorem denseGatherBusesV_plan_mem (fidx : DenseForcedIdx p) (plans : List (Dens
   exact ⟨plan, hmem, by simpa [plan] using hbi', by simpa [plan] using husable,
     by simpa [plan] using hvars⟩
 
+/-! ### The variable-free summary's verdict
+
+`constOk = true` is sound for free — it only drops obligations from the scan, which can add
+survivors and so shrink the forced set. What needs an argument is `false`, which forces every key:
+`denseVarlessBiOkV` reports `false` only for an interaction that is genuinely variable-free (its own
+`denseBIVars` re-check) and whose obligation fails on the empty point, and such an interaction is
+violated by *every* environment — so under a satisfying `denv` the summary is `true`. -/
+
+theorem denseVarlessBiOkV_of_sat (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p)
+    (hsat : (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)) :
+    denseVarlessBiOkV bs facts bi = true := by
+  unfold denseVarlessBiOkV
+  by_cases hvars : (denseBIVars bi).isEmpty = true
+  · have hnil : denseBIVars bi = [] := List.isEmpty_iff.mp hvars
+    have hrestr := denseSurvivesAllMV_restriction facts [] [bi] [] denv
+      (by intro e he; simp at he)
+      (by intro b hb; cases List.mem_singleton.mp hb; exact hsat)
+      (by intro e he; simp at he)
+      (by intro b hb i hi; cases List.mem_singleton.mp hb; rw [hnil] at hi; simp at hi)
+    rw [Bool.or_eq_true]
+    exact Or.inr (by rw [denseCompiledSurvV_eq]; simpa using hrestr)
+  · simp [hvars]
+
+theorem denseBusVarlessSummaryV_constOk (bs : BusSemantics p) (facts : BusFacts p bs)
+    (varless : Array Nat) (arr : Array (DenseBusPlan p)) (denv : VarId → ZMod p)
+    (hsat : ∀ plan ∈ arr, (denseBIEval plan.interaction denv).multiplicity ≠ 0 →
+      bs.accepts (denseBIEval plan.interaction denv)) :
+    (denseBusVarlessSummaryV bs facts varless arr).constOk = true := by
+  unfold denseBusVarlessSummaryV
+  rw [← Array.foldl_toList]
+  suffices h : ∀ (l : List Nat) (s : DenseBusVarlessSummary p), s.constOk = true →
+      (l.foldl (fun s i =>
+        if h : i < arr.size then
+          if arr[i].usable then
+            { count := s.count + 1,
+              informative := s.informative || arr[i].informative,
+              allDomainRedundant := s.allDomainRedundant && arr[i].domainRedundant,
+              constOk := s.constOk && denseVarlessBiOkV bs facts arr[i].interaction }
+          else s
+        else s) s).constOk = true from h varless.toList ⟨0, false, true, true⟩ rfl
+  intro l
+  induction l with
+  | nil => intro s hs; exact hs
+  | cons i rest ih =>
+      intro s hs
+      refine ih _ ?_
+      by_cases hi : i < arr.size
+      · by_cases hu : arr[i].usable = true
+        · simp only [hi, ↓reduceDIte, hu, ↓reduceIte, hs, Bool.true_and]
+          exact denseVarlessBiOkV_of_sat bs facts arr[i].interaction denv
+            (hsat arr[i] (Array.getElem_mem hi))
+        · simp only [hi, ↓reduceDIte, hu, Bool.false_eq_true, ↓reduceIte]; exact hs
+      · simp only [hi, ↓reduceDIte]; exact hs
+
 /-- **Value-only `forcedOver` entailment.** Every forced pair `(x, c)` is entailed by `denv`, given
-    the domain table is sound at `denv` and the covered items evaluate/oblige correctly. -/
+    the domain table is sound at `denv` and the covered items evaluate/oblige correctly. The
+    variable-free summary must read `constOk` (`denseBusVarlessSummaryV_constOk`); `false` short-
+    circuits the scan to "every key is 0", which is only entailed because it cannot happen under a
+    satisfying `denv`. -/
 theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
     (T : DenseDomainTable p) (fidx : DenseForcedIdx p) (xs : List VarId) (denv : VarId → ZMod p)
     (hTs : DenseTableSoundAt denv T)
+    (hconstOk : fidx.busVarless.constOk = true)
     (hes : ∀ e ∈ (denseGatherConstraintsV fidx xs).active,
       e.eval denv = 0 ∧ ∀ i ∈ e.vars, i ∈ xs)
     (hbis : ∀ bi ∈ (denseGatherBusesV fidx xs).interactions,
@@ -1833,7 +1892,8 @@ theorem denseForcedOverV_entails (bs : BusSemantics p) (facts : BusFacts p bs)
           intro f hf
           have hf' : f ∈ ((fdoms.map Prod.fst).zip cands).filterMap
               (fun xc => xc.2.map (fun c => (xc.1, c))) := by
-            simpa only [denseRunForcedPlanV, denseRunForcedScanV, hscan] using hf
+            simpa only [denseRunForcedPlanV, denseRunForcedScanV, hconstOk, Bool.not_true,
+              Bool.false_eq_true, if_false, hscan] using hf
           obtain ⟨n, hn1, hn2⟩ := mem_zip_filterMap (fdoms.map Prod.fst) cands f hf'
           have hforce := denseScanBoxV_forces _ _ cands hscan n f.2 hn2 _ hinbox hsurv
           rw [List.getElem?_map, hn1] at hforce
@@ -2070,7 +2130,7 @@ def dbTargets (bs : BusSemantics p) (facts : BusFacts p bs)
 /-- The inverted index built by `denseDomainBatchσV`. -/
 def dbFidx (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseForcedIdx p :=
-  denseForcedIdxV (dbConstraintPlans bs facts d) (dbBusPlans bs facts d)
+  denseForcedIdxV bs facts (dbConstraintPlans bs facts d) (dbBusPlans bs facts d)
 
 theorem denseDomainBatchσV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
@@ -2091,8 +2151,13 @@ theorem denseDomainBatchσV_entailed [Fact p.Prime] [NeZero p]
   case hforced =>
     intro xs f hf denv hsat
     refine denseForcedOverV_entails bs facts (dbT bs facts d) (dbFidx bs facts d) xs denv
-      ?_ ?_ ?_ f hf
+      ?_ ?_ ?_ ?_ f hf
     · exact dbT_soundAt bs facts d denv hsat
+    · refine denseBusVarlessSummaryV_constOk bs facts _ _ denv (fun plan hplan => ?_)
+      have hmem : plan ∈ dbBusPlans bs facts d := by simpa using hplan
+      rw [dbBusPlans, denseBusPlansV] at hmem
+      obtain ⟨bi0, hbi0, rfl⟩ := List.mem_map.mp hmem
+      exact hsat.2 bi0 hbi0
     · intro e he
       obtain ⟨plan, hplan, hpe, hpvars, _⟩ := denseGatherConstraintsV_plan_mem
         (dbFidx bs facts d) (dbConstraintPlans bs facts d) rfl xs he

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -471,7 +471,10 @@ be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide
 worth a prototype on one index first.
 
 **R13. domainBatch is per-target *setup*-bound, not enumeration-bound** (measured 2026-07-28, LBR
-profiles over five OpenVM cases + SP1 keccak; entry 152). Phase shares of in-pass samples:
+profiles over five OpenVM cases + SP1 keccak; entry 152). **The table below is CPU; for the wall,
+see entry 155's `IO` phase timers** — the pass is 70 % serial and its largest single item, the
+variable-free bus tail in the gathers, does not appear here at all (it is spread across the
+`denseCompileCBiPredsV` and gather rows). Phase shares of in-pass samples:
 
 | phase | sha256 apc_001 | keccak | SP1 keccak | eth apc_071 | wasm apc_005 |
 |---|---:|---:|---:|---:|---:|
@@ -485,18 +488,13 @@ profiles over five OpenVM cases + SP1 keccak; entry 152). Phase shares of in-pas
 Pass-only cost classes on sha256: 32.5 % closure-apply + 25 % refcount — `BusFacts` closure calls and
 the allocation traffic of their results. The `.fallback` row is **done (entry 152)**. Open, in order:
 
-   - **(a) Hoist the target-independent bus classification.** `denseCompiledSurvV` runs
-     `denseCompileCBiPredV facts keys bi` per gathered interaction *per target*, and everything it
-     does except `denseCompileE keys <slot>` depends on `bi` alone (`neverViolates`, `varRangeBus`,
-     `tupleRangeBus`, `byteXorSpec`, `spec.decode`, `rangeCheckAt` + its pattern, `constValue?`).
-     Inside that phase the keys-dependent `denseCompileEs` is only 11 %; the rest is
-     `lean_apply_1` (57 %) + `lean_dec_ref_cold` (27 %). Two tiers: a per-`busId` fact-answer cache
-     threaded as a *value* (entry 143's lesson — never a closure in a thunk payload), with a
-     `denseVarBucket_mem`-shaped membership lemma, ~60–100 lines and ≈ 45 % of the phase; or the
-     complete version, a keys-free `DenseBiPredShape` stored in `DenseBusPlan` (built once per
-     invocation) plus `denseCompileShape keys mult shape = denseCompileCBiPredV facts keys bi`, whose
-     hypothesis discharges through the existing `denseGatherBusesV_plan_mem`, ~200–350 lines.
-     Expect pass ≈ 0.55× on sha256/keccak.
+   - ~~**(a) Hoist the target-independent bus classification.**~~ **retired as a wall lever
+     (entry 155)**. The 56–70 % is CPU *inside the fan-out*, which is 18 % of the pass's wall — and
+     the hoist was built once and measured **1.01–1.04×**, because it drains parallel slack and
+     moves the residue into the serial prologue. Entry 155 then deleted 8.93 M of the 9.07 M
+     per-target classifications on sha256 by other means (the variable-free tail was 3 446 of the
+     3 446 interactions each scan job compiled), so what is left to hoist is ~1 % of the pass. Keep
+     it only as a CPU/CI-throughput item, and **time the phases before believing any share here**.
    - **(b) One constant pattern per interaction.** `denseInteractionBound` rebuilds
      `bi.payload.map DenseExpr.constValue?` per *queried variable*, and `denseAddBusVars` /
      `denseBiInformative` compute the same bound twice per variable. `denseInteractionBoundPat`
@@ -519,6 +517,12 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      unchanged — but keep the `maxEnumWork`/`boxSize` gates on the *full* product or effectiveness
      moves. ~250–400 lines; **measure first** with a box-shape/point counter (entry 151 built one):
      if the wide boxes are single-variable, neither pays.
+   - ~~**Per-target walk of the variable-free bus tail**~~ **done (entry 155)**: `denseGatherBusesV`
+     folded `bisIdx.varless` into every target (3 446 interactions × 66 062 targets = 228 M gather
+     steps on sha256 cycle 0, plus 8.93 M compiles and 26.8 M per-point evaluations of a
+     point-independent value). A per-invocation `DenseBusVarlessSummary` seeds the gather instead;
+     domainBatch **0.495×** on sha256 `apc_001`, 0.83–0.94× on every other representative, output
+     byte-identical. The constraint side's `activeVarless` is ~2 items here and was left alone.
    - **(e) Cheap micros.** `BusMap` is an assoc-list lookup closure (`toBusMap`) queried per point and
      per fact call — 1–2 % of the run, and substituting an array-backed lookup at the `Main.lean` /
      `Ffi.lean` boundary needs **no proof** (every theorem is ∀ busMap). `DenseForcedScanV.work` (the
@@ -528,6 +532,17 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      prototype belongs here first.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **Retiring domainBatch's task fan-out** (`parallel := false`): 0.96× sha256 / 0.91× keccak against
+  the pre-entry-155 baseline, but **+700 ms on top of entry 155** (measured twice) and a wash on
+  keccak. The fan-out loses only on cycle 0 — whose work entry 155 deleted — and wins on the
+  box-heavy tail cycles (cycle 5: 182 ms parallel vs 919 ms serial). The live lever is
+  `DenseForcedScanV.work`, which models `boxSize × items` and ignores the boxSize-independent
+  per-item compile term; it appears in no soundness lemma, so re-weighting it is proof-free.
+- **Entry 154's work-gated gathers (`denseCapStep`, PR #250) on top of entry 155**: 8944 vs 8983 ms
+  on sha256 and ≤ 1 % on six other cases, both signs — noise. Its 0.81× came from the cap aborting
+  inside the 3 446-item variable-free tail; with the tail an O(1) seed there is nothing left to
+  abort. Subsumed, not complementary.
 
 - **Whole-system content-hash gating of passes across cycles**: catches ~0 % — the fixpoint only
   retains cycles that changed something, so some pass always dirties the hash (#146 measurement).

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5375,3 +5375,71 @@ Peak RSS checked because the index is now stored as both lists and arrays, i.e. 
 could make a parallel-only regression real: wasm-eth apc_012 241.7 → 228.1 MB, openvm-eth apc_005
 111.8 → 112.4 MB.
 **Worked: yes (busPairCancel 0.33× on its worst case, corpus 0.570× on the pass, output byte-identical; draft PR #253).**
+
+### 155. Runtime: domainBatch summarizes the variable-free bus tail once per invocation (0.49x on sha256)
+TARGETED the corpus's top pass (`ranked_passes.md`: domainBatch 35.6 s / 12.2 %, 18.6 s of 171 s on
+sha256 `apc_001`). **Timed the phases before profiling**, and the two instruments disagreed hard.
+`perf` puts 70 % of the pass's CPU in `denseCompileCBiPredsV` (R13(a), the per-target bus
+classification) — but an `IO` probe on the system the pass actually receives puts the *wall* at
+**70 % serial**: `denseAddConstraintDoms` 1341 ms, `denseAddBusDoms` 702, `denseAddByteDoms` 158,
+`denseConstraintPlansV` 1952, `denseBusPlansV` 1215, index+targets 593, `denseDedupTargetsV` 854,
+**preflight (the gathers) 6184**, fan-out 3450, σ-apply + degree guard + forcing 2183. The pass's
+in-pass sample share is 34.9 % of the run against 12.1 % of wall, so every share in R13 is CPU
+divided over the fan-out's threads.
+COUNTED the funnel on cycle 0 (199 740 constraints): 283 304 targets → 190 243 unique → 66 062 reach
+the gathers → 26 082 plans → **2 592 scans enumerating 7 776 points in total**. And every scan job
+gathers **exactly 3 446 interactions** — the *variable-free* ones. `denseGatherBusesV` ends every
+gather with `denseGatherBusArrayV … fidx.bisIdx.varless`, and a variable-free plan satisfies
+`denseVarsInListF xs []` for every target, so the tail is walked per target: **3 446 × 66 062 =
+228 M gather steps (5.4 s serial)**, then **8.93 M per-target classifications** and **26.8 M
+per-point predicate evaluations** — all recomputing a value that does not depend on the target.
+Entry 130 fixed exactly this shape for the *inactive variable-free constraints*
+(`inactiveVarlessCount`) and left the bus array behind.
+THE FIX is a per-invocation `DenseBusVarlessSummary` in `DenseForcedIdx` (count, informative,
+allDomainRedundant, constOk). `denseGatherBusesV` seeds its accumulator from it instead of folding
+the array, so the gather walks only the anchor buckets of `xs` (8.4 positions per target here); the
+tail's obligations are folded once into `constOk`, and `denseRunForcedScanV` short-circuits to
+"every key is 0" when it is `false` — which is what the per-point predicate did anyway, since a
+variable-free item compiles to an `IExpr` with no `.ix` node and so evaluates the same at every
+point. The counts stay in the gather, so the work gate, the `informative` gate and the
+`.done` shortcut all decide identically (dropping them from `bis.count` would let more targets
+through `maxEnumWork` — an effectiveness change, the trap entry 152 flagged for
+`denseBiInformative`).
+PROOF (all under `Implementation/`): `constOk = true` is sound for free — it only removes
+obligations from the scan, which can add survivors and so shrink the forced set. Only `false` needs
+an argument, and it gets the entry-90 treatment: `denseVarlessBiOkV` **re-checks `denseBIVars` at
+use**, so only a genuinely variable-free interaction can report `false`, and such an interaction is
+violated by every environment. `denseVarlessBiOkV_of_sat` reuses `denseCompiledSurvV_eq` +
+`denseSurvivesAllMV_restriction` at `keys = []`, `denseBusVarlessSummaryV_constOk` folds it over the
+index array, and `denseForcedOverV_entails` takes the summary's verdict as one new hypothesis,
+discharged at the `denseDomainBatchσV_entailed` call site from `hsat.2` exactly as `hbis` is. The
+gather's own lemmas (`denseGatherBusesV_interactions_mem` and the plan-membership chain) needed
+**no change**: dropping items only shrinks the gathered list, which the untrusted-index shape
+already allows.
+NUMBERS (this 20-core box, serial, interleaved; domainBatch ms, then case total): sha256 `apc_001`
+**18 068 → 8 939 (0.495×)**, total 148 551 → 137 848 (**0.928×**); keccak `apc_001` 1348 → 1128
+(0.84×), total 12 134 → 11 795; wasm-eth `apc_063` 1568 → 1413 (0.90×); wasm-eth `apc_012`
+1523 → 1432 (0.94×); openvm-eth `apc_071` 563 → 468 (0.83×); wasm-eth `apc_005` 35 → 30 (0.86×);
+SP1 keccak 1017 → 929 (0.91×). No other pass column moves outside noise (29 columns ≥ 800 ms on
+sha256, all 0.96–1.04×).
+VERIFIED: `opt-export` **byte-identical** on sha256 `apc_001` (5.76 MB), OpenVM keccak, openvm-eth
+`apc_006` / `apc_100`, wasm-eth `apc_005` / `apc_012` and SP1 keccak; keccak `run` counts identical
+(2021 / 186 / 1748); `lake build` clean, no warnings; `check-proof-integrity` passes (axioms
+propext / Classical.choice / Quot.sound, no unused theorems).
+TWO ALSO-RANS, both measured and both rejected. **(a) Retiring the task fan-out**
+(`parallel := false`, three one-token edits — `denseCollectForcedV_eq_serial` already proves both
+branches equal for any `parallel`): 0.96× on sha256 and 0.91× on keccak *against the old baseline*,
+because 64 chunks of ≤ 61 ms lose to spawn/join (measured in the probe: 2992 ms parallel against
+2179 ms for the same chunks run one at a time on cycle 0). But stacked on this entry it is **+700 ms
+worse on sha256 in both reps** and a wash on keccak: the fan-out loses only on cycle 0, whose work
+was 96 % the variable-free tail, and wins on the box-heavy tail cycles (cycle 5: 182 ms parallel vs
+919 ms serial). Keep the fan-out; the open lever there is `DenseForcedScanV.work`, which models
+`boxSize × items` and ignores the boxSize-independent per-item compile term (and appears in no
+soundness lemma, so re-weighting it is proof-free). **(b) Entry 154's work-gated gathers**
+(`denseCapStep`, PR #250) stacked on this entry: 8944 vs 8983 ms on sha256, ≤ 1 % on six other
+cases, both signs — noise. Its 0.81× came from the cap aborting *inside* the 3 446-item tail; with
+the tail an O(1) seed the cap has only the 8.4 bucket positions left to abort. **Entry 154 is
+subsumed, not complementary** — it would pay again only where one target's bucket hits run into the
+thousands.
+**Worked: yes (domainBatch 0.495× on its worst case, 0.83–0.94× on every other representative,
+output byte-identical; draft PR).**


### PR DESCRIPTION
`domainBatch` is the corpus's top pass (`ranked_passes.md`: 35.6 s / 12.2 %, 18.6 s of 171 s on sha256 `apc_001`). Timing its phases from `IO` — rather than reading a `perf` share — puts **70 % of the pass in serial code**, and the largest single item is one line in the gather.

## What was wrong

`denseGatherBusesV` ended every gather with `denseGatherBusArrayV … fidx.bisIdx.varless`, and a variable-free plan satisfies `denseVarsInListF xs []` for *every* target. On sha256 `apc_001`'s first invocation:

| | |
|---|---:|
| targets → unique → reaching the gathers → plans → **scans** | 283 304 → 190 243 → 66 062 → 26 082 → **2 592** |
| box points enumerated by all 2 592 scans **in total** | **7 776** |
| interactions gathered per scan job | **3 446, all variable-free** |
| gather steps for the tail (3 446 × 66 062) | **228 M (5.4 s, serial)** |
| per-target classifications of the tail | **8.93 M** |
| per-point predicate evaluations of the tail | **26.8 M** |

Every one of those recomputes a value that does not depend on the target. Entry 130 fixed exactly this shape for the *inactive variable-free constraints* (`inactiveVarlessCount`) and left the bus array behind.

## What this does

A per-invocation `DenseBusVarlessSummary` in `DenseForcedIdx` carries the tail's count, its `informative`/`domainRedundant` folds and the constant verdict of its obligations. The gather seeds its accumulator from the summary and walks only the anchor buckets of `xs` (8.4 positions per target here), and `denseRunForcedScanV` short-circuits to "every key is 0" when the verdict is `false` — which is what the per-point predicate yielded anyway, since a variable-free expression compiles to an `IExpr` with no `.ix` node.

**The counts stay in the gather**, so the `maxEnumWork` gate, the `informative` gate and the `.done` shortcut decide identically. Dropping them from `bis.count` would let more targets through the work gate — an effectiveness change, the trap entry 152 flagged for `denseBiInformative`.

## Proof

`constOk = true` is sound for free: it only removes obligations from the scan, which can add survivors and so shrink the forced set. Only `false` needs an argument, and it gets the entry-90 treatment — `denseVarlessBiOkV` **re-checks `denseBIVars` at use**, so only a genuinely variable-free interaction can report it, and such an interaction is violated by every environment.

- `denseVarlessBiOkV_of_sat` — reuses `denseCompiledSurvV_eq` + `denseSurvivesAllMV_restriction` at `keys = []`.
- `denseBusVarlessSummaryV_constOk` — folds it over the index array.
- `denseForcedOverV_entails` — one new hypothesis, discharged at the `denseDomainBatchσV_entailed` call site from `hsat.2` exactly as `hbis` already is.

The gather's own lemmas (`denseGatherBusesV_interactions_mem` and the plan-membership chain) are unchanged: dropping items only shrinks the gathered list, which the untrusted-index shape already allows. All under `Implementation/`; the audited surface is untouched.

## Measured

20-core box, serial, interleaved; `domainBatch` ms, then case total:

| case | domainBatch | ratio | case total | ratio |
|---|---:|---:|---:|---:|
| sha256 `apc_001` | 18 068 → **8 939** | **0.495×** | 148 551 → 137 848 | **0.928×** |
| keccak `apc_001` | 1348 → 1128 | 0.84× | 12 134 → 11 795 | 0.97× |
| wasm-eth `apc_063` | 1568 → 1413 | 0.90× | 12 371 → 12 185 | 0.98× |
| wasm-eth `apc_012` | 1523 → 1432 | 0.94× | 15 472 → 15 132 | 0.98× |
| openvm-eth `apc_071` | 563 → 468 | 0.83× | 1285 → 1188 | 0.92× |
| wasm-eth `apc_005` | 35 → 30 | 0.86× | 180 → 172 | 0.96× |
| SP1 keccak `apc_001` | 1017 → 929 | 0.91× | 6167 → 6058 | 0.98× |

No collateral movement: of the 29 pass columns ≥ 800 ms on sha256, every one is 0.96–1.04×.

**Output byte-identical** (`opt-export`, `cmp`) on sha256 `apc_001` (5.76 MB), OpenVM keccak, openvm-eth `apc_006`/`apc_100`, wasm-eth `apc_005`/`apc_012` and SP1 keccak; keccak `run` counts identical (2021 / 186 / 1748). `lake build` clean, no warnings; `check-proof-integrity` passes (propext / Classical.choice / Quot.sound, no unused theorems).

## Two also-rans, measured and rejected (log entry 155)

- **Retiring the task fan-out** (`parallel := false`, three one-token edits since `denseCollectForcedV_eq_serial` is already proven for any `parallel`): 0.96× sha256 / 0.91× keccak against the *old* baseline, but **+700 ms on top of this PR** in both reps. The fan-out loses only on cycle 0 — whose work this PR deletes — and wins on the box-heavy tail cycles (cycle 5: 182 ms parallel vs 919 ms serial). The live lever there is `DenseForcedScanV.work`, which models `boxSize × items` and ignores the boxSize-independent per-item compile term (and appears in no soundness lemma).
- **Entry 154's work-gated gathers (`denseCapStep`, PR #250) stacked on this**: 8944 vs 8983 ms on sha256, ≤ 1 % on six other cases, both signs — noise. Its 0.81× came from the cap aborting *inside* the 3 446-item tail; with the tail an O(1) seed there is nothing left to abort. Subsumed, not complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)