### PR TITLE
perf(flagFold): the box-tautology certificate reads the domain memo (0.35x on the pass, sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagFoldDrops.lean
@@ -20,61 +20,43 @@ variable {p : ℕ}
 def denseSingleVarCs (all : List (DenseExpr p)) : List (DenseExpr p) :=
   all.filter (fun c => (HashedDedup.hashedEraseDups (hash ·) c.vars).length == 1)
 
-def denseBtCertImpl (singles : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
-  2 ≤ c.vars.eraseDups.length &&
-  (let doms := c.vars.eraseDups.filterMap (fun v =>
-     (denseFindDomainAlg singles v).map (fun d => (v, d)))
-   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+def denseBtCertImpl (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
+  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
+  2 ≤ vs.length &&
+  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = vs) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (denseAssignments doms).all (fun pt => zmodIsZero (c.eval (denseEnvOfFast pt))))
 
-/-- Certificate: `c` mentions ≥ 2 distinct variables, every one carries a proven finite domain
-    (from the single-variable constraints), the joint box is small, and `c` vanishes on all of it. -/
-def denseBtCert (singles : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
-  2 ≤ c.vars.eraseDups.length &&
-  (let doms := c.vars.eraseDups.filterMap (fun v =>
-     (denseFindDomainAlg singles v).map (fun d => (v, d)))
-   decide (doms.map Prod.fst = c.vars.eraseDups) &&
+/-- Certificate: `c` mentions ≥ 2 distinct variables, `domOf` reports a finite domain for every
+    one of them, the joint box is small, and `c` vanishes on all of it. `domOf` is untrusted here —
+    soundness comes from the caller's justification of the domains it reports
+    (`boxTautoReplace_denseCorrect`'s `hdomOf`). -/
+def denseBtCert (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
+  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
+  2 ≤ vs.length &&
+  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
+   decide (doms.map Prod.fst = vs) &&
    decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
    (denseAssignments doms).all (fun pt => decide (c.eval (denseEnvOfFast pt) = 0)))
 
 @[csimp] theorem denseBtCert_eq_impl : @denseBtCert = @denseBtCertImpl := by
-  funext q singles c
-  simp [denseBtCert, denseBtCertImpl]
-
-def denseBtPreImpl (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
-  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
-  2 ≤ vs.length &&
-  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
-   decide (doms.map Prod.fst = vs) &&
-   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
-   (denseAssignments doms).all (fun pt => zmodIsZero (c.eval (denseEnvOfFast pt))))
-
-/-- A cheap prefilter over a precomputed domain lookup; accepted candidates re-run the real
-    `denseBtCert`. -/
-def denseBtPre (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p) : Bool :=
-  let vs := HashedDedup.hashedEraseDups (hash ·) c.vars
-  2 ≤ vs.length &&
-  (let doms := vs.filterMap (fun v => (domOf v).map (fun d => (v, d)))
-   decide (doms.map Prod.fst = vs) &&
-   decide ((doms.map (fun vd => vd.2.length)).prod ≤ 32) &&
-   (denseAssignments doms).all (fun pt => decide (c.eval (denseEnvOfFast pt) = 0)))
-
-@[csimp] theorem denseBtPre_eq_impl : @denseBtPre = @denseBtPreImpl := by
   funext q domOf c
-  simp [denseBtPre, denseBtPreImpl]
-
-/-- The replacement condition: the memoized prefilter gates the (expensive) certificate. -/
-def denseBtKeep (singles : List (DenseExpr p)) (domOf : VarId → Option (List (ZMod p)))
-    (c : DenseExpr p) : Bool :=
-  denseBtPre domOf c && denseBtCert singles c
+  simp [denseBtCert, denseBtCertImpl]
 
 /-- Replace certified box tautologies by the trivial constraint `0`. -/
 def DenseConstraintSystem.boxTautoReplaceWith (d : DenseConstraintSystem p)
-    (singles : List (DenseExpr p)) (domOf : VarId → Option (List (ZMod p))) :
-    DenseConstraintSystem p :=
+    (domOf : VarId → Option (List (ZMod p))) : DenseConstraintSystem p :=
   { d with algebraicConstraints := d.algebraicConstraints.map (fun c =>
-      if denseBtKeep singles domOf c then DenseExpr.const 0 else c) }
+      if denseBtCert domOf c then DenseExpr.const 0 else c) }
+
+/-- Memo table for the per-variable domain lookups, first occurrence winning. Every entry is the
+    bucket's own `denseFindDomainAlg` verdict (`denseBtDomCache_sound`), which is what justifies the
+    domains `denseBtCert` then reads. -/
+def denseBtDomCache (domIdx : Std.HashMap VarId (List (DenseExpr p))) (vs : List VarId) :
+    Std.HashMap VarId (Option (List (ZMod p))) :=
+  vs.foldl (fun m v => if m.contains v then m
+    else m.insert v (denseFindDomainAlg (denseVarBucketLookup domIdx v) v)) ∅
 
 /-- Box-tautology drop (part B): a multi-variable constraint that vanishes at every point of its
     variables' proven finite-domain box is replaced by the literal `0`. E.g. with `x, y ∈ {0,1}`
@@ -83,19 +65,12 @@ def DenseConstraintSystem.boxTautoReplaceWith (d : DenseConstraintSystem p)
 def denseBoxTautoDropF (pw : PrimeWitness p) (_bs : BusSemantics p)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let singles := denseSingleVarCs d.algebraicConstraints
-    -- Bucket single-variable constraints by their one variable, so `denseFindDomainAlg` scans only
-    -- that variable's bucket (same domain, no O(#singles) walk per variable).
-    let singlesBy : Std.HashMap VarId (List (DenseExpr p)) :=
-      singles.reverse.foldl (fun m c =>
-        match HashedDedup.hashedEraseDups (hash ·) c.vars with
-        | [v] => m.insert v (c :: m.getD v [])
-        | _ => m) ∅
-    let cache : Std.HashMap VarId (Option (List (ZMod p))) :=
-      (d.algebraicConstraints.flatMap DenseExpr.vars).foldl
-        (fun m v => if m.contains v then m
-         else m.insert v (denseFindDomainAlg (singlesBy.getD v []) v)) ∅
-    d.boxTautoReplaceWith singles (fun v => cache.getD v none)
+    -- The certificate's domains come from this memo, so each variable's domain is derived once
+    -- per invocation, from its own bucket, rather than per candidate constraint from the whole
+    -- single-variable list. `denseBtDomCache_sound` is what makes the memo trustworthy.
+    let domIdx := denseVarBucket DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)
+    let cache := denseBtDomCache domIdx (d.algebraicConstraints.flatMap DenseExpr.vars)
+    d.boxTautoReplaceWith (fun v => cache.getD v none)
   else d
 
 /-! ## Part C: pointwise-duplicate stateless check removal (dense) -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagFoldDrops.lean
@@ -17,52 +17,96 @@ variable {p : ℕ}
 
 /-! ## Part B: box-tautology replacement -/
 
-/-- `denseBtKeep` implies its certificate. -/
-theorem denseBtKeep_cert {singles : List (DenseExpr p)}
-    {domOf : VarId → Option (List (ZMod p))} {c : DenseExpr p}
-    (h : denseBtKeep singles domOf c = true) : denseBtCert singles c = true := by
-  unfold denseBtKeep at h
-  rw [Bool.and_eq_true] at h
-  exact h.2
-
-/-- A false certificate falsifies `denseBtKeep`. -/
-theorem denseBtKeep_of_cert_false {singles : List (DenseExpr p)}
-    {domOf : VarId → Option (List (ZMod p))} {c : DenseExpr p}
-    (h : denseBtCert singles c = false) : denseBtKeep singles domOf c = false := by
-  unfold denseBtKeep
-  rw [h, Bool.and_false]
+/-- A constraint with fewer than two distinct variables fails `denseBtCert`'s first guard. -/
+theorem denseBtCert_of_lt_two {domOf : VarId → Option (List (ZMod p))} {c : DenseExpr p}
+    (hs : c.vars.eraseDups.length ≤ 1) : denseBtCert domOf c = false := by
+  unfold denseBtCert
+  have h1 : ¬ (2 ≤ (HashedDedup.hashedEraseDups (hash ·) c.vars).length) := by
+    rw [HashedDedup.hashedEraseDups_eq]; omega
+  simp [h1]
 
 /-- A single-variable constraint is never replaced (it fails the `≥ 2` guard), so it survives
     verbatim into the output — the box justification stands on the output's own satisfaction. -/
 theorem denseSingleVar_mem_boxTautoReplace (d : DenseConstraintSystem p)
     (domOf : VarId → Option (List (ZMod p))) (c : DenseExpr p)
     (hc : c ∈ d.algebraicConstraints) (hs : (c.vars.eraseDups.length == 1) = true) :
-    c ∈ (d.boxTautoReplaceWith (denseSingleVarCs d.algebraicConstraints)
-      domOf).algebraicConstraints := by
-  have hcf : denseBtCert (denseSingleVarCs d.algebraicConstraints) c = false := by
-    unfold denseBtCert
-    have h1 : ¬ (2 ≤ c.vars.eraseDups.length) := by
-      have := of_decide_eq_true hs
-      omega
-    simp [h1]
+    c ∈ (d.boxTautoReplaceWith domOf).algebraicConstraints := by
   refine List.mem_map.2 ⟨c, hc, ?_⟩
-  rw [denseBtKeep_of_cert_false hcf]
+  rw [denseBtCert_of_lt_two (by have := of_decide_eq_true hs; omega)]
   simp
 
-/-- Box-tautology replacement correctness: every replaced constraint is a tautology over its box
-    (justified from the never-replaced single-variable constraints), so satisfaction is preserved on
-    the same environment and bus effects are untouched. -/
+/-! ### The domain memo table reports only bucket-justified domains
+
+`denseBtDomCache` inserts `denseFindDomainAlg (bucket v) v` under `v` on first sight and never
+overwrites, so every entry it reports is that bucket's own verdict. This is what lets
+`denseBtCert` — whose `domOf` is otherwise untrusted — carry the box justification. -/
+
+/-- Fold invariant: every key the accumulator reports maps to its bucket's `denseFindDomainAlg`. -/
+theorem denseBtDomCacheGo_sound (domIdx : Std.HashMap VarId (List (DenseExpr p))) :
+    ∀ (vs : List VarId) (m : Std.HashMap VarId (Option (List (ZMod p)))),
+      (∀ k o, m[k]? = some o → o = denseFindDomainAlg (denseVarBucketLookup domIdx k) k) →
+      ∀ k o, (vs.foldl (fun (m : Std.HashMap VarId (Option (List (ZMod p)))) v =>
+                 if m.contains v then m
+                 else m.insert v (denseFindDomainAlg (denseVarBucketLookup domIdx v) v)) m)[k]?
+               = some o →
+        o = denseFindDomainAlg (denseVarBucketLookup domIdx k) k := by
+  intro vs
+  induction vs with
+  | nil => intro m hm k o h; exact hm k o h
+  | cons v rest ih =>
+    intro m hm k o h
+    rw [List.foldl_cons] at h
+    by_cases hc : m.contains v = true
+    · exact ih m hm k o (by rwa [if_pos hc] at h)
+    · refine ih _ ?_ k o (by rwa [if_neg hc] at h)
+      intro k' o' hk'
+      rw [Std.HashMap.getElem?_insert] at hk'
+      by_cases hvk : (v == k') = true
+      · rw [if_pos hvk] at hk'
+        have : k' = v := (eq_of_beq hvk).symm
+        subst this
+        exact (Option.some.inj hk').symm
+      · rw [if_neg hvk] at hk'
+        exact hm k' o' hk'
+
+/-- Every domain `denseBtDomCache` reports is the corresponding bucket's `denseFindDomainAlg`. -/
+theorem denseBtDomCache_sound (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (vs : List VarId) (v : VarId) (dm : List (ZMod p))
+    (h : (denseBtDomCache domIdx vs).getD v none = some dm) :
+    denseFindDomainAlg (denseVarBucketLookup domIdx v) v = some dm := by
+  unfold denseBtDomCache at h
+  rw [Std.HashMap.getD_eq_getD_getElem?] at h
+  cases hk : (vs.foldl (fun (m : Std.HashMap VarId (Option (List (ZMod p)))) w =>
+      if m.contains w then m
+      else m.insert w (denseFindDomainAlg (denseVarBucketLookup domIdx w) w)) ∅)[v]? with
+  | none => rw [hk] at h; simp at h
+  | some o =>
+    rw [hk] at h
+    simp only [Option.getD_some] at h
+    subst h
+    exact (denseBtDomCacheGo_sound domIdx vs ∅
+      (by intro k o hko; simp at hko) v (some dm) hk).symm
+
+/-- Box-tautology replacement correctness: every replaced constraint is a tautology over its box.
+The domains come from `domOf`, which is untrusted — `hdomOf` re-derives each reported domain as the
+verdict of `denseFindDomainAlg` on `v`'s bucket, and `hidx` places that bucket inside the
+never-replaced single-variable constraints, so the box justification stands on the output's own
+satisfaction. Satisfaction is then preserved on the same environment and bus effects are
+untouched. -/
 theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
     (d : DenseConstraintSystem p) (bs : BusSemantics p) (isInput : VarId → Bool)
-    (domOf : VarId → Option (List (ZMod p))) :
-    DensePassCorrect isInput d
-      (d.boxTautoReplaceWith (denseSingleVarCs d.algebraicConstraints) domOf) [] bs := by
-  have hzero : ∀ denv, (d.boxTautoReplaceWith (denseSingleVarCs d.algebraicConstraints)
-      domOf).satisfies bs denv →
-      ∀ c ∈ d.algebraicConstraints,
-        denseBtCert (denseSingleVarCs d.algebraicConstraints) c = true → c.eval denv = 0 := by
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (hidx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v,
+      c ∈ denseSingleVarCs d.algebraicConstraints)
+    (domOf : VarId → Option (List (ZMod p)))
+    (hdomOf : ∀ v dm, domOf v = some dm →
+      denseFindDomainAlg (denseVarBucketLookup domIdx v) v = some dm) :
+    DensePassCorrect isInput d (d.boxTautoReplaceWith domOf) [] bs := by
+  have hzero : ∀ denv, (d.boxTautoReplaceWith domOf).satisfies bs denv →
+      ∀ c ∈ d.algebraicConstraints, denseBtCert domOf c = true → c.eval denv = 0 := by
     intro denv hsat c _hc hcert
     unfold denseBtCert at hcert
+    rw [HashedDedup.hashedEraseDups_eq] at hcert
     rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true] at hcert
     obtain ⟨_h2, ⟨⟨hcover, _hcap⟩, hall⟩⟩ := hcert
     have hcover' := of_decide_eq_true hcover
@@ -73,47 +117,45 @@ theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
         have h := (List.mem_filter.1 hc').2
         rwa [HashedDedup.hashedEraseDups_eq] at h
       exact hsat.1 c' (denseSingleVar_mem_boxTautoReplace d domOf c' hmem hsingle)
+    have hbucket : ∀ v, ∀ c' ∈ denseVarBucketLookup domIdx v, c'.eval denv = 0 :=
+      fun v c' hc' => hdom c' (hidx v c' hc')
     have hmemdoms : ∀ vd ∈ c.vars.eraseDups.filterMap (fun v =>
-        (denseFindDomainAlg (denseSingleVarCs d.algebraicConstraints) v).map (fun dm => (v, dm))),
-        denv vd.1 ∈ vd.2 := by
+        (domOf v).map (fun dm => (v, dm))), denv vd.1 ∈ vd.2 := by
       intro vd hvd
       obtain ⟨v, _hv, hvd'⟩ := List.mem_filterMap.1 hvd
-      cases hfd : denseFindDomainAlg (denseSingleVarCs d.algebraicConstraints) v with
+      cases hfd : domOf v with
       | none => rw [hfd] at hvd'; simp at hvd'
       | some dm =>
           rw [hfd] at hvd'
           simp only [Option.map_some, Option.some.injEq] at hvd'
           obtain rfl := hvd'.symm
-          exact denseFindDomainAlg_sound denv (denseSingleVarCs d.algebraicConstraints) v dm hfd hdom
+          exact denseFindDomainAlg_sound denv (denseVarBucketLookup domIdx v) v dm
+            (hdomOf v dm hfd) (hbucket v)
     have hpt := mem_denseAssignments (c.vars.eraseDups.filterMap (fun v =>
-      (denseFindDomainAlg (denseSingleVarCs d.algebraicConstraints) v).map (fun dm => (v, dm))))
-      denv hmemdoms
+      (domOf v).map (fun dm => (v, dm)))) denv hmemdoms
     have hptz := of_decide_eq_true (List.all_eq_true.mp hall _ hpt)
     have hagree : c.eval (denseEnvOfFast ((c.vars.eraseDups.filterMap (fun v =>
-        (denseFindDomainAlg (denseSingleVarCs d.algebraicConstraints) v).map
-          (fun dm => (v, dm)))).map (fun vd => (vd.1, denv vd.1)))) = c.eval denv := by
+        (domOf v).map (fun dm => (v, dm)))).map (fun vd => (vd.1, denv vd.1)))) = c.eval denv := by
       refine DenseExpr.eval_congr c _ denv (fun v hv => ?_)
       refine denseEnvOfFast_map _ denv v ?_
       rw [show ((c.vars.eraseDups.filterMap (fun v =>
-        (denseFindDomainAlg (denseSingleVarCs d.algebraicConstraints) v).map
-          (fun dm => (v, dm)))).map Prod.fst) = c.vars.eraseDups from hcover']
+        (domOf v).map (fun dm => (v, dm)))).map Prod.fst) = c.vars.eraseDups from hcover']
       exact List.mem_eraseDups.2 hv
     rw [← hagree]; exact hptz
