### PR TITLE
perf(zmod): stop rebuilding the ZMod.commRing dictionary per call

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -166,16 +166,16 @@ theorem pipeline_respectsDeg (b : DegreeBound) : RespectsDeg b (pipeline (p := p
 def Derivations.safeMethod (ds : Derivations p) (inputVars : List Variable) (v : Variable) :
     ComputationMethod p :=
   match ds.methodFor v with
-  | some cm => if ∀ x ∈ cm.vars, x ∈ inputVars then cm else .const 0
-  | none => .const 0
+  | some cm => if ∀ x ∈ cm.vars, x ∈ inputVars then cm else .const (zmodZeroP _)
+  | none => .const (zmodZeroP _)
 
 /-- `Derivations.safeMethod` with both of its scans served from indexes: `methods` is `ds` keyed by
     derived variable, `inputs` holds the input variables (`safeMethodIdx_eq`). -/
 def Derivations.safeMethodIdx (methods : Std.HashMap Variable (ComputationMethod p))
     (inputs : Std.HashSet Variable) (v : Variable) : ComputationMethod p :=
   match methods[v]? with
-  | some cm => if cm.vars.all (fun x => inputs.contains x) then cm else .const 0
-  | none => .const 0
+  | some cm => if cm.vars.all (fun x => inputs.contains x) then cm else .const (zmodZeroP _)
+  | none => .const (zmodZeroP _)
 
 /-- Keep one structurally safe derivation for each no-ID output variable.
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -293,9 +293,16 @@ theorem denseAddrAffineNeqWith_eq (ops : DenseZModOps p) (shape : MemoryBusShape
 
 /-! ## The nonzero-witness (register-vs-RAM) address-disequality certificate -/
 
+def denseIsZeroLinImpl (l : DenseLinExpr p) : Bool :=
+  l.norm.terms.isEmpty && zmodIsZero l.norm.const
+
 /-- A dense linear form is identically zero (empty terms and zero constant after normalization). -/
 def denseIsZeroLin (l : DenseLinExpr p) : Bool :=
-  l.norm.terms.isEmpty && decide (l.norm.const = 0)
+  l.norm.terms.isEmpty && zmodIsZero l.norm.const
+
+@[csimp] theorem denseIsZeroLin_eq_impl : @denseIsZeroLin = @denseIsZeroLinImpl := by
+  funext q l
+  simp [denseIsZeroLin, denseIsZeroLinImpl]
 
 /-- Nonzero linear factors of a single reciprocal product `a * b + r` with `r` a nonzero constant:
     `a·b = −r ≠ 0`, so each factor that linearizes is a nonzero witness. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -21,8 +21,15 @@ structure DenseLinExpr (p : ℕ) where
 def DenseLinExpr.eval (l : DenseLinExpr p) (denv : VarId → ZMod p) : ZMod p :=
   l.const + (l.terms.map (fun t => t.2 * denv t.1)).sum
 
+def DenseLinExpr.addImpl (a b : DenseLinExpr p) : DenseLinExpr p :=
+  ⟨zmodAdd a.const b.const, a.terms ++ b.terms⟩
+
 def DenseLinExpr.add (a b : DenseLinExpr p) : DenseLinExpr p :=
   ⟨a.const + b.const, a.terms ++ b.terms⟩
+
+@[csimp] theorem DenseLinExpr_add_eq_impl : @DenseLinExpr.add = @DenseLinExpr.addImpl := by
+  funext q a b
+  simp [DenseLinExpr.add, DenseLinExpr.addImpl]
 
 def DenseLinExpr.scale (k : ZMod p) (a : DenseLinExpr p) : DenseLinExpr p :=
   ⟨k * a.const, a.terms.map (fun t => (t.1, k * t.2))⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BoxRewrite.lean
@@ -60,7 +60,7 @@ def denseMonoExpr (mc : List VarId × ZMod p) : DenseExpr p :=
 
 /-- Rebuild an expression from monomials (dropping zero coefficients). -/
 def denseExprOfPoly (ms : List (List VarId × ZMod p)) : DenseExpr p :=
-  match ms.filter (fun mc => !(mc.2 == 0)) with
+  match ms.filter (fun mc => !(zmodIsZero mc.2)) with
   | [] => DenseExpr.const 0
   | mc :: rest => rest.foldl (fun acc mc' => DenseExpr.add acc (denseMonoExpr mc')) (denseMonoExpr mc)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCore.lean
@@ -66,11 +66,21 @@ theorem denseSideEffects_dropPair_equiv (bs : BusSemantics p) (denv : VarId → 
   simp only [multiplicitySum_append, multiplicitySum, hmsgEq, hRm]
   split_ifs <;> ring
 
+def denseActiveStatefulMsgsImpl (bs : BusSemantics p) (denv : VarId → ZMod p)
+    (L : List (BusInteraction (DenseExpr p))) : List (BusInteraction (ZMod p)) :=
+  (L.map (fun bi => denseBIEval bi denv)).filter
+    (fun m => !zmodIsZero m.multiplicity && bs.isStateful m.busId)
+
 /-- The active, stateful evaluated messages of a raw dense interaction list. -/
 def denseActiveStatefulMsgs (bs : BusSemantics p) (denv : VarId → ZMod p)
     (L : List (BusInteraction (DenseExpr p))) : List (BusInteraction (ZMod p)) :=
   (L.map (fun bi => denseBIEval bi denv)).filter
     (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)
+
+@[csimp] theorem denseActiveStatefulMsgs_eq_impl :
+    @denseActiveStatefulMsgs = @denseActiveStatefulMsgsImpl := by
+  funext q bs denv L
+  simp [denseActiveStatefulMsgs, denseActiveStatefulMsgsImpl]
 
 theorem denseActiveStatefulMsgs_append (bs : BusSemantics p) (denv : VarId → ZMod p)
     (L1 L2 : List (BusInteraction (DenseExpr p))) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
@@ -140,6 +140,21 @@ def denseAffineJustified (bound : Nat) (bnd : VarId → Option Nat) (e : DenseEx
 
 /-! ## Basis justification -/
 
+def denseFormBoundAtImpl {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (i : Nat) : Option (DenseLinExpr p × Nat) :=
+  match bi.multiplicity.constValue? with
+  | none => none
+  | some mval =>
+    if zmodIsZero mval then none
+    else
+      match bi.payload[i]?,
+            facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i with
+      | some e, some B =>
+        match denseLinearize e with
+        | some L => some (L.norm, B)
+        | none => none
+      | _, _ => none
+
 /-- The linearized (merged) form and bound of payload slot `i` of `bi`, when the multiplicity is
     a nonzero constant and the slot carries a `slotBound`. -/
 def denseFormBoundAt {bs : BusSemantics p} (facts : BusFacts p bs)
@@ -156,6 +171,10 @@ def denseFormBoundAt {bs : BusSemantics p} (facts : BusFacts p bs)
         | some L => some (L.norm, B)
         | none => none
       | _, _ => none
+
+@[csimp] theorem denseFormBoundAt_eq_impl : @denseFormBoundAt = @denseFormBoundAtImpl := by
+  funext q bs facts bi i
+  simp [denseFormBoundAt, denseFormBoundAtImpl]
 
 /-- Fuel-bounded basis reduction: is `L`'s value provably `< bound − used` via per-variable bounds
     (finish arm) after subtracting integer multiples of range-checked slot forms from `fwits`? -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
@@ -20,6 +20,18 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+def denseInteractionBoundPatImpl (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (mval? : Option (ZMod p))
+    (pat : List (Option (ZMod p))) (i : VarId) : Option Nat :=
+  match mval? with
+  | none => none
+  | some mval =>
+    if zmodIsZero mval then none
+    else
+      match denseVarSlot i bi.payload with
+      | none => none
+      | some slot => facts.slotBound bi.busId mval pat slot
+
 /-- `denseInteractionBound` with the multiplicity constant and constant-payload pattern hoisted out
     of the caller's per-payload-variable loop (they are per-interaction values). Definitionally the
     same function at the canonical arguments (`denseInteractionBoundPat_eq`). -/
@@ -34,6 +46,11 @@ def denseInteractionBoundPat (bs : BusSemantics p) (facts : BusFacts p bs)
       match denseVarSlot i bi.payload with
       | none => none
       | some slot => facts.slotBound bi.busId mval pat slot
+
+@[csimp] theorem denseInteractionBoundPat_eq_impl :
+    @denseInteractionBoundPat = @denseInteractionBoundPatImpl := by
+  funext q bs facts bi m pat i
+  simp [denseInteractionBoundPat, denseInteractionBoundPatImpl]
 
 /-- Candidate positions of bound-deriving interactions, per variable (ascending), built once per
     invocation. Untrusted — `denseDropWitsIdxGo` re-checks liveness, the dropped pair, and the bound

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -15,8 +15,15 @@ variable {p : ℕ}
 
 /-! ## Address/equality helpers -/
 
+def denseEqExprImpl (e2 e1 : DenseExpr p) : DenseExpr p :=
+  .add e2 (.mul (.const (zmodNegOneP p)) e1)
+
 /-- `e₂ - e₁` as a dense expression. -/
 def denseEqExpr (e2 e1 : DenseExpr p) : DenseExpr p := .add e2 (.mul (.const (-1)) e1)
+
+@[csimp] theorem denseEqExpr_eq_impl : @denseEqExpr = @denseEqExprImpl := by
+  funext q e2 e1
+  simp [denseEqExpr, denseEqExprImpl]
 
 def denseMultConst (bi : BusInteraction (DenseExpr p)) : Option (ZMod p) :=
   bi.multiplicity.constValue?

--- a/ApcOptimizer/Implementation/OptimizerPasses/DegenRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DegenRange.lean
@@ -56,6 +56,17 @@ def denseRangeEq? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
     else none
   | _ => none
 
+def denseBoolCheckImpl? {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p) :=
+  match facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+  | some (valSlot, bound) =>
+    if (match bi.multiplicity with | .const c => zmodIsOne c | _ => false) && bound == 2 then
+      match bi.payload[valSlot]? with
+      | some (DenseExpr.var x) => some (denseBoolC (DenseExpr.var x))
+      | _ => none
+    else none
+  | none => none
+
 /-- The booleanity `x·(x−1)` of a width-1 (`bound = 2`) check whose value slot is a bare variable
     `x`. -/
 def denseBoolCheck? {bs : BusSemantics p} (facts : BusFacts p bs)
@@ -68,5 +79,14 @@ def denseBoolCheck? {bs : BusSemantics p} (facts : BusFacts p bs)
       | _ => none
     else none
   | none => none
+
+@[csimp] theorem denseBoolCheck_q_eq_impl : @denseBoolCheck? = @denseBoolCheckImpl? := by
+  funext q bs facts bi
+  unfold denseBoolCheck? denseBoolCheckImpl?
+  cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+  | none => rfl
+  | some vb =>
+    obtain ⟨valSlot, bound⟩ := vb
+    cases bi.multiplicity <;> simp
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
@@ -135,6 +135,19 @@ def denseVarSlot (i : VarId) : List (DenseExpr p) → Option Nat
   | [] => none
   | e :: rest => if denseIsVarOf i e then some 0 else (denseVarSlot i rest).map (· + 1)
 
+/-- `denseInteractionBound` with the `mval = 0` test taken on `ZMod.val`, which needs no
+    `CommRing (ZMod p)` dictionary. -/
+def denseInteractionBoundImpl (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (i : VarId) : Option Nat :=
+  match bi.multiplicity.constValue? with
+  | none => none
+  | some mval =>
+    if mval.val = 0 then none
+    else
+      match denseVarSlot i bi.payload with
+      | none => none
+      | some slot => facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) slot
+
 /-- One value bound for `i` from a constant-nonzero-multiplicity interaction carrying `.var i`
     in a fact-bounded raw payload slot. -/
 def denseInteractionBound (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -147,6 +160,11 @@ def denseInteractionBound (bs : BusSemantics p) (facts : BusFacts p bs)
       match denseVarSlot i bi.payload with
       | none => none
       | some slot => facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) slot
+
+@[csimp] theorem denseInteractionBound_eq_impl :
+    @denseInteractionBound = @denseInteractionBoundImpl := by
+  funext q bs facts bi i
+  simp [denseInteractionBound, denseInteractionBoundImpl]
 
 /-- Probe payload: constant slots at their constants, slot `i` at the candidate, others `0`. -/
 def denseProbeBase (payload : List (DenseExpr p)) (i : Nat) (v : ZMod p) : List (ZMod p) :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainBatch.lean
@@ -155,10 +155,11 @@ theorem denseEnvOfW_eq (pt : List (VarId × ZMod p)) (y : VarId) :
       simp only [denseEnvOfW, denseEnvOfFast, ih]
 
 def denseEnvOfFastFast (pt : List (VarId × ZMod p)) (y : VarId) : ZMod p :=
-  denseEnvOfW 0 pt y
+  denseEnvOfW (zmodZeroP p) pt y
 
 @[csimp] theorem denseEnvOfFast_eq_fast : @denseEnvOfFast = @denseEnvOfFastFast := by
   funext p pt y
+  rw [denseEnvOfFastFast, zmodZeroP_eq]
   exact (denseEnvOfW_eq pt y).symm
 
 def denseContainsFast (xs : List VarId) (y : VarId) : Bool :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -15,6 +15,109 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+/-! ## Dictionary-free field access
+
+`p` is a runtime value, so `ZMod p`'s `CommRing` instance is never a closed term: a function that
+merely *mentions* `0` or `1` rebuilds `ZMod.commRing p` plus 3–5 projections at its own entry, and
+Lean floats that construction ahead of every branch test.
+
+`ZMod.commRing` mirrors `ZMod`'s own `Nat.casesOn` split (`Mathlib/Data/ZMod/Defs.lean`), so every
+operation *is* the corresponding `Int`/`Fin` primitive underneath — reaching it through the instance
+is what costs. Casing on `p` directly, in the shape `ZMod.val` itself uses, gets the primitive with
+no dictionary. Likewise `ZMod.val` is a bare `Fin.val` / `Int.natAbs` projection, so a test routed
+through it builds nothing. -/
+
+def zmodAddP : ∀ {p : ℕ}, ZMod p → ZMod p → ZMod p
+  | 0 => Int.add
+  | _ + 1 => Fin.add
+
+def zmodMulP : ∀ {p : ℕ}, ZMod p → ZMod p → ZMod p
+  | 0 => Int.mul
+  | _ + 1 => Fin.mul
+
+def zmodZeroP : ∀ (p : ℕ), ZMod p
+  | 0 => (0 : ℤ)
+  | n + 1 => (⟨0, Nat.succ_pos n⟩ : Fin (n + 1))
+
+def zmodOneP : ∀ (p : ℕ), ZMod p
+  | 0 => (1 : ℤ)
+  | n + 1 => (⟨1 % (n + 1), Nat.mod_lt _ (Nat.succ_pos n)⟩ : Fin (n + 1))
+
+/-- `-1`, i.e. `p - 1`; at `p = 1` that is `0`, which is correct in the trivial ring. -/
+def zmodNegOneP : ∀ (p : ℕ), ZMod p
+  | 0 => (-1 : ℤ)
+  | n + 1 => (⟨n, Nat.lt_succ_self n⟩ : Fin (n + 1))
+
+/-- `c = 0`, dictionary-free: `val` sends `0` to `0` and nothing else, at every `p`
+    (`ZMod.val_eq_zero`). -/
+def zmodIsZero (c : ZMod p) : Bool := c.val == 0
+
+/-- `c = 1` at `p = 0`, where `val = Int.natAbs` identifies `1` with `-1`. Kept in its own function
+    so its dictionary stays off `zmodIsOne`'s entry; unreachable at runtime (`p` is a prime). -/
+def zmodIsOneSlow (c : ZMod p) : Bool := decide (c = 1)
+
+/-- `c = 1`, dictionary-free for `p ≠ 0`: `(1 : ZMod p).val = 1 % p` (`ZMod.val_one_eq_one_mod`). -/
+def zmodIsOne (c : ZMod p) : Bool :=
+  if p = 0 then zmodIsOneSlow c else c.val == 1 % p
+
+
+/-- `a + b` behind a call, so a caller's constant/constant branch does not pull the `CommRing` chain
+    to every entry to that caller. -/
+def zmodAdd (a b : ZMod p) : ZMod p := zmodAddP a b
+
+/-- `a * b` behind a call; see `zmodAdd`. -/
+def zmodMul (a b : ZMod p) : ZMod p := zmodMulP a b
+
+/-! ### Bridge lemmas
+
+These are the whole proof surface of the change: each primitive is `@[simp]`-normalized back to the
+`ZMod` operation it implements, so proofs that reason about the definitions never see the primitive.
+The `…P` value lemmas are the same five obligations as `denseZModOps`' `_eq` fields. -/
+
+@[simp] theorem zmodIsZero_eq (c : ZMod p) : zmodIsZero c = decide (c = 0) := by
+  unfold zmodIsZero
+  by_cases h : c = 0
+  · simp [h]
+  · simp [h, (ZMod.val_eq_zero c).not.2 h]
+
+/-- `ZMod.commRing`'s operations are the `Int`/`Fin` ones by definition, so each primitive matches
+    its ring operation by cases on `p`. -/
+@[simp] theorem zmodAddP_eq (a b : ZMod p) : zmodAddP a b = a + b := by
+  cases p with | zero => rfl | succ n => rfl
+
+@[simp] theorem zmodMulP_eq (a b : ZMod p) : zmodMulP a b = a * b := by
+  cases p with | zero => rfl | succ n => rfl
+
+@[simp] theorem zmodZeroP_eq : zmodZeroP p = 0 := by
+  cases p with | zero => rfl | succ n => rfl
+
+@[simp] theorem zmodOneP_eq : zmodOneP p = 1 := by
+  cases p with | zero => rfl | succ n => rfl
+
+@[simp] theorem zmodNegOneP_eq : zmodNegOneP p = -1 := by
+  cases p with
+  | zero => rfl
+  | succ n =>
+    refine ZMod.val_injective (n + 1) ?_
+    rw [ZMod.val_neg_one]
+    rfl
+
+@[simp] theorem zmodAdd_eq (a b : ZMod p) : zmodAdd a b = a + b := zmodAddP_eq a b
+@[simp] theorem zmodMul_eq (a b : ZMod p) : zmodMul a b = a * b := zmodMulP_eq a b
+
+/-- `val` is injective for `p ≠ 0`, which is what makes the `= 1` / `= -1` tests sound; at `p = 0`
+    (`val = Int.natAbs`, which merges `1` and `-1`) the slow path is taken instead. -/
+@[simp] theorem zmodIsOne_eq (c : ZMod p) : zmodIsOne c = decide (c = 1) := by
+  unfold zmodIsOne
+  cases p with
+  | zero => simp [zmodIsOneSlow]
+  | succ n =>
+    have hone : (1 : ZMod (n + 1)).val = 1 % (n + 1) := ZMod.val_one_eq_one_mod (n + 1)
+    simp only [Nat.succ_ne_zero, if_false]
+    by_cases h : c = 1
+    · simp [h, hone]
+    · simpa [h] using fun hv => h (ZMod.val_injective (n + 1) (by rw [hv, hone]))
+
 /-! ## Dense types -/
 
 /-- A dense arithmetic expression: the spec `Expression` with `VarId` leaves. -/
@@ -53,17 +156,19 @@ structure DenseZModOps (p : ℕ) where
   one_eq : one = 1
   negOne_eq : negOne = -1
 
+/-- Every field is a primitive, so constructing the record builds no `CommRing (ZMod p)` dictionary
+    — which is what makes each `…With ops` twin cheap. -/
 def denseZModOps : DenseZModOps p where
-  add := (inferInstance : Add (ZMod p)).add
-  mul := (inferInstance : Mul (ZMod p)).mul
-  zero := 0
-  one := 1
-  negOne := -1
-  add_eq := fun _ _ => rfl
-  mul_eq := fun _ _ => rfl
-  zero_eq := rfl
-  one_eq := rfl
-  negOne_eq := rfl
+  add := zmodAddP
+  mul := zmodMulP
+  zero := zmodZeroP p
+  one := zmodOneP p
+  negOne := zmodNegOneP p
+  add_eq := zmodAddP_eq
+  mul_eq := zmodMulP_eq
+  zero_eq := zmodZeroP_eq
+  one_eq := zmodOneP_eq
+  negOne_eq := zmodNegOneP_eq
 
 /-! ## Dense expression operations (runtime; specified against decode below) -/
 
@@ -74,12 +179,34 @@ def DenseExpr.degree : DenseExpr p → Nat
   | .add a b => max a.degree b.degree
   | .mul a b => a.degree + b.degree
 
+/-- `eval` mentions `+`/`*`, so it derived the whole `CommRing` chain at *every node*. This twin
+    routes both through the primitives; the `@[csimp]` below lives here, in the earliest dense
+    module, so it fires for every pass. -/
+
+def DenseExpr.evalImpl (e : DenseExpr p) (denv : VarId → ZMod p) : ZMod p :=
+  match e with
+  | .const n => n
+  | .var i => denv i
+  | .add a b => zmodAddP (a.evalImpl denv) (b.evalImpl denv)
+  | .mul a b => zmodMulP (a.evalImpl denv) (b.evalImpl denv)
+
 def DenseExpr.eval (e : DenseExpr p) (denv : VarId → ZMod p) : ZMod p :=
   match e with
   | .const n => n
   | .var i => denv i
   | .add a b => a.eval denv + b.eval denv
   | .mul a b => a.eval denv * b.eval denv
+
+theorem DenseExpr.evalImpl_eq (e : DenseExpr p) (denv : VarId → ZMod p) :
+    e.evalImpl denv = e.eval denv := by
+  induction e with
+  | const n => rfl
+  | var i => rfl
+  | add a b iha ihb => rw [DenseExpr.evalImpl, DenseExpr.eval, zmodAddP_eq, iha, ihb]
+  | mul a b iha ihb => rw [DenseExpr.evalImpl, DenseExpr.eval, zmodMulP_eq, iha, ihb]
+
+@[csimp] theorem DenseExpr.eval_eq_evalImpl : @DenseExpr.eval = @DenseExpr.evalImpl := by
+  funext q e denv; exact (DenseExpr.evalImpl_eq e denv).symm
 
 /-- The `VarId`s occurring in a dense expression, in left-to-right order. -/
 def DenseExpr.vars : DenseExpr p → List VarId

--- a/ApcOptimizer/Implementation/OptimizerPasses/ExprOps.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ExprOps.lean
@@ -42,6 +42,16 @@ theorem DenseConstraintSystem.mapExpr_covered {reg : VarRegistry} {g : DenseExpr
 
 /-! ## Dense constant folding -/
 
+/-- No `CommRing (ZMod p)` reaches the entry: the sum is behind `zmodAdd` and the zero tests go
+    through `ZMod.val`. Lean floats an instance chain ahead of every branch test, so keeping the
+    arithmetic behind a call is what empties the entry. -/
+def DenseExpr.foldAddImpl (a b : DenseExpr p) : DenseExpr p :=
+  match a, b with
+  | .const m, .const n => .const (zmodAdd m n)
+  | .const m, b => if zmodIsZero m then b else .add (.const m) b
+  | a, .const n => if zmodIsZero n then a else .add a (.const n)
+  | a, b => .add a b
+
 /-- Smart addition on dense expressions. -/
 def DenseExpr.foldAdd (a b : DenseExpr p) : DenseExpr p :=
   match a, b with
@@ -50,6 +60,19 @@ def DenseExpr.foldAdd (a b : DenseExpr p) : DenseExpr p :=
   | a, .const n => if n = 0 then a else .add a (.const n)
   | a, b => .add a b
 
+@[csimp] theorem DenseExpr_foldAdd_eq_impl : @DenseExpr.foldAdd = @DenseExpr.foldAddImpl := by
+  funext q a b
+  simp [DenseExpr.foldAdd, DenseExpr.foldAddImpl]
+
+/-- As `foldAddImpl`; the annihilated result is returned as `.const m` rather than `.const 0`, which
+    is the same value on that branch and avoids needing the zero literal at all. -/
+def DenseExpr.foldMulImpl (a b : DenseExpr p) : DenseExpr p :=
+  match a, b with
+  | .const m, .const n => .const (zmodMul m n)
+  | .const m, b => if zmodIsZero m then .const m else if zmodIsOne m then b else .mul (.const m) b
+  | a, .const n => if zmodIsZero n then .const n else if zmodIsOne n then a else .mul a (.const n)
+  | a, b => .mul a b
+
 /-- Smart multiplication on dense expressions. -/
 def DenseExpr.foldMul (a b : DenseExpr p) : DenseExpr p :=
   match a, b with
@@ -57,6 +80,12 @@ def DenseExpr.foldMul (a b : DenseExpr p) : DenseExpr p :=
   | .const m, b => if m = 0 then .const 0 else if m = 1 then b else .mul (.const m) b
   | a, .const n => if n = 0 then .const 0 else if n = 1 then a else .mul a (.const n)
   | a, b => .mul a b
+
+@[csimp] theorem DenseExpr_foldMul_eq_impl : @DenseExpr.foldMul = @DenseExpr.foldMulImpl := by
+  funext q a b
+  unfold DenseExpr.foldMul DenseExpr.foldMulImpl
+  -- the annihilating branches return `.const m` for an `m` the guard has already forced to `0`
+  split <;> simp_all
 
 /-- Bottom-up constant folding: evaluates constant subexpressions and drops `+0`, `*1`, `*0`.
     E.g. `2 * 3 + x` folds to `6 + x`, and `1 * x + 0` to `x`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
@@ -20,6 +20,14 @@ variable {p : ℕ}
 def denseSingleVarCs (all : List (DenseExpr p)) : List (DenseExpr p) :=
   all.filter (fun c => (HashedDedup.hashedEraseDups (hash ·) c.vars).length == 1)
 
+def denseBtCertImpl (singles : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
+  2 ≤ c.vars.eraseDups.length &&
+  (let doms := c.vars.eraseDups.filterMap (fun v =>
+     (denseFindDomainAlg singles v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+   (denseAssignments doms).all (fun pt => zmodIsZero (c.eval (denseEnvOfFast pt))))
+
 /-- Certificate: `c` mentions ≥ 2 distinct variables, every one carries a proven finite domain
     (from the single-variable constraints), the joint box is small, and `c` vanishes on all of it. -/
 def denseBtCert (singles : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
@@ -30,6 +38,18 @@ def denseBtCert (singles : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (denseAssignments doms).all (fun pt => decide (c.eval (denseEnvOfFast pt) = 0)))
 
+@[csimp] theorem denseBtCert_eq_impl : @denseBtCert = @denseBtCertImpl := by
+  funext q singles c
+  simp [denseBtCert, denseBtCertImpl]
+
+def denseBtPreImpl (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
+  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
+  2 ≤ vs.length &&
+  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = vs) &&
+   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
+   (denseAssignments doms).all (fun pt => zmodIsZero (c.eval (denseEnvOfFast pt))))
+
 /-- A cheap prefilter over a precomputed domain lookup; accepted candidates re-run the real
     `denseBtCert`. -/
 def denseBtPre (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
@@ -39,6 +59,10 @@ def denseBtPre (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bo
    decide (doms.map Prod.fst = vs) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (denseAssignments doms).all (fun pt => decide (c.eval (denseEnvOfFast pt) = 0)))
+
+@[csimp] theorem denseBtPre_eq_impl : @denseBtPre = @denseBtPreImpl := by
+  funext q domOf c
+  simp [denseBtPre, denseBtPreImpl]
 
 /-- The replacement condition: the memoized prefilter gates the (expensive) certificate. -/
 def denseBtKeep (singles : List (DenseExpr p)) (domOf : VarId → Option (List (ZMod p)))

--- a/ApcOptimizer/Implementation/OptimizerPasses/FxSubst.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FxSubst.lean
@@ -13,6 +13,13 @@ variable {p : ℕ}
 
 /-! ## Part A: the entailed nonlinear substitution (dense) -/
 
+def denseIndicatorProdImpl (others : List VarId) (pt : List (VarId × ZMod p)) : DenseExpr p :=
+  others.foldl (fun acc v =>
+    if zmodIsOne (denseEnvOfFast pt v) then DenseExpr.mul acc (DenseExpr.var v)
+    else DenseExpr.mul acc (DenseExpr.add (DenseExpr.const (zmodOneP p))
+      (DenseExpr.mul (DenseExpr.const (zmodNegOneP p)) (DenseExpr.var v))))
+    (DenseExpr.const (zmodOneP p))
+
 /-- Boolean indicator product `∏ (v or 1−v)` selecting one point of the box. Heuristic data —
     the certificate validates its values pointwise, so the construction carries no proof. -/
 def denseIndicatorProd (others : List VarId) (pt : List (VarId × ZMod p)) : DenseExpr p :=
@@ -21,6 +28,17 @@ def denseIndicatorProd (others : List VarId) (pt : List (VarId × ZMod p)) : Den
     else DenseExpr.mul acc (DenseExpr.add (DenseExpr.const 1)
       (DenseExpr.mul (DenseExpr.const (-1)) (DenseExpr.var v)))) (DenseExpr.const 1)
 
+@[csimp] theorem denseIndicatorProd_eq_impl : @denseIndicatorProd = @denseIndicatorProdImpl := by
+  funext q others pt
+  simp [denseIndicatorProd, denseIndicatorProdImpl]
+
+def denseBuildEImpl (d : DenseFuData p) (vy : VarId) : DenseExpr p :=
+  let others := d.rxVars.eraseDups.filter (fun v => v != vy)
+  d.pts.foldl (fun acc ptb =>
+    if ptb.2 && zmodIsOne (denseEnvOfFast ptb.1 vy) then
+      DenseExpr.add acc (denseIndicatorProd others ptb.1)
+    else acc) (DenseExpr.const (zmodZeroP p))
+
 /-- Interpolate the target's value over the survivor-side flags from the compatible points. -/
 def denseBuildE (d : DenseFuData p) (vy : VarId) : DenseExpr p :=
   let others := d.rxVars.eraseDups.filter (fun v => v != vy)
@@ -28,6 +46,10 @@ def denseBuildE (d : DenseFuData p) (vy : VarId) : DenseExpr p :=
     if ptb.2 && (denseEnvOfFast ptb.1 vy == 1) then
       DenseExpr.add acc (denseIndicatorProd others ptb.1)
     else acc) (DenseExpr.const 0)
+
+@[csimp] theorem denseBuildE_eq_impl : @denseBuildE = @denseBuildEImpl := by
+  funext q d vy
+  simp [denseBuildE, denseBuildEImpl]
 
 /-- Per-target certificate: `vy` is a Y-side flag, the candidate solution `E` mentions neither
     `vy` nor anything outside the survivor's payload, and at every offset-compatible point the

--- a/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
@@ -208,6 +208,14 @@ def denseInteractionSeedsGo (bs : BusSemantics p) (facts : BusFacts p bs)
     | some e, some B => denseSlotSeeds bnd B e
     | _, _ => [])
 
+def denseInteractionSeedsImpl (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
+  match bi.multiplicity.constValue? with
+  | none => []
+  | some mval =>
+    if zmodIsZero mval then []
+    else denseInteractionSeedsGo bs facts bnd bi mval (bi.payload.map DenseExpr.constValue?)
+
 /-- All seeds of one interaction: every payload slot with a `slotBound`. -/
 def denseInteractionSeeds (bs : BusSemantics p) (facts : BusFacts p bs)
     (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
@@ -216,6 +224,11 @@ def denseInteractionSeeds (bs : BusSemantics p) (facts : BusFacts p bs)
   | some mval =>
     if mval = 0 then []
     else denseInteractionSeedsGo bs facts bnd bi mval (bi.payload.map DenseExpr.constValue?)
+
+@[csimp] theorem denseInteractionSeeds_eq_impl :
+    @denseInteractionSeeds = @denseInteractionSeedsImpl := by
+  funext q bs facts bnd bi
+  simp [denseInteractionSeeds, denseInteractionSeedsImpl]
 
 /-- All seeds over the system: every bounded interaction slot, plus every algebraic constraint
     consumed as a bound-`1` slot. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Normalize.lean
@@ -617,11 +617,20 @@ def DenseNormRes.expr : DenseNormRes p → DenseExpr p
   | .lin l => l.norm.toExpr
   | .opq e => e
 
+def DenseNormRes.lin?Impl : DenseNormRes p → Option (DenseLinExpr p)
+  | .var x => some ⟨zmodZeroP p, [(x, zmodOneP p)]⟩
+  | .lin l => some l
+  | .opq _ => none
+
 /-- The linear form of a deferred result — the `.2` of `denseNormalizeFused`. -/
 def DenseNormRes.lin? : DenseNormRes p → Option (DenseLinExpr p)
   | .var x => some ⟨0, [(x, 1)]⟩
   | .lin l => some l
   | .opq _ => none
+
+@[csimp] theorem DenseNormRes_lin_q_eq_impl : @DenseNormRes.lin? = @DenseNormRes.lin?Impl := by
+  funext q r
+  simp [DenseNormRes.lin?, DenseNormRes.lin?Impl]
 
 def denseNormalizeFusedFast : DenseExpr p → DenseNormRes p
   | .const n => .lin ⟨n, []⟩

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -336,7 +336,8 @@ theorem denseAddrTwoRootNeq_sound (reg : VarRegistry) (shape : MemoryBusShape)
 /-- A form recognized as identically zero evaluates to `0`. -/
 theorem denseIsZeroLin_sound (l : DenseLinExpr p) (h : denseIsZeroLin l = true)
     (denv : VarId → ZMod p) : l.eval denv = 0 := by
-  grind [denseIsZeroLin, DenseLinExpr.eval, DenseLinExpr.norm_eval l denv, List.isEmpty_iff]
+  grind [denseIsZeroLin, zmodIsZero_eq, DenseLinExpr.eval, DenseLinExpr.norm_eval l denv,
+    List.isEmpty_iff]
 
 /-- Each recognized factor of a reciprocal product `a·b + r` (`r` a nonzero constant) is nonzero. -/
 theorem denseReciprocalWitsProd_sound (a b r : DenseExpr p) (g : DenseLinExpr p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainBatch.lean
@@ -1488,8 +1488,8 @@ theorem denseCompiledSurvV_eq (bs : BusSemantics p) (facts : BusFacts p bs)
     | some preds =>
       change denseSurvivesAllCWV denseZModOps (fun v => decide (v = denseZModOps.zero))
           facts ces preds pt = denseSurvivesAllMV facts es bis keys pt
-      exact denseSurvivesAllCWV_eq denseZModOps _ (fun _ => rfl)
-        bs facts es bis keys ces preds pt hce hcb
+      exact denseSurvivesAllCWV_eq denseZModOps (fun v => decide (v = denseZModOps.zero))
+        (fun _ => by simp [denseZModOps]) bs facts es bis keys ces preds pt hce hcb
 
 /-- The restriction of a satisfying `denv` survives the covered-item predicate (value-only). -/
 theorem denseSurvivesAllMV_restriction {bs : BusSemantics p} (facts : BusFacts p bs)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
@@ -91,7 +91,8 @@ theorem denseGroupSurvivorsEV_eq (es : List (DenseExpr p)) (xs : List VarId)
       show denseSurvZeroCWV denseZModOps (fun v => decide (v = denseZModOps.zero)) ces a
         = es.all (fun c => decide (c.eval (denseEnvOfKeysV xs a) = 0))
       unfold denseSurvZeroCWV
-      exact denseCompileEs_allV denseZModOps _ (fun _ => rfl) xs a es ces hce
+      exact denseCompileEs_allV denseZModOps (fun v => decide (v = denseZModOps.zero))
+        (fun _ => by simp [denseZModOps]) xs a es ces hce
 
 theorem mem_denseGroupSurvivorsEV (es : List (DenseExpr p)) (xs : List VarId)
     (domVals : List (List (ZMod p))) (pt : List (ZMod p)) (hmem : pt ∈ denseAssignmentsV domVals)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -77,7 +77,8 @@ theorem DenseExpr.evalWith_eq (add mul : ZMod p → ZMod p → ZMod p)
 
 theorem DenseExpr.evalFast_eq (e : DenseExpr p) (denv : VarId → ZMod p) :
     e.evalFast denv = e.eval denv :=
-  DenseExpr.evalWith_eq _ _ (fun _ _ => rfl) (fun _ _ => rfl) denv e
+  DenseExpr.evalWith_eq zmodAdd zmodMul (fun _ _ => zmodAdd_eq _ _) (fun _ _ => zmodMul_eq _ _)
+    denv e
 
 theorem denseBoolConstraint_eval_of_bool (b : VarId) (denv : VarId → ZMod p)
     (h : denv b = 0 ∨ denv b = 1) : (denseBoolConstraint b).eval denv = 0 := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -28,9 +28,7 @@ def DenseExpr.evalWith (add mul : ZMod p → ZMod p → ZMod p) (denv : VarId �
 
 /-- `DenseExpr.eval`, deriving the field operations once per call instead of per node. -/
 def DenseExpr.evalFast (e : DenseExpr p) (denv : VarId → ZMod p) : ZMod p :=
-  let addI : Add (ZMod p) := inferInstance
-  let mulI : Mul (ZMod p) := inferInstance
-  e.evalWith addI.add mulI.mul denv
+  e.evalWith zmodAdd zmodMul denv
 
 /-- `b · (b − 1)`. -/
 def denseBoolConstraint (b : VarId) : DenseExpr p :=
@@ -770,9 +768,24 @@ structure DenseReencodeWork (p : ℕ) where
       variable fold per cleanup cycle for a bound it never consults. -/
   bounded : Bool
 
+def denseIsZeroImpl : DenseExpr p → Bool
+  | .const n => zmodIsZero n
+  | _ => false
+
 def denseIsZero : DenseExpr p → Bool
   | .const n => n == 0
   | _ => false
+
+@[csimp] theorem denseIsZero_eq_impl : @denseIsZero = @denseIsZeroImpl := by
+  funext q e
+  cases e with
+  | const n =>
+      show (n == 0) = zmodIsZero n
+      simp only [zmodIsZero_eq]
+      rfl
+  | var _ => rfl
+  | add _ _ => rfl
+  | mul _ _ => rfl
 
 /-- `denseIsZero` with the field zero as a parameter. The compiler floats the `0`'s whole
     `ZMod.commRing` chain to the head of `denseIsZero`, *before* the constructor test, so a caller
@@ -839,7 +852,8 @@ def denseWorkSpliceCs (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Opti
   | i, c :: rest, acc, lp, lf, ok =>
       if maxPos < i then (acc.reverse ++ (c :: rest), lp, lf, ok)
       else if denseCoveredBy xs c then
-        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest ((.const 0) :: acc) lp lf ok
+        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest
+          ((.const 0) :: acc) lp lf ok
       else if c.sharesVarIn xs || c.hasConstFoldableNode then
         let c' := denseGroupRewrite xs bits σfn patts c
         let lp' := c'.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) lp
@@ -1751,7 +1765,8 @@ def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (usePosB : List
       let c := st.arrCs[i]
       if denseCoveredBy xs c then
         -- covered ⇒ `c.hasVar` ⇒ `c` was not a tombstone, so the live count drops by one
-        { st with arrCs := st.arrCs.set i (.const 0), rootCache := st.rootCache.erase i,
+        { st with arrCs := st.arrCs.set i (.const 0),
+                  rootCache := st.rootCache.erase i,
                   foldCs := st.foldCs.erase i, liveCs := st.liveCs - 1 }
       else if c.sharesVarIn xs || c.hasConstFoldableNode then
         let c' := denseGroupRewrite xs bits σfn patts c

--- a/ApcOptimizer/Implementation/OptimizerPasses/Rewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Rewrite.lean
@@ -36,9 +36,18 @@ theorem DenseConstraintSystem.filterBus_covered {reg : VarRegistry}
 
 /-! ## Small dense expression predicates -/
 
+def DenseExpr.isConstZeroImpl : DenseExpr p → Bool
+  | .const n => zmodIsZero n
+  | _ => false
+
 /-- Is the dense expression the literal constant `0`? -/
 def DenseExpr.isConstZero : DenseExpr p → Bool
-  | .const n => decide (n = 0)
+  | .const n => zmodIsZero n
   | _ => false
+
+@[csimp] theorem DenseExpr_isConstZero_eq_impl :
+    @DenseExpr.isConstZero = @DenseExpr.isConstZeroImpl := by
+  funext q e
+  simp [DenseExpr.isConstZero, DenseExpr.isConstZeroImpl]
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -23,10 +23,35 @@ variable {p : ℕ}
 Unlike `denseLinearize`, the remainder may be nonlinear, so this succeeds where the affine machinery
 gives up. -/
 
+def DenseExpr.splitAtImpl (x : VarId) : DenseExpr p → Option (ZMod p × DenseExpr p)
+  | .const n => some (zmodZeroP p, .const n)
+  | .var y =>
+      if y = x then some (zmodOneP p, .const (zmodZeroP p))
+      else some (zmodZeroP p, .var y)
+  | .add a b =>
+      match a.splitAtImpl x, b.splitAtImpl x with
+      | some (ca, ra), some (cb, rb) => some (zmodAdd ca cb, .add ra rb)
+      | _, _ => none
+  | .mul a b =>
+      if a.mentions x || b.mentions x then
+        match a.constValue? with
+        | some k =>
+            match b.splitAtImpl x with
+            | some (cb, rb) => some (zmodMul k cb, .mul a rb)
+            | none => none
+        | none =>
+            match b.constValue? with
+            | some k =>
+                match a.splitAtImpl x with
+                | some (ca, ra) => some (zmodMul k ca, .mul ra b)
+                | none => none
+            | none => none
+      else some (zmodZeroP p, .mul a b)
+
 /-- Decompose `e` as `k·x + r`: `k` a field constant, `r` not mentioning `x` (by construction). -/
 def DenseExpr.splitAt (x : VarId) : DenseExpr p → Option (ZMod p × DenseExpr p)
   | .const n => some (0, .const n)
-  | .var y => if y = x then some (1, .const 0) else some (0, .var y)
+  | .var y => if y = x then some (1, .const (zmodZeroP p)) else some (0, .var y)
   | .add a b =>
       match a.splitAt x, b.splitAt x with
       | some (ca, ra), some (cb, rb) => some (ca + cb, .add ra rb)
@@ -46,6 +71,15 @@ def DenseExpr.splitAt (x : VarId) : DenseExpr p → Option (ZMod p × DenseExpr 
                 | none => none
             | none => none
       else some (0, .mul a b)
+
+@[csimp] theorem DenseExpr_splitAt_eq_impl : @DenseExpr.splitAt = @DenseExpr.splitAtImpl := by
+  funext q x e
+  induction e with
+  | const n => simp [DenseExpr.splitAt, DenseExpr.splitAtImpl]
+  | var y => by_cases h : y = x <;> simp [DenseExpr.splitAt, DenseExpr.splitAtImpl, h]
+  | add a b iha ihb => simp only [DenseExpr.splitAt, DenseExpr.splitAtImpl, iha, ihb, zmodAdd_eq]
+  | mul a b iha ihb =>
+      simp only [DenseExpr.splitAt, DenseExpr.splitAtImpl, iha, ihb, zmodMul_eq, zmodZeroP_eq]
 
 /-! ## Bounds through scaled range checks
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/SeqzCollapse.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SeqzCollapse.lean
@@ -102,13 +102,13 @@ def denseSeqzMatchMarkerSum : DenseExpr p → Option (VarId × VarId × VarId ×
 
 /-- Match `-1 + x` (a variable), returning `x`. -/
 def denseSeqzMatchNegVar : DenseExpr p → Option VarId
-  | .add (.const c) (.var x) => if c = (-1 : ZMod p) then some x else none
+  | .add (.const c) (.var x) => if c = (zmodNegOneP p) then some x else none
   | _ => none
 
 /-- Match constraint E11 `s0 · ((-1 + a0)·(K + R))`, returning `(a0, K, R)`. -/
 def denseSeqzMatchE11 (s0 : DenseExpr p) : DenseExpr p → Option (VarId × ZMod p × VarId)
   | .mul lhs (.mul (.add (.const c) (.var a0)) (.add (.const k) (.var r))) =>
-      if lhs = s0 ∧ c = (-1 : ZMod p) then some (a0, k, r) else none
+      if lhs = s0 ∧ c = (zmodNegOneP p) then some (a0, k, r) else none
   | _ => none
 
 /-- Match a prefix constraint `prefixE · (aᵢ · KR)`, returning `aᵢ`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/TupleRange.lean
@@ -34,6 +34,16 @@ def denseMatchByteSingle (bs : BusSemantics p) (facts : BusFacts p bs)
     | _ => none
   else none
 
+def denseMatchRangeCheckImpl (bs : BusSemantics p) (facts : BusFacts p bs) (s2 : Nat)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p × ZMod p) :=
+  if facts.varRangeBus bi.busId then
+    match bi.multiplicity, bi.payload with
+    | .const c, [y, .const b] =>
+        if zmodIsOne c && decide (b.val ≤ 17) && decide (2 ^ b.val = s2)
+        then some (y, b) else none
+    | _, _ => none
+  else none
+
 /-- If `bi` is a range check `[y, b]` (multiplicity `1`, constant supported width, exact size
     `2 ^ b = s2`) on a `varRangeBus`, return `(y, b)`. -/
 def denseMatchRangeCheck (bs : BusSemantics p) (facts : BusFacts p bs) (s2 : Nat)
@@ -45,6 +55,11 @@ def denseMatchRangeCheck (bs : BusSemantics p) (facts : BusFacts p bs) (s2 : Nat
         then some (y, b) else none
     | _, _ => none
   else none
+
+@[csimp] theorem denseMatchRangeCheck_eq_impl :
+    @denseMatchRangeCheck = @denseMatchRangeCheckImpl := by
+  funext q bs facts s2 bi
+  simp [denseMatchRangeCheck, denseMatchRangeCheckImpl]
 
 /-- The declared tuple buses with a byte-sized first slot, probed over a bounded id range (the
     target bus typically carries no interaction in the input circuit, so its id cannot be read off

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -164,7 +164,7 @@ Remaining per-pass: **reencode 96 s, busUnify 40 s, busPairCancel 40 s, gauss 36
 20 s (parallel), bytePack 17 s, flagFold 15 s, normalize1 14 s, rootPairUnify 13 s, carryBranch
 13 s**; the tail below that is ~60 s over 25 passes. Cycles 0–2 are still ~78 % of the total.
 Whole-run perf: ~25 % `lean_dec_ref_cold` + ~17 % allocator + ~8 % `lean_apply_1` — the budget is
-still memory traffic, not arithmetic; the `ZMod.commRing` rebuild chain (R9) is ~5 %.
+still memory traffic, not arithmetic; the `ZMod.commRing` rebuild chain is gone (R9, entry 156).
 **reencode is again the top pass (96 s)** and its cost is now diffuse: `denseLookupIx` +
 `denseAssignments` (the survivor enumeration) ~1.6 % of CPU, `DenseExpr.vars`/`hashedDedup` ~2 %
 (per-target `c.vars.eraseDups` gates and the per-accept `denseBuildPruned`), `denseGroupRewrite` +
@@ -423,9 +423,9 @@ Design (b) (a maintained per-address-key `pending` bit with recompute-on-drop) i
 invalidation, and a value-identical transformation of the existing fold.
    **What is left in the pass (6.4 s on sha256 `apc_001`, measured post-153)**, in order:
    the surviving certificate evaluations — `denseAddrNonzeroNeqP` is allocation- and
-   `ZMod`-dictionary-bound (R9; `denseIsZeroLin` derives the whole `CommRing` chain *before* testing
-   `terms.isEmpty`, and `denseDiffSumP` rebuilds it per subset, 4 subsets per compared pair on a
-   two-slot address); the per-invocation index builds (`denseRecvIndexAll`, `denseKeyIdxBuild`,
+   allocation-bound (`denseIsZeroLin`'s zero test is dictionary-free since entry 156, but
+   `denseDiffSumP` still rebuilds the chain per subset, 4 subsets per compared pair on a
+   two-slot address — R9b); the per-invocation index builds (`denseRecvIndexAll`, `denseKeyIdxBuild`,
    `denseBuildBoundIdx`/`FormIdx`, 5.4 % of the pre-153 pass); the per-drop `alive` copy (below);
    and `denseInteractionBound`'s per-variable pattern rebuild (R13b).
 
@@ -434,16 +434,28 @@ variable; `addVarsFast` + `@[csimp] addVars_eq_fast` hoists them. The `@[csimp]`
 zero-proof-churn way to swap an implementation — prefer it over threading a fast path through the
 proofs. Same shape may still apply to `denseDeepEnumDoms`/`denseRootsIn`-style per-variable loops.
 
-**R9. Stop rebuilding `ZMod.commRing` per helper call**  ·  *horizontal, medium value / medium
-effort*. Any helper doing `ZMod` arithmetic without a threaded `DenseZModOps` re-materializes the
-whole Mathlib `CommRing` structure (plus 3–4 hierarchy projections) **per call** — visible as
-`lp_mathlib_ZMod_commRing` + projections at ~3 % (sha) to ~10 % (ecrecover) of whole-run CPU
-*before* counting their allocator/dec_ref share; the generated C shows the rebuild at every entry
-(e.g. `denseRootsOfTerms`). Hot chain: `denseLinearize`, `DenseLinExpr.norm/scale/coeff/others`,
-`denseTwoRootOf?`, `DenseExpr.fold`, `denseRootsIn`, `denseBitCM` — called per constraint per
-cycle by the TwoRootMap/AddrCerts/candidate builders of busUnify/busPairCancel/rootPairUnify.
-Thread `ops` through `@[csimp]` fast twins (the gauss entries 118–119 pattern; rootPairUnify's
-remaining 33 s is mostly this).
+**R9 (done, entry 156).** The `ZMod.commRing` rebuild measured **17.7 % of the run** on sha256
+`apc_001`, not the ~3–5 % recorded here. Fixed by primitives that case on `p` directly
+(`zmodAddP`/`zmodZeroP`/`zmodIsZero`/… in `Encoding.lean`), a `denseZModOps` built from them (which
+cheapens all 34 `…With ops` twins at once), and `@[csimp]` twins at the live sites: **0.68–0.90×
+per corpus**. Three things worth carrying forward:
+
+- **Reachability before conversion.** 149 of 288 chain-building functions in the IR are already
+  `csimp`'d away and unreachable; a C sweep alone cannot tell. `gauss` looked like the biggest
+  target and was already ops-threaded.
+- **Definitional equality is the limit.** A site whose surrounding `@[csimp]`/`…With_eq` proof is
+  `rfl` cannot take a primitive (`zmodZeroP p` is not definitionally `0`). Converting *every*
+  remaining live site measured **+0.4 %** for ~25 broken proofs — not worth it.
+- **Where a twin already exists, edit only the twin**; the in-place edit costs proof work and buys
+  no runtime.
+
+**R9b. What is left, and why it is expensive.** `rootPairUnify` (8.9 s on sha256) barely moved
+(0.99×): its live chain-builders are `denseRpCheckPair`/`denseRpCheckPairIdx`/`denseScaledSlotBound`,
+all reverted above for the definitional-equality reason. Same for `HintCollapse`, `SeqzCollapse`,
+`ByteCheckPack` and `BoxRewrite`. Landing these means restating the affected `…With_eq` bridges to
+rewrite through `zmodZeroP_eq`/`zmodOneP_eq` rather than `rfl` — mechanical, but ~25 proof sites for
+a few percent. Note also `Affine.trySolve`/`trySolveUnit` and `denseScaledSlotBound` need the ring
+for `⁻¹`/`scale` regardless, so converting only their guards would not empty their entries.
 
 **R10. busUnify symbolic-window sweep at SHA scale**  ·  *52 s on sha256_big*. `denseSweepGo`
 tests every symbolic-address message against every open window: `constOpen.toList` is rebuilt per

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5443,3 +5443,60 @@ subsumed, not complementary** — it would pay again only where one target's buc
 thousands.
 **Worked: yes (domainBatch 0.495× on its worst case, 0.83–0.94× on every other representative,
 output byte-identical; draft PR).**
+
+### 156. Runtime: dictionary-free `ZMod` primitives (0.68–0.90x per corpus, sha256 0.79x)
+TARGETED R9, which sized the `ZMod.commRing` rebuild at "~3–5 % (sha) to ~10 % (ecrecover)". That
+estimate was **3–4× stale**: on merged main the chain is **17.7 % of the run** on sha256 `apc_001`
+(LBR, 44 325 samples — leaf is a Mathlib instance/projection 5.7 %, plus allocator/refcounter whose
+immediate caller is one of those 12.1 %). Everything around it had been optimized away since R9 was
+written. `nat/bignum` is **0.2 %** of the run: the field *arithmetic* is free (BabyBear values are
+tagged immediates), what costs is building the structures that describe it.
+MECHANISM. `p` is a runtime value, so `ZMod p`'s `CommRing` is never a closed term Lean can lift
+into a `lean_once_cell`. Worse, Lean **floats the construction ahead of every branch test**:
+`DenseExpr.foldAdd`'s C built five `lp_mathlib_` calls before `lean_obj_tag(a)`, so the common
+`a, b => .add a b` arm — which touches no field element — paid the whole chain and then `dec_ref`'d
+it. `ZMod.commRing` mirrors `ZMod`'s own `Nat.casesOn` split, so each operation *is* the `Int`/`Fin`
+primitive underneath; casing on `p` directly (the shape `ZMod.val` uses) gets it with no dictionary.
+THREE STEPS, each measured before the next. (1) `denseInteractionBound`'s `mval = 0` on `ZMod.val`:
+0.967× on sha256 — predicted ~2 %, and *not* diffuse as first read, it is almost entirely one pass
+(`subsumedRange` **5646 → 0.276×**, invisible until the harness tracked all 42 pass columns rather
+than 16). (2) The literal-comparison sites: 0.894×. (3) `denseZModOps` built from primitives —
+one definition, and all 34 existing `…With ops` twins get cheap at ~30 call sites with no call-site
+edits — plus the live arithmetic sites: 0.79×.
+THE BIGGEST SINGLE WIN was not in R9's list. `DenseExpr.eval` is live and rebuilt the chain **at
+every node**, while its ops-threaded twin `DenseExpr.evalWith` sits in `Reencode.lean` used by
+`reencode` alone — and being downstream of `Encoding.lean` it could never have been wired by
+`@[csimp]` (entry 149's rule). Declaring the `csimp` beside `eval` in `Encoding.lean` reaches all
+41 call sites, including `denseBIEval` and every enumeration pass.
+REACHABILITY FIRST, and it changed the plan twice. A call-graph walk from the entry point showed
+**149 of 288 chain-building functions are unreachable** — already `csimp`'d away. So `gauss`
+(13.3 s, 0.99×) is *not* an opportunity: `denseSparseSubstF`/`Fused` are already ops-threaded, only
+two spec loops remain live. Converting what a C sweep finds would have wasted over half the effort.
+THE TAIL IS NOT WORTH IT — measured, not guessed. Converting *every* live site adds **0.4 %** over
+the above and breaks ~25 proofs. The rule: a site whose surrounding `@[csimp]`/`…With_eq` proof
+asserts *definitional* equality (`rfl`) cannot take a primitive, since `zmodZeroP p` is not
+definitionally `0`. That is what reverted `Reencode.denseBitBoxFast`, `Gauss.densePm1DescWith_eq`,
+`BusUnify.denseMemEqConstraints_eq_fast`, `denseEnvOfKeysV` (11 sites in `Proofs/DomainBatch`) and
+eight other files. Corollary worth keeping: **where a twin already exists, edit only the twin** —
+the in-place edit adds proof cost for no extra runtime.
+NUMBERS (this 20-core box, serial; vs clean `origin/main` 0a5c983). Full corpora: openvm-eth
+98.2 → 87.9 s (**0.90×**, median 0.73×); wasm-eth 61.8 → 47.8 s (**0.77×**); sp1:rsp 10.2 → 6.85 s
+(**0.68×**). Cases: sha256 `apc_001` 137.7 → 109.4 s (**0.79×**), wasm-eth `apc_012` 15.2 → 11.9
+(0.78×), keccak `apc_001` 11.6 → 8.34 (0.72×), openvm-eth `apc_006` 1.51 → 1.02 (0.68×). No
+regression in the slowest ten of any corpus (worst 0.94×). Passes on sha256: constFold0/1/2
+0.52–0.58×, subsumedRange 0.28×, trivialConstr 0.57×, degenRange 0.64×, normalize1/2 0.63–0.68×,
+busUnify 0.68×, intervalForce 0.73×, flagUnify 0.75×, digitFold 0.70×, domainBatch 0.82×.
+PROOF SURFACE: **9 bridge lemmas** in `Encoding.lean` (seven by `cases p <;> rfl`, since the ring
+operations *are* the primitives; `zmodIsZero_eq` off `ZMod.val_eq_zero`, which needs no `NeZero`;
+`zmodIsOne_eq` off `ZMod.val_injective` + `val_one_eq_one_mod` with the `p = 0` case split out) plus
+**21 `@[csimp]` twins**, and **4 lines** of downstream repair — an `_` that used to unify with `0`
+and now needs `denseZModOps.zero` named. No pass correctness theorem changes shape.
+VERIFIED: `run` output byte-identical to main on openvm-eth `apc_006`, wasm-eth `apc_012`, keccak
+`apc_001`; `lake build` clean, no warnings; `check-proof-integrity` passes (propext /
+Classical.choice / Quot.sound, no unused theorems); every `csimp` confirmed live in the C (scan (b)).
+TWO REJECTED. **(a) R9's step 4** (thread one `ops` from the pipeline entry): its premise is gone —
+building the record is now 2 closures + 3 calls + a ctor with no Mathlib in it, so the widest change
+in the plan buys the least. **(b) `zmodIsNegOne`** (`c.val == p - 1`, sound for `p ≠ 0`): deleted.
+Its only site was `Affine.trySolve`, which needs the ring for `⁻¹` and `scale` regardless, so
+converting one test would not empty its entry.
+**Worked: yes (0.68–0.90x per corpus, output byte-identical; draft PR).**


### PR DESCRIPTION
`p` is a runtime value, so `ZMod p`'s `CommRing` instance is never a closed term Lean can lift into a
`lean_once_cell`. Every function that does field arithmetic — **or merely writes the literal `0`** —
materializes `ZMod.commRing p` plus 3–5 projections at its own entry, allocates them, and frees them
on return. Worse, Lean *floats that construction ahead of every branch test*: `DenseExpr.foldAdd`
built five `lp_mathlib_` calls before it read `lean_obj_tag(a)`, so the overwhelmingly common
`a, b => .add a b` arm — which touches no field element at all — paid the whole chain and then
`dec_ref`'d it.

`nat/bignum` is 0.2% of the run: the field *arithmetic* is nearly free (BabyBear/KoalaBear values are
tagged immediates). What costs is building the structures that describe the arithmetic.

`ideas.md` R9 named this mechanism but sized it at "~3–5% (sha) to ~10% (ecrecover)". That estimate
was 3–4× stale — on merged main it measures **17.7% of the run** on sha256 `apc_001`, because
everything around it has been optimized away since R9 was written.

## Approach

`ZMod.commRing` mirrors `ZMod`'s own `Nat.casesOn` split (`Mathlib/Data/ZMod/Defs.lean`), so every
operation *is* the corresponding `Int`/`Fin` primitive underneath — reaching it through the instance
is the whole cost. Casing on `p` directly, in the shape `ZMod.val` itself uses, gets the primitive
with no dictionary. Likewise `ZMod.val` is a bare `Fin.val`/`Int.natAbs` projection, so a `= 0` test
routed through it builds nothing — not a cheaper dictionary, none.

Three commits, each measured before the next was written:

1. **The primitives and their bridge lemmas** (`Encoding.lean`), plus `denseZModOps` rebuilt from
   them — one definition, and all 34 existing `…With ops` twins become cheap at ~30 call sites with
   no call-site edits.
2. **Literal comparisons** through `ZMod.val`.
3. **The live literal-construction sites** in the linear-algebra and enumeration layers.

The largest single win was not in R9's list: `DenseExpr.eval` rebuilt the chain **at every node**.
`DenseExpr.evalWith` already existed for exactly this but is used only by `reencode`, and living
downstream of `Encoding.lean` it could never have been wired by `@[csimp]` (entry 149's ordering
rule). Declaring the twin beside `eval` in the earliest dense module reaches all 41 call sites.

## Scope was set by reachability, not by a C sweep

A call-graph walk from the entry point shows **149 of 288 chain-building functions are already
`csimp`'d away and unreachable**. Converting what a mechanical C sweep finds would have wasted over
half the effort — and it killed the target that looked biggest: `gauss` (13.3 s on sha256) is
*already* ops-threaded, only two specialized loops remain live.

Converting the *entire* remaining live surface was also tried and reverted: it measured **+0.4%** and
broke ~25 proofs. The limit is precise — a site whose surrounding `@[csimp]`/`…With_eq` proof asserts
*definitional* equality cannot take a primitive, since `zmodZeroP p` is not definitionally `0`. Left
as R9b in `ideas.md`, with the affected files named.

## Correctness

Nothing changes what any pass computes, so **no pass correctness theorem changes shape**. The whole
proof surface is **9 bridge lemmas** in `Encoding.lean` that `@[simp]`-normalize each primitive back
to its ring operation, so proofs never see a primitive:

- seven go by `cases p <;> rfl`, since the ring operations *are* the primitives;
- `zmodIsZero_eq` rests on `ZMod.val_eq_zero`, which holds for **all** `n` with no `NeZero`;
- `zmodIsOne_eq` needs `ZMod.val_injective` + `ZMod.val_one_eq_one_mod`. `= 1` is *not* soundly
  `val = 1`: `val` is not injective at `p = 0` (`natAbs` merges `1` and `-1`) and
  `(1 : ZMod 1).val = 0`. So `zmodIsOne` is `val == 1 % p` — correct for every `p ≠ 0`, `p = 1`
  included — with the `p = 0` case delegated to a separate function so its dictionary stays off the
  caller's entry. `p` is a prime at runtime.

Plus 21 `@[csimp]` twins, and **4 lines** of downstream repair (an `_` that used to unify with `0`
and now needs `denseZModOps.zero` named).

## Verification

- `lake build` clean, no warnings.
- `Scripts/check-proof-integrity.sh` passes: axioms `propext` / `Classical.choice` / `Quot.sound`,
  no unused theorems, no `sorry`/`implemented_by`/`native_decide`.
- Every `@[csimp]` confirmed live in the generated C (`OptimizingRuntime.md` scan (b)) — the twins
  are not dead on arrival.
- `run` output **byte-identical** to `main` on openvm-eth `apc_006`, wasm-eth `apc_012` and
  keccak `apc_001`; this is a runtime change only, so effectiveness should be unchanged — CI's
  benchmark is the authority on that.

Runtime figures left to CI rather than quoted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)