### PR TITLE
perf(gauss): VarId-indexed arrays for the scheduler's per-variable indexes (0.86x on the pass, sha256)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -24,6 +24,16 @@ def DenseExpr.isVar : DenseExpr p → Bool
   | .var _ => true
   | _ => false
 
+/-- Grow `a` so `i` is in range, filling with `d`; doubling, so repeated growth stays amortized.
+
+The per-variable indexes below are `VarId.index`-keyed arrays rather than `Std.HashMap VarId _`
+because `Array.modify` hands the element to its update function uniquely: a nested
+`m.insert x ((m[x]?).getD ∅ |>.insert e)` instead copies the inner set on every update, the map
+still holding a reference to it. -/
+def denseArrEnsure {α : Type} (a : Array α) (i : Nat) (d : α) : Array α :=
+  if i < a.size then a
+  else a ++ Array.replicate (max (i + 1) (2 * a.size) - a.size) d
+
 /-- The occurrence-weighted duplication cost of pivoting on `v`, with a protection penalty. -/
 def denseGaussScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId)
     (oc : Nat) : Nat :=
@@ -498,11 +508,11 @@ def denseReducedSubst (r : DenseGaussReduced p) (x : VarId)
 
 structure DenseSparseSolved (p : ℕ) where
   map : Std.HashMap VarId (DenseLinExpr p)
-  revDeps : Std.HashMap VarId (Std.HashSet VarId)
+  revDeps : Array (Std.HashSet VarId)
 
 namespace DenseSparseSolved
 
-def empty : DenseSparseSolved p := { map := ∅, revDeps := ∅ }
+def empty : DenseSparseSolved p := { map := ∅, revDeps := #[] }
 
 def fn (dσ : DenseSparseSolved p) : VarId → Option (DenseLinExpr p) := fun i => dσ.map[i]?
 
@@ -513,7 +523,8 @@ def insertAll (dσ : DenseSparseSolved p) :
       DenseSparseSolved.insertAll
         { map := dσ.map.insert x t
           revDeps := t.terms.foldl
-            (fun rd zc => rd.insert zc.1 (((rd[zc.1]?).getD ∅).insert x)) dσ.revDeps }
+            (fun rd zc => (denseArrEnsure rd zc.1.index ∅).modify zc.1.index (·.insert x))
+            dσ.revDeps }
         rest
 
 def materialize (dσ : DenseSparseSolved p) : DenseSolved p :=
@@ -574,7 +585,7 @@ def denseSparseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId
       match denseReducedBest c' occ prot with
       | none => denseSparseGaussLoop occ prot rest dσ
       | some (x, t) =>