-  have hiff : ∀ denv, (d.boxTautoReplaceWith (denseSingleVarCs d.algebraicConstraints)
-      domOf).satisfies bs denv ↔ d.satisfies bs denv := by
+  have hiff : ∀ denv, (d.boxTautoReplaceWith domOf).satisfies bs denv ↔ d.satisfies bs denv := by
     intro denv
     constructor
     · intro hsat
       refine ⟨fun c hc => ?_, hsat.2⟩
-      by_cases hcond : denseBtKeep (denseSingleVarCs d.algebraicConstraints) domOf c = true
-      · exact hzero denv hsat c hc (denseBtKeep_cert hcond)
+      by_cases hcond : denseBtCert domOf c = true
+      · exact hzero denv hsat c hc hcond
       · have h0 := hsat.1 _ (List.mem_map.2 ⟨c, hc, rfl⟩)
         rw [if_neg hcond] at h0
         exact h0
     · intro hsat
       refine ⟨fun c' hc' => ?_, hsat.2⟩
       obtain ⟨c, hc, rfl⟩ := List.mem_map.1 hc'
-      by_cases hcond : denseBtKeep (denseSingleVarCs d.algebraicConstraints) domOf c = true
+      by_cases hcond : denseBtCert domOf c = true
       · rw [if_pos hcond]; rfl
       · rw [if_neg hcond]; exact hsat.1 c hc
   refine DensePassCorrect.ofEnvEq ?_ ?_ ?_ ?_
@@ -128,7 +170,7 @@ theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
     simp only [DenseConstraintSystem.occ, List.mem_append, List.mem_flatMap] at hi
     rcases hi with ⟨c', hc', hic⟩ | ⟨bi, hbi, hib⟩
     · obtain ⟨c, hcm, rfl⟩ := List.mem_map.1 hc'
-      by_cases hcond : denseBtKeep (denseSingleVarCs d.algebraicConstraints) domOf c = true
+      by_cases hcond : denseBtCert domOf c = true
       · rw [if_pos hcond] at hic; simp [DenseExpr.vars] at hic
       · rw [if_neg hcond] at hic
         exact DenseConstraintSystem.mem_occ_of_constraint hcm hic
@@ -140,13 +182,12 @@ theorem DenseConstraintSystem.boxTautoReplace_denseCorrect [Fact p.Prime]
 /-- Coverage is preserved: replaced constraints are `const 0` (no variables) or original (covered);
     bus interactions unchanged. -/
 theorem DenseConstraintSystem.boxTautoReplaceWith_covered {reg : VarRegistry}
-    {d : DenseConstraintSystem p} (singles : List (DenseExpr p))
-    (domOf : VarId → Option (List (ZMod p))) (hc : d.CoveredBy reg) :
-    (d.boxTautoReplaceWith singles domOf).CoveredBy reg := by
+    {d : DenseConstraintSystem p} (domOf : VarId → Option (List (ZMod p)))
+    (hc : d.CoveredBy reg) : (d.boxTautoReplaceWith domOf).CoveredBy reg := by
   refine ⟨fun e he => ?_, fun bi hbi => hc.2 bi hbi⟩
   simp only [DenseConstraintSystem.boxTautoReplaceWith] at he
   obtain ⟨c, hcm, rfl⟩ := List.mem_map.1 he
