### PR TITLE
perf(derivations): index the output-derivation pruning (3.7x on the openvm-eth family)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -23,6 +23,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DegenRange
 import ApcOptimizer.Implementation.OptimizerPasses.IdentitySubst
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.IdentitySubst
 import ApcOptimizer.Implementation.OptimizerPasses.DenseUmbrella
+import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 
 set_option autoImplicit false
 
@@ -168,11 +169,25 @@ def Derivations.safeMethod (ds : Derivations p) (inputVars : List Variable) (v :
   | some cm => if ∀ x ∈ cm.vars, x ∈ inputVars then cm else .const 0
   | none => .const 0
 
-/-- Keep one structurally safe derivation for each no-ID output variable. -/
+/-- `Derivations.safeMethod` with both of its scans served from indexes: `methods` is `ds` keyed by
+    derived variable, `inputs` holds the input variables (`safeMethodIdx_eq`). -/
+def Derivations.safeMethodIdx (methods : Std.HashMap Variable (ComputationMethod p))
+    (inputs : Std.HashSet Variable) (v : Variable) : ComputationMethod p :=
+  match methods[v]? with
+  | some cm => if cm.vars.all (fun x => inputs.contains x) then cm else .const 0
+  | none => .const 0
+
+/-- Keep one structurally safe derivation for each no-ID output variable.
+
+    Both `Circuit.vars` lists count variable *occurrences*, so every scan here is indexed:
+    `methodFor` walks all of `ds` on each lookup, and the input-variable test would rescan
+    `inputVars` per referenced variable. `forOutput_eq` is the index-free reading. -/
 def Derivations.forOutput (ds : Derivations p) (inputVars outputVars : List Variable) :
     Derivations p :=
-  (outputVars.filter (fun v => v.powdrId?.isNone)).eraseDups.map
-    (fun v => (v, ds.safeMethod inputVars v))
+  let methods := Std.HashMap.ofList ds
+  let inputs := Std.HashSet.ofList inputVars
+  (HashedDedup.hashedEraseDups hash (outputVars.filter (fun v => v.powdrId?.isNone))).map
+    (fun v => (v, Derivations.safeMethodIdx methods inputs v))
 
 /-- The fact-aware circuit optimizer: given proven `BusFacts` (which fixes the implicit `bs`), run
     the pipeline and return the output system with the `Derivations` for its new variables. -/
@@ -245,10 +260,48 @@ theorem Derivations.methodFor_map_same (vs : List Variable)
         · have hvu : ¬v = u := fun h => huv h.symm
           simp [hvrest, huv, hvu]
 
+/-- `methodFor` is `findSomeRev?` with a keyed probe — the shape `Std.HashMap`'s `insertMany` lookup
+    lemma reports, so the two agree in `getElem?_ofList`. -/
+theorem Derivations.methodFor_eq_findSomeRev? (ds : Derivations p) (v : Variable) :
+    ds.findSomeRev? (fun ⟨u, cm⟩ => if u == v then some cm else none) = ds.methodFor v := by
+  induction ds with
+  | nil => rfl
+  | cons d rest ih =>
+      obtain ⟨u, cm⟩ := d
+      rw [List.findSomeRev?, ih, Derivations.methodFor]
+      cases Derivations.methodFor rest v with
+      | some later => rfl
+      | none => simp
+
+/-- Keying `ds` by variable preserves `methodFor`: `insertMany` keeps the last binding for a
+    duplicated key, and so does `methodFor`. -/
+theorem Derivations.getElem?_ofList (ds : Derivations p) (v : Variable) :
+    (Std.HashMap.ofList ds)[v]? = ds.methodFor v := by
+  rw [Std.HashMap.ofList_eq_insertMany_empty, Std.HashMap.getElem?_insertMany_list,
+    Std.HashMap.getElem?_empty, Derivations.methodFor_eq_findSomeRev?]
+  cases ds.methodFor v <;> rfl
+
+theorem Derivations.safeMethodIdx_eq (ds : Derivations p) (inputVars : List Variable)
+    (v : Variable) :
+    Derivations.safeMethodIdx (Std.HashMap.ofList ds) (Std.HashSet.ofList inputVars) v
+      = ds.safeMethod inputVars v := by
+  rw [Derivations.safeMethodIdx, Derivations.safeMethod, Derivations.getElem?_ofList]
+  cases ds.methodFor v with
+  | none => rfl
+  | some cm =>
+      exact if_congr (by simp [List.all_eq_true, Std.HashSet.contains_ofList]) rfl rfl
+
+theorem Derivations.forOutput_eq (ds : Derivations p) (inputVars outputVars : List Variable) :
+    ds.forOutput inputVars outputVars
+      = (outputVars.filter (fun v => v.powdrId?.isNone)).eraseDups.map
+          (fun v => (v, ds.safeMethod inputVars v)) := by
+  simp only [Derivations.forOutput, HashedDedup.hashedEraseDups_eq]
+  exact List.map_congr_left fun v _ => by rw [Derivations.safeMethodIdx_eq]
+
 theorem Derivations.forOutput_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
     {v : Variable} (hv : v ∈ outputVars) (hpw : v.powdrId? = none) :
     (ds.forOutput inputVars outputVars).methodFor v = some (ds.safeMethod inputVars v) := by
-  unfold Derivations.forOutput
+  rw [Derivations.forOutput_eq]
   rw [Derivations.methodFor_map_same, if_pos]
   simp [hv, hpw]
 
@@ -288,7 +341,7 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
     change d ∈ (pipeline b cs bs facts).derivs.forOutput cs.vars
       (pipeline b cs bs facts).out.vars at hd
     change d.1 ∈ (pipeline b cs bs facts).out.vars
-    rw [Derivations.forOutput, List.mem_map] at hd
+    rw [Derivations.forOutput_eq, List.mem_map] at hd
     obtain ⟨v, hv, rfl⟩ := hd
     exact List.mem_of_mem_filter (List.mem_eraseDups.mp hv)
   · -- Every output variable is either reused from the input or has a safe method.


### PR DESCRIPTION
## What regressed

Timing the Lean optimizer against powdr's native Rust optimizer over 20,115 real APC input circuits (9 benchmarks, guest suite + openvm-eth block 24171377) showed total Lean time going **7,202s → 10,832s (+50%)** between `f38461c` and `0a5c983`, while the Rust side over the same circuits stayed flat (−2%).

Bisecting over the 18 commits in that range, on five openvm-eth APCs of 3.2k–4.3k variables that regressed hardest, run alone (Lean optimizer time only, sum over the five):

| rev | | |
|---|---|---|
| `f38461c` | 6.73s | good |
| `e7292cb` (#240) | 6.95s | good |
| `21102c2` (#244) | 6.39s | good |
| **`74515b5` (#242)** | **24.05s** | **bad** |
| `e180ffe` (#246) | 23.75s | bad |
| `0a5c983` (main) | 22.51s | bad |

Its parent is clean and nothing after it recovers, so #242 accounts for the whole +50%. The spec hoist in that PR is not the problem — requiring `Derivations.cover` without a trace is a genuine strengthening, and it's a good change. What costs the time is *how* the implementation discharges it.

## Why it costs time

To make `cover` structurally true, `forOutput` builds a total, sanitized derivation map over the no-ID output variables. It did that with three list scans, each superlinear because **both `Circuit.vars` lists count variable occurrences, not distinct variables**:

- `Derivations.methodFor` walks *all* of `ds` per looked-up variable — it recurses before testing the head (that's what makes the last binding win), so there is no early exit;
- `List.eraseDups` tests each occurrence against the kept-so-far list (`eraseDupsBy.loop`);
- the `∀ x ∈ cm.vars, x ∈ inputVars` safety test rescans `inputVars` per referenced variable.

`Variable` equality is `String` equality, so each comparison in those scans is a string compare. (The pre-#242 line was already quadratic — `derivs.filter (·.1 ∈ out.vars)` is `|ds|` membership scans over an occurrence list — which is why this ends up slightly faster than pre-#242 as well.)

## The fix

Serve all three from indexes, and keep the list-shaped definition as a proven-equal reading:

- `ds` keyed by variable via `Std.HashMap.ofList`, whose `insertMany` lookup lemma keeps the **last** binding for a duplicated key — exactly `methodFor`'s rule (`getElem?_ofList`, via `methodFor_eq_findSomeRev?`);
- the input variables as a `Std.HashSet` (`Std.HashSet.contains_ofList`);
- the existing, already-proven `HashedDedup.hashedEraseDups` for the dedup.

`forOutput_eq` rewrites the indexed definition back to the previous list-shaped one, so **the output list is bit-for-bit unchanged** and the correctness proof keeps its previous shape (two `rw` sites). No change to the audited surface; no new `csimp`, `sorry`, or trusted implementation.

`lake build` is clean (no warnings) and `Scripts/check-proof-integrity.sh` passes: correctness theorems still rest only on `propext`/`Classical.choice`/`Quot.sound`, and no theorem is orphaned.

## Measurements

Isolated on a 48-core box (each circuit run alone, so these are lower than the loaded full-suite numbers), Lean optimizer time only:

| circuit | `f38461c` (pre-#242) | `0a5c983` (main) | this PR |
|---|---|---|---|
| five 3.2k–4.3k-var openvm-eth APCs (sum) | 8.17s | 23.69s | **7.31s** |
| one 29,340-var openvm-eth APC | 21.91s | 167.26s | **18.34s** |

So **3.2× on the small five and 9.1× on the 29k-variable APC** versus main, landing slightly ahead of pre-#242 (the small-circuit numbers carry ~20% run-to-run variance on this box; the 29k figure is well outside it). Effectiveness is unchanged by construction — the returned derivation list is proven identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKR42FVxb2GLyEesKGgyvK