-          let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+          let touched := (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
             (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
           let pairs := touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
           denseSparseGaussLoop occ prot rest (dσ.insertAll pairs)
@@ -623,9 +634,9 @@ abbrev DenseMarkowitzHeap :=
 
 structure DenseMarkowitzState (p : ℕ) where
   rows : Array (DenseMarkowitzRow p)
-  degrees : Std.HashMap VarId Nat
-  rowDeps : Std.HashMap VarId (Std.HashSet Nat)
-  pivotRows : Std.HashMap VarId (Std.HashSet Nat)
+  degrees : Array Nat
+  rowDeps : Array (Std.HashSet Nat)
+  pivotRows : Array (Std.HashSet Nat)
   heap : DenseMarkowitzHeap
 
 def denseMarkowitzPivots (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
@@ -702,39 +713,35 @@ def denseMarkowitzRefreshRow (r : DenseMarkowitzRow p) (x : VarId) (t : DenseLin
     generation := r.generation + 1
     active := true }
 
-def denseMarkowitzDegreeAdd (m : Std.HashMap VarId Nat) (xs : List VarId) :
-    Std.HashMap VarId Nat :=
-  xs.foldl (fun m x => m.insert x (m.getD x 0 + 1)) m
+def denseMarkowitzDegreeAdd (m : Array Nat) (xs : List VarId) : Array Nat :=
+  xs.foldl (fun m x => (denseArrEnsure m x.index 0).modify x.index (· + 1)) m
 
-def denseMarkowitzDegreeSub (m : Std.HashMap VarId Nat) (xs : List VarId) :
-    Std.HashMap VarId Nat :=
-  xs.foldl (fun m x => m.insert x (m.getD x 0 - 1)) m
+def denseMarkowitzDegreeSub (m : Array Nat) (xs : List VarId) : Array Nat :=
+  xs.foldl (fun m x => (denseArrEnsure m x.index 0).modify x.index (· - 1)) m
 
-def denseMarkowitzIndexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).insert rowId)) idx
+def denseMarkowitzIndexRow (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
+  xs.foldl (fun idx x => (denseArrEnsure idx x.index ∅).modify x.index (·.insert rowId)) idx
 
-def denseMarkowitzUnindexRow (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Std.HashMap VarId (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => idx.insert x (((idx[x]?).getD ∅).erase rowId)) idx
+def denseMarkowitzUnindexRow (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
+  xs.foldl (fun idx x => (denseArrEnsure idx x.index ∅).modify x.index (·.erase rowId)) idx
 
-def denseMarkowitzIndexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
-    Std.HashMap VarId (Std.HashSet Nat) :=
+def denseMarkowitzIndexPivots (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (pivots : List DenseMarkowitzPivot) : Array (Std.HashSet Nat) :=
   pivots.foldl
-    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).insert rowId)) idx
+    (fun idx q => (denseArrEnsure idx q.var.index ∅).modify q.var.index (·.insert rowId)) idx
 
-def denseMarkowitzUnindexPivots (idx : Std.HashMap VarId (Std.HashSet Nat))
-    (rowId : Nat) (pivots : List DenseMarkowitzPivot) :
-    Std.HashMap VarId (Std.HashSet Nat) :=
+def denseMarkowitzUnindexPivots (idx : Array (Std.HashSet Nat))
+    (rowId : Nat) (pivots : List DenseMarkowitzPivot) : Array (Std.HashSet Nat) :=
   pivots.foldl
-    (fun idx q => idx.insert q.var (((idx[q.var]?).getD ∅).erase rowId)) idx
+    (fun idx q => (denseArrEnsure idx q.var.index ∅).modify q.var.index (·.erase rowId)) idx
 
 def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
     (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
     (r : DenseMarkowitzRow p) (q : DenseMarkowitzPivot) : DenseMarkowitzEntry :=
-  let solvedDegree := ((dσ.revDeps[q.var]?).getD ∅).size
-  let activeDegree := st.degrees.getD q.var 1
+  let solvedDegree := (dσ.revDeps.getD q.var.index ∅).size
+  let activeDegree := st.degrees.getD q.var.index 1
   { isProtected := if prot.contains q.var then 1 else 0
     fill := q.rhsNnz * (activeDegree - 1)
     rewrite := q.rhsNnz * solvedDegree
@@ -768,20 +775,22 @@ def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarI
 
 def denseMarkowitzBuild (constraints : List (DenseExpr p))
     (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzState p :=
+  let rows := constraints.foldl (fun rs c => rs.push (denseMarkowitzRow rs.size c occ prot))
+    (#[] : Array (DenseMarkowitzRow p))
+  -- The per-variable indexes are `VarId.index`-keyed arrays, sized once: substitution only ever
+  -- copies variables between rows, so no index can exceed the system's maximum.
+  let n := rows.foldl (fun m r => r.vars.foldl (fun m x => max m (x.index + 1)) m) 0
   let base : DenseMarkowitzState p :=
-    { rows := #[]
-      degrees := ∅
-      rowDeps := ∅
-      pivotRows := ∅
+    { rows
+      degrees := Array.replicate n 0
+      rowDeps := Array.replicate n ∅
+      pivotRows := Array.replicate n ∅
       heap := ∅ }
-  let indexed := constraints.foldl (fun st c =>
-    let rowId := st.rows.size
-    let r := denseMarkowitzRow rowId c occ prot
+  let indexed := rows.foldl (fun st r =>
     { st with
-      rows := st.rows.push r
       degrees := denseMarkowitzDegreeAdd st.degrees r.vars
-      rowDeps := denseMarkowitzIndexRow st.rowDeps rowId r.vars
-      pivotRows := denseMarkowitzIndexPivots st.pivotRows rowId r.pivots }) base
+      rowDeps := denseMarkowitzIndexRow st.rowDeps r.rowId r.vars
+      pivotRows := denseMarkowitzIndexPivots st.pivotRows r.rowId r.pivots }) base
   indexed.rows.foldl (fun st r =>
     match denseMarkowitzBestEntry? occ prot DenseSparseSolved.empty st r.rowId r with
     | none => st
@@ -806,10 +815,10 @@ def denseMarkowitzPopValid : Nat → DenseMarkowitzState p →
           if denseMarkowitzEntryValid st entry then some (entry, st)
           else denseMarkowitzPopValid fuel st
 
-def denseMarkowitzCollectIds (idx : Std.HashMap VarId (Std.HashSet Nat))
+def denseMarkowitzCollectIds (idx : Array (Std.HashSet Nat))
     (xs : Std.HashSet VarId) : Std.HashSet Nat :=
   xs.toList.foldl (fun out x =>
-    ((idx[x]?).getD ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
+    (idx.getD x.index ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
 
 def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
     (dσ : DenseSparseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
@@ -820,7 +829,7 @@ def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
 def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
     (x : VarId) (t : DenseLinExpr p) (st : DenseMarkowitzState p) :
     DenseMarkowitzState p × Std.HashSet VarId :=
-  let rowIds := ((st.rowDeps[x]?).getD ∅).toList
+  let rowIds := (st.rowDeps.getD x.index ∅).toList
   rowIds.foldl (fun (st, changed) rowId =>
     match st.rows[rowId]? with
     | none => (st, changed)
@@ -855,7 +864,7 @@ def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
 
 def denseMarkowitzAdoptPairs (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p) :
     List (VarId × DenseLinExpr p) :=
-  let touched := ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+  let touched := (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
     (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
   touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -602,7 +602,7 @@ theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSys
             intro z hz
             exact hcclosed z (denseReducedBest_terms c' occ prot x t hpick z hz)
           have htouched : ∀ y s, (y, s) ∈
-                ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+                (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
                   (dσ.map[y]?).bind
                     (fun s => if s.mentions x then some (y, s) else none)) →
               dσ.fn y = some s := by
@@ -694,7 +694,7 @@ theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstrain
                     exact hcclosed z
                       (denseMarkowitzPick_terms c' entry.pivot x t occ prot hpick z hz)
                   have htouched : ∀ y s, (y, s) ∈
-                        ((dσ.revDeps[x]?).getD ∅).toList.filterMap (fun y =>
+                        (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
                           (dσ.map[y]?).bind
                             (fun s => if s.mentions x then some (y, s) else none)) →
                       dσ.fn y = some s := by

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -376,6 +376,13 @@ index gate**  ·  mostly **done (entries 105/107/109/145)**:
      under the current substitution before adoption. Entry 134 keeps the exact source-order path
      below 8192 rows: the scheduler's fixed cost is not justified there, and changing the affine
      basis in nonlinear-connected components can worsen later syntactic cleanup.
+   - ~~gauss's per-variable scheduler indexes~~ **done (entry 158)**: `rowDeps`, `pivotRows`,
+     `degrees` and `DenseSparseSolved.revDeps` are `VarId.index`-keyed arrays updated with
+     `Array.modify`. **0.86x on the pass** (CI serial bench, sha256: 13.1 → 11.3 s; this container
+     reads 0.70x repeatably, 4/4 pairs — see the entry), byte-identical, zero proof work. It is a
+     **Markowitz-path win**: the openvm-eth corpus, whose gauss invocations are all source-order, is
+     a wash (100 cases, 1.000x total, 0.984x gauss, no case worse than 1.047x). See R12 and the
+     gauss residual below.
    - **Still open — component-aware Gauss scheduling**: source-order and Markowitz eliminate the
      same number of pivots on the affected SP1 shapes, but choose different bases where affine rows
      share variables with nonlinear constraints. Preserve source order only in those connected
@@ -480,12 +487,25 @@ rewrite the evaluator arms the same way (`Bool.decide_and` bridges proofs). Audi
 `decide (… ∧ …)` in per-point code (`denseScaledSlotBound`'s guard is a cheaper instance of the
 same pattern).
 
-**R12. Array-index the dense per-variable maps**  ·  *speculative, measure first*. Every
-`Std.HashMap`/`HashSet` operation dispatches `BEq`/`Hashable` through boxed closures
-(`lean_apply_1/2`, ~8 % whole-run). `VarId.index` is dense and bounded by the registry size, so
-the per-variable bucket maps (`DenseCovIndex.buckets`, `denseVarBucket`, `denseTouchedSet`) could
-be `Array (List Nat)` / bitsets keyed directly — no hashing, no dispatch. Wide but mechanical;
-worth a prototype on one index first.
+**R12. Array-index the dense per-variable maps**  ·  **no longer speculative — first instance landed
+(entry 158, gauss 0.86x, byte-identical, zero proof)**. Every `Std.HashMap`/`HashSet` operation
+dispatches `BEq`/`Hashable` through boxed closures (`lean_apply_1/2`, ~8 % whole-run), and a
+*nested* index (`m.insert x ((m[x]?).getD ∅ |>.insert e)`) additionally **copies the inner set on
+every update**, because the map still references the set that was just read out of it. `VarId.index`
+is dense and bounded by the registry, so such an index becomes an `Array` keyed by `.index`, updated
+with `Array.modify`, which hands the element over uniquely and mutates in place.
+   Entry 158 did gauss's four (`rowDeps`, `pivotRows`, `degrees`, `DenseSparseSolved.revDeps`): the
+   two mechanisms together were **28 % of that pass**, `hash/std` fell 15.7 → 10.3 % of it and
+   `lean_copy_expand_array` 5.7 → 0.5 %. Two lessons carry:
+   - **Pre-size or double.** Growing an index one variable at a time with `a ++ replicate k d` is
+     quadratic; size it once from a known bound (gauss takes `1 + max index` over the rows it just
+     built) or grow by doubling.
+   - **Check whether the index is planning data first.** Gauss's scheduler appears in no correctness
+     theorem, so the conversion needed *no* proof; only `revDeps`, which the entailment argument
+     mentions, cost two restated hypotheses.
+   Still open, same shape: `DenseCovIndex.buckets`, `denseVarBucket`, `denseTouchedSet`, and
+   `DenseSolved.revDeps` (domainBatch / flagUnify / fxSubst / rootPairUnify). Also `occ`
+   (`Std.HashMap VarId Nat`, threaded through four `csimp`'d descriptor twins — more edits, ~0.4 s).
 
 **R13. domainBatch is per-target *setup*-bound, not enumeration-bound** (measured 2026-07-28, LBR
 profiles over five OpenVM cases + SP1 keccak; entry 152). **The table below is CPU; for the wall,
@@ -548,6 +568,55 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      Preflight's `T.doms xs` is 6.8 % on sha256, all `Std.HashMap VarId` probes: the R12 array-indexed
      prototype belongs here first.
 
+### gauss residual after entry 158 (arrays for the scheduler indexes)  ·  *runtime, sha256*
+
+Measured on sha256 `apc_001` (gauss 11.3 s of 102.0 s on CI, 8 676 ms of 99 256 on this container —
+still the top pass either way), LBR shares of the post-entry-158 pass; the **shares** transfer
+between boxes, the ms estimates below are this container's. Ranked by size ÷ effort; **the whole Markowitz scheduler is planning data that
+appears in no correctness theorem, so 1–4 need no proof at all** — only value equality if the change
+is to stay byte-identical.
+
+1. **One walk in `DenseGaussReduced.fromExpr`** (16.9 % + 3.8 % = the whole of `denseMarkowitzBuild`,
+   ~1.8 s). It calls `denseLinearize e`; on failure `e.normalize` — a full tree rebuild — and
+   `denseLinearize` again, per constraint per invocation (11 of them). The retry can only succeed
+   where a *merged* linear form cancels to a constant (`denseLinearize`'s `mul` branch tests
+   `la.terms.isEmpty` on the **unmerged** list, so `(x - x) * y` fails before normalization and
+   linearizes after). `denseNormalizeResWith` (`Normalize.lean:665`) already carries each node's
+   linear form; a variant whose `mul` branch tests `la.norm.terms.isEmpty` answers both questions in
+   one walk. **Not obviously byte-identical** (term order after merging may differ) — count both
+   verdicts side by side over cycles 0–1 first. ~0.8–1.2 s.
+2. **`denseMarkowitzPivots` without its per-row `HashMap`** (6.3 %). It builds `denseCoeffIdx l.terms`
+   plus a `seen` set, but **every affine row in gauss is `norm`-alized** (`fromExpr`, `denseLinSubstF`,
+   `denseLinAdd`, `denseLinScale` and the fused walk all end in `.norm`), so each variable occurs once
+   with a nonzero coefficient: `coeff = t.2`, `count = 1`, `rhsNnz = terms.length - 1`, the `±1` and
+   unit descriptor lists are disjoint and the dedup is a no-op. One pass, no hash structure, gated on
+   `terms.length ≤ 32` with the current code above the gate (as `denseMergeTermsWith` does).
+   Byte-identical by construction, ~25 lines. ~0.3–0.5 s.
+3. **Delta index/degree updates in `denseMarkowitzRefreshRows`** (index 6.6 % + `refreshRow` 6.7 %).
+   It unindexes every variable of the old row and re-indexes every variable of the new one, when the
+   delta is "drop the pivot, add what the substituted row brought in" — ~1.4 M redundant index
+   operations per big invocation. Byte-identical (`degrees` is exact, so sub-then-add on a shared
+   variable is a no-op and `Nat` truncation cannot bite). ~0.3–0.6 s.
+4. **The rekey fan-out**: 257 515 re-keys for 52 194 adoptions in cycle 1, because `changed` includes
+   every variable of every rewritten stored solution (307 948 of them) although those only move the
+   *third* lexicographic key (`rewrite`). Dropping them would cut re-keys ~5× and with them the entry
+   allocations behind the `pop` phase (10.4 %, of which Batteries' heap code is only 2.1 % — the rest
+   is refcounting and allocating entry records). **Not byte-identical** → CI matrix. ~0.8 s.
+5. **Defer the back-substitution into stored solutions** (`denseLinSubst` 6.2 % + `insertAll` 1.1 % +
+   `adoptPairs`, and the fan-out grows with circuit size — the only idea here that changes gauss's
+   *exponent*). `denseMarkowitzAdoptPairs` eagerly rewrites every stored solution mentioning the new
+   pivot; a triangular store resolved once at `materialize` is `O(total)` instead of
+   `O(chain × total)`. Blocked on the loop needing a **fully resolved** σ for
+   `denseSparseSubstF dσ.fn c` (a triangular one would let pivots be chosen for already-solved
+   variables and leave them in the output), so it needs an on-demand memoized resolver — whose term
+   order differs from step-by-step rewriting, i.e. output changes and `insertAll_preserves`' argument
+   must be redone. Largest and riskiest; open it last.
+
+**Measured sub-bar / do not re-propose** (also in the dead-end list below): reusing
+`st.rows[rowId].reduced` instead of re-substituting the source constraint on selection is 2.2 % of the
+pass (~0.27 s) and would dissolve the pass's untrusted-metadata story; the `ZMod` angle is 1.3 % (both
+`Gauss.c` sweep hits are dead `csimp` originals); a different heap is worth 2.1 %.
+
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
 - **Indexing `densePdKeep`'s re-verification** (flagFold part C): `findIdx?` deep-equality scans and
@@ -576,6 +645,17 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
   inside the 3 446-item variable-free tail; with the tail an O(1) seed there is nothing left to
   abort. Subsumed, not complementary.
 
+- **Adopting the Markowitz row's maintained `reduced` form instead of re-substituting the source
+  constraint** (gauss): the from-source `denseSparseSubstF dσ.fn c` on selection measures **134 ms
+  per big invocation, ~0.27 s over the sha256 run (2.2 % of the pass, entry 158)** — sub-bar, and it
+  is what makes every heap decision untrusted (the pass's soundness story is "re-solve from the
+  source under the current substitution before adopting"). Reusing the maintained row would move the
+  entailment obligation onto a per-row scheduler invariant for 2 % of the pass.
+- **Bundling gauss's array conversion with algorithm changes** (PR #193, 2026-07-23): exact live
+  reverse dependencies + streaming pivot selection + specialized final substitution + no solution
+  materialization, all at once, measured a **regression** (3 954 vs 3 287 ms on wasm-eth `apc_037`)
+  and never landed. The representation-only slice of the same idea is 0.86x (entry 158). Land the
+  piece you can measure alone.
 - **Whole-system content-hash gating of passes across cycles**: catches ~0 % — the fixpoint only
   retains cycles that changed something, so some pass always dirties the hash (#146 measurement).
   Only fine-grained dirtiness (R6) reaches the ~61 % no-op invocations.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5562,3 +5562,88 @@ denominator shrank. **(c) Dropping the memo entirely** — attractive because it
 4 747 ms, because `denseFindDomainAlg` then re-runs per (constraint, variable) and `denseRootsIn`
 reallocates each domain list. Keep the memo and prove the invariant.
 **Worked: yes (flagFold 0.349x on its worst case, 0.928x end-to-end, output byte-identical; PR).**
+
+
+### 158. Runtime: `VarId.index`-keyed planning indexes in Gauss (0.86x on the pass, sha256)
+TARGETED the run's **top pass**: on merged main (`2979bfa`, i.e. after entry 157 shrank flagFold),
+sha256 `apc_001` spends **12 425 ms of 103 303 in `gauss` (12.0 %)**, ahead of rootPairUnify (9.0 s),
+busUnify (7.9 s) and reencode (7.6 s). Its two expensive invocations are cleanup cycles 0 and 1
+(3 543 + 6 108 ms = 79 % of the pass), both on the Markowitz path (199 740 / 146 363 constraints),
+and they eliminate 96 696 variables between them — so the lever is cost per elimination.
+**TIMED THE PHASES BEFORE PROFILING.** A throwaway `IO` probe (`gsPhases` in `Main.lean`, hooked
+where the pass runs, each phase forced with `IO.lazyPure`) split the pass's wall as
+**occ 417 / prot 65 / markowitzBuild 2 452 / markowitzLoop 6 043 / materialize 106 /
+substF+force 1 552 ms** summed over its 11 invocations, and a second instrumented copy of the loop
+counted, for cycle 1 alone: 52 194 adoptions, 185 635 rows refreshed, **257 515 rows re-keyed**,
+**307 948 stored solutions rewritten**, heap high-water 123 697 entries. The columns account for
+~87 % of the profiler's number; the rest is `guardDegree`'s degree walk plus the profiler's own
+`varCount` force, which are charged to the pass but are not gauss (R5 territory).
+MECHANISM. The LBR profile then put **19.0 % of the pass in per-variable index maintenance**
+(`rowDeps`/`pivotRows`/`degrees`) and **9.2 % in `DenseSparseSolved.insertAll`** (`revDeps`) — 85 % of
+gauss's whole hash traffic in those four indexes, with `AssocList.replace …insert` the single largest
+allocator caller (17.1 %) and `lean_copy_expand_array` at 5.7 % of the pass. Every update read
+`idx[x]?` and inserted the modified value back, so it paid the boxed `Hashable VarId` dispatch twice,
+an `AssocList.replace` on the bucket, **and a full copy of the inner `Std.HashSet`** — the map still
+holds a reference to the set that was just read out of it, so the insert cannot mutate in place.
+THE FIX keys all four by `VarId.index` in `Array`s and updates them with `Array.modify`, which hands
+the element over uniquely (the PR #206 mechanism). The three Markowitz arrays are sized once in
+`denseMarkowitzBuild` — it now builds `rows` first, then `n = 1 + max index`, which is safe because
+substitution only ever copies variables between rows, so no later index can exceed the system's
+maximum; `revDeps` has no natural pre-size at `DenseSparseSolved.empty` and grows by doubling
+(`denseArrEnsure`). Net **+4 lines** of runtime.
+PROOF SURFACE: **none.** Nothing in `Proofs/Gauss.lean` inspects the Markowitz state — the loop
+soundness proof only uses `denseMarkowitzPick_sound` on the row it re-substitutes from the *source*
+constraint, plus `insertAll_preserves` — so the entire scheduler is untrusted planning data. The
+`revDeps` half needed **two hypothesis statements** restated (`((dσ.revDeps[x]?).getD ∅)` →
+`(dσ.revDeps.getD x.index ∅)` in the two `htouched` hypotheses); their proof bodies only use
+`List.mem_filterMap` and are source-agnostic. No pass correctness theorem changes shape.
+WHY IT IS BYTE-IDENTICAL even though iteration order changes: `denseMarkowitzEntryBetter` is a total
+order whose last key (`generation`) is only ever reached between two entries of the *same* row (all
+earlier keys include `rowId`), and `denseMarkowitzRekey` visits each row at most once per adoption
+(`CollectIds` dedups), so generation numbers are order-independent; `degrees` stays exact because
+sub-then-add on a variable present in both the old and the new row is a no-op.
+NUMBERS. **CI serial `Runtime Bench`, sha256, both sides on one runner** (the authoritative A/B):
+gauss **13.1 → 11.3 s (0.86x)**, whole run 105.0 → 102.0 s (**0.97x**). No other pass column moves
+outside noise (worst 1.03x). Effectiveness matrix: **+0.000x on all three axes across all six sets,
+per-case circuit sizes identical** — the byte-identity claim, confirmed independently.
+   This 20-core box, serial and interleaved, reads the same change **twice as large on the pass**,
+and does so repeatably — four independent pairs: gauss 12 281 → 8 596, 12 425 → 8 676,
+12 157 → 8 571, 12 188 → 8 566 ms (**0.700–0.705x**, totals 0.960–0.968x). So the disagreement is not
+local noise: −3.7 s on the pass here against −1.8 s on CI, while the *end-to-end* deltas agree
+(−4.0 vs −3.0 s), and CI's *baseline* gauss (13.1 s) is close to this box's (12.2 s) while its
+*target* is not (11.3 vs 8.6 s). Unexplained; the mechanism is memory traffic (deleted
+inner-`HashSet` copies), which is exactly the kind of win that varies with the memory system, and
+entry 147's rule says believe `Runtime Bench`. **Quote 0.86x, the conservative one.**
+   OPENVM-ETH FULL CORPUS (100 cases, `profile`, interleaved per case, this box): total
+**24.22 → 24.21 s (1.000x)**, gauss 1.71 → 1.69 s (0.984x); of the 20 cases carrying ≥ 20 ms of
+gauss, median 1.000x, best 0.914x (`apc_071`), worst 1.047x, and **no case regresses by more than
+5 %**. Collateral columns are flat (reencode 1.006x, flagFold 1.009x, domainBatch 0.997x, busUnify
+0.995x). That is the expected shape: every gauss invocation on these small systems takes the
+source-order path (n < 8192), where only the `revDeps` half applies — the win is a Markowitz-path
+win, and it does not cost anything where the path is not taken. CI's openvm-eth per-pass table
+agrees (gauss 189 → 187 ms).
+   Other cases (local box, interleaved, gauss ms): keccak `apc_001` 805/855 → 661/688 (0.81x);
+wasm-eth `apc_006` 596/599 → 479/489 (0.81x); wasm-eth `apc_012` 1 096 → 915/919 (0.84x);
+openvm-eth `apc_037` 182/187 → 166/175 (0.94x — all nine of its gauss invocations take the
+source-order path, which only the `revDeps` half touches). CI's openvm-eth per-pass table agrees on
+that control: gauss 189 → 187 ms (0.99x). Split of the win locally: the three Markowitz indexes are
+0.78x, `revDeps` takes it to 0.70x (and is the only half that reaches the source-order path).
+VERIFIED: `opt-export` **byte-identical** on openvm-eth `apc_006` / `apc_100`, keccak `apc_001`,
+wasm-eth `apc_005` / `apc_012`, sha256 `apc_001` (5.76 MB), SP1 keccak `apc_001`, SP1 rsp `apc_001`;
+`lake build` clean, no warnings; `check-proof-integrity` passes (propext / Classical.choice /
+Quot.sound, no unused theorems).
+THIS IS R12's FIRST LANDED INSTANCE and it retires its "speculative, measure first" caveat. It is
+also the narrow slice of open draft **PR #193** ("Use exact array-backed state in Gauss", 2026-07-23),
+which bundled the same representation change with exact live reverse dependencies, streaming pivot
+selection, a specialized final substitution and dropping solution materialization — and measured a
+**regression** (3 954 vs 3 287 ms on wasm-eth `apc_037`). Representation-only, byte-identical, it is
+a 0.86x win: the lesson is the entry-153 one again — land the piece you can measure alone.
+WHERE THE PASS STANDS AFTER THIS (same LBR method, local box, gauss 8 634 ms — shares transfer,
+the ms do not): row substitution 17.8 %,
+`DenseGaussReduced.fromExpr` 16.9 % (all of `denseMarkowitzBuild` — it runs `denseLinearize`, then
+`normalize`, then `denseLinearize` again per constraint per invocation), heap pop 10.4 %, `substF`
+7.9 %, `refreshRow` 6.7 %, index maintenance 6.6 % (was 19.0), `denseMarkowitzPivots` 6.3 %,
+`denseLinSubst` 6.2 %, `occ` 5.4 %, rekey 4.3 %, `insertAll` 1.1 % (was 9.2). `hash/std` 15.7 →
+10.3 %, `lean_copy_expand_array` 5.7 → 0.5 %. The ranked residual is in `ideas.md`.
+**Worked: yes (gauss 0.86x on its worst case and 0.97x end-to-end on the CI serial bench,
+output byte-identical; PR #260).**


### PR DESCRIPTION
## What changed

`gauss`'s four per-variable indexes — `DenseMarkowitzState.rowDeps` / `pivotRows` / `degrees` and
`DenseSparseSolved.revDeps` — were `Std.HashMap VarId _` (three of them holding `Std.HashSet`s),
updated as `idx.insert x (((idx[x]?).getD ∅).insert e)`. They are now `Array`s keyed by
`VarId.index`, updated with `Array.modify`.

Each old update paid, per variable:

- the boxed `Hashable VarId` dispatch **twice** (the read and the write-back),
- an `AssocList.replace` on the bucket, and
- **a full copy of the inner `Std.HashSet`** — `idx[x]?` leaves the set referenced by the map, so
  the following `.insert` cannot mutate in place.

`Array.modify` hands the element to its update function uniquely, so the inner insert is in place
(the PR #206 mechanism). `denseMarkowitzBuild` now builds `rows` first and sizes the three scheduler
arrays once from `1 + max index`: substitution only ever copies variables between rows, so no later
index can exceed the system's maximum. `revDeps` has no such bound at `DenseSparseSolved.empty`, so
it grows by doubling (`denseArrEnsure`).

Net **+4 lines** of runtime code.

## Why here

On merged main, sha256 `apc_001` spends **12 425 ms of 103 303 in `gauss` (12.0 %)** — the run's top
pass after #259. Its two expensive invocations (cleanup cycles 0 and 1, 79 % of the pass) run the
Markowitz path over 199 740 / 146 363 constraints and eliminate 96 696 variables, so the lever is
cost per elimination.

Phases were timed before profiling (a throwaway `IO` probe in `Main.lean`, reverted):
occ 417 / prot 65 / markowitzBuild 2 452 / **markowitzLoop 6 043** / materialize 106 /
substF+force 1 552 ms, summed over the pass's 11 invocations. An instrumented copy of the loop
counted, for cycle 1 alone: 52 194 adoptions, 185 635 rows refreshed, 257 515 rows re-keyed,
307 948 stored solutions rewritten.

The LBR profile then put **19.0 % of the pass in the three scheduler indexes and 9.2 % in
`insertAll`'s `revDeps` fold** — 85 % of gauss's entire hash traffic, with `AssocList.replace …insert`
the single largest allocator caller (17.1 %) and `lean_copy_expand_array` at 5.7 % of the pass.

## Proof surface: none

Nothing in `Proofs/Gauss.lean` inspects the Markowitz state — `denseSparseMarkowitzLoop_sound` gets
everything it needs from `denseMarkowitzPick_sound` applied to the row it re-substitutes from the
**source** constraint, plus `insertAll_preserves` — so the whole scheduler is untrusted planning
data. The `revDeps` half needed **two hypothesis statements** restated
(`((dσ.revDeps[x]?).getD ∅)` → `(dσ.revDeps.getD x.index ∅)` in the two `htouched` hypotheses);
their bodies only use `List.mem_filterMap` and were untouched. No pass correctness theorem changes
shape.

## Effectiveness: byte-identical

Iteration order changes, but decisions cannot: `denseMarkowitzEntryBetter` is a total order whose
last key (`generation`) is only reachable between two entries of the *same* row (every earlier key
includes `rowId`), and `denseMarkowitzRekey` visits each row at most once per adoption
(`CollectIds` dedups), so generation numbers are order-independent. `degrees` stays exact because
sub-then-add on a variable present in both the old and the new row is a no-op.

`opt-export` is **byte-identical** to `origin/main` on openvm-eth `apc_006` / `apc_100`, keccak
`apc_001`, wasm-eth `apc_005` / `apc_012`, sha256 `apc_001` (5.76 MB), SP1 keccak `apc_001` and
SP1 rsp `apc_001`.

## Numbers

**CI serial `Runtime Bench`, sha256, both sides on one runner** ([run 30569809811](https://github.com/powdr-labs/apc-optimizer/actions/runs/30569809811)) — the authoritative A/B:

| | main | this PR | Δ |
|---|---:|---:|---:|
| **gauss** | **13.1 s** | **11.3 s** | **0.86×** |
| whole run | 105.0 s | 102.0 s | 0.97× |

No other pass column moves outside noise (worst 1.03×). The effectiveness matrix reports
`+0.000×` on variables, bus interactions and constraints across **all six benchmark sets**, with
per-case circuit sizes identical — the byte-identity claim, confirmed independently of the local
`opt-export` diffs.

A local 20-core box, serial and interleaved, reads the pass **twice as improved**, and repeatably —
four independent pairs at **0.700–0.705×** (12 281 → 8 596, 12 425 → 8 676, 12 157 → 8 571,
12 188 → 8 566 ms; totals 0.960–0.968×). So the gap is not local noise: −3.7 s on the pass here
against −1.8 s on CI, while the end-to-end deltas agree (−4.0 vs −3.0 s), and CI's *baseline* gauss
(13.1 s) is close to this box's (12.2 s) while its *target* is not (11.3 vs 8.6 s). Unexplained; the
mechanism is memory traffic (deleted inner-`HashSet` copies), which is the kind of win that varies
with the memory system. Per the log's entry-147 rule this PR quotes the conservative CI number.

**openvm-eth full corpus, 100 cases, interleaved per case (local):** total 24.22 → 24.21 s
(**1.000×**), gauss 1.71 → 1.69 s (0.984×); of the 20 cases carrying ≥ 20 ms of gauss, median
1.000×, best 0.914×, worst 1.047×, and **no case regresses by more than 5 %**. Collateral columns
flat (reencode 1.006×, flagFold 1.009×, domainBatch 0.997×, busUnify 0.995×). That is the expected
shape — every gauss invocation on these small systems takes the source-order path (n < 8192), where
only the `revDeps` half applies, so this is a Markowitz-path win that costs nothing where the path
is not taken.

Other cases (local box, interleaved, gauss ms): keccak `apc_001` 805/855 → 661/688 (0.81×), wasm-eth
`apc_006` 596/599 → 479/489 (0.81×), wasm-eth `apc_012` 1 096 → 915/919 (0.84×), openvm-eth
`apc_037` 182/187 → 166/175 (0.94×). `apc_037` is the control: all nine of its gauss invocations take
the source-order path (n < 8192), which only the `revDeps` half touches — and CI's openvm-eth
per-pass table agrees there (gauss 189 → 187 ms, 0.99×). Split of the win locally: the three
scheduler indexes give 0.78×, `revDeps` takes it to 0.70×.

## Relation to open PR #193

#193 ("Use exact array-backed state in Gauss") bundled this representation change with exact live
reverse dependencies, streaming first-wins pivot selection, a specialized final substitution and
dropping solution materialization — and measured a **regression** (3 954 vs 3 287 ms on wasm-eth
`apc_037`). This PR is the representation-only slice, measured alone and byte-identical.

## What is left in gauss

Ranked with post-change shares in `agent-docs/ideas.md` (§ *gauss residual after entry 158*): the
three walks in `DenseGaussReduced.fromExpr` (16.9 %), the per-row `HashMap` in
`denseMarkowitzPivots` (6.3 %, and provably redundant — every gauss row is `norm`-alized), delta
index updates in `denseMarkowitzRefreshRows`, the 257 515-rekey fan-out, and deferred
back-substitution. Two dead ends recorded, including reusing the maintained Markowitz row instead of
re-substituting the source (2.2 % of the pass, and it would move the entailment obligation onto a
scheduler invariant).

## Validation

- `lake build` — clean, no warnings
- `Scripts/check-proof-integrity.sh` — passes (propext / Classical.choice / Quot.sound; no unused
  theorems)
- `git diff --check`
- `opt-export` byte-identical on the eight cases above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