-  by_cases hcond : denseBtKeep singles domOf c = true
+  by_cases hcond : denseBtCert domOf c = true
   · rw [if_pos hcond]; intro i hi; simp [DenseExpr.vars] at hi
   · rw [if_neg hcond]; exact hc.1 c hcm
 
@@ -156,7 +197,7 @@ theorem denseBoxTautoDropF_covered (pw : PrimeWitness p) (reg : VarRegistry) (bs
     (denseBoxTautoDropF pw bs d).CoveredBy reg := by
   unfold denseBoxTautoDropF
   split_ifs with hp
-  · exact DenseConstraintSystem.boxTautoReplaceWith_covered _ _ hcov
+  · exact DenseConstraintSystem.boxTautoReplaceWith_covered _ hcov
   · exact hcov
 
 /-- The part-B transform is `DensePassCorrect`. -/
@@ -167,6 +208,8 @@ theorem denseBoxTautoDropF_correct (pw : PrimeWitness p) (reg : VarRegistry) (bs
   split_ifs with hp
   · haveI : Fact p.Prime := ⟨pw.correct hp⟩
     exact DenseConstraintSystem.boxTautoReplace_denseCorrect d bs reg.isInput _
+      (denseVarBucket_mem DenseExpr.vars (denseSingleVarCs d.algebraicConstraints)) _
+      (fun v dm h => denseBtDomCache_sound _ _ v dm h)
   · exact DensePassCorrect.refl reg.isInput d bs
 
 /-- The dense box-tautology drop pass (part B of the flagFold composite). -/

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -194,9 +194,14 @@ these need no new proof.
      `denseFindDomainAlg` is served from a `denseVarBucket` over the single-variable constraints
      (uncapped, order-preserving → identical first match), threaded as a *value* — a lookup closure
      in the thunk payload re-ran the whole index build per query (13× regression, see the entry).
-     busPairCancel 90 → 50 s. `flagUnify`, `flagFoldDrops`, `boxRewrite`, `fxSubst` and
-     `rootPairUnify` still call `denseFindDomainAlg` on whole lists; same fix applies if they show
-     up in a profile (flagFold 15 s and rootPairUnify 13 s are the candidates).
+     busPairCancel 90 → 50 s. ~~`flagFoldDrops`~~ **done (entry 157)**: its box-tautology
+     certificate re-derived the domains from the unbucketed single-variable list per candidate —
+     9.2 s of a 13.7 s pass on sha256 `apc_001` — while the bucket built in the same function served
+     only the prefilter in front of it. `flagUnify`, `boxRewrite`, `fxSubst` and `rootPairUnify`
+     still call `denseFindDomainAlg` on whole lists; same fix applies if they show up in a profile
+     (rootPairUnify 9 s is the candidate, and `boxRewrite`'s `denseBrRw`/`denseBrCert` call it up to
+     three times per variable — 0.7 s on sha256, but 32 % of openvm-eth `apc_067`'s flagFold in one
+     cycle).
    - `busPairCancel`: ~~`liveArr` materialization per candidate~~ **done (#210)** — see R8.
      The O(B²) *certificate* scans remain (R8 design (b)); in coda mode the `addrHash`
      bucket is O(B) per hot address — add a position cursor. ~~`dropWits` from-0 array scan per
@@ -545,6 +550,21 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
+- **Indexing `densePdKeep`'s re-verification** (flagFold part C): `findIdx?` deep-equality scans and
+  `List.take` prefixes replaced by a `densePdValHash` position index over an array — **0.98x on
+  flagFold, sub-bar** (entry 157). The cost it targets is real (866 ms on sha256 `apc_001`, 574 of it
+  in cycle 8 across 268 proposed value buckets, and `nverd = 0` everywhere, so it is all
+  false-positive rejection) but only ~a third is recoverable this way. Worth ~11.5 % of the
+  *post*-entry-157 pass when bundled with the prologue item below; not on its own.
+- **flagFold's `boxTautoDrop` prologue, standalone**: an allocation-free capped distinct-variable
+  walk replacing `hashedEraseDups`'s per-constraint `Std.HashMap`, a nested fold replacing the
+  710 146-element `flatMap DenseExpr.vars`, and a cache seeded only from queryable constraints —
+  **0.93x, sub-bar** (entry 157). ~1.1 s together, each piece 0.2-0.35 s.
+- **Dropping flagFold's domain memo** in favour of per-query bucket lookups: **regression**, 4 970 vs
+  4 747 ms (entry 157). It would delete the one non-trivial proof obligation of that entry, but
+  `denseFindDomainAlg` then re-runs per (constraint, variable) and `denseRootsIn` reallocates each
+  domain list. An index is not a substitute for a memo when the query *count* is the problem.
+
 - **Retiring domainBatch's task fan-out** (`parallel := false`): 0.96× sha256 / 0.91× keccak against
   the pre-entry-155 baseline, but **+700 ms on top of entry 155** (measured twice) and a wash on
   keccak. The fan-out loses only on cycle 0 — whose work entry 155 deleted — and wins on the
@@ -652,10 +672,19 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
   measured (entry 152)**: gathers are 4.6 % of the pass at sha scale and target dedup 0.4 %; the
   per-target cost that follows them is the survivor *compile* (56 %), not the gather or the scan.
   See R13.
-- **flagFold cycle 0 (24 s, zero effect)**: NOT the domain lookups (bucketing them changed
-  nothing). Suspect `denseFuCandidates`' per-interaction `O.vars.eraseDups × splitAt` on large
-  first-slot payloads, or the per-matched-pair box evaluation in `denseFuPairData?`. Sample the
-  window before building anything.
+- ~~**flagFold cycle 0 (24 s, zero effect)**: NOT the domain lookups (bucketing them changed
+  nothing). Suspect `denseFuCandidates`' per-interaction `O.vars.eraseDups × splitAt`~~ — **both
+  halves wrong, measured (entry 157)**. It *was* the domain lookups: `denseBtPre` and `denseBtCert`
+  are the same predicate over different domain sources, and the earlier session bucketed the
+  prefilter while the certificate kept scanning all 23 489 single-variable constraints per queried
+  variable. Fixed, 0.349x on the pass. And `denseFuCandidates` is **166 ms of the whole sha256 run**
+  (50 ms in cycle 0): the per-variable `splitAt` really does allocate a full copy of the slot-0
+  payload just to test `R.vars.isEmpty`, and a coefficient-plus-`hasVar` twin would avoid it, but
+  `fxSubst`'s entire real cost is ~0.85 s and `denseFuPairData?` never fires on this APC
+  (`solved = 0` on every invocation). Sub-bar; do not build it without a case where `fxSubst`
+  dominates.
+  **The lesson worth keeping: when two functions compute the same predicate, an index wired into
+  one of them buys nothing.** Check which one the hot path calls.
 
 ### domainBatch residual after entry 151 (byte-operand domains)  ·  *runtime, sp1*  ·  medium value
 Entry 151 BISECTED domainBatch (the ideas' "58% is the domain-table build/cache" guess was WRONG — the

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5500,3 +5500,65 @@ in the plan buys the least. **(b) `zmodIsNegOne`** (`c.val == p - 1`, sound for 
 Its only site was `Affine.trySolve`, which needs the ring for `⁻¹` and `scale` regardless, so
 converting one test would not empty its entry.
 **Worked: yes (0.68–0.90x per corpus, output byte-identical; draft PR).**
+
+### 157. Runtime: flagFold's box-tautology certificate reads the domain memo (0.35x on the pass, sha256)
+TARGETED the corpus's — and now the run's — **top pass**: on merged main, sha256 `apc_001` spends
+**13 739 ms of 110 403 in `flagFold` (12.4 %)**, ahead of gauss (12.1 s) and reencode (7.4 s).
+It reached the top only because entries 153/155/156 shrank everything around it.
+**TIMED THE PHASES BEFORE PROFILING**, which is the only reason this was found. `flagFold` is a
+composite of four sub-passes (`FlagFold.lean`) and the profiler reports only the composite; a
+throwaway `IO` probe (`ffPhases` in `Main.lean`, hooked where the pass runs, each phase forced with
+`IO.lazyPure`) split its wall as **fxSubst 1120 / boxRewrite 918 / boxTautoDrop 10 578 /
+pointwiseDupDrop 2449 ms** — and inside `boxTautoDrop`: singles 215, `singlesBy` 44, `flatMap vars`
+190, cache 347, `denseBtPre` 332, **`denseBtCert` 9 200**, all but 4 ms of it in cleanup cycle 0.
+MECHANISM. `denseBtPre` and `denseBtCert` computed the **same predicate**; only the domain source
+differed. `denseBtPre` read a per-variable memo; `denseBtCert singles c` called
+`denseFindDomainAlg singles v` per variable, **linearly scanning all 23 489 single-variable
+constraints** with `DenseExpr.mentions` on each — ~2.7e8 tree walks for 9 072 candidates. And
+`npre = ncert = 9 072`: every constraint the prefilter admitted also passed the certificate, so the
+whole 9.2 s re-derived a verdict already reached. The bucketing added in the entry-148 session
+(`singlesBy` + `cache`) was wired into the **prefilter only**, so it never removed the scan it was
+built to remove.
+THIS RETIRES A RECORDED DEAD END. `ideas.md` said *"flagFold cycle 0 (24 s, zero effect): NOT the
+domain lookups (bucketing them changed nothing)"*. It is the domain lookups; the earlier measurement
+bucketed the wrong one of two structurally identical tests. Re-measured with a named mechanism, as
+the re-proposal rule requires.
+THE FIX deletes `denseBtCert`/`denseBtCertImpl`/`denseBtKeep` and promotes the memo-reading test to
+*be* the certificate (renamed `denseBtPre` → `denseBtCert`, which is what it now is — nothing sits
+behind it). `denseBoxTautoDropF` builds `domIdx := denseVarBucket DenseExpr.vars (denseSingleVarCs …)`
+— the same helper part C already uses, so `denseVarBucket_mem` applies unchanged — and
+`denseBtDomCache` memoizes `denseFindDomainAlg (bucket v) v` per variable, first occurrence winning.
+Each variable's domain is derived once per invocation from a 1-3 item bucket instead of once per
+candidate constraint from the whole list. Net **−22 lines of runtime**.
+PROOF (all under `Implementation/`, no pass correctness theorem changes shape). `domOf` is untrusted:
+`boxTautoReplace_denseCorrect` takes two new hypotheses — `hidx` (the bucket lies inside
+`denseSingleVarCs`, from `denseVarBucket_mem`) and `hdomOf` (every reported domain is that bucket's
+`denseFindDomainAlg` verdict, from the new `denseBtDomCache_sound`) — and feeds
+`denseFindDomainAlg_sound` the bucket rather than the whole list. That is entry 143's shape, not a
+"bucketed = unbucketed" equality: soundness only needs *every constraint in the list handed to
+`denseFindDomainAlg`* to vanish, which holds for any sublist of the system. `denseBtDomCacheGo_sound`
+is the one genuinely new argument — a `foldl` invariant ("every key the accumulator reports maps to
+its bucket's verdict") over `Std.HashMap.getElem?_insert`. **+53 lines of proof, −34 deleted.**
+NUMBERS (this 20-core box, serial, interleaved; flagFold ms, then case total): sha256 `apc_001`
+**13 739 → 4 795 (0.349x)**, total 110 403 → 102 502 (**0.928x**); keccak `apc_001` 563 → 480
+(0.85x), total 8 857 → 8 628; openvm-eth `apc_067` 173 → 169 (0.98x); wasm-eth `apc_012` 471 → 478
+(1.01x). No other pass column moves outside noise. The win is concentrated where the
+single-variable list is long — keccak's is 812 candidates against sha's 9 072.
+VERIFIED: `opt-export` **byte-identical** on sha256 `apc_001` (5.76 MB), OpenVM keccak, openvm-eth
+`apc_006` / `apc_100`, wasm-eth `apc_005` / `apc_012`; `lake build` clean, no warnings;
+`check-proof-integrity` passes (propext / Classical.choice / Quot.sound, no unused theorems).
+THREE ALSO-RANS, all measured (unproven implementations, interleaved) and all rejected.
+**(a) Indexing `densePdKeep`'s re-verification** (`findIdx?` deep-equality scans + `List.take`
+prefixes replaced by a `densePdValHash` position index over an array): 14 057 vs 14 365 ms,
+**0.98x — sub-bar**. The 866 ms the probe measured there is real (574 ms in cycle 8 alone, 268
+proposed value buckets) and `nverd = 0` on every invocation, so it is all spent rejecting false
+positives — but indexing recovers only a third of it. **(b) The `boxTautoDrop` prologue bundle**
+(allocation-free capped distinct-variable walk replacing `hashedEraseDups`'s per-constraint
+`Std.HashMap`, nested fold replacing the 710 146-element `flatMap DenseExpr.vars`, cache seeded only
+from queryable constraints): 13 418 ms, **0.93x — sub-bar**. Stacked on this entry (a)+(b) are worth
+545 ms of a 4 747 ms pass (11.5 % of the *post*-entry pass), so they only pay as a bundle after the
+denominator shrank. **(c) Dropping the memo entirely** — attractive because it deletes
+`denseBtDomCacheGo_sound`, the one non-trivial obligation here — is a **regression**: 4 970 vs
+4 747 ms, because `denseFindDomainAlg` then re-runs per (constraint, variable) and `denseRootsIn`
+reallocates each domain list. Keep the memo and prove the invariant.
+**Worked: yes (flagFold 0.349x on its worst case, 0.928x end-to-end, output byte-identical; PR).**


### PR DESCRIPTION
`flagFold` is currently the **top pass of the whole run** on sha256 `apc_001` — **13 739 ms of
110 403** (12.4 %), ahead of gauss and reencode. It reached the top only because entries
153/155/156 shrank everything around it.

## Where the time was

`flagFold` is a composite of four sub-passes and the profiler reports only the composite, so a
throwaway `IO` probe timed them on the system the pass actually receives:

| sub-pass | ms | share |
|---|---:|---:|
| `fxSubst` | 1 120 | 7 % |
| `boxRewrite` | 918 | 6 % |
| **`boxTautoDrop`** | **10 578** | **70 %** |
| `pointwiseDupDrop` | 2 449 | 16 % |

and inside `boxTautoDrop`, **`denseBtCert` was 9 200 ms** — 66 % of the whole pass — all but 4 ms of
it in cleanup cycle 0.

## Mechanism

`denseBtPre` and `denseBtCert` computed the **same predicate**; only the domain source differed.
`denseBtPre` read a per-variable memo; `denseBtCert singles c` called `denseFindDomainAlg singles v`
per variable, **linearly scanning all 23 489 single-variable constraints** with `DenseExpr.mentions`
on each — ~2.7 × 10⁸ tree walks for 9 072 candidates. And `npre = ncert = 9 072`: every constraint
the prefilter admitted also passed the certificate, so the entire 9.2 s re-derived a verdict already
reached.

The bucket built in that very function (`singlesBy` + `cache`) was wired into the **prefilter only**,
so it never removed the scan it was built to remove. This is why `ideas.md` recorded *"flagFold: NOT
the domain lookups (bucketing them changed nothing)"* as a dead end — that entry is retired here with
a named mechanism, as the re-proposal rule requires.

## The change

Delete `denseBtCert`/`denseBtCertImpl`/`denseBtKeep` and promote the memo-reading test to *be* the
certificate (`denseBtPre` renamed `denseBtCert` — nothing sits behind it now). `denseBoxTautoDropF`
builds `domIdx` with `denseVarBucket` (the same helper part C already uses, so `denseVarBucket_mem`
applies unchanged) and `denseBtDomCache` memoizes `denseFindDomainAlg (bucket v) v` per variable,
first occurrence winning. Each variable's domain is derived once per invocation from a 1–3 item
bucket instead of once per candidate constraint from the whole list. **Net −22 lines of runtime.**

## Proof

`domOf` stays untrusted. `boxTautoReplace_denseCorrect` takes two new hypotheses — `hidx` (the bucket
lies inside `denseSingleVarCs`, from `denseVarBucket_mem`) and `hdomOf` (every reported domain is
that bucket's `denseFindDomainAlg` verdict, from the new `denseBtDomCache_sound`) — and feeds
`denseFindDomainAlg_sound` the bucket rather than the whole list. That is entry 143's shape, **not** a
"bucketed = unbucketed" equality: soundness only needs every constraint in the list handed to
`denseFindDomainAlg` to vanish, which holds for any sublist of the system.

`denseBtDomCacheGo_sound` is the one genuinely new argument — a `foldl` invariant ("every key the
accumulator reports maps to its bucket's verdict") over `Std.HashMap.getElem?_insert`.
**+53 lines of proof, −34 deleted; no pass correctness theorem changes shape.**

## Numbers

Interleaved, serial, 20-core box (flagFold ms, then case total):

| case | flagFold | × pass | total | × total |
|---|---:|---:|---:|---:|
| **sha256 `apc_001`** | **13 739 → 4 795** | **0.349** | 110 403 → 102 502 | **0.928** |
| keccak `apc_001` | 563 → 480 | 0.85 | 8 857 → 8 628 | 0.97 |
| openvm-eth `apc_067` | 173 → 169 | 0.98 | 1 307 → 1 285 | 0.98 |
| wasm-eth `apc_012` | 471 → 478 | 1.01 | 12 235 → 12 240 | 1.00 |

No other pass column moves outside noise. The win scales with the length of the single-variable list
— keccak's is 812 candidates against sha256's 9 072.

## Verification

- `opt-export` **byte-identical to main** on sha256 `apc_001` (5.76 MB), OpenVM keccak, openvm-eth
  `apc_006`/`apc_100`, wasm-eth `apc_005`/`apc_012`. Pure runtime change; **effectiveness cannot move.**
- `lake build` clean, no warnings.
- `check-proof-integrity.sh` passes: axioms `propext` / `Classical.choice` / `Quot.sound`, no
  `sorry`/`admit`/`native_decide`, no unused theorems.

## Three also-rans, all measured, all rejected

Each was implemented unproven and timed before any proof work:

1. **Indexing `densePdKeep`'s re-verification** — **0.98× on the pass, sub-bar.** The cost is real
   (866 ms, 574 of it in cycle 8; `nverd = 0` everywhere, so it is all false-positive rejection) but
   only ~a third is recoverable that way.
2. **The `boxTautoDrop` prologue bundle** (allocation-free distinct-variable walk, no
   `flatMap DenseExpr.vars` materialization, narrower cache seed) — **0.93×, sub-bar.**
   Stacked on this PR, (1)+(2) are worth 545 ms of a 4 747 ms pass — 11.5 % of the *post*-PR pass —
   so they only pay as a bundle once this has shrunk the denominator. Happy to follow up.
3. **Dropping the memo entirely** — a **regression** (4 970 vs 4 747 ms), even though it would delete
   the one non-trivial obligation in this PR: `denseFindDomainAlg` then re-runs per
   (constraint, variable) and `denseRootsIn` reallocates each domain list.

Details and tables in log entry 157; `ideas.md` updated (R1 flagFoldDrops closed, dead end retired,
the three also-rans recorded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
