### PR TITLE
perf(gauss): rebuild the pass as a watch-driven sparse engine (0.29–0.46× on the pass, sha256 total 0.87×)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -62,7 +62,7 @@ def cleanupPasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
   [ ("degenRange", denseDegenRangePass pw),
     ("xorEqExtract", denseXorEqExtractPass),
     ("carryBranch", denseCarryBranchPass pw),
-    ("gauss", denseGaussElimPass),
+    ("gauss", denseGaussElimFPass),
     ("normalize1", denseNormalizePass),
     ("constFold1", denseConstantFoldPass),
     ("domainBatch", denseDomainBatchPassV pw),

--- a/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Affine.lean
@@ -265,56 +265,6 @@ def DenseLinExpr.toExpr (l : DenseLinExpr p) : DenseExpr p :=
 `densePm1PivotsOf`/`denseUnitPivotsOf`, which compare variables (filter on `t.1 = x`) and are
 consumed by the Gauss proof (`Proofs/Gauss.lean`). -/
 
-/-! ## `denseLinearize` introduces no new variable
-
-Proved locally here (Normalize.lean sits downstream); consumed by `Proofs/Gauss.lean`. -/
-
-/-- Every term variable of `denseLinearize e` occurs in `e`. -/
-theorem denseLinearize_mem_vars (e : DenseExpr p) (l : DenseLinExpr p)
-    (h : denseLinearize e = some l) : ∀ i ∈ l.terms.map Prod.fst, i ∈ e.vars := by
-  induction e generalizing l with
-  | const n => simp only [denseLinearize, Option.some.injEq] at h; subst h; simp
-  | var y =>
-      simp only [denseLinearize, Option.some.injEq] at h; subst h
-      intro x hx; simpa [DenseExpr.vars] using hx
-  | add a b iha ihb =>
-      cases hla : denseLinearize a with
-      | none => simp [denseLinearize, hla] at h
-      | some la => cases hlb : denseLinearize b with
-        | none => simp [denseLinearize, hla, hlb] at h
-        | some lb =>
-          simp only [denseLinearize, hla, hlb, Option.some.injEq] at h
-          subst h
-          intro x hx
-          simp only [DenseLinExpr.add, List.map_append, List.mem_append] at hx
-          simp only [DenseExpr.vars, List.mem_append]
-          exact hx.imp (iha la hla x) (ihb lb hlb x)
-  | mul a b iha ihb =>
-      cases hla : denseLinearize a with
-      | none => simp [denseLinearize, hla] at h
-      | some la => cases hlb : denseLinearize b with
-        | none => simp [denseLinearize, hla, hlb] at h
-        | some lb =>
-          by_cases h1 : la.terms.isEmpty = true
-          · simp only [denseLinearize, hla, hlb, if_pos h1, Option.some.injEq] at h
-            subst h
-            intro x hx
-            have hst : (lb.scale la.const).terms.map Prod.fst = lb.terms.map Prod.fst := by
-              simp [DenseLinExpr.scale, List.map_map, Function.comp_def]
-            rw [hst] at hx
-            exact List.mem_append.2 (Or.inr (ihb lb hlb x hx))
-          · by_cases h2 : lb.terms.isEmpty = true
-            · simp only [denseLinearize, hla, hlb, if_neg h1, if_pos h2, Option.some.injEq] at h
-              subst h
-              intro x hx
-              have hst : (la.scale lb.const).terms.map Prod.fst = la.terms.map Prod.fst := by
-                simp [DenseLinExpr.scale, List.map_map, Function.comp_def]
-              rw [hst] at hx
-              exact List.mem_append.2 (Or.inl (iha la hla x hx))
-            · simp only [denseLinearize, hla, hlb] at h
-              rw [if_neg h1, if_neg h2] at h
-              exact absurd h (by simp)
-
 /-! ## Coefficient / remainder of a dense linear form -/
 
 /-- Total coefficient of `x` in a dense linear form. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -533,9 +533,13 @@ def gDrainAt (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (S : G
         else if min l.terms.length gMaxBucket > b then
           (S.setRow i l, q.push l.terms.length i, prog)
         else
-          let n := S.order.size
           let S := gTake ops occ prot S i l
-          (S, q, prog || S.order.size != n)
+          -- Progress is read back off `status` (`gTake` retires slot `i` exactly when it pivots)
+          -- rather than compared against `S.order.size` taken before the call: holding a reference
+          -- to `order` across `gTake` makes `gAdopt`'s `pushOrder` copy the whole array, so every
+          -- adoption costs O(|order|) — 34% of the pass on sha256.
+          let adopted := (S.status[i]?).getD 1 == 2
+          (S, q, prog || adopted)
 
 /-- One queue step: pop the shortest pending row and handle it. -/
 def gDrainStep (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (S : GSt p)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Gauss.lean
@@ -5,8 +5,22 @@ import Batteries.Data.BinaryHeap
 
 set_option autoImplicit false
 
-/-! # Dense Gauss elimination: pivot scoring, the loop, the transform.
-Correctness and the wired `denseGaussElimPass` live in `Proofs/Gauss.lean`. -/
+/-! # Dense Gauss elimination
+
+The affine substitution layer (`denseLinSubstF`, `denseSparseSolveAt`), then the sparse engine built
+on it. Correctness and the wired `denseGaussElimFPass` live in `Proofs/Gauss.lean`.
+
+Each algebraic constraint is walked **once** into either a sparse affine row or a *blocked* verdict
+carrying the variables to watch (`gEval`); a blocked constraint is re-walked only when one of those
+variables is solved, which is the only way its first surviving variable×variable product can
+collapse. Rows are developed against the solution map when the scheduler reaches them, never
+re-derived from the source expression. Every per-variable index is a `VarId.index`-keyed array.
+
+Two schedulers, on the `denseMarkowitzMinRows` gate: source order below it (the SP1 `rsp` shapes need
+that basis), shortest-row-first above it (in source order a substitution chain there inflates a
+stored solution to hundreds of terms before it cancels back down).
+
+`DenseSolved` is the plain solution map the domain / flag / fx / rootPair passes share. -/
 
 namespace ApcOptimizer.Dense
 
@@ -33,146 +47,6 @@ still holding a reference to it. -/
 def denseArrEnsure {α : Type} (a : Array α) (i : Nat) (d : α) : Array α :=
   if i < a.size then a
   else a ++ Array.replicate (max (i + 1) (2 * a.size) - a.size) d
-
-/-- The occurrence-weighted duplication cost of pivoting on `v`, with a protection penalty. -/
-def denseGaussScore (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId)
-    (oc : Nat) : Nat :=
-  let base := (occ.getD v 1 - 1) * (1 + oc)
-  if prot.contains v then base + 1000000 else base
-
-/-- One index step: add `t`'s coefficient and one occurrence to `t.1`'s entry (0 if absent). -/
-def denseIdxStep (m : Std.HashMap VarId (ZMod p × Nat)) (t : VarId × ZMod p) :
-    Std.HashMap VarId (ZMod p × Nat) :=
-  m.insert t.1 (((m[t.1]?).getD (0, 0)).1 + t.2, ((m[t.1]?).getD (0, 0)).2 + 1)
-
-/-- The coefficient/occurrence index of a term list. -/
-def denseCoeffIdx (terms : List (VarId × ZMod p)) : Std.HashMap VarId (ZMod p × Nat) :=
-  terms.foldl denseIdxStep ∅
-
-/-! ## Descriptors -/
-
-/-- `±1`-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` succeeds. -/
-def densePm1Desc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    Option (VarId × Nat) :=
-  if ((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1 then
-    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
-  else none
-
-/-- Unit-pivot descriptor: `some (v, score)` exactly when `l.trySolve v` fails but
-    `l.trySolveUnit v` succeeds. -/
-def denseUnitDesc (idx : Std.HashMap VarId (ZMod p × Nat)) (total : Nat)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    Option (VarId × Nat) :=
-  if ¬(((idx[v]?).getD (0, 0)).1 = 1 ∨ ((idx[v]?).getD (0, 0)).1 = -1)
-      ∧ ((idx[v]?).getD (0, 0)).1 * (((idx[v]?).getD (0, 0)).1)⁻¹ = 1 then
-    some (v, denseGaussScore occ prot v (total - ((idx[v]?).getD (0, 0)).2))
-  else none
-
-/-- All pivot descriptors, `±1` first (matching the order of `densePm1PivotsOf ++
-    denseUnitPivotsOf`). -/
-def densePivotDescs (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    List (VarId × Nat) :=
-  let idx := denseCoeffIdx l.terms
-  let total := l.terms.length
-  (l.terms.map Prod.fst).filterMap (densePm1Desc idx total occ prot)
-    ++ (l.terms.map Prod.fst).filterMap (denseUnitDesc idx total occ prot)
-
-/-! ## Boxed runtime twins -/
-
-def denseIdxStepWith (ops : DenseZModOps p) (m : Std.HashMap VarId (ZMod p × Nat))
-    (t : VarId × ZMod p) : Std.HashMap VarId (ZMod p × Nat) :=
-  let old := (m[t.1]?).getD (ops.zero, 0)
-  m.insert t.1 (ops.add old.1 t.2, old.2 + 1)
-
-def denseCoeffIdxWith (ops : DenseZModOps p) :
-    List (VarId × ZMod p) → Std.HashMap VarId (ZMod p × Nat) →
-      Std.HashMap VarId (ZMod p × Nat)
-  | [], m => m
-  | t :: rest, m => denseCoeffIdxWith ops rest (denseIdxStepWith ops m t)
-
-def denseCoeffIdxFast (terms : List (VarId × ZMod p)) : Std.HashMap VarId (ZMod p × Nat) :=
-  let ops : DenseZModOps p := denseZModOps
-  denseCoeffIdxWith ops terms ∅
-
-theorem denseIdxStepWith_eq (ops : DenseZModOps p) (m : Std.HashMap VarId (ZMod p × Nat))
-    (t : VarId × ZMod p) : denseIdxStepWith ops m t = denseIdxStep m t := by
-  simp only [denseIdxStepWith, denseIdxStep, ops.zero_eq, ops.add_eq]
-
-theorem denseCoeffIdxWith_eq (ops : DenseZModOps p) (terms : List (VarId × ZMod p))
-    (m : Std.HashMap VarId (ZMod p × Nat)) :
-    denseCoeffIdxWith ops terms m = terms.foldl denseIdxStep m := by
-  induction terms generalizing m with
-  | nil => rfl
-  | cons t rest ih =>
-    rw [denseCoeffIdxWith, denseIdxStepWith_eq, List.foldl_cons, ih]
-
-@[csimp] theorem denseCoeffIdx_eq_fast : @denseCoeffIdx = @denseCoeffIdxFast := by
-  funext p terms
-  simp only [denseCoeffIdx, denseCoeffIdxFast, denseCoeffIdxWith_eq]
-
-def densePm1DescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    Option (VarId × Nat) :=
-  let cv := (idx[v]?).getD (ops.zero, 0)
-  if cv.1 = ops.one ∨ cv.1 = ops.negOne then
-    some (v, denseGaussScore occ prot v (total - cv.2))
-  else none
-
-def denseUnitDescWith (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    Option (VarId × Nat) :=
-  let cv := (idx[v]?).getD (ops.zero, 0)
-  if ¬(cv.1 = ops.one ∨ cv.1 = ops.negOne) ∧
-      ops.mul cv.1 cv.1⁻¹ = ops.one then
-    some (v, denseGaussScore occ prot v (total - cv.2))
-  else none
-
-def densePivotDescsWith (ops : DenseZModOps p) (l : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : List (VarId × Nat) :=
-  let idx := denseCoeffIdxWith ops l.terms ∅
-  let total := l.terms.length
-  (l.terms.map Prod.fst).filterMap (densePm1DescWith ops idx total occ prot) ++
-    (l.terms.map Prod.fst).filterMap (denseUnitDescWith ops idx total occ prot)
-
-def densePivotDescsFast (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : List (VarId × Nat) :=
-  let ops : DenseZModOps p := denseZModOps
-  densePivotDescsWith ops l occ prot
-
-theorem densePm1DescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    densePm1DescWith ops idx total occ prot v = densePm1Desc idx total occ prot v := by
-  simp only [densePm1DescWith, densePm1Desc, ops.zero_eq, ops.one_eq, ops.negOne_eq]
-
-theorem denseUnitDescWith_eq (ops : DenseZModOps p) (idx : Std.HashMap VarId (ZMod p × Nat))
-    (total : Nat) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) (v : VarId) :
-    denseUnitDescWith ops idx total occ prot v = denseUnitDesc idx total occ prot v := by
-  simp only [denseUnitDescWith, denseUnitDesc, ops.zero_eq, ops.one_eq, ops.negOne_eq, ops.mul_eq]
-
-theorem densePivotDescsWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    densePivotDescsWith ops l occ prot = densePivotDescs l occ prot := by
-  unfold densePivotDescsWith densePivotDescs denseCoeffIdx
-  rw [denseCoeffIdxWith_eq]
-  simp only [densePm1DescWith_eq, denseUnitDescWith_eq]
-
-@[csimp] theorem densePivotDescs_eq_fast : @densePivotDescs = @densePivotDescsFast := by
-  funext p l occ prot
-  exact (densePivotDescsWith_eq denseZModOps l occ prot).symm
-
-/-- Occurrence counts of every variable across the dense system (one traversal). -/
-def denseOccurrenceMap (d : DenseConstraintSystem p) : Std.HashMap VarId Nat :=
-  let addE := fun (m : Std.HashMap VarId Nat) (e : DenseExpr p) =>
-    e.foldVars (fun m x => m.insert x (m.getD x 0 + 1)) m
-  let m := d.algebraicConstraints.foldl addE ∅
-  d.busInteractions.foldl (fun m bi => bi.payload.foldl addE (addE m bi.multiplicity)) m
-
-/-- Variables occurring as a *raw* payload slot of a stateless interaction. -/
-def denseProtectedVars (d : DenseConstraintSystem p) (bs : BusSemantics p) : Std.HashSet VarId :=
-  d.busInteractions.foldl (init := ∅) fun s bi =>
-    if bs.isStateful bi.busId then s
-    else bi.payload.foldl (fun s e => match e with | .var x => s.insert x | _ => s) s
 
 /-- A plain (proof-free) solution map keyed by `VarId`; correctness is established by the
     correctness proof (`Proofs/Gauss.lean`), not carried as a structure invariant. -/
@@ -210,13 +84,7 @@ theorem insertAll_map :
 
 end DenseSolved
 
-/-! ## Dynamic sparse scheduling -/
-
-def DenseExpr.uniqueVars (e : DenseExpr p) : List VarId :=
-  let st := e.foldVars (fun (out, seen) x =>
-    if seen.contains x then (out, seen) else (x :: out, seen.insert x))
-    (([], ∅) : List VarId × Std.HashSet VarId)
-  st.1.reverse
+/-! ## Sparse affine substitution -/
 
 /-- Substitute sparse affine rows into an affine row, preserving first-occurrence term order. -/
 def denseLinSubstF (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p)) :
@@ -235,9 +103,6 @@ def denseLinSubstF (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p))
 def denseLinSubst (l : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) : DenseLinExpr p :=
   denseLinSubstF l (fun y => if y = x then some t else none)
 
-def denseLinAdd (a b : DenseLinExpr p) : DenseLinExpr p :=
-  (a.add b).norm
-
 def denseLinScale (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
   (l.scale k).norm
 
@@ -254,285 +119,21 @@ def denseLinSubstFWith (ops : DenseZModOps p) (l : DenseLinExpr p)
     | none => [yc])
   (DenseLinExpr.mk const terms).normWith ops
 
-def denseLinSubstFFast (l : DenseLinExpr p) (σ : VarId → Option (DenseLinExpr p)) :
-    DenseLinExpr p :=
-  denseLinSubstFWith denseZModOps l σ
-
 theorem denseLinSubstFWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p)
     (σ : VarId → Option (DenseLinExpr p)) : denseLinSubstFWith ops l σ = denseLinSubstF l σ := by
   simp only [denseLinSubstFWith, denseLinSubstF, DenseLinExpr.normWith_eq, ops.add_eq, ops.mul_eq,
     denseScaleTermsWith_eq]
 
-@[csimp] theorem denseLinSubstF_eq_fast : @denseLinSubstF = @denseLinSubstFFast := by
-  funext p l σ
-  exact (denseLinSubstFWith_eq denseZModOps l σ).symm
-
-def denseLinAddWith (ops : DenseZModOps p) (a b : DenseLinExpr p) : DenseLinExpr p :=
-  (a.addWith ops b).normWith ops
-
-def denseLinAddFast (a b : DenseLinExpr p) : DenseLinExpr p :=
-  denseLinAddWith denseZModOps a b
-
-theorem denseLinAddWith_eq (ops : DenseZModOps p) (a b : DenseLinExpr p) :
-    denseLinAddWith ops a b = denseLinAdd a b := by
-  simp only [denseLinAddWith, denseLinAdd, DenseLinExpr.addWith_eq, DenseLinExpr.normWith_eq]
-
-@[csimp] theorem denseLinAdd_eq_fast : @denseLinAdd = @denseLinAddFast := by
-  funext p a b
-  exact (denseLinAddWith_eq denseZModOps a b).symm
-
 def denseLinScaleWith (ops : DenseZModOps p) (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
   (l.scaleWith ops k).normWith ops
-
-def denseLinScaleFast (k : ZMod p) (l : DenseLinExpr p) : DenseLinExpr p :=
-  denseLinScaleWith denseZModOps k l
 
 theorem denseLinScaleWith_eq (ops : DenseZModOps p) (k : ZMod p) (l : DenseLinExpr p) :
     denseLinScaleWith ops k l = denseLinScale k l := by
   simp only [denseLinScaleWith, denseLinScale, DenseLinExpr.scaleWith_eq, DenseLinExpr.normWith_eq]
 
-@[csimp] theorem denseLinScale_eq_fast : @denseLinScale = @denseLinScaleFast := by
-  funext p k l
-  exact (denseLinScaleWith_eq denseZModOps k l).symm
-
 def DenseLinExpr.mentions (l : DenseLinExpr p) (x : VarId) : Bool :=
   l.terms.any (fun yc => yc.1 = x)
 
-inductive DenseGaussReduced (p : ℕ) where
-  | affine (row : DenseLinExpr p)
-  | nonlinear (expr : DenseExpr p)
-
-namespace DenseGaussReduced
-
-def toExpr : DenseGaussReduced p → DenseExpr p
-  | .affine row => row.toExpr
-  | .nonlinear expr => expr
-
-def vars : DenseGaussReduced p → List VarId
-  | .affine row => row.terms.map Prod.fst
-  | .nonlinear expr => expr.uniqueVars
-
-def fromExpr (e : DenseExpr p) : DenseGaussReduced p :=
-  match denseLinearize e with
-  | some row => .affine row.norm
-  | none =>
-      let normalized := e.normalize
-      match denseLinearize normalized with
-      | some row => .affine row.norm
-      | none => .nonlinear normalized
-
-end DenseGaussReduced
-
-def denseReducedAdd (ra rb : DenseGaussReduced p) : DenseGaussReduced p :=
-  match ra, rb with
-  | .affine la, .affine lb => .affine (denseLinAdd la lb)
-  | _, _ => .nonlinear (.add ra.toExpr rb.toExpr)
-
-def denseReducedMul (ra rb : DenseGaussReduced p) : DenseGaussReduced p :=
-  match ra, rb with
-  | .affine la, .affine lb =>
-      if la.terms.isEmpty then .affine (denseLinScale la.const lb)
-      else if lb.terms.isEmpty then .affine (denseLinScale lb.const la)
-      else .nonlinear (.mul la.toExpr lb.toExpr)
-  | _, _ => .nonlinear (.mul ra.toExpr rb.toExpr)
-
-/-- Simultaneous sparse substitution and affine normalization, retaining expressions only for
-    genuinely nonlinear subtrees. -/
-def denseSparseSubstF (σ : VarId → Option (DenseLinExpr p)) : DenseExpr p → DenseGaussReduced p
-  | .const n => .affine ⟨n, []⟩
-  | .var x =>
-      match σ x with
-      | some row => .affine row
-      | none => .affine ⟨0, [(x, 1)]⟩
-  | e@(.add a b) =>
-      match denseLinearize e with
-      | some row => .affine (denseLinSubstF row σ)
-      | none =>
-          let ra := denseSparseSubstF σ a
-          let rb := denseSparseSubstF σ b
-          denseReducedAdd ra rb
-  | e@(.mul a b) =>
-      match denseLinearize e with
-      | some row => .affine (denseLinSubstF row σ)
-      | none =>
-          let ra := denseSparseSubstF σ a
-          let rb := denseSparseSubstF σ b
-          denseReducedMul ra rb
-
-/-! ## Fused substitution walk (runtime `@[csimp]` replacement for `denseSparseSubstF`)
-
-`denseSparseSubstF` re-runs `denseLinearize` over the whole node at every node of the nonlinear
-spine, and substitutes into every affine node whose parent then re-substitutes the merged row —
-both quadratic in the size of a constraint. The fused walk carries each node's linear form up
-(`lin?`, provably `denseLinearize`) and leaves the substitution undeveloped (`lin`) while a parent
-can still absorb it. -/
-
-inductive DenseSubstRes (p : ℕ) where
-  | pre (r : DenseGaussReduced p) (l : DenseLinExpr p)
-  | lin (l : DenseLinExpr p)
-  | opq (r : DenseGaussReduced p)
-
-def DenseSubstRes.reduced (σ : VarId → Option (DenseLinExpr p)) :
-    DenseSubstRes p → DenseGaussReduced p
-  | .pre r _ => r
-  | .lin l => .affine (denseLinSubstF l σ)
-  | .opq r => r
-
-def DenseSubstRes.lin? : DenseSubstRes p → Option (DenseLinExpr p)
-  | .pre _ l => some l
-  | .lin l => some l
-  | .opq _ => none
-
-def denseSparseSubstFused (σ : VarId → Option (DenseLinExpr p)) :
-    DenseExpr p → DenseSubstRes p
-  | .const n => .pre (.affine ⟨n, []⟩) ⟨n, []⟩
-  | .var x =>
-      .pre (match σ x with | some row => .affine row | none => .affine ⟨0, [(x, 1)]⟩)
-        ⟨0, [(x, 1)]⟩
-  | .add a b =>
-      let ra := denseSparseSubstFused σ a
-      let rb := denseSparseSubstFused σ b
-      match ra.lin?, rb.lin? with
-      | some la, some lb => .lin (la.add lb)
-      | _, _ => .opq (denseReducedAdd (ra.reduced σ) (rb.reduced σ))
-  | .mul a b =>
-      let ra := denseSparseSubstFused σ a
-      let rb := denseSparseSubstFused σ b
-      match ra.lin?, rb.lin? with
-      | some la, some lb =>
-          if la.terms.isEmpty then .lin (lb.scale la.const)
-          else if lb.terms.isEmpty then .lin (la.scale lb.const)
-          else .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
-      | _, _ => .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
-
-/-- Boxed twin of the fused walk. Its `var` leaf builds `⟨0, [(x, 1)]⟩`, so without a shared
-    `DenseZModOps p` every variable occurrence of every constraint costs two instance chains. -/
-def denseSparseSubstFusedWith (ops : DenseZModOps p) (σ : VarId → Option (DenseLinExpr p)) :
-    DenseExpr p → DenseSubstRes p
-  | .const n => .pre (.affine ⟨n, []⟩) ⟨n, []⟩
-  | .var x =>
-      .pre (match σ x with | some row => .affine row | none => .affine ⟨ops.zero, [(x, ops.one)]⟩)
-        ⟨ops.zero, [(x, ops.one)]⟩
-  | .add a b =>
-      let ra := denseSparseSubstFusedWith ops σ a
-      let rb := denseSparseSubstFusedWith ops σ b
-      match ra.lin?, rb.lin? with
-      | some la, some lb => .lin (la.addWith ops lb)
-      | _, _ => .opq (denseReducedAdd (ra.reduced σ) (rb.reduced σ))
-  | .mul a b =>
-      let ra := denseSparseSubstFusedWith ops σ a
-      let rb := denseSparseSubstFusedWith ops σ b
-      match ra.lin?, rb.lin? with
-      | some la, some lb =>
-          if la.terms.isEmpty then .lin (lb.scaleWith ops la.const)
-          else if lb.terms.isEmpty then .lin (la.scaleWith ops lb.const)
-          else .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
-      | _, _ => .opq (denseReducedMul (ra.reduced σ) (rb.reduced σ))
-
-theorem denseSparseSubstFusedWith_eq (ops : DenseZModOps p) (σ : VarId → Option (DenseLinExpr p))
-    (e : DenseExpr p) : denseSparseSubstFusedWith ops σ e = denseSparseSubstFused σ e := by
-  induction e with
-  | const n => rfl
-  | var x =>
-      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, ops.zero_eq, ops.one_eq]
-  | add a b iha ihb =>
-      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, iha, ihb,
-        DenseLinExpr.addWith_eq]
-  | mul a b iha ihb =>
-      simp only [denseSparseSubstFusedWith, denseSparseSubstFused, iha, ihb,
-        DenseLinExpr.scaleWith_eq]
-
-def denseSparseSubstFusedFast (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
-    DenseSubstRes p :=
-  denseSparseSubstFusedWith denseZModOps σ e
-
-@[csimp] theorem denseSparseSubstFused_eq_fast :
-    @denseSparseSubstFused = @denseSparseSubstFusedFast := by
-  funext p σ e
-  exact (denseSparseSubstFusedWith_eq denseZModOps σ e).symm
-
-def denseSparseSubstFFast (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
-    DenseGaussReduced p :=
-  (denseSparseSubstFused σ e).reduced σ
-
-theorem denseSparseSubstFused_lin (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
-    (denseSparseSubstFused σ e).lin? = denseLinearize e := by
-  induction e with
-  | const n => rfl
-  | var x => rfl
-  | add a b iha ihb =>
-      rw [denseSparseSubstFused, denseLinearize]
-      rw [show (denseSparseSubstFused σ a).lin? = denseLinearize a from iha] at *
-      cases denseLinearize a <;> cases hb : (denseSparseSubstFused σ b).lin? <;>
-        rw [hb] at ihb <;> simp [DenseSubstRes.lin?, ← ihb]
-  | mul a b iha ihb =>
-      rw [denseSparseSubstFused, denseLinearize]
-      rw [show (denseSparseSubstFused σ a).lin? = denseLinearize a from iha] at *
-      cases denseLinearize a <;> cases hb : (denseSparseSubstFused σ b).lin? <;>
-        rw [hb] at ihb <;>
-        simp only [← ihb] <;> first | rfl | (split_ifs <;> rfl)
-
-theorem denseSparseSubstFused_reduced (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p) :
-    (denseSparseSubstFused σ e).reduced σ = denseSparseSubstF σ e := by
-  induction e with
-  | const n => rfl
-  | var x => rfl
-  | add a b iha ihb =>
-      rw [denseSparseSubstFused, denseSparseSubstF, denseLinearize,
-        denseSparseSubstFused_lin σ a, denseSparseSubstFused_lin σ b]
-      simp only [DenseSubstRes.reduced] at iha ihb ⊢
-      cases denseLinearize a <;> cases denseLinearize b <;>
-        first | rfl | rw [iha, ihb]
-  | mul a b iha ihb =>
-      rw [denseSparseSubstFused, denseSparseSubstF, denseLinearize,
-        denseSparseSubstFused_lin σ a, denseSparseSubstFused_lin σ b]
-      simp only [DenseSubstRes.reduced] at iha ihb ⊢
-      cases hla : denseLinearize a with
-      | none => rw [iha, ihb]
-      | some la =>
-        cases hlb : denseLinearize b with
-        | none => rw [iha, ihb]
-        | some lb =>
-          dsimp only
-          split_ifs <;> first | rfl | rw [iha, ihb]
-
-@[csimp] theorem denseSparseSubstF_eq_fast : @denseSparseSubstF = @denseSparseSubstFFast := by
-  funext p σ e
-  exact (denseSparseSubstFused_reduced σ e).symm
-
-def denseReducedSubst (r : DenseGaussReduced p) (x : VarId)
-    (t : DenseLinExpr p) : DenseGaussReduced p :=
-  match r with
-  | .affine row => .affine (denseLinSubst row x t)
-  | .nonlinear expr => denseSparseSubstF (fun y => if y = x then some t else none) expr
-
-structure DenseSparseSolved (p : ℕ) where
-  map : Std.HashMap VarId (DenseLinExpr p)
-  revDeps : Array (Std.HashSet VarId)
-
-namespace DenseSparseSolved
-
-def empty : DenseSparseSolved p := { map := ∅, revDeps := #[] }
-
-def fn (dσ : DenseSparseSolved p) : VarId → Option (DenseLinExpr p) := fun i => dσ.map[i]?
-
-def insertAll (dσ : DenseSparseSolved p) :
-    List (VarId × DenseLinExpr p) → DenseSparseSolved p
-  | [] => dσ
-  | (x, t) :: rest =>
-      DenseSparseSolved.insertAll
-        { map := dσ.map.insert x t
-          revDeps := t.terms.foldl
-            (fun rd zc => (denseArrEnsure rd zc.1.index ∅).modify zc.1.index (·.insert x))
-            dσ.revDeps }
-        rest
-
-def materialize (dσ : DenseSparseSolved p) : DenseSolved p :=
-  let map := dσ.map.toList.foldl
-    (fun out xt => out.insert xt.1 xt.2.toExpr) (∅ : Std.HashMap VarId (DenseExpr p))
-  { map, revDeps := ∅ }
-
-end DenseSparseSolved
 
 def denseSparseSolveAt (l : DenseLinExpr p) (x : VarId) :
     Option (VarId × DenseLinExpr p) :=
@@ -552,407 +153,492 @@ def denseSparseSolveAtWith (ops : DenseZModOps p) (l : DenseLinExpr p) (x : VarI
     some (x, denseLinScaleWith ops (ops.mul ops.negOne c⁻¹) (l.others x))
   else none
 
-def denseSparseSolveAtFast (l : DenseLinExpr p) (x : VarId) : Option (VarId × DenseLinExpr p) :=
-  denseSparseSolveAtWith denseZModOps l x
-
 theorem denseSparseSolveAtWith_eq (ops : DenseZModOps p) (l : DenseLinExpr p) (x : VarId) :
     denseSparseSolveAtWith ops l x = denseSparseSolveAt l x := by
   simp only [denseSparseSolveAtWith, denseSparseSolveAt, DenseLinExpr.coeff,
     denseCoeffSumWith_eq, denseLinScaleWith_eq, ops.one_eq, ops.negOne_eq, ops.mul_eq,
     ← neg_eq_neg_one_mul]
 
-@[csimp] theorem denseSparseSolveAt_eq_fast : @denseSparseSolveAt = @denseSparseSolveAtFast := by
-  funext p l x
-  exact (denseSparseSolveAtWith_eq denseZModOps l x).symm
-
-def denseSparseBest (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
-  match (densePivotDescs l occ prot).argmin Prod.snd with
-  | none => none
-  | some (x, _) => denseSparseSolveAt l x
-
-def denseReducedBest (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
-  match r with
-  | .affine row => denseSparseBest row occ prot
-  | .nonlinear _ => none
-
-def denseSparseGaussLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    List (DenseExpr p) → DenseSparseSolved p → DenseSparseSolved p
-  | [], dσ => dσ
-  | c :: rest, dσ =>
-      let c' := denseSparseSubstF dσ.fn c
-      match denseReducedBest c' occ prot with
-      | none => denseSparseGaussLoop occ prot rest dσ
-      | some (x, t) =>
-          let touched := (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
-            (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-          let pairs := touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
-          denseSparseGaussLoop occ prot rest (dσ.insertAll pairs)
-
-structure DenseMarkowitzPivot where
-  var : VarId
-  rhsNnz : Nat
-
-structure DenseMarkowitzRow (p : ℕ) where
-  rowId : Nat
-  reduced : DenseGaussReduced p
-  vars : List VarId
-  pivots : List DenseMarkowitzPivot
-  generation : Nat
-  active : Bool
-
-structure DenseMarkowitzEntry where
-  isProtected : Nat
-  fill : Nat
-  rewrite : Nat
-  localScore : Nat
-  rowId : Nat
-  pivot : VarId
-  generation : Nat
-
-def denseMarkowitzEntryBetter (a b : DenseMarkowitzEntry) : Bool :=
-  if a.isProtected < b.isProtected then true
-  else if b.isProtected < a.isProtected then false
-  else if a.fill < b.fill then true
-  else if b.fill < a.fill then false
-  else if a.rewrite < b.rewrite then true
-  else if b.rewrite < a.rewrite then false
-  else if a.localScore < b.localScore then true
-  else if b.localScore < a.localScore then false
-  else if a.rowId < b.rowId then true
-  else if b.rowId < a.rowId then false
-  else if a.pivot.index < b.pivot.index then true
-  else if b.pivot.index < a.pivot.index then false
-  else a.generation < b.generation
-
-def denseMarkowitzHeapLt (a b : DenseMarkowitzEntry) : Bool :=
-  denseMarkowitzEntryBetter b a
-
-abbrev DenseMarkowitzHeap :=
-  Batteries.BinaryHeap DenseMarkowitzEntry denseMarkowitzHeapLt
-
-structure DenseMarkowitzState (p : ℕ) where
-  rows : Array (DenseMarkowitzRow p)
-  degrees : Array Nat
-  rowDeps : Array (Std.HashSet Nat)
-  pivotRows : Array (Std.HashSet Nat)
-  heap : DenseMarkowitzHeap
-
-def denseMarkowitzPivots (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
-  match r with
-  | .nonlinear _ => []
-  | .affine l =>
-      let idx := denseCoeffIdx l.terms
-      let vars := l.terms.map Prod.fst
-      let descs := vars.filterMap (densePm1Desc idx l.terms.length occ prot) ++
-        vars.filterMap (denseUnitDesc idx l.terms.length occ prot)
-      let out := descs.foldl (fun (out, seen) (x, _) =>
-        if seen.contains x then (out, seen)
-        else
-          let cv := (idx[x]?).getD (0, 0)
-          ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
-        (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
-      out.1.reverse
-
-/-- Boxed twin of `denseMarkowitzPivots`. The body re-inlines `densePivotDescs` rather than calling
-    it, so that function's `@[csimp]` does not reach the two descriptor scans here. -/
-def denseMarkowitzPivotsWith (ops : DenseZModOps p) (r : DenseGaussReduced p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
-  match r with
-  | .nonlinear _ => []
-  | .affine l =>
-      let idx := denseCoeffIdxWith ops l.terms ∅
-      let vars := l.terms.map Prod.fst
-      let descs := vars.filterMap (densePm1DescWith ops idx l.terms.length occ prot) ++
-        vars.filterMap (denseUnitDescWith ops idx l.terms.length occ prot)
-      let out := descs.foldl (fun (out, seen) (x, _) =>
-        if seen.contains x then (out, seen)
-        else
-          let cv := (idx[x]?).getD (ops.zero, 0)
-          ({ var := x, rhsNnz := l.terms.length - cv.2 } :: out, seen.insert x))
-        (([], ∅) : List DenseMarkowitzPivot × Std.HashSet VarId)
-      out.1.reverse
-
-def denseMarkowitzPivotsFast (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : List DenseMarkowitzPivot :=
-  denseMarkowitzPivotsWith denseZModOps r occ prot
-
-theorem denseMarkowitzPivotsWith_eq (ops : DenseZModOps p) (r : DenseGaussReduced p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    denseMarkowitzPivotsWith ops r occ prot = denseMarkowitzPivots r occ prot := by
-  cases r with
-  | nonlinear _ => rfl
-  | affine l =>
-      simp only [denseMarkowitzPivotsWith, denseMarkowitzPivots, denseCoeffIdx,
-        denseCoeffIdxWith_eq, densePm1DescWith_eq, denseUnitDescWith_eq, ops.zero_eq]
-
-@[csimp] theorem denseMarkowitzPivots_eq_fast :
-    @denseMarkowitzPivots = @denseMarkowitzPivotsFast := by
-  funext p r occ prot
-  exact (denseMarkowitzPivotsWith_eq denseZModOps r occ prot).symm
-
-def denseMarkowitzRow (rowId : Nat) (e : DenseExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (generation : Nat := 0) : DenseMarkowitzRow p :=
-  let reduced := DenseGaussReduced.fromExpr e
-  { rowId
-    reduced
-    vars := reduced.vars
-    pivots := denseMarkowitzPivots reduced occ prot
-    generation
-    active := true }
-
-def denseMarkowitzRefreshRow (r : DenseMarkowitzRow p) (x : VarId) (t : DenseLinExpr p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzRow p :=
-  let reduced := denseReducedSubst r.reduced x t
-  { rowId := r.rowId
-    reduced
-    vars := reduced.vars
-    pivots := denseMarkowitzPivots reduced occ prot
-    generation := r.generation + 1
-    active := true }
-
-def denseMarkowitzDegreeAdd (m : Array Nat) (xs : List VarId) : Array Nat :=
-  xs.foldl (fun m x => (denseArrEnsure m x.index 0).modify x.index (· + 1)) m
-
-def denseMarkowitzDegreeSub (m : Array Nat) (xs : List VarId) : Array Nat :=
-  xs.foldl (fun m x => (denseArrEnsure m x.index 0).modify x.index (· - 1)) m
-
-def denseMarkowitzIndexRow (idx : Array (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => (denseArrEnsure idx x.index ∅).modify x.index (·.insert rowId)) idx
-
-def denseMarkowitzUnindexRow (idx : Array (Std.HashSet Nat))
-    (rowId : Nat) (xs : List VarId) : Array (Std.HashSet Nat) :=
-  xs.foldl (fun idx x => (denseArrEnsure idx x.index ∅).modify x.index (·.erase rowId)) idx
-
-def denseMarkowitzIndexPivots (idx : Array (Std.HashSet Nat))
-    (rowId : Nat) (pivots : List DenseMarkowitzPivot) : Array (Std.HashSet Nat) :=
-  pivots.foldl
-    (fun idx q => (denseArrEnsure idx q.var.index ∅).modify q.var.index (·.insert rowId)) idx
-
-def denseMarkowitzUnindexPivots (idx : Array (Std.HashSet Nat))
-    (rowId : Nat) (pivots : List DenseMarkowitzPivot) : Array (Std.HashSet Nat) :=
-  pivots.foldl
-    (fun idx q => (denseArrEnsure idx q.var.index ∅).modify q.var.index (·.erase rowId)) idx
-
-def denseMarkowitzEntryOf (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
-    (r : DenseMarkowitzRow p) (q : DenseMarkowitzPivot) : DenseMarkowitzEntry :=
-  let solvedDegree := (dσ.revDeps.getD q.var.index ∅).size
-  let activeDegree := st.degrees.getD q.var.index 1
-  { isProtected := if prot.contains q.var then 1 else 0
-    fill := q.rhsNnz * (activeDegree - 1)
-    rewrite := q.rhsNnz * solvedDegree
-    localScore := denseGaussScore occ prot q.var q.rhsNnz
-    rowId
-    pivot := q.var
-    generation := r.generation }
-
-def denseMarkowitzBestEntry? (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat)
-    (r : DenseMarkowitzRow p) : Option DenseMarkowitzEntry :=
-  r.pivots.foldl (fun best q =>
-    let entry := denseMarkowitzEntryOf occ prot dσ st rowId r q
-    match best with
-    | none => some entry
-    | some old => if denseMarkowitzEntryBetter entry old then some entry else best) none
-
-def denseMarkowitzPushRow (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSparseSolved p) (st : DenseMarkowitzState p) (rowId : Nat) :
-    DenseMarkowitzState p :=
-  match st.rows[rowId]? with
-  | none => st
-  | some r =>
-      if !r.active then st
-      else
-        let r' := { r with generation := r.generation + 1 }
-        let st' := { st with rows := st.rows.setIfInBounds rowId r' }
-        match denseMarkowitzBestEntry? occ prot dσ st' rowId r' with
-        | none => st'
-        | some entry => { st' with heap := st'.heap.insert entry }
-
-def denseMarkowitzBuild (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseMarkowitzState p :=
-  let rows := constraints.foldl (fun rs c => rs.push (denseMarkowitzRow rs.size c occ prot))
-    (#[] : Array (DenseMarkowitzRow p))
-  -- The per-variable indexes are `VarId.index`-keyed arrays, sized once: substitution only ever
-  -- copies variables between rows, so no index can exceed the system's maximum.
-  let n := rows.foldl (fun m r => r.vars.foldl (fun m x => max m (x.index + 1)) m) 0
-  let base : DenseMarkowitzState p :=
-    { rows
-      degrees := Array.replicate n 0
-      rowDeps := Array.replicate n ∅
-      pivotRows := Array.replicate n ∅
-      heap := ∅ }
-  let indexed := rows.foldl (fun st r =>
-    { st with
-      degrees := denseMarkowitzDegreeAdd st.degrees r.vars
-      rowDeps := denseMarkowitzIndexRow st.rowDeps r.rowId r.vars
-      pivotRows := denseMarkowitzIndexPivots st.pivotRows r.rowId r.pivots }) base
-  indexed.rows.foldl (fun st r =>
-    match denseMarkowitzBestEntry? occ prot DenseSparseSolved.empty st r.rowId r with
-    | none => st
-    | some entry => { st with heap := st.heap.insert entry }) indexed
-
-def denseMarkowitzEntryValid (st : DenseMarkowitzState p)
-    (entry : DenseMarkowitzEntry) : Bool :=
-  match st.rows[entry.rowId]? with
-  | none => false
-  | some r =>
-      r.active && r.generation == entry.generation
-
-def denseMarkowitzPopValid : Nat → DenseMarkowitzState p →
-    Option (DenseMarkowitzEntry × DenseMarkowitzState p)
-  | 0, _ => none
-  | fuel + 1, st =>
-      let (entry?, heap) := st.heap.extractMax
-      let st := { st with heap }
-      match entry? with
-      | none => none
-      | some entry =>
-          if denseMarkowitzEntryValid st entry then some (entry, st)
-          else denseMarkowitzPopValid fuel st
-
-def denseMarkowitzCollectIds (idx : Array (Std.HashSet Nat))
-    (xs : Std.HashSet VarId) : Std.HashSet Nat :=
-  xs.toList.foldl (fun out x =>
-    (idx.getD x.index ∅).toList.foldl (fun out rowId => out.insert rowId) out) ∅
-
-def denseMarkowitzRekey (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (dσ : DenseSparseSolved p) (changed : Std.HashSet VarId) (st : DenseMarkowitzState p) :
-    DenseMarkowitzState p :=
-  (denseMarkowitzCollectIds st.pivotRows changed).toList.foldl
-    (denseMarkowitzPushRow occ prot dσ) st
-
-def denseMarkowitzRefreshRows (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (x : VarId) (t : DenseLinExpr p) (st : DenseMarkowitzState p) :
-    DenseMarkowitzState p × Std.HashSet VarId :=
-  let rowIds := (st.rowDeps.getD x.index ∅).toList
-  rowIds.foldl (fun (st, changed) rowId =>
-    match st.rows[rowId]? with
-    | none => (st, changed)
-    | some r =>
-        if !r.active || !r.vars.contains x then (st, changed)
-        else
-          let r' := denseMarkowitzRefreshRow r x t occ prot
-          let changed := (r.vars ++ r'.vars).foldl (fun s y => s.insert y) changed
-          ({ st with
-              rows := st.rows.setIfInBounds rowId r'
-              degrees := denseMarkowitzDegreeAdd
-                (denseMarkowitzDegreeSub st.degrees r.vars) r'.vars
-              rowDeps := denseMarkowitzIndexRow
-                (denseMarkowitzUnindexRow st.rowDeps rowId r.vars) rowId r'.vars
-              pivotRows := denseMarkowitzIndexPivots
-                (denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots) rowId r'.pivots },
-            changed)) (st, ∅)
-
-def denseMarkowitzDeactivate (rowId : Nat) (st : DenseMarkowitzState p) :
-    DenseMarkowitzState p × Std.HashSet VarId :=
-  match st.rows[rowId]? with
-  | none => (st, ∅)
-  | some r =>
-      let changed := r.vars.foldl (fun s x => s.insert x) ∅
-      ({ st with
-          rows := st.rows.setIfInBounds rowId
-            { r with active := false, generation := r.generation + 1 }
-          degrees := denseMarkowitzDegreeSub st.degrees r.vars
-          rowDeps := denseMarkowitzUnindexRow st.rowDeps rowId r.vars
-          pivotRows := denseMarkowitzUnindexPivots st.pivotRows rowId r.pivots },
-        changed)
-
-def denseMarkowitzAdoptPairs (dσ : DenseSparseSolved p) (x : VarId) (t : DenseLinExpr p) :
-    List (VarId × DenseLinExpr p) :=
-  let touched := (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
-    (dσ.map[y]?).bind (fun s => if s.mentions x then some (y, s) else none))
-  touched.map (fun ys => (ys.1, denseLinSubst ys.2 x t)) ++ [(x, t)]
-
-def denseMarkowitzAdopt (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (entry : DenseMarkowitzEntry) (x : VarId) (t : DenseLinExpr p)
-    (pairs : List (VarId × DenseLinExpr p)) (st : DenseMarkowitzState p)
-    (dσ : DenseSparseSolved p) : DenseMarkowitzState p :=
-  let (st, selectedVars) := denseMarkowitzDeactivate entry.rowId st
-  let (st, rowVars) := denseMarkowitzRefreshRows occ prot x t st
-  let changed := pairs.foldl (fun changed yt =>
-    yt.2.terms.foldl (fun changed yc => changed.insert yc.1) changed) (selectedVars ∪ rowVars)
-  denseMarkowitzRekey occ prot dσ changed st
-
-def denseMarkowitzPick (r : DenseGaussReduced p) (x : VarId) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : Option (VarId × DenseLinExpr p) :=
-  let hinted := match r with
-    | .affine l => denseSparseSolveAt l x
-    | .nonlinear _ => none
-  match hinted with
-  | some xt => some xt
-  | none => denseReducedBest r occ prot
-
-def denseMarkowitzLoop (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (sources : Array (DenseExpr p)) : Nat → DenseMarkowitzState p →
-      DenseSparseSolved p → DenseSparseSolved p
-  | 0, _, dσ => dσ
-  | fuel + 1, st, dσ =>
-      match denseMarkowitzPopValid (st.heap.size + 1) st with
-      | none => dσ
-      | some (entry, st) =>
-          match sources[entry.rowId]? with
-          | none => denseMarkowitzLoop occ prot sources fuel
-              (denseMarkowitzDeactivate entry.rowId st).1 dσ
-          | some c =>
-              let c' := denseSparseSubstF dσ.fn c
-              match denseMarkowitzPick c' entry.pivot occ prot with
-              | none => denseMarkowitzLoop occ prot sources fuel
-                  (denseMarkowitzDeactivate entry.rowId st).1 dσ
-              | some (x, t) =>
-                  let pairs := denseMarkowitzAdoptPairs dσ x t
-                  let dσ := dσ.insertAll pairs
-                  let st := denseMarkowitzAdopt occ prot entry x t pairs st dσ
-                  denseMarkowitzLoop occ prot sources fuel
-                    st dσ
-
-def denseMarkowitzSchedule (constraints : List (DenseExpr p)) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) : DenseSparseSolved p :=
-  let sources := constraints.toArray
-  let st := denseMarkowitzBuild constraints occ prot
-  denseMarkowitzLoop occ prot sources sources.size st DenseSparseSolved.empty
-
-def denseSourceOrderSchedule (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSparseSolved p :=
-  let first := denseSparseGaussLoop occ prot constraints DenseSparseSolved.empty
-  if first.map.isEmpty then first else denseSparseGaussLoop occ prot constraints first
-
-def denseMarkowitzMinRows : Nat := 8192
-
-def denseGaussSchedule (constraints : List (DenseExpr p))
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) : DenseSolved p :=
-  (if constraints.length < denseMarkowitzMinRows
-    then denseSourceOrderSchedule constraints occ prot
-    else denseMarkowitzSchedule constraints occ prot).materialize
-
+/-- Every variable of `l.others v` is a variable of `l`; consumed by `denseSparseSolveAt_terms`. -/
 theorem DenseLinExpr.others_terms_fst_mem (l : DenseLinExpr p) (v : VarId) (x : VarId)
     (h : x ∈ (l.others v).terms.map Prod.fst) : x ∈ l.terms.map Prod.fst := by
   simp only [DenseLinExpr.others, List.mem_map] at h ⊢
   obtain ⟨tt, htt, rfl⟩ := h
   exact ⟨tt, List.mem_of_mem_filter htt, rfl⟩
 
+/-- Above this many constraints the fill-aware scheduler takes over from source order. Below it the
+    SP1 `rsp` shapes need the source-order basis: the fill-aware one there costs 8 of its 100 cases
+    +88 variables (`agent-docs/log.md` entry 160). -/
+def denseMarkowitzMinRows : Nat := 8192
+
+/-! ## The substituted-evaluation walk -/
+
+/-- Substituted evaluation of a subtree: a constant, an affine form (terms not yet merged), or
+    blocked by a surviving variable×variable product, carrying the variables to watch. -/
+inductive GRes (p : ℕ) where
+  | cst (c : ZMod p)
+  | lin (l : DenseLinExpr p)
+  | blk (ws : List VarId)
+
+/-- The solution map as a lookup function; `VarId.index`-keyed, so no hashing. -/
+def gSolFn (sol : Array (Option (DenseLinExpr p))) : VarId → Option (DenseLinExpr p) :=
+  fun i => (sol[i.index]?).getD none
+
+def gAddRes (ops : DenseZModOps p) : GRes p → GRes p → GRes p
+  | .blk w, _ => .blk w
+  | _, .blk w => .blk w
+  | .cst c1, .cst c2 => .cst (ops.add c1 c2)
+  | .cst c1, .lin l2 => .lin ⟨ops.add c1 l2.const, l2.terms⟩
+  | .lin l1, .cst c2 => .lin ⟨ops.add l1.const c2, l1.terms⟩
+  | .lin l1, .lin l2 => .lin (l1.addWith ops l2)
+
+/-- A product is affine exactly when one side's *merged* substituted form is constant; otherwise the
+    node blocks, and the merged sides' variables are what can unblock it. -/
+def gMulRes (ops : DenseZModOps p) : GRes p → GRes p → GRes p
+  | .blk w, _ => .blk w
+  | _, .blk w => .blk w
+  | .cst c1, .cst c2 => .cst (ops.mul c1 c2)
+  | .cst c1, .lin l2 => .lin (l2.scaleWith ops c1)
+  | .lin l1, .cst c2 => .lin (l1.scaleWith ops c2)
+  | .lin l1, .lin l2 =>
+      let n1 := l1.normWith ops
+      if n1.terms.isEmpty then .lin (l2.scaleWith ops n1.const)
+      else
+        let n2 := l2.normWith ops
+        if n2.terms.isEmpty then .lin (n1.scaleWith ops n2.const)
+        else .blk (n1.terms.map Prod.fst ++ n2.terms.map Prod.fst)
+
+/-- Walk `e` under the solution map. Blocking propagates unconditionally through `add` and `mul`, so
+    the walk stops at the first surviving product and allocates nothing on that path. -/
+def gEval (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p))) :
+    DenseExpr p → GRes p
+  | .const n => .cst n
+  | .var x =>
+      match gSolFn sol x with
+      | some t => .lin t
+      | none => .lin ⟨ops.zero, [(x, ops.one)]⟩
+  | .add a b =>
+      match gEval ops sol a with
+      | .blk w => .blk w
+      | ra => gAddRes ops ra (gEval ops sol b)
+  | .mul a b =>
+      match gEval ops sol a with
+      | .blk w => .blk w
+      | ra => gMulRes ops ra (gEval ops sol b)
+
+/-- The walk's verdict at a constraint root: a merged row, or the variables to watch. -/
+inductive GTop (p : ℕ) where
+  | row (l : DenseLinExpr p)
+  | blocked (ws : List VarId)
+
+def gRoot (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p))) (e : DenseExpr p) :
+    GTop p :=
+  match gEval ops sol e with
+  | .cst c => .row ⟨c, []⟩
+  | .lin l => .row (l.normWith ops)
+  | .blk ws => .blocked ws
+
+/-! ## Pivot selection
+
+`denseGaussScore` on a merged row is `(occ[v] - 1) * |terms|`, plus `1000000` when protected, since
+every variable of a merged row occurs exactly once. So the choice is: smallest score, `±1`
+coefficients before other units, earliest term — one scan, with `occ`/`prot` as arrays. -/
+
+def gScore (occ : Array Nat) (prot : Array Bool) (v : VarId) (n : Nat) : Nat :=
+  let base := ((occ[v.index]?).getD 1 - 1) * n
+  if (prot[v.index]?).getD false then base + 1000000 else base
+
+def gIsPm1 (ops : DenseZModOps p) (c : ZMod p) : Bool :=
+  zmodIsOne c || zmodIsOne (ops.mul ops.negOne c)
+
+/-- Best candidate by `(score, ±1 first, position)`, skipping `banned` variables. -/
+def gBestGo (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (n : Nat)
+    (banned : List VarId) : List (VarId × ZMod p) → Option (VarId × Nat × Bool) → Option VarId
+  | [], best => best.map (·.1)
+  | (v, c) :: rest, best =>
+      if banned.contains v then gBestGo ops occ prot n banned rest best
+      else
+        let s := gScore occ prot v n
+        let pm1 := gIsPm1 ops c
+        match best with
+        | none => gBestGo ops occ prot n banned rest (some (v, s, pm1))
+        | some (bv, bs, bpm1) =>
+            if s < bs || (s == bs && pm1 && !bpm1) then
+              gBestGo ops occ prot n banned rest (some (v, s, pm1))
+            else gBestGo ops occ prot n banned rest (some (bv, bs, bpm1))
+
+/-- Pick the best pivot and solve for it, skipping candidates whose coefficient is not a unit (only
+    reachable on a non-prime modulus — `denseSparseSolveAt` decides). -/
+def gPick (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (l : DenseLinExpr p) :
+    Nat → List VarId → Option (VarId × DenseLinExpr p)
+  | 0, _ => none
+  | fuel + 1, banned =>
+      match gBestGo ops occ prot l.terms.length banned l.terms none with
+      | none => none
+      | some x =>
+          match denseSparseSolveAtWith ops l x with
+          | some xt => some xt
+          | none => gPick ops occ prot l fuel (x :: banned)
+
+/-! ## Engine state
+
+`rows` and `sol` carry the entailment invariant (`Proofs/Gauss.lean`); everything else is
+scheduling data that occurs in no theorem — a stale entry costs time, never soundness. -/
+
+structure GSt (p : ℕ) where
+  /-- Pending row per constraint slot, developed against `sol` when the scheduler reaches it. -/
+  rows : Array (DenseLinExpr p)
+  /-- `0` blocked · `1` pending affine row · `2` used or dead. -/
+  status : Array UInt8
+  /-- The solution map, kept fully back-substituted. -/
+  sol : Array (Option (DenseLinExpr p))
+  /-- Variable → solved variables whose row mentions it (stale-tolerant, re-checked at use). -/
+  solRev : Array (Array VarId)
+  /-- Variable → blocked constraints to re-walk when it is solved. -/
+  watch : Array (Array Nat)
+  woken : Array Bool
+  /-- Adoption order; the domain of the solution map. -/
+  order : Array VarId
+
+def GSt.empty (nc nv : Nat) : GSt p :=
+  { rows := Array.replicate nc ⟨zmodZeroP p, []⟩
+    status := Array.replicate nc 0
+    sol := Array.replicate nv none
+    solRev := Array.replicate nv #[]
+    watch := Array.replicate nv #[]
+    woken := Array.replicate nc false
+    order := #[] }
+
+/-- Substitute `x := t` into one stored solution. -/
+def gSubst1 (ops : DenseZModOps p) (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) :
+    DenseLinExpr p :=
+  denseLinSubstFWith ops s (fun z => if z = x then some t else none)
+
+def gAddRev (t : DenseLinExpr p) (y : VarId) (solRev : Array (Array VarId)) :
+    Array (Array VarId) :=
+  t.terms.foldl (fun rd zc => (denseArrEnsure rd zc.1.index #[]).modify zc.1.index (·.push y))
+    solRev
+
+def gWatchOne (i : Nat) (w : Array (Array Nat)) (v : VarId) : Array (Array Nat) :=
+  (denseArrEnsure w v.index #[]).modify v.index (·.push i)
+
+/-! ### Field updates
+
+Each helper destructures the state before writing, so the array being written is uniquely owned.
+`{ S with f := g S.f }` instead leaves `S.f` shared and copies the whole array — measured at 7× on
+keccak when `gAdopt` did it to `watch`. -/
+
+def GSt.setStatus (S : GSt p) (i : Nat) (v : UInt8) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status.setIfInBounds i v, sol := sol, solRev := solRev,
+    watch := watch, woken := woken, order := order }
+
+def GSt.setRow (S : GSt p) (i : Nat) (l : DenseLinExpr p) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows.setIfInBounds i l, status := status, sol := sol, solRev := solRev,
+    watch := watch, woken := woken, order := order }
+
+def GSt.setPending (S : GSt p) (i : Nat) (l : DenseLinExpr p) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows.setIfInBounds i l, status := status.setIfInBounds i 1, sol := sol,
+    solRev := solRev, watch := watch, woken := woken, order := order }
+
+def GSt.clearWoken (S : GSt p) (i : Nat) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol, solRev := solRev, watch := watch,
+    woken := woken.setIfInBounds i false, order := order }
+
+def GSt.addWatch (S : GSt p) (i : Nat) (ws : List VarId) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol, solRev := solRev,
+    watch := ws.foldl (gWatchOne i) watch, woken := woken, order := order }
+
+def GSt.setSol (S : GSt p) (y : VarId) (v : Option (DenseLinExpr p)) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol.setIfInBounds y.index v, solRev := solRev,
+    watch := watch, woken := woken, order := order }
+
+/-- Record that the variables of `t` are now mentioned by `y`'s stored solution. -/
+def GSt.pushRev (S : GSt p) (t : DenseLinExpr p) (y : VarId) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol, solRev := gAddRev t y solRev,
+    watch := watch, woken := woken, order := order }
+
+def GSt.clearRev (S : GSt p) (x : VarId) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol, solRev := solRev.setIfInBounds x.index #[],
+    watch := watch, woken := woken, order := order }
+
+/-- Wake every constraint watching `x`, and drop its watch list. -/
+def GSt.fireWatch (S : GSt p) (x : VarId) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  let ws := (watch[x.index]?).getD #[]
+  { rows := rows, status := status, sol := sol, solRev := solRev,
+    watch := watch.setIfInBounds x.index #[],
+    woken := ws.foldl (fun w c => w.setIfInBounds c true) woken, order := order }
+
+def GSt.pushOrder (S : GSt p) (x : VarId) : GSt p :=
+  let ⟨rows, status, sol, solRev, watch, woken, order⟩ := S
+  { rows := rows, status := status, sol := sol, solRev := solRev, watch := watch,
+    woken := woken, order := order.push x }
+
+/-- Develop `x := t` into the stored solutions listed in `ys`, keeping the map back-substituted. -/
+def gRewriteStored (ops : DenseZModOps p) (x : VarId) (t : DenseLinExpr p) (ys : Array VarId) :
+    Nat → GSt p → GSt p
+  | 0, S => S
+  | k + 1, S =>
+      match ys[ys.size - (k + 1)]? with
+      | none => gRewriteStored ops x t ys k S
+      | some y =>
+          match gSolFn S.sol y with
+          | some s =>
+              if s.mentions x then
+                gRewriteStored ops x t ys k
+                  ((S.setSol y (some (gSubst1 ops s x t))).pushRev t y)
+              else gRewriteStored ops x t ys k S
+          | none => gRewriteStored ops x t ys k S
+
+/-- Adopt `x := t`, solved from constraint `i`: keep the stored solutions back-substituted, record
+    the solution, and wake the constraints watching `x`. Pending rows are untouched — they are
+    developed when the scheduler reaches them. -/
+def gAdopt (ops : DenseZModOps p) (S : GSt p) (i : Nat) (x : VarId) (t : DenseLinExpr p) : GSt p :=
+  -- Every field is read out once and then updated through a destructuring helper: reading a field
+  -- twice inside one record update leaves it shared, and the write copies the whole array
+  -- (measured: 7× on keccak).
+  let ys := ((S.solRev[x.index]?).getD #[])
+  let S := gRewriteStored ops x t ys ys.size (S.clearRev x)
+  (((((S.setSol x (some t)).pushRev t x).fireWatch x).pushOrder x).setStatus i 2)
+
+/-- Develop a pending row against the solution map. A row mentioning no solved variable is returned
+    as it stands, which is the common case and costs no allocation. -/
+def gDevelop (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p))) (r : DenseLinExpr p) :
+    DenseLinExpr p :=
+  if r.terms.any (fun t => (gSolFn sol t.1).isSome) then denseLinSubstFWith ops r (gSolFn sol)
+  else r
+
+/-! ## Visiting a constraint -/
+
+/-- Take the pivot of a developed row, or retire the slot. -/
+def gTake (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (S : GSt p) (i : Nat)
+    (l : DenseLinExpr p) : GSt p :=
+  if l.terms.isEmpty then S.setStatus i 2
+  else
+    match gPick ops occ prot l (l.terms.length + 1) [] with
+    | none => S.setPending i l
+    | some (x, t) => gAdopt ops S i x t
+
+/-- Visit constraint `i`: develop its pending row and pivot, or — if a watched variable was solved
+    since the last look — re-walk it from the source expression. -/
+def gVisit (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (cs : Array (DenseExpr p)) (S : GSt p) (i : Nat) : GSt p :=
+  let st := (S.status[i]?).getD 2
+  if st == 1 then
+    match S.rows[i]? with
+    | none => S
+    | some r => gTake ops occ prot S i (gDevelop ops S.sol r)
+  else if st == 0 && (S.woken[i]?).getD false then
+    let S := S.clearWoken i
+    match cs[i]? with
+    | none => S
+    | some c =>
+        match gRoot ops S.sol c with
+        | .blocked ws => S.addWatch i ws
+        | .row l => gTake ops occ prot S i l
+  else S
+
+/-- One walk per constraint: a pending row, or a watch registration. -/
+def gBuildGo (ops : DenseZModOps p) (cs : Array (DenseExpr p)) : Nat → GSt p → GSt p
+  | 0, S => S
+  | k + 1, S =>
+      let i := cs.size - (k + 1)
+      gBuildGo ops cs k <|
+        match cs[i]? with
+        | none => S
+        | some c =>
+            match gRoot ops S.sol c with
+            | .row l => if l.terms.isEmpty then S.setStatus i 2 else S.setPending i l
+            | .blocked ws => S.addWatch i ws
+
+def gBuild (ops : DenseZModOps p) (cs : Array (DenseExpr p)) (nv : Nat) : GSt p :=
+  gBuildGo ops cs cs.size (GSt.empty cs.size nv)
+
+/-! ## Source-order scheduling (below the gate) -/
+
+def gSweepGo (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (cs : Array (DenseExpr p)) : Nat → GSt p → GSt p
+  | 0, S => S
+  | k + 1, S => gSweepGo ops occ prot cs k (gVisit ops occ prot cs S (cs.size - (k + 1)))
+
+/-- Two source-order sweeps: every constraint once, then the woken ones. -/
+def gRun (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (cs : Array (DenseExpr p)) (nv : Nat) : GSt p :=
+  gSweepGo ops occ prot cs cs.size (gSweepGo ops occ prot cs cs.size (gBuild ops cs nv))
+
+/-! ## Fill-aware scheduling (above the gate)
+
+Rows are held in buckets by their last known term count; a row whose developed form outgrew its
+bucket is re-filed rather than pivoted, so the key needs no eager maintenance. FIFO within a bucket,
+so source order breaks ties. -/
+
+def gMaxBucket : Nat := 16
+
+structure GQueue where
+  buckets : Array (Array Nat)
+  heads : Array Nat
+
+def GQueue.empty : GQueue :=
+  { buckets := Array.replicate (gMaxBucket + 1) #[], heads := Array.replicate (gMaxBucket + 1) 0 }
+
+def GQueue.push (q : GQueue) (n : Nat) (i : Nat) : GQueue :=
+  let ⟨buckets, heads⟩ := q
+  { buckets := buckets.modify (min n gMaxBucket) (·.push i), heads := heads }
+
+/-- Smallest bucket with an unconsumed entry. -/
+def GQueue.next (q : GQueue) : Nat → Option Nat
+  | 0 => none
+  | k + 1 =>
+      let b := gMaxBucket + 1 - (k + 1)
+      if 0 < b && (q.heads[b]?).getD 0 < ((q.buckets[b]?).getD #[]).size then some b
+      else q.next k
+
+def GQueue.pop (q : GQueue) (b : Nat) : Option Nat × GQueue :=
+  let ⟨buckets, heads⟩ := q
+  let h := (heads[b]?).getD 0
+  let i? := ((buckets[b]?).getD #[])[h]?
+  (i?, { buckets := buckets, heads := heads.setIfInBounds b (h + 1) })
+
+/-- Seed the queue from the pending rows, in source order. -/
+def gSeedGo (S : GSt p) : Nat → GQueue → GQueue
+  | 0, q => q
+  | k + 1, q =>
+      let i := S.status.size - (k + 1)
+      gSeedGo S k <|
+        if (S.status[i]?).getD 2 == 1 then
+          match S.rows[i]? with
+          | some l => q.push l.terms.length i
+          | none => q
+        else q
+
+/-- Handle the popped row `i`: develop it, then re-file it (it outgrew bucket `b`), retire it, or
+    pivot on it. -/
+def gDrainAt (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (S : GSt p)
+    (q : GQueue) (prog : Bool) (b i : Nat) : GSt p × GQueue × Bool :=
+  if (S.status[i]?).getD 2 != 1 then (S, q, prog)
+  else
+    match S.rows[i]? with
+    | none => (S, q, prog)
+    | some r =>
+        let l := gDevelop ops S.sol r
+        if l.terms.isEmpty then (S.setStatus i 2, q, prog)
+        else if min l.terms.length gMaxBucket > b then
+          (S.setRow i l, q.push l.terms.length i, prog)
+        else
+          let n := S.order.size
+          let S := gTake ops occ prot S i l
+          (S, q, prog || S.order.size != n)
+
+/-- One queue step: pop the shortest pending row and handle it. -/
+def gDrainStep (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) (S : GSt p)
+    (q : GQueue) (prog : Bool) : GSt p × GQueue × Bool :=
+  match q.next (gMaxBucket + 1) with
+  | none => (S, q, prog)
+  | some b =>
+      match q.pop b with
+      | (none, q) => (S, q, prog)
+      | (some i, q) => gDrainAt ops occ prot S q prog b i
+
+/-- Drain the queue, smallest bucket first. -/
+def gDrainGo (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool) :
+    Nat → GSt p → GQueue → Bool → GSt p × GQueue × Bool
+  | 0, S, q, prog => (S, q, prog)
+  | fuel + 1, S, q, prog =>
+      match q.next (gMaxBucket + 1) with
+      | none => (S, q, prog)
+      | some _ =>
+          match gDrainStep ops occ prot S q prog with
+          | (S, q, prog) => gDrainGo ops occ prot fuel S q prog
+
+/-- Re-walk the constraints woken since the last round, queueing the ones that turned affine. -/
+def gWakeGo (ops : DenseZModOps p) (cs : Array (DenseExpr p)) :
+    Nat → GSt p → GQueue → Bool → GSt p × GQueue × Bool
+  | 0, S, q, prog => (S, q, prog)
+  | k + 1, S, q, prog =>
+      let i := cs.size - (k + 1)
+      if (S.status[i]?).getD 2 == 0 && (S.woken[i]?).getD false then
+        let S := S.clearWoken i
+        match cs[i]? with
+        | none => gWakeGo ops cs k S q prog
+        | some c =>
+            match gRoot ops S.sol c with
+            | .blocked ws => gWakeGo ops cs k (S.addWatch i ws) q prog
+            | .row l =>
+                if l.terms.isEmpty then gWakeGo ops cs k (S.setStatus i 2) q prog
+                else gWakeGo ops cs k (S.setPending i l) (q.push l.terms.length i) true
+      else gWakeGo ops cs k S q prog
+
+def gRoundsGo (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (cs : Array (DenseExpr p)) : Nat → GSt p → GQueue → GSt p
+  | 0, S, _ => S
+  | round + 1, S, q =>
+      match gDrainGo ops occ prot ((gMaxBucket + 2) * cs.size + 8) S q false with
+      | (S, q, _) =>
+        match gWakeGo ops cs cs.size S q false with
+        | (S, q, prog) => if prog then gRoundsGo ops occ prot cs round S q else S
+
+def gRunFill (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (cs : Array (DenseExpr p)) (nv : Nat) : GSt p :=
+  let S := gBuild ops cs nv
+  gRoundsGo ops occ prot cs (cs.size + 1) S (gSeedGo S S.status.size GQueue.empty)
+
+/-! ## Prologue and output -/
+
+def gOccAdd (m : Array Nat) (e : DenseExpr p) : Array Nat :=
+  e.foldVars (fun m x => (denseArrEnsure m x.index 0).modify x.index (· + 1)) m
+
+/-- `denseOccurrenceMap` and `denseProtectedVars` as `VarId.index`-keyed arrays. Both are scoring
+    inputs only: they occur in no theorem. -/
+def gPrepare (bs : BusSemantics p) (d : DenseConstraintSystem p) : Array Nat × Array Bool :=
+  let occ := d.busInteractions.foldl
+    (fun m bi => bi.payload.foldl gOccAdd (gOccAdd m bi.multiplicity))
+    (d.algebraicConstraints.foldl gOccAdd #[])
+  let prot := d.busInteractions.foldl (init := Array.replicate occ.size false) fun s bi =>
+    if bs.isStateful bi.busId then s
+    else bi.payload.foldl
+      (fun s e => match e with | .var x => s.setIfInBounds x.index true | _ => s) s
+  (occ, prot)
+
+/-- The solution map as a `VarId.index`-keyed array of dense expressions. -/
+def gOutGo (S : GSt p) : Nat → Array (Option (DenseExpr p)) → Array (Option (DenseExpr p))
+  | 0, out => out
+  | k + 1, out =>
+      gOutGo S k <|
+        match S.order[S.order.size - (k + 1)]? with
+        | none => out
+        | some x =>
+            match gSolFn S.sol x with
+            | some l => out.setIfInBounds x.index (some l.toExpr)
+            | none => out
+
+def gOutFn (out : Array (Option (DenseExpr p))) : VarId → Option (DenseExpr p) :=
+  fun i => (out[i.index]?).getD none
+
+/-- Solve the system: the prologue, then whichever scheduler the gate selects. -/
+def gSolveSystem (bs : BusSemantics p) (d : DenseConstraintSystem p) : GSt p :=
+  let ops : DenseZModOps p := denseZModOps
+  let cs := d.algebraicConstraints.toArray
+  match gPrepare bs d with
+  | (occ, prot) =>
+      if cs.size < denseMarkowitzMinRows then gRun ops occ prot cs occ.size
+      else gRunFill ops occ prot cs occ.size
+
+/-- The solution map as a `VarId.index`-keyed array; `sol` was sized to the variable bound. -/
+def gOutOf (S : GSt p) : Array (Option (DenseExpr p)) :=
+  gOutGo S S.order.size (Array.replicate S.sol.size none)
+
 /-- Batch linear (Gauss) elimination. From a constraint like `x - 2*y - 3 = 0` it derives the
-    assignment `x := 2*y + 3`, choosing pivots globally by dynamic Markowitz fill cost on large
-    systems and preserving source order on smaller systems. -/
-def denseGaussElim (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
-  let occ := denseOccurrenceMap d
-  let prot := denseProtectedVars d bs
-  let solved := denseGaussSchedule d.algebraicConstraints occ prot
-  if solved.map.isEmpty then d else d.substF solved.fn
-
-/-- `denseGaussElim` as an explicit `if` (the `let` zeta-reduces). -/
-theorem denseGaussElim_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
-    denseGaussElim bs d =
-      if (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).map.isEmpty
-      then d
-      else d.substF (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn := rfl
-
-/-! `denseGaussElimPass` (the wired pass) is built and proved in `Proofs/Gauss.lean`. -/
+    assignment `x := 2*y + 3`, choosing pivots by occurrence-weighted duplication cost. -/
+def denseGaussElimF (bs : BusSemantics p) (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  let S := gSolveSystem bs d
+  if S.order.isEmpty then d else d.substF (gOutFn (gOutOf S))
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Gauss.lean
@@ -4,10 +4,19 @@ import ApcOptimizer.Implementation.OptimizerPasses.Proofs.FlagUnify
 
 set_option autoImplicit false
 
-/-! # Correctness for the dense Gauss-elimination pass.
-Substitution-shaped: correctness rides on `DenseConstraintSystem.substF_denseCorrect`
-(`Proofs/DomainBatch.lean`), fed the final solution map's entailment and occurrence closure, both
-established by `denseSparseMarkowitzLoop_sound`. -/
+/-! # Correctness for the dense Gauss-elimination pass
+
+Substitution-shaped, like every solver pass: correctness rides on
+`DenseConstraintSystem.substF_denseCorrect`, fed the final solution map's *entailment* and
+*occurrence closure*. Those two facts are all the spec asks for, so the scheduler — buckets, watch
+lists, `occ`/`prot`, `status`, `woken` — appears nowhere below: a wrong entry costs elimination
+opportunities, never soundness.
+
+Part one is the affine layer: substituting a solution map into a row preserves its value and
+introduces no variable, and solving an entailed row for a unit-coefficient variable yields an
+entailed assignment. Part two carries two invariants through the engine (`GInv`) — every pending row
+is entailed and occurrence-closed, every stored solution is an entailed assignment with the same
+closure — of which `gAdopt` is the only step that touches either. -/
 
 namespace ApcOptimizer.Dense
 
@@ -96,268 +105,10 @@ theorem denseLinSubstF_terms_closed (l : DenseLinExpr p)
       subst zc
       exact hzc ▸ hσ yc.1 row hrow rc.1 (List.mem_map.2 ⟨rc, hrc, rfl⟩)
 
-theorem denseLinAdd_eval (a b : DenseLinExpr p) (denv : VarId → ZMod p) :
-    (denseLinAdd a b).eval denv = a.eval denv + b.eval denv := by
-  rw [denseLinAdd, DenseLinExpr.norm_eval, DenseLinExpr.add_eval]
-
 theorem denseLinScale_eval (k : ZMod p) (l : DenseLinExpr p) (denv : VarId → ZMod p) :
     (denseLinScale k l).eval denv = k * l.eval denv := by
   rw [denseLinScale, DenseLinExpr.norm_eval, DenseLinExpr.scale_eval]
 
-theorem denseLinAdd_toExpr_eval (a b : DenseLinExpr p) (denv : VarId → ZMod p) :
-    (denseLinAdd a b).toExpr.eval denv = a.toExpr.eval denv + b.toExpr.eval denv := by
-  simp only [DenseLinExpr.toExpr_eval, denseLinAdd_eval]
-
-theorem denseLinScale_toExpr_eval (k : ZMod p) (l : DenseLinExpr p)
-    (denv : VarId → ZMod p) :
-    (denseLinScale k l).toExpr.eval denv = k * l.toExpr.eval denv := by
-  simp only [DenseLinExpr.toExpr_eval, denseLinScale_eval]
-
-theorem denseLinAdd_terms_closed (a b : DenseLinExpr p) (S : VarId → Prop)
-    (ha : ∀ z ∈ a.terms.map Prod.fst, S z)
-    (hb : ∀ z ∈ b.terms.map Prod.fst, S z) :
-    ∀ z ∈ (denseLinAdd a b).terms.map Prod.fst, S z := by
-  intro z hz
-  have hz' := DenseLinExpr.norm_terms_fst (a.add b) z hz
-  simp only [DenseLinExpr.add, List.map_append, List.mem_append] at hz'
-  exact hz'.elim (ha z) (hb z)
-
-theorem denseLinScale_terms_closed (k : ZMod p) (l : DenseLinExpr p) (S : VarId → Prop)
-    (hl : ∀ z ∈ l.terms.map Prod.fst, S z) :
-    ∀ z ∈ (denseLinScale k l).terms.map Prod.fst, S z := by
-  intro z hz
-  have hz' := DenseLinExpr.norm_terms_fst (l.scale k) z hz
-  rw [DenseLinExpr.scale_terms_fst] at hz'
-  exact hl z hz'
-
-theorem denseSparseMulReduced_eval (ra rb : DenseGaussReduced p) (denv : VarId → ZMod p) :
-    (denseReducedMul ra rb).toExpr.eval denv
-      = ra.toExpr.eval denv * rb.toExpr.eval denv := by
-  cases ra with
-  | nonlinear ea =>
-      cases rb <;> simp [denseReducedMul, DenseGaussReduced.toExpr, DenseExpr.eval]
-  | affine la =>
-      cases rb with
-      | nonlinear eb => simp [denseReducedMul, DenseGaussReduced.toExpr, DenseExpr.eval]
-      | affine lb =>
-          simp only [denseReducedMul, DenseGaussReduced.toExpr]
-          by_cases ha : la.terms.isEmpty
-          · rw [if_pos ha]
-            simp only [denseLinScale_toExpr_eval]
-            rw [DenseLinExpr.toExpr_eval la]
-            simp [DenseLinExpr.eval, List.isEmpty_iff.1 ha]
-          · rw [if_neg ha]
-            by_cases hb : lb.terms.isEmpty
-            · rw [if_pos hb]
-              simp only [denseLinScale_toExpr_eval]
-              rw [DenseLinExpr.toExpr_eval lb]
-              simp [DenseLinExpr.eval, List.isEmpty_iff.1 hb, mul_comm]
-            · rw [if_neg hb]
-              rfl
-
-theorem denseSparseSubstF_eval (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p)
-    (denv : VarId → ZMod p) (hσ : ∀ i row, σ i = some row → denv i = row.eval denv) :
-    (denseSparseSubstF σ e).toExpr.eval denv = e.eval denv := by
-  have henv : denseLinEnv σ denv = denv := by
-    funext i
-    cases hi : σ i with
-    | none => simp [denseLinEnv, hi]
-    | some row => simp [denseLinEnv, hi, hσ i row hi]
-  induction e with
-  | const n => rfl
-  | var i =>
-      simp only [denseSparseSubstF]
-      cases hi : σ i with
-      | none =>
-          simp only [DenseGaussReduced.toExpr, DenseExpr.eval]
-          rw [DenseLinExpr.toExpr_eval]
-          simp [DenseLinExpr.eval]
-      | some row =>
-          simp only [DenseGaussReduced.toExpr, DenseExpr.eval]
-          rw [DenseLinExpr.toExpr_eval, ← hσ i row hi]
-  | add a b iha ihb =>
-      simp only [denseSparseSubstF]
-      cases hlin : denseLinearize (.add a b) with
-      | some row =>
-          simp only [DenseGaussReduced.toExpr]
-          rw [DenseLinExpr.toExpr_eval, denseLinSubstF_eval, henv,
-            ← denseLinearize_eval (.add a b) row hlin]
-      | none =>
-          cases ha : denseSparseSubstF σ a <;>
-            cases hb : denseSparseSubstF σ b <;>
-            simp_all [denseReducedAdd, DenseGaussReduced.toExpr, DenseExpr.eval,
-              denseLinAdd_toExpr_eval]
-  | mul a b iha ihb =>
-      simp only [denseSparseSubstF]
-      cases hlin : denseLinearize (.mul a b) with
-      | some row =>
-          simp only [DenseGaussReduced.toExpr]
-          rw [DenseLinExpr.toExpr_eval, denseLinSubstF_eval, henv,
-            ← denseLinearize_eval (.mul a b) row hlin]
-      | none =>
-          have hm := denseSparseMulReduced_eval
-            (denseSparseSubstF σ a) (denseSparseSubstF σ b) denv
-          rw [iha, ihb] at hm
-          simpa only [DenseExpr.eval] using hm
-
-def DenseGaussReduced.support : DenseGaussReduced p → List VarId
-  | .affine row => row.terms.map Prod.fst
-  | .nonlinear expr => expr.vars
-
-def DenseGaussReduced.Closed (r : DenseGaussReduced p) (S : VarId → Prop) : Prop :=
-  ∀ z ∈ r.support, S z
-
-theorem denseSparseAddReduced_closed (ra rb : DenseGaussReduced p) (S : VarId → Prop)
-    (ha : ra.Closed S) (hb : rb.Closed S) :
-    (denseReducedAdd ra rb).Closed S := by
-  revert ha hb
-  cases ra with
-  | affine la =>
-      cases rb with
-      | affine lb =>
-          intro ha hb
-          simp only [denseReducedAdd, DenseGaussReduced.Closed,
-            DenseGaussReduced.support] at ha hb ⊢
-          exact denseLinAdd_terms_closed la lb S ha hb
-      | nonlinear eb =>
-          intro ha hb
-          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact DenseLinExpr.toExpr_vars la z hz |> ha z
-          · exact hb z hz
-  | nonlinear ea =>
-      cases rb with
-      | affine lb =>
-          intro ha hb
-          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact ha z hz
-          · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
-      | nonlinear eb =>
-          intro ha hb
-          simp only [denseReducedAdd, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact ha z hz
-          · exact hb z hz
-
-theorem denseSparseMulReduced_closed (ra rb : DenseGaussReduced p) (S : VarId → Prop)
-    (ha : ra.Closed S) (hb : rb.Closed S) :
-    (denseReducedMul ra rb).Closed S := by
-  revert ha hb
-  cases ra with
-  | affine la =>
-      cases rb with
-      | affine lb =>
-          intro ha hb
-          simp only [denseReducedMul, DenseGaussReduced.Closed,
-            DenseGaussReduced.support] at ha hb ⊢
-          by_cases hla : la.terms.isEmpty
-          · rw [if_pos hla]
-            exact denseLinScale_terms_closed la.const lb S hb
-          · rw [if_neg hla]
-            by_cases hlb : lb.terms.isEmpty
-            · rw [if_pos hlb]
-              exact denseLinScale_terms_closed lb.const la S ha
-            · rw [if_neg hlb]
-              intro z hz
-              simp only [DenseExpr.vars, List.mem_append] at hz
-              rcases hz with hz | hz
-              · exact DenseLinExpr.toExpr_vars la z hz |> ha z
-              · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
-      | nonlinear eb =>
-          intro ha hb
-          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact DenseLinExpr.toExpr_vars la z hz |> ha z
-          · exact hb z hz
-  | nonlinear ea =>
-      cases rb with
-      | affine lb =>
-          intro ha hb
-          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact ha z hz
-          · exact DenseLinExpr.toExpr_vars lb z hz |> hb z
-      | nonlinear eb =>
-          intro ha hb
-          simp only [denseReducedMul, DenseGaussReduced.Closed, DenseGaussReduced.support,
-            DenseGaussReduced.toExpr] at ha hb ⊢
-          intro z hz
-          simp only [DenseExpr.vars, List.mem_append] at hz
-          rcases hz with hz | hz
-          · exact ha z hz
-          · exact hb z hz
-
-theorem denseSparseSubstF_closed (σ : VarId → Option (DenseLinExpr p)) (e : DenseExpr p)
-    (S : VarId → Prop) (he : ∀ z ∈ e.vars, S z)
-    (hσ : ∀ i row, σ i = some row → ∀ z ∈ row.terms.map Prod.fst, S z) :
-    (denseSparseSubstF σ e).Closed S := by
-  induction e with
-  | const n =>
-      simp [denseSparseSubstF, DenseGaussReduced.Closed, DenseGaussReduced.support]
-  | var i =>
-      simp only [denseSparseSubstF]
-      cases hi : σ i with
-      | none =>
-          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support,
-            List.map_singleton, List.mem_singleton]
-          intro z hz
-          subst z
-          exact he i (by simp [DenseExpr.vars])
-      | some row =>
-          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
-          exact hσ i row hi
-  | add a b iha ihb =>
-      simp only [denseSparseSubstF]
-      cases hlin : denseLinearize (.add a b) with
-      | some row =>
-          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
-          apply denseLinSubstF_terms_closed row σ S
-          · intro z hz
-            exact he z (denseLinearize_mem_vars (.add a b) row hlin z hz)
-          · exact hσ
-      | none =>
-          have hea : ∀ z ∈ a.vars, S z :=
-            fun z hz => he z (by simp [DenseExpr.vars, hz])
-          have heb : ∀ z ∈ b.vars, S z :=
-            fun z hz => he z (by simp [DenseExpr.vars, hz])
-          have ha := iha hea
-          have hb := ihb heb
-          exact denseSparseAddReduced_closed
-            (denseSparseSubstF σ a) (denseSparseSubstF σ b) S ha hb
-  | mul a b iha ihb =>
-      simp only [denseSparseSubstF]
-      cases hlin : denseLinearize (.mul a b) with
-      | some row =>
-          simp only [DenseGaussReduced.Closed, DenseGaussReduced.support]
-          apply denseLinSubstF_terms_closed row σ S
-          · intro z hz
-            exact he z (denseLinearize_mem_vars (.mul a b) row hlin z hz)
-          · exact hσ
-      | none =>
-          have hea : ∀ z ∈ a.vars, S z :=
-            fun z hz => he z (by simp [DenseExpr.vars, hz])
-          have heb : ∀ z ∈ b.vars, S z :=
-            fun z hz => he z (by simp [DenseExpr.vars, hz])
-          have ha := iha hea
-          have hb := ihb heb
-          exact denseSparseMulReduced_closed
-            (denseSparseSubstF σ a) (denseSparseSubstF σ b) S ha hb
 
 theorem denseLinSubst_eval (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p)
     (denv : VarId → ZMod p) (hx : denv x = t.eval denv) :
@@ -433,462 +184,1024 @@ theorem denseSparseSolveAt_terms (l : DenseLinExpr p) (x y : VarId)
     rw [DenseLinExpr.scale_terms_fst] at hz'
     exact l.others_terms_fst_mem x z hz'
 
-theorem denseSparseBest_sound (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
-    (h : denseSparseBest l occ prot = some (y, t))
-    (denv : VarId → ZMod p) (hl : l.eval denv = 0) :
-    denv y = t.eval denv := by
-  unfold denseSparseBest at h
-  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
-  | none => simp [hm] at h
-  | some q =>
-      simp only [hm] at h
-      exact denseSparseSolveAt_sound l q.1 y t h denv hl
+/-! ## The three predicates -/
 
-theorem denseSparseBest_terms (l : DenseLinExpr p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
-    (h : denseSparseBest l occ prot = some (y, t)) :
-    ∀ z ∈ t.terms.map Prod.fst, z ∈ l.terms.map Prod.fst := by
-  unfold denseSparseBest at h
-  cases hm : (densePivotDescs l occ prot).argmin Prod.snd with
-  | none => simp [hm] at h
-  | some q =>
-      simp only [hm] at h
-      exact denseSparseSolveAt_terms l q.1 y t h
+/-- `l` vanishes on every satisfying assignment. -/
+def GEnt (bs : BusSemantics p) (d : DenseConstraintSystem p) (l : DenseLinExpr p) : Prop :=
+  ∀ denv, d.satisfies bs denv → l.eval denv = 0
 
-theorem denseReducedBest_sound (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
-    (h : denseReducedBest r occ prot = some (y, t))
-    (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
-    denv y = t.eval denv := by
-  cases r with
-  | nonlinear e => simp [denseReducedBest] at h
-  | affine l =>
-      exact denseSparseBest_sound l occ prot y t h denv
-        (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
+/-- `x` equals `t` on every satisfying assignment. -/
+def GAsg (bs : BusSemantics p) (d : DenseConstraintSystem p) (x : VarId) (t : DenseLinExpr p) :
+    Prop :=
+  ∀ denv, d.satisfies bs denv → denv x = t.eval denv
 
-theorem denseReducedBest_terms (r : DenseGaussReduced p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) (y : VarId) (t : DenseLinExpr p)
-    (h : denseReducedBest r occ prot = some (y, t)) :
-    ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
-  cases r with
-  | nonlinear e => simp [denseReducedBest] at h
-  | affine l => exact denseSparseBest_terms l occ prot y t h
+/-- Every variable of `l` occurs in the system. -/
+def GCl (d : DenseConstraintSystem p) (l : DenseLinExpr p) : Prop :=
+  ∀ z ∈ l.terms.map Prod.fst, z ∈ d.occ
 
-theorem denseMarkowitzPick_sound (r : DenseGaussReduced p) (hint y : VarId)
-    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (h : denseMarkowitzPick r hint occ prot = some (y, t))
-    (denv : VarId → ZMod p) (hr : r.toExpr.eval denv = 0) :
-    denv y = t.eval denv := by
-  unfold denseMarkowitzPick at h
-  cases r with
-  | nonlinear e =>
-      simp only at h
-      exact denseReducedBest_sound (.nonlinear e) occ prot y t h denv hr
-  | affine l =>
-      cases hs : denseSparseSolveAt l hint with
-      | none =>
-          simp only [hs] at h
-          exact denseReducedBest_sound (.affine l) occ prot y t h denv hr
-      | some q =>
-          have hq : q = (y, t) := Option.some.inj (by simpa [hs] using h)
-          rw [hq] at hs
-          exact denseSparseSolveAt_sound l hint y t hs denv
-            (by simpa [DenseGaussReduced.toExpr, DenseLinExpr.toExpr_eval] using hr)
+theorem GCl_nil (d : DenseConstraintSystem p) (c : ZMod p) : GCl d ⟨c, []⟩ := by
+  intro z hz; simp at hz
 
-theorem denseMarkowitzPick_terms (r : DenseGaussReduced p) (hint y : VarId)
-    (t : DenseLinExpr p) (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (h : denseMarkowitzPick r hint occ prot = some (y, t)) :
-    ∀ z ∈ t.terms.map Prod.fst, z ∈ r.support := by
-  unfold denseMarkowitzPick at h
-  cases r with
-  | nonlinear e =>
-      simp only at h
-      exact denseReducedBest_terms (.nonlinear e) occ prot y t h
-  | affine l =>
-      cases hs : denseSparseSolveAt l hint with
-      | none =>
-          simp only [hs] at h
-          exact denseReducedBest_terms (.affine l) occ prot y t h
-      | some q =>
-          have hq : q = (y, t) := Option.some.inj (by simpa [hs] using h)
-          rw [hq] at hs
-          exact denseSparseSolveAt_terms l hint y t hs
+/-! ## The walk
 
-theorem DenseSparseSolved.insertAll_map :
-    ∀ (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p),
-      (dσ.insertAll pairs).map =
-        pairs.foldl (fun m pr => m.insert pr.1 pr.2) dσ.map := by
-  intro pairs
-  induction pairs with
-  | nil => intro dσ; rfl
-  | cons hd tl ih =>
-      intro dσ
-      obtain ⟨x, t⟩ := hd
-      simp only [DenseSparseSolved.insertAll, List.foldl_cons]
-      rw [ih]
+`GRes.toLin` is the affine form a walk result stands for; `blk` stands for none, which is what makes
+the blocked case vacuous in every lemma below. -/
 
-theorem sparseFoldlInsert_preserves {Q : VarId → DenseLinExpr p → Prop} :
-    ∀ (pairs : List (VarId × DenseLinExpr p))
-      (m : Std.HashMap VarId (DenseLinExpr p)),
-      (∀ i t, m[i]? = some t → Q i t) → (∀ pr ∈ pairs, Q pr.1 pr.2) →
-      ∀ i t, (pairs.foldl (fun out pr => out.insert pr.1 pr.2) m)[i]? = some t →
-        Q i t := by
-  intro pairs
-  induction pairs with
-  | nil => intro m hm _ i t ht; exact hm i t ht
-  | cons hd rest ih =>
-      intro m hm hpairs i t ht
-      obtain ⟨x, t0⟩ := hd
-      simp only [List.foldl_cons] at ht
-      refine ih (m.insert x t0) ?_
-        (fun pr hpr => hpairs pr (List.mem_cons_of_mem _ hpr)) i t ht
-      intro j s hjs
-      rw [Std.HashMap.getElem?_insert] at hjs
-      split_ifs at hjs with hjx
-      · simp only [Option.some.injEq] at hjs
-        have hj : x = j := by simpa using hjx
-        rw [← hjs, ← hj]
-        exact hpairs (x, t0) (List.mem_cons_self ..)
-      · exact hm j s hjs
+def GRes.toLin : GRes p → Option (DenseLinExpr p)
+  | .cst c => some ⟨c, []⟩
+  | .lin l => some l
+  | .blk _ => none
 
-theorem DenseSparseSolved.insertAll_preserves {Q : VarId → DenseLinExpr p → Prop}
-    (pairs : List (VarId × DenseLinExpr p)) (dσ : DenseSparseSolved p)
-    (hσ : ∀ i t, dσ.fn i = some t → Q i t)
-    (hpairs : ∀ pr ∈ pairs, Q pr.1 pr.2) :
-    ∀ i t, (dσ.insertAll pairs).fn i = some t → Q i t := by
-  intro i t ht
-  simp only [DenseSparseSolved.fn, DenseSparseSolved.insertAll_map] at ht
-  exact sparseFoldlInsert_preserves pairs dσ.map hσ hpairs i t ht
+theorem gAddRes_eval (ops : DenseZModOps p) (ra rb : GRes p) (l : DenseLinExpr p)
+    (h : (gAddRes ops ra rb).toLin = some l) :
+    ∃ la lb, ra.toLin = some la ∧ rb.toLin = some lb ∧
+      ∀ denv, l.eval denv = la.eval denv + lb.eval denv := by
+  cases ra with
+  | blk w => simp [gAddRes, GRes.toLin] at h
+  | cst c1 =>
+      cases rb with
+      | blk w => simp [gAddRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          exact ⟨⟨c1, []⟩, ⟨c2, []⟩, rfl, rfl, by intro denv; simp [DenseLinExpr.eval, ops.add_eq]⟩
+      | lin l2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          refine ⟨⟨c1, []⟩, l2, rfl, rfl, ?_⟩
+          intro denv
+          simp only [DenseLinExpr.eval, ops.add_eq, List.map_nil, List.sum_nil, add_zero]
+          ring
+  | lin l1 =>
+      cases rb with
+      | blk w => simp [gAddRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          refine ⟨l1, ⟨c2, []⟩, rfl, rfl, ?_⟩
+          intro denv
+          simp only [DenseLinExpr.eval, ops.add_eq, List.map_nil, List.sum_nil, add_zero]
+          ring
+      | lin l2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          refine ⟨l1, l2, rfl, rfl, ?_⟩
+          intro denv
+          rw [DenseLinExpr.addWith_eq, DenseLinExpr.add_eval]
 
-theorem denseSparseGaussLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    ∀ (pending : List (DenseExpr p)) (dσ : DenseSparseSolved p),
-      (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
-      (∀ denv, d.satisfies bs denv → ∀ i t,
-        dσ.fn i = some t → denv i = t.eval denv) →
-      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) →
-      (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseSparseGaussLoop occ prot pending dσ).fn i = some t →
-          denv i = t.eval denv) ∧
-      (∀ i t, (denseSparseGaussLoop occ prot pending dσ).fn i = some t →
-          ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
-  intro pending
-  induction pending with
-  | nil => intro dσ _ hσs hσv; exact ⟨hσs, hσv⟩
-  | cons c rest ih =>
-      intro dσ hpend hσs hσv
-      have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
-      have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
-        fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
-      let c' := denseSparseSubstF dσ.fn c
-      cases hpick : denseReducedBest (denseSparseSubstF dσ.fn c) occ prot with
-      | none =>
-          simp only [denseSparseGaussLoop, hpick]
-          exact ih dσ hrest hσs hσv
-      | some xt =>
-          obtain ⟨x, t⟩ := xt
-          have hcclosed : c'.Closed (· ∈ d.occ) := by
-            apply denseSparseSubstF_closed dσ.fn c
-            · intro z hz
-              exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
-            · exact hσv
-          have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
-            intro denv hsat
-            apply denseReducedBest_sound c' occ prot x t hpick denv
-            rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
-            exact hsat.1 c hcmem
-          have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
+theorem gAddRes_terms (ops : DenseZModOps p) (ra rb : GRes p) (l la lb : DenseLinExpr p)
+    (h : (gAddRes ops ra rb).toLin = some l)
+    (hla : ra.toLin = some la) (hlb : rb.toLin = some lb) :
+    ∀ z ∈ l.terms.map Prod.fst,
+      z ∈ la.terms.map Prod.fst ∨ z ∈ lb.terms.map Prod.fst := by
+  cases ra with
+  | blk w => simp [gAddRes, GRes.toLin] at h
+  | cst c1 =>
+      cases rb with
+      | blk w => simp [gAddRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h hla hlb
+          subst h; intro z hz; simp at hz
+      | lin l2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h hla hlb
+          subst h; subst hlb; intro z hz; exact Or.inr hz
+  | lin l1 =>
+      cases rb with
+      | blk w => simp [gAddRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h hla hlb
+          subst h; subst hla; intro z hz; exact Or.inl hz
+      | lin l2 =>
+          simp only [gAddRes, GRes.toLin, Option.some.injEq] at h hla hlb
+          subst h; subst hla; subst hlb
+          intro z hz
+          rw [DenseLinExpr.addWith_eq] at hz
+          simpa [DenseLinExpr.add, List.map_append] using hz
+
+theorem gMulRes_eval (ops : DenseZModOps p) (ra rb : GRes p) (l : DenseLinExpr p)
+    (h : (gMulRes ops ra rb).toLin = some l) :
+    ∃ la lb, ra.toLin = some la ∧ rb.toLin = some lb ∧
+      ∀ denv, l.eval denv = la.eval denv * lb.eval denv := by
+  cases ra with
+  | blk w => simp [gMulRes, GRes.toLin] at h
+  | cst c1 =>
+      cases rb with
+      | blk w => simp [gMulRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          exact ⟨⟨c1, []⟩, ⟨c2, []⟩, rfl, rfl, by intro denv; simp [DenseLinExpr.eval, ops.mul_eq]⟩
+      | lin l2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          refine ⟨⟨c1, []⟩, l2, rfl, rfl, ?_⟩
+          intro denv
+          rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_eval]
+          simp only [DenseLinExpr.eval, List.map_nil, List.sum_nil, add_zero]
+  | lin l1 =>
+      cases rb with
+      | blk w => simp [gMulRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h
+          subst h
+          refine ⟨l1, ⟨c2, []⟩, rfl, rfl, ?_⟩
+          intro denv
+          rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_eval]
+          simp only [DenseLinExpr.eval, List.map_nil, List.sum_nil, add_zero]
+          ring
+      | lin l2 =>
+          refine ⟨l1, l2, rfl, rfl, ?_⟩
+          simp only [gMulRes] at h
+          by_cases h1 : (l1.normWith ops).terms.isEmpty
+          · rw [if_pos h1] at h
+            simp only [GRes.toLin, Option.some.injEq] at h
+            subst h
+            intro denv
+            rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_eval]
+            have hn : (l1.normWith ops).terms = [] := List.isEmpty_iff.1 (by simpa using h1)
+            have hc : (l1.normWith ops).eval denv = (l1.normWith ops).const := by
+              simp only [DenseLinExpr.eval, hn, List.map_nil, List.sum_nil, add_zero]
+            have hq : (l1.normWith ops).eval denv = l1.eval denv := by
+              rw [DenseLinExpr.normWith_eq, DenseLinExpr.norm_eval]
+            rw [← hq, hc]
+          · rw [if_neg h1] at h
+            by_cases h2 : (l2.normWith ops).terms.isEmpty
+            · rw [if_pos h2] at h
+              simp only [GRes.toLin, Option.some.injEq] at h
+              subst h
+              intro denv
+              rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_eval]
+              have hn : (l2.normWith ops).terms = [] := List.isEmpty_iff.1 (by simpa using h2)
+              have hc : (l2.normWith ops).eval denv = (l2.normWith ops).const := by
+                simp only [DenseLinExpr.eval, hn, List.map_nil, List.sum_nil, add_zero]
+              have hq : (l2.normWith ops).eval denv = l2.eval denv := by
+                rw [DenseLinExpr.normWith_eq, DenseLinExpr.norm_eval]
+              have e1 : (l1.normWith ops).eval denv = l1.eval denv := by
+                rw [DenseLinExpr.normWith_eq, DenseLinExpr.norm_eval]
+              rw [e1, ← hq, hc, mul_comm]
+            · rw [if_neg h2] at h
+              simp [GRes.toLin] at h
+
+theorem gMulRes_terms (ops : DenseZModOps p) (ra rb : GRes p) (l la lb : DenseLinExpr p)
+    (h : (gMulRes ops ra rb).toLin = some l)
+    (hla : ra.toLin = some la) (hlb : rb.toLin = some lb) :
+    ∀ z ∈ l.terms.map Prod.fst,
+      z ∈ la.terms.map Prod.fst ∨ z ∈ lb.terms.map Prod.fst := by
+  cases ra with
+  | blk w => simp [gMulRes, GRes.toLin] at h
+  | cst c1 =>
+      cases rb with
+      | blk w => simp [gMulRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h
+          subst h; intro z hz; simp at hz
+      | lin l2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h hlb
+          subst h; subst hlb
+          intro z hz
+          rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_terms_fst] at hz
+          exact Or.inr hz
+  | lin l1 =>
+      cases rb with
+      | blk w => simp [gMulRes, GRes.toLin] at h
+      | cst c2 =>
+          simp only [gMulRes, GRes.toLin, Option.some.injEq] at h hla
+          subst h; subst hla
+          intro z hz
+          rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_terms_fst] at hz
+          exact Or.inl hz
+      | lin l2 =>
+          simp only [GRes.toLin, Option.some.injEq] at hla hlb
+          subst hla; subst hlb
+          simp only [gMulRes] at h
+          by_cases h1 : (l1.normWith ops).terms.isEmpty
+          · rw [if_pos h1] at h
+            simp only [GRes.toLin, Option.some.injEq] at h
+            subst h
             intro z hz
-            exact hcclosed z (denseReducedBest_terms c' occ prot x t hpick z hz)
-          have htouched : ∀ y s, (y, s) ∈
-                (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
-                  (dσ.map[y]?).bind
-                    (fun s => if s.mentions x then some (y, s) else none)) →
-              dσ.fn y = some s := by
-            intro y s hys
-            obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
-            obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
-            by_cases hm : s'.mentions x
-            · rw [if_pos hm] at hif
-              simp only [Option.some.injEq, Prod.mk.injEq] at hif
-              obtain ⟨rfl, rfl⟩ := hif
-              exact hs'
-            · rw [if_neg hm] at hif
-              exact absurd hif (by simp)
-          simp only [denseSparseGaussLoop, hpick]
-          refine ih _ hrest ?_ ?_
-          · intro denv hsat
-            refine DenseSparseSolved.insertAll_preserves _ dσ (hσs denv hsat) ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-              exact hy.trans (denseLinSubst_eval s x t denv (hx denv hsat)).symm
-            · rw [List.mem_singleton] at hin
-              subst hin
-              exact hx denv hsat
-          · refine DenseSparseSolved.insertAll_preserves _ dσ hσv ?_
-            intro pr hpr
-            rcases List.mem_append.1 hpr with hin | hin
-            · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-              have hmemys : dσ.fn y = some s := htouched y s hys
-              exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
-                (hσv y s hmemys) htocc
-            · rw [List.mem_singleton] at hin
-              subst hin
-              exact htocc
+            rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_terms_fst] at hz
+            exact Or.inr hz
+          · rw [if_neg h1] at h
+            by_cases h2 : (l2.normWith ops).terms.isEmpty
+            · rw [if_pos h2] at h
+              simp only [GRes.toLin, Option.some.injEq] at h
+              subst h
+              intro z hz
+              rw [DenseLinExpr.scaleWith_eq, DenseLinExpr.scale_terms_fst,
+                DenseLinExpr.normWith_eq] at hz
+              exact Or.inl (DenseLinExpr.norm_terms_fst l1 z hz)
+            · rw [if_neg h2] at h
+              simp [GRes.toLin] at h
 
-theorem denseSparseMarkowitzLoop_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId)
-    (sources : Array (DenseExpr p))
-    (hsrc : ∀ (i : Nat) (c : DenseExpr p),
-      sources[i]? = some c → c ∈ d.algebraicConstraints) :
-    ∀ (fuel : Nat) (st : DenseMarkowitzState p) (dσ : DenseSparseSolved p),
-      (∀ denv, d.satisfies bs denv → ∀ i t,
-        dσ.fn i = some t → denv i = t.eval denv) →
-      (∀ i t, dσ.fn i = some t → ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) →
-      (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
-          denv i = t.eval denv) ∧
-      (∀ i t, (denseMarkowitzLoop occ prot sources fuel st dσ).fn i = some t →
-          ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
+/-- The walk is eval-preserving: whenever it produces an affine form, that form agrees with the
+    expression on every assignment the stored solutions are true of. -/
+theorem gEval_eval (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p)))
+    (denv : VarId → ZMod p)
+    (hσ : ∀ i t, gSolFn sol i = some t → denv i = t.eval denv) :
+    ∀ (e : DenseExpr p) (l : DenseLinExpr p), (gEval ops sol e).toLin = some l →
+      e.eval denv = l.eval denv := by
+  intro e
+  induction e with
+  | const n =>
+      intro l h
+      simp only [gEval, GRes.toLin, Option.some.injEq] at h
+      subst h
+      simp [DenseExpr.eval, DenseLinExpr.eval]
+  | var x =>
+      intro l h
+      simp only [gEval] at h
+      cases hx : gSolFn sol x with
+      | none =>
+          rw [hx] at h
+          simp only [GRes.toLin, Option.some.injEq] at h
+          subst h
+          simp [DenseExpr.eval, DenseLinExpr.eval, ops.zero_eq, ops.one_eq]
+      | some t =>
+          rw [hx] at h
+          simp only [GRes.toLin, Option.some.injEq] at h
+          subst h
+          exact hσ x t hx
+  | add a b iha ihb =>
+      intro l h
+      simp only [gEval] at h
+      cases ha : gEval ops sol a with
+      | blk w => rw [ha] at h; simp [GRes.toLin] at h
+      | cst c1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, hev⟩ := gAddRes_eval ops _ _ l h
+          rw [DenseExpr.eval, iha la (by rw [ha]; exact hla), ihb lb hlb, hev]
+      | lin l1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, hev⟩ := gAddRes_eval ops _ _ l h
+          rw [DenseExpr.eval, iha la (by rw [ha]; exact hla), ihb lb hlb, hev]
+  | mul a b iha ihb =>
+      intro l h
+      simp only [gEval] at h
+      cases ha : gEval ops sol a with
+      | blk w => rw [ha] at h; simp [GRes.toLin] at h
+      | cst c1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, hev⟩ := gMulRes_eval ops _ _ l h
+          rw [DenseExpr.eval, iha la (by rw [ha]; exact hla), ihb lb hlb, hev]
+      | lin l1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, hev⟩ := gMulRes_eval ops _ _ l h
+          rw [DenseExpr.eval, iha la (by rw [ha]; exact hla), ihb lb hlb, hev]
+
+/-- The walk introduces no variable: every term variable of the result comes from the expression or
+    from a stored solution. -/
+theorem gEval_terms (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p)))
+    (S : VarId → Prop) (hσ : ∀ i t, gSolFn sol i = some t → ∀ z ∈ t.terms.map Prod.fst, S z) :
+    ∀ (e : DenseExpr p) (l : DenseLinExpr p), (gEval ops sol e).toLin = some l →
+      (∀ z ∈ e.vars, S z) → ∀ z ∈ l.terms.map Prod.fst, S z := by
+  intro e
+  induction e with
+  | const n =>
+      intro l h _
+      simp only [gEval, GRes.toLin, Option.some.injEq] at h
+      subst h; intro z hz; simp at hz
+  | var x =>
+      intro l h he
+      simp only [gEval] at h
+      cases hx : gSolFn sol x with
+      | none =>
+          rw [hx] at h
+          simp only [GRes.toLin, Option.some.injEq] at h
+          subst h
+          intro z hz
+          simp only [List.map_cons, List.map_nil, List.mem_singleton] at hz
+          rw [hz]
+          exact he x (by simp [DenseExpr.vars])
+      | some t =>
+          rw [hx] at h
+          simp only [GRes.toLin, Option.some.injEq] at h
+          subst h
+          exact hσ x t hx
+  | add a b iha ihb =>
+      intro l h he
+      have hea : ∀ z ∈ a.vars, S z := fun z hz => he z (by simp [DenseExpr.vars, hz])
+      have heb : ∀ z ∈ b.vars, S z := fun z hz => he z (by simp [DenseExpr.vars, hz])
+      simp only [gEval] at h
+      cases ha : gEval ops sol a with
+      | blk w => rw [ha] at h; simp [GRes.toLin] at h
+      | cst c1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, _⟩ := gAddRes_eval ops _ _ l h
+          intro z hz
+          rcases gAddRes_terms ops _ _ l la lb h hla hlb z hz with hz' | hz'
+          · exact iha la (by rw [ha]; exact hla) hea z hz'
+          · exact ihb lb hlb heb z hz'
+      | lin l1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, _⟩ := gAddRes_eval ops _ _ l h
+          intro z hz
+          rcases gAddRes_terms ops _ _ l la lb h hla hlb z hz with hz' | hz'
+          · exact iha la (by rw [ha]; exact hla) hea z hz'
+          · exact ihb lb hlb heb z hz'
+  | mul a b iha ihb =>
+      intro l h he
+      have hea : ∀ z ∈ a.vars, S z := fun z hz => he z (by simp [DenseExpr.vars, hz])
+      have heb : ∀ z ∈ b.vars, S z := fun z hz => he z (by simp [DenseExpr.vars, hz])
+      simp only [gEval] at h
+      cases ha : gEval ops sol a with
+      | blk w => rw [ha] at h; simp [GRes.toLin] at h
+      | cst c1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, _⟩ := gMulRes_eval ops _ _ l h
+          intro z hz
+          rcases gMulRes_terms ops _ _ l la lb h hla hlb z hz with hz' | hz'
+          · exact iha la (by rw [ha]; exact hla) hea z hz'
+          · exact ihb lb hlb heb z hz'
+      | lin l1 =>
+          rw [ha] at h
+          obtain ⟨la, lb, hla, hlb, _⟩ := gMulRes_eval ops _ _ l h
+          intro z hz
+          rcases gMulRes_terms ops _ _ l la lb h hla hlb z hz with hz' | hz'
+          · exact iha la (by rw [ha]; exact hla) hea z hz'
+          · exact ihb lb hlb heb z hz'
+
+/-- `gRoot`'s row agrees with the constraint on every assignment the stored solutions are true of. -/
+theorem gRoot_eval (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p)))
+    (denv : VarId → ZMod p) (hσ : ∀ i t, gSolFn sol i = some t → denv i = t.eval denv)
+    (e : DenseExpr p) (l : DenseLinExpr p) (h : gRoot ops sol e = .row l) :
+    e.eval denv = l.eval denv := by
+  simp only [gRoot] at h
+  cases he : gEval ops sol e with
+  | cst c =>
+      rw [he] at h
+      simp only [GTop.row.injEq] at h
+      subst h
+      exact gEval_eval ops sol denv hσ e _ (by rw [he]; rfl)
+  | lin l1 =>
+      rw [he] at h
+      simp only [GTop.row.injEq] at h
+      subst h
+      rw [gEval_eval ops sol denv hσ e l1 (by rw [he]; rfl), DenseLinExpr.normWith_eq,
+        DenseLinExpr.norm_eval]
+  | blk w => rw [he] at h; simp at h
+
+/-- `gRoot`'s row introduces no variable. -/
+theorem gRoot_terms (ops : DenseZModOps p) (sol : Array (Option (DenseLinExpr p)))
+    (S : VarId → Prop) (hσ : ∀ i t, gSolFn sol i = some t → ∀ z ∈ t.terms.map Prod.fst, S z)
+    (e : DenseExpr p) (l : DenseLinExpr p) (h : gRoot ops sol e = .row l)
+    (he : ∀ z ∈ e.vars, S z) : ∀ z ∈ l.terms.map Prod.fst, S z := by
+  simp only [gRoot] at h
+  cases hev : gEval ops sol e with
+  | cst c =>
+      rw [hev] at h
+      simp only [GTop.row.injEq] at h
+      subst h
+      intro z hz; simp at hz
+  | lin l1 =>
+      rw [hev] at h
+      simp only [GTop.row.injEq] at h
+      subst h
+      intro z hz
+      rw [DenseLinExpr.normWith_eq] at hz
+      exact gEval_terms ops sol S hσ e l1 (by rw [hev]; rfl) he z
+        (DenseLinExpr.norm_terms_fst l1 z hz)
+  | blk w => rw [hev] at h; simp at h
+
+
+/-! ## Array-index plumbing
+
+Both invariants are stated over `getElem?`, so each write needs only "the entry is the new value, or
+the one that was there before". -/
+
+theorem gSolFn_set (sol : Array (Option (DenseLinExpr p))) (i : Nat) (v : Option (DenseLinExpr p))
+    (x : VarId) :
+    (i = x.index ∧ gSolFn (sol.setIfInBounds i v) x = v) ∨
+      gSolFn (sol.setIfInBounds i v) x = gSolFn sol x := by
+  unfold gSolFn
+  by_cases hx : i = x.index
+  · subst hx
+    by_cases hi : x.index < sol.size
+    · exact Or.inl ⟨rfl, by simp [hi]⟩
+    · exact Or.inr (by
+        simp [hi])
+  · right; simp [hx]
+
+theorem gRows_set (rows : Array (DenseLinExpr p)) (i : Nat) (l : DenseLinExpr p) (j : Nat)
+    (l' : DenseLinExpr p) (h : (rows.setIfInBounds i l)[j]? = some l') :
+    l' = l ∨ rows[j]? = some l' := by
+  by_cases hj : i = j
+  · subst hj
+    by_cases hi : i < rows.size
+    · rw [show (rows.setIfInBounds i l)[i]? = some l by
+        simp [hi]] at h
+      exact Or.inl (Option.some.inj h).symm
+    · rw [show (rows.setIfInBounds i l)[i]? = rows[i]? by
+        simp [hi]] at h
+      exact Or.inr h
+  · rw [show (rows.setIfInBounds i l)[j]? = rows[j]? by
+      simp [hj]] at h
+    exact Or.inr h
+
+theorem gRows_replicate (n : Nat) (c : ZMod p) (j : Nat) (l : DenseLinExpr p)
+    (h : (Array.replicate n (⟨c, []⟩ : DenseLinExpr p))[j]? = some l) : l = ⟨c, []⟩ := by
+  by_cases hj : j < n
+  · rw [show (Array.replicate n (⟨c, []⟩ : DenseLinExpr p))[j]? = some ⟨c, []⟩ by
+      simp [hj]] at h
+    exact (Option.some.inj h).symm
+  · rw [show (Array.replicate n (⟨c, []⟩ : DenseLinExpr p))[j]? = none by
+      simp [hj]] at h
+    exact absurd h (by simp)
+
+/-! ## The engine invariant -/
+
+/-- Pending rows are entailed and occurrence-closed; stored solutions are entailed assignments with
+    the same closure. Nothing else about the state is claimed. -/
+structure GInv (bs : BusSemantics p) (d : DenseConstraintSystem p) (S : GSt p) : Prop where
+  rows : ∀ (i : Nat) (l : DenseLinExpr p), S.rows[i]? = some l → GEnt bs d l ∧ GCl d l
+  sol : ∀ (x : VarId) (t : DenseLinExpr p), gSolFn S.sol x = some t → GAsg bs d x t ∧ GCl d t
+
+/-! ### Scheduling-only writes
+
+`setStatus`, `setWoken` and `addWatch` rebuild the record without touching `rows` or `sol`, so they
+preserve the invariant by projection. -/
+
+@[simp] theorem setStatus_rows (S : GSt p) (i : Nat) (v : UInt8) :
+    (S.setStatus i v).rows = S.rows := by cases S; rfl
+@[simp] theorem setStatus_sol (S : GSt p) (i : Nat) (v : UInt8) :
+    (S.setStatus i v).sol = S.sol := by cases S; rfl
+@[simp] theorem clearWoken_rows (S : GSt p) (i : Nat) : (S.clearWoken i).rows = S.rows := by
+  cases S; rfl
+@[simp] theorem clearWoken_sol (S : GSt p) (i : Nat) : (S.clearWoken i).sol = S.sol := by
+  cases S; rfl
+@[simp] theorem addWatch_rows (S : GSt p) (i : Nat) (ws : List VarId) :
+    (S.addWatch i ws).rows = S.rows := by cases S; rfl
+@[simp] theorem addWatch_sol (S : GSt p) (i : Nat) (ws : List VarId) :
+    (S.addWatch i ws).sol = S.sol := by cases S; rfl
+@[simp] theorem setRow_sol (S : GSt p) (i : Nat) (l : DenseLinExpr p) :
+    (S.setRow i l).sol = S.sol := by cases S; rfl
+@[simp] theorem setRow_rows (S : GSt p) (i : Nat) (l : DenseLinExpr p) :
+    (S.setRow i l).rows = S.rows.setIfInBounds i l := by cases S; rfl
+@[simp] theorem setPending_sol (S : GSt p) (i : Nat) (l : DenseLinExpr p) :
+    (S.setPending i l).sol = S.sol := by cases S; rfl
+@[simp] theorem setPending_rows (S : GSt p) (i : Nat) (l : DenseLinExpr p) :
+    (S.setPending i l).rows = S.rows.setIfInBounds i l := by cases S; rfl
+
+theorem GInv.setStatus {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (i : Nat) (v : UInt8) : GInv bs d (S.setStatus i v) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.clearWoken {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (i : Nat) : GInv bs d (S.clearWoken i) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.addWatch {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (i : Nat) (ws : List VarId) : GInv bs d (S.addWatch i ws) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.setRow {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (i : Nat) (l : DenseLinExpr p) (hl : GEnt bs d l ∧ GCl d l) :
+    GInv bs d (S.setRow i l) := by
+  refine ⟨?_, by simpa using h.sol⟩
+  intro j l' hj
+  rw [setRow_rows] at hj
+  rcases gRows_set S.rows i l j l' hj with rfl | hj'
+  · exact hl
+  · exact h.rows j l' hj'
+
+theorem GInv.setPending {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (i : Nat) (l : DenseLinExpr p) (hl : GEnt bs d l ∧ GCl d l) :
+    GInv bs d (S.setPending i l) := by
+  refine ⟨?_, by simpa using h.sol⟩
+  intro j l' hj
+  rw [setPending_rows] at hj
+  rcases gRows_set S.rows i l j l' hj with rfl | hj'
+  · exact hl
+  · exact h.rows j l' hj'
+
+
+/-! ### Solution-map writes -/
+
+@[simp] theorem setSol_rows (S : GSt p) (y : VarId) (v : Option (DenseLinExpr p)) :
+    (S.setSol y v).rows = S.rows := by cases S; rfl
+@[simp] theorem setSol_sol (S : GSt p) (y : VarId) (v : Option (DenseLinExpr p)) :
+    (S.setSol y v).sol = S.sol.setIfInBounds y.index v := by cases S; rfl
+@[simp] theorem pushRev_rows (S : GSt p) (t : DenseLinExpr p) (y : VarId) :
+    (S.pushRev t y).rows = S.rows := by cases S; rfl
+@[simp] theorem pushRev_sol (S : GSt p) (t : DenseLinExpr p) (y : VarId) :
+    (S.pushRev t y).sol = S.sol := by cases S; rfl
+@[simp] theorem clearRev_rows (S : GSt p) (x : VarId) : (S.clearRev x).rows = S.rows := by
+  cases S; rfl
+@[simp] theorem clearRev_sol (S : GSt p) (x : VarId) : (S.clearRev x).sol = S.sol := by
+  cases S; rfl
+@[simp] theorem fireWatch_rows (S : GSt p) (x : VarId) : (S.fireWatch x).rows = S.rows := by
+  cases S; rfl
+@[simp] theorem fireWatch_sol (S : GSt p) (x : VarId) : (S.fireWatch x).sol = S.sol := by
+  cases S; rfl
+@[simp] theorem pushOrder_rows (S : GSt p) (x : VarId) : (S.pushOrder x).rows = S.rows := by
+  cases S; rfl
+@[simp] theorem pushOrder_sol (S : GSt p) (x : VarId) : (S.pushOrder x).sol = S.sol := by
+  cases S; rfl
+
+theorem GInv.pushRev {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (t : DenseLinExpr p) (y : VarId) : GInv bs d (S.pushRev t y) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.clearRev {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (x : VarId) : GInv bs d (S.clearRev x) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.fireWatch {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (x : VarId) : GInv bs d (S.fireWatch x) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.pushOrder {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (x : VarId) : GInv bs d (S.pushOrder x) :=
+  ⟨by simpa using h.rows, by simpa using h.sol⟩
+
+theorem GInv.setSol {bs : BusSemantics p} {d : DenseConstraintSystem p} {S : GSt p}
+    (h : GInv bs d S) (y : VarId) (t : DenseLinExpr p) (ht : GAsg bs d y t ∧ GCl d t) :
+    GInv bs d (S.setSol y (some t)) := by
+  refine ⟨by simpa using h.rows, ?_⟩
+  intro x u hx
+  rw [setSol_sol] at hx
+  rcases gSolFn_set S.sol y.index (some t) x with ⟨hix, hset⟩ | hset
+  · rw [hset] at hx
+    have hu : t = u := Option.some.inj hx
+    have hxy : y = x := by cases y; cases x; simp_all
+    subst hu; subst hxy
+    exact ht
+  · rw [hset] at hx; exact h.sol x u hx
+
+/-! ### Developing a row -/
+
+/-- The stored solutions are all true at any satisfying assignment, so substituting them into a row
+    preserves its value. -/
+theorem gDevelop_ok (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (S : GSt p) (h : GInv bs d S) (r : DenseLinExpr p) (hr : GEnt bs d r ∧ GCl d r) :
+    GEnt bs d (gDevelop ops S.sol r) ∧ GCl d (gDevelop ops S.sol r) := by
+  unfold gDevelop
+  split
+  · refine ⟨?_, ?_⟩
+    · intro denv hsat
+      rw [denseLinSubstFWith_eq, denseLinSubstF_eval]
+      have henv : denseLinEnv (gSolFn S.sol) denv = denv := by
+        funext i
+        cases hi : gSolFn S.sol i with
+        | none => simp [denseLinEnv, hi]
+        | some row => simp [denseLinEnv, hi, (h.sol i row hi).1 denv hsat]
+      rw [henv]
+      exact hr.1 denv hsat
+    · rw [denseLinSubstFWith_eq]
+      exact denseLinSubstF_terms_closed r _ (· ∈ d.occ) hr.2
+        (fun i row hrow => (h.sol i row hrow).2)
+  · exact hr
+
+/-! ### The adoption step -/
+
+theorem gSubst1_eq (ops : DenseZModOps p) (s : DenseLinExpr p) (x : VarId) (t : DenseLinExpr p) :
+    gSubst1 ops s x t = denseLinSubst s x t := by
+  simp only [gSubst1, denseLinSubstFWith_eq, denseLinSubst]
+
+theorem gRewriteStored_inv (ops : DenseZModOps p) (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) (x : VarId) (t : DenseLinExpr p) (ys : Array VarId)
+    (ht : GAsg bs d x t ∧ GCl d t) :
+    ∀ (k : Nat) (S : GSt p), GInv bs d S → GInv bs d (gRewriteStored ops x t ys k S) := by
+  intro k
+  induction k with
+  | zero => intro S h; exact h
+  | succ k ih =>
+      intro S h
+      rw [gRewriteStored]
+      cases hy : ys[ys.size - (k + 1)]? with
+      | none => simpa using ih S h
+      | some y =>
+          dsimp only
+          cases hs : gSolFn S.sol y with
+          | none => simpa using ih S h
+          | some s =>
+              dsimp only
+              by_cases hm : s.mentions x
+              · rw [if_pos hm]
+                refine ih _ ((h.setSol y (gSubst1 ops s x t) ?_).pushRev t y)
+                have hsy := h.sol y s hs
+                refine ⟨?_, ?_⟩
+                · intro denv hsat
+                  rw [gSubst1_eq, denseLinSubst_eval s x t denv (ht.1 denv hsat)]
+                  exact hsy.1 denv hsat
+                · rw [gSubst1_eq]
+                  exact denseLinSubst_terms_closed s x t (· ∈ d.occ) hsy.2 ht.2
+              · rw [if_neg hm]
+                exact ih S h
+
+theorem gAdopt_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (S : GSt p) (h : GInv bs d S) (i : Nat) (x : VarId) (t : DenseLinExpr p)
+    (ht : GAsg bs d x t ∧ GCl d t) : GInv bs d (gAdopt ops S i x t) := by
+  rw [gAdopt]
+  exact ((((gRewriteStored_inv ops bs d x t _ ht _ _ (h.clearRev x)).setSol x t
+    ht).pushRev t x).fireWatch x).pushOrder x |>.setStatus i 2
+
+/-! ### Taking a pivot -/
+
+/-- `denseSparseSolveAt` always solves for the variable it was asked about. -/
+theorem denseSparseSolveAt_fst (l : DenseLinExpr p) (y z : VarId) (t : DenseLinExpr p)
+    (h : denseSparseSolveAt l y = some (z, t)) : z = y := by
+  unfold denseSparseSolveAt at h
+  split_ifs at h <;> simp_all
+
+theorem gPick_solveAt (ops : DenseZModOps p) (occ : Array Nat) (prot : Array Bool)
+    (l : DenseLinExpr p) : ∀ (fuel : Nat) (banned : List VarId) (x : VarId) (t : DenseLinExpr p),
+      gPick ops occ prot l fuel banned = some (x, t) → denseSparseSolveAt l x = some (x, t) := by
   intro fuel
   induction fuel with
-  | zero => intro st dσ hσs hσv; exact ⟨hσs, hσv⟩
+  | zero => intro banned x t h; simp [gPick] at h
   | succ fuel ih =>
-      intro st dσ hσs hσv
-      cases hpop : denseMarkowitzPopValid (st.heap.size + 1) st with
-      | none =>
-          simp only [denseMarkowitzLoop, hpop]
-          exact ⟨hσs, hσv⟩
-      | some out =>
-          obtain ⟨entry, st'⟩ := out
-          cases hsource : sources[entry.rowId]? with
+      intro banned x t h
+      cases hb : gBestGo ops occ prot l.terms.length banned l.terms none with
+      | none => simp [gPick, hb] at h
+      | some y =>
+          cases hs : denseSparseSolveAtWith ops l y with
           | none =>
-              simp only [denseMarkowitzLoop, hpop, hsource]
-              exact ih _ _ hσs hσv
-          | some c =>
-              have hcmem : c ∈ d.algebraicConstraints := hsrc entry.rowId c hsource
-              let c' := denseSparseSubstF dσ.fn c
-              cases hpick :
-                  denseMarkowitzPick (denseSparseSubstF dσ.fn c) entry.pivot occ prot with
-              | none =>
-                  simp only [denseMarkowitzLoop, hpop, hsource, hpick]
-                  exact ih _ _ hσs hσv
-              | some xt =>
-                  obtain ⟨x, t⟩ := xt
-                  have hcclosed : c'.Closed (· ∈ d.occ) := by
-                    apply denseSparseSubstF_closed dσ.fn c
-                    · intro z hz
-                      exact DenseConstraintSystem.mem_occ_of_constraint hcmem hz
-                    · exact hσv
-                  have hx : ∀ denv, d.satisfies bs denv → denv x = t.eval denv := by
-                    intro denv hsat
-                    apply denseMarkowitzPick_sound c' entry.pivot x t occ prot hpick denv
-                    rw [denseSparseSubstF_eval dσ.fn c denv (hσs denv hsat)]
-                    exact hsat.1 c hcmem
-                  have htocc : ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ := by
-                    intro z hz
-                    exact hcclosed z
-                      (denseMarkowitzPick_terms c' entry.pivot x t occ prot hpick z hz)
-                  have htouched : ∀ y s, (y, s) ∈
-                        (dσ.revDeps.getD x.index ∅).toList.filterMap (fun y =>
-                          (dσ.map[y]?).bind
-                            (fun s => if s.mentions x then some (y, s) else none)) →
-                      dσ.fn y = some s := by
-                    intro y s hys
-                    obtain ⟨_, _, hy'⟩ := List.mem_filterMap.1 hys
-                    obtain ⟨s', hs', hif⟩ := Option.bind_eq_some_iff.1 hy'
-                    by_cases hm : s'.mentions x
-                    · rw [if_pos hm] at hif
-                      simp only [Option.some.injEq, Prod.mk.injEq] at hif
-                      obtain ⟨rfl, rfl⟩ := hif
-                      exact hs'
-                    · rw [if_neg hm] at hif
-                      exact absurd hif (by simp)
-                  let pairs := denseMarkowitzAdoptPairs dσ x t
-                  let dσ' := dσ.insertAll pairs
-                  have hnexts : ∀ denv, d.satisfies bs denv → ∀ i u,
-                      dσ'.fn i = some u → denv i = u.eval denv := by
-                    intro denv hsat
-                    refine DenseSparseSolved.insertAll_preserves pairs dσ
-                      (hσs denv hsat) ?_
-                    intro pr hpr
-                    unfold denseMarkowitzAdoptPairs at hpr
-                    rcases List.mem_append.1 hpr with hin | hin
-                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-                      have hmemys : dσ.fn y = some s := htouched y s hys
-                      have hy : denv y = s.eval denv := hσs denv hsat y s hmemys
-                      exact hy.trans
-                        (denseLinSubst_eval s x t denv (hx denv hsat)).symm
-                    · rw [List.mem_singleton] at hin
-                      subst hin
-                      exact hx denv hsat
-                  have hnextv : ∀ i u, dσ'.fn i = some u →
-                      ∀ z ∈ u.terms.map Prod.fst, z ∈ d.occ := by
-                    refine DenseSparseSolved.insertAll_preserves pairs dσ hσv ?_
-                    intro pr hpr
-                    unfold denseMarkowitzAdoptPairs at hpr
-                    rcases List.mem_append.1 hpr with hin | hin
-                    · obtain ⟨⟨y, s⟩, hys, rfl⟩ := List.mem_map.1 hin
-                      have hmemys : dσ.fn y = some s := htouched y s hys
-                      exact denseLinSubst_terms_closed s x t (· ∈ d.occ)
-                        (hσv y s hmemys) htocc
-                    · rw [List.mem_singleton] at hin
-                      subst hin
-                      exact htocc
-                  simp only [denseMarkowitzLoop, hpop, hsource, hpick]
-                  exact ih _ dσ' hnexts hnextv
+              simp only [gPick, hb, hs] at h
+              exact ih (y :: banned) x t h
+          | some q =>
+              simp only [gPick, hb, hs, Option.some.injEq] at h
+              rw [denseSparseSolveAtWith_eq] at hs
+              subst h
+              have hxy : x = y := denseSparseSolveAt_fst l y x t hs
+              subst hxy
+              exact hs
 
-theorem denseSparseMarkowitzSchedule_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
-        denv i = t.eval denv) ∧
-    (∀ i t, (denseMarkowitzSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
-  apply denseSparseMarkowitzLoop_sound bs d occ prot d.algebraicConstraints.toArray
-  · intro i c hc
-    rw [List.getElem?_toArray] at hc
-    exact List.mem_of_getElem? hc
-  · intro _ _ _ _ h
-    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
-  · intro _ _ h
-    exact absurd h (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty])
-
-theorem denseSparseSourceOrderSchedule_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (occ : Std.HashMap VarId Nat)
-    (prot : Std.HashSet VarId) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
-        denv i = t.eval denv) ∧
-    (∀ i t, (denseSourceOrderSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) := by
-  have hfirst := denseSparseGaussLoop_sound bs d occ prot
-    d.algebraicConstraints DenseSparseSolved.empty
-    (fun _c hc => hc)
-    (fun _ _ _ _ hti =>
-      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
-    (fun _ _ hti =>
-      absurd hti (by simp [DenseSparseSolved.fn, DenseSparseSolved.empty]))
-  by_cases hempty :
-      (denseSparseGaussLoop occ prot d.algebraicConstraints
-        DenseSparseSolved.empty).map.isEmpty
-  · simpa [denseSourceOrderSchedule, hempty] using hfirst
-  · have hsecond := denseSparseGaussLoop_sound bs d occ prot
-      d.algebraicConstraints
-      (denseSparseGaussLoop occ prot d.algebraicConstraints DenseSparseSolved.empty)
-      (fun _c hc => hc) hfirst.1 hfirst.2
-    simpa [denseSourceOrderSchedule, hempty] using hsecond
-
-theorem DenseSparseSolved.materialize_lookup (dσ : DenseSparseSolved p)
-    (i : VarId) (e : DenseExpr p) (h : dσ.materialize.fn i = some e) :
-    ∃ row, dσ.fn i = some row ∧ e = row.toExpr := by
-  simp only [DenseSparseSolved.materialize, DenseSolved.fn] at h
-  let pairs := dσ.map.toList.map (fun xt => (xt.1, xt.2.toExpr))
-  have hpairs :
-      pairs.foldl (fun out xt => out.insert xt.1 xt.2)
-          (∅ : Std.HashMap VarId (DenseExpr p)) =
-        dσ.map.toList.foldl (fun out xt => out.insert xt.1 xt.2.toExpr) ∅ := by
-    exact List.foldl_map
-  rw [← hpairs] at h
-  apply foldl_insert_getElem pairs
-    (∅ : Std.HashMap VarId (DenseExpr p))
-    (Q := fun j out => ∃ row, dσ.fn j = some row ∧ out = row.toExpr)
-  · intro j out hj
-    exact absurd hj (by simp)
-  · intro pr hpr
-    obtain ⟨xt, hxt, rfl⟩ := List.mem_map.1 hpr
-    refine ⟨xt.2, ?_, rfl⟩
-    exact Std.HashMap.mem_toList_iff_getElem?_eq_some.1 hxt
-  · exact h
-
-theorem DenseSparseSolved.materialize_sound (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (dσ : DenseSparseSolved p)
-    (hs : ∀ denv, d.satisfies bs denv → ∀ i t,
-      dσ.fn i = some t → denv i = t.eval denv)
-    (hv : ∀ i t, dσ.fn i = some t →
-      ∀ z ∈ t.terms.map Prod.fst, z ∈ d.occ) :
-    (∀ denv, d.satisfies bs denv → ∀ i e,
-        dσ.materialize.fn i = some e → denv i = e.eval denv) ∧
-    (∀ i e, dσ.materialize.fn i = some e → ∀ z ∈ e.vars, z ∈ d.occ) := by
-  constructor
-  · intro denv hsat i e he
-    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
-    rw [DenseLinExpr.toExpr_eval]
-    exact hs denv hsat i row hrow
-  · intro i e he z hz
-    obtain ⟨row, hrow, rfl⟩ := dσ.materialize_lookup i e he
-    exact hv i row hrow z (DenseLinExpr.toExpr_vars row z hz)
-
-theorem denseGaussSchedule_sound (bs : BusSemantics p) (d : DenseConstraintSystem p)
-    (occ : Std.HashMap VarId Nat) (prot : Std.HashSet VarId) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
-        denv i = t.eval denv) ∧
-    (∀ i t, (denseGaussSchedule d.algebraicConstraints occ prot).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  unfold denseGaussSchedule
+theorem gTake_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (S : GSt p) (h : GInv bs d S) (i : Nat)
+    (l : DenseLinExpr p) (hl : GEnt bs d l ∧ GCl d l) :
+    GInv bs d (gTake ops occ prot S i l) := by
+  rw [gTake]
   split
-  · exact DenseSparseSolved.materialize_sound bs d _
-      (denseSparseSourceOrderSchedule_sound bs d occ prot).1
-      (denseSparseSourceOrderSchedule_sound bs d occ prot).2
-  · exact DenseSparseSolved.materialize_sound bs d _
-      (denseSparseMarkowitzSchedule_sound bs d occ prot).1
-      (denseSparseMarkowitzSchedule_sound bs d occ prot).2
+  · exact h.setStatus i 2
+  · cases hp : gPick ops occ prot l (l.terms.length + 1) [] with
+    | none => simpa using h.setPending i l hl
+    | some q =>
+        obtain ⟨x, t⟩ := q
+        dsimp only
+        have hsolve := gPick_solveAt ops occ prot l _ [] x t hp
+        refine gAdopt_inv ops bs d S h i x t ⟨?_, ?_⟩
+        · intro denv hsat
+          exact denseSparseSolveAt_sound l x x t hsolve denv (hl.1 denv hsat)
+        · intro z hz
+          exact hl.2 z (denseSparseSolveAt_terms l x x t hsolve z hz)
 
 
-/-! ## The pass's correctness -/
+/-! ## The schedulers
 
-/-- The scheduled solution map is entailed and occurrence-closed. -/
-theorem denseGaussElim_loop_invariant (bs : BusSemantics p) (d : DenseConstraintSystem p) :
-    (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseGaussSchedule d.algebraicConstraints
-          (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
-          denv i = t.eval denv) ∧
-    (∀ i t, (denseGaussSchedule d.algebraicConstraints
-        (denseOccurrenceMap d) (denseProtectedVars d bs)).fn i = some t →
-        ∀ z ∈ t.vars, z ∈ d.occ) := by
-  exact denseGaussSchedule_sound bs d (denseOccurrenceMap d) (denseProtectedVars d bs)
+Both are plain recursions over the state, and the invariant is preserved by every step regardless of
+the order they pick — which is exactly why the buckets, the watch lists and `occ`/`prot` need no
+correctness argument. -/
 
-/-- `denseGaussElim` preserves coverage: on the non-trivial branch it substitutes an
-    occurrence-closed solution map, whose solutions are covered because their variables occur in a
-    covered system. -/
-theorem denseGaussElim_covered (reg : VarRegistry) (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
-    (denseGaussElim bs d).CoveredBy reg := by
-  rw [denseGaussElim_eq]
+theorem gVisit_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (cs : Array (DenseExpr p))
+    (hcs : ∀ (j : Nat) (c : DenseExpr p), cs[j]? = some c → c ∈ d.algebraicConstraints)
+    (S : GSt p) (h : GInv bs d S) (i : Nat) : GInv bs d (gVisit ops occ prot cs S i) := by
+  rw [gVisit]
+  split
+  · cases hr : S.rows[i]? with
+    | none => simpa using h
+    | some r =>
+        dsimp only
+        exact gTake_inv ops bs d occ prot S h i _ (gDevelop_ok ops bs d S h r (h.rows i r hr))
+  · split
+    · cases hc : cs[i]? with
+      | none => simpa using h.clearWoken i
+      | some c =>
+          dsimp only
+          have hcm : c ∈ d.algebraicConstraints := hcs i c hc
+          have h' : GInv bs d (S.clearWoken i) := h.clearWoken i
+          cases hg : gRoot ops (S.clearWoken i).sol c with
+          | blocked ws => simpa using h'.addWatch i ws
+          | row l =>
+              dsimp only
+              refine gTake_inv ops bs d occ prot _ h' i l ⟨?_, ?_⟩
+              · intro denv hsat
+                have hσ : ∀ (j : VarId) (t : DenseLinExpr p),
+                    gSolFn (S.clearWoken i).sol j = some t → denv j = t.eval denv :=
+                  fun j t hj => (h'.sol j t hj).1 denv hsat
+                rw [← gRoot_eval ops _ denv hσ c l hg]
+                exact hsat.1 c hcm
+              · refine gRoot_terms ops _ (· ∈ d.occ)
+                  (fun j t hj => (h'.sol j t hj).2) c l hg ?_
+                intro z hz
+                exact DenseConstraintSystem.mem_occ_of_constraint hcm hz
+    · exact h
+
+theorem gBuildGo_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (cs : Array (DenseExpr p))
+    (hcs : ∀ (j : Nat) (c : DenseExpr p), cs[j]? = some c → c ∈ d.algebraicConstraints) :
+    ∀ (k : Nat) (S : GSt p), GInv bs d S → GInv bs d (gBuildGo ops cs k S) := by
+  intro k
+  induction k with
+  | zero => intro S h; exact h
+  | succ k ih =>
+      intro S h
+      rw [gBuildGo]
+      refine ih _ ?_
+      cases hc : cs[cs.size - (k + 1)]? with
+      | none => simpa using h
+      | some c =>
+          dsimp only
+          have hcm : c ∈ d.algebraicConstraints := hcs _ c hc
+          cases hg : gRoot ops S.sol c with
+          | blocked ws => simpa using h.addWatch _ ws
+          | row l =>
+              have hl : GEnt bs d l ∧ GCl d l := by
+                refine ⟨?_, ?_⟩
+                · intro denv hsat
+                  have hσ : ∀ (j : VarId) (t : DenseLinExpr p),
+                      gSolFn S.sol j = some t → denv j = t.eval denv :=
+                    fun j t hj => (h.sol j t hj).1 denv hsat
+                  rw [← gRoot_eval ops _ denv hσ c l hg]
+                  exact hsat.1 c hcm
+                · refine gRoot_terms ops _ (· ∈ d.occ) (fun j t hj => (h.sol j t hj).2) c l hg ?_
+                  intro z hz
+                  exact DenseConstraintSystem.mem_occ_of_constraint hcm hz
+              dsimp only
+              split
+              · exact h.setStatus _ 2
+              · exact h.setPending _ l hl
+
+theorem gSweepGo_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (cs : Array (DenseExpr p))
+    (hcs : ∀ (j : Nat) (c : DenseExpr p), cs[j]? = some c → c ∈ d.algebraicConstraints) :
+    ∀ (k : Nat) (S : GSt p), GInv bs d S → GInv bs d (gSweepGo ops occ prot cs k S) := by
+  intro k
+  induction k with
+  | zero => intro S h; exact h
+  | succ k ih =>
+      intro S h
+      rw [gSweepGo]
+      exact ih _ (gVisit_inv ops bs d occ prot cs hcs S h _)
+
+theorem gDrainAt_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (S : GSt p) (q : GQueue) (prog : Bool) (b i : Nat)
+    (h : GInv bs d S) : GInv bs d (gDrainAt ops occ prot S q prog b i).1 := by
+  rw [gDrainAt]
+  split
+  · exact h
+  · cases hr : S.rows[i]? with
+    | none => simpa using h
+    | some r =>
+        dsimp only
+        have hl := gDevelop_ok ops bs d S h r (h.rows i r hr)
+        split
+        · exact h.setStatus i 2
+        · split
+          · exact h.setRow i _ hl
+          · exact gTake_inv ops bs d occ prot S h i _ hl
+
+theorem gDrainStep_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (S : GSt p) (q : GQueue) (prog : Bool)
+    (h : GInv bs d S) : GInv bs d (gDrainStep ops occ prot S q prog).1 := by
+  rw [gDrainStep]
+  split
+  · exact h
+  · split
+    · exact h
+    · exact gDrainAt_inv ops bs d occ prot S _ prog _ _ h
+
+theorem gDrainGo_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) :
+    ∀ (fuel : Nat) (S : GSt p) (q : GQueue) (prog : Bool), GInv bs d S →
+      GInv bs d (gDrainGo ops occ prot fuel S q prog).1 := by
+  intro fuel
+  induction fuel with
+  | zero => intro S q prog h; exact h
+  | succ fuel ih =>
+      intro S q prog h
+      rw [gDrainGo]
+      cases hb : q.next (gMaxBucket + 1) with
+      | none => simpa using h
+      | some b =>
+          dsimp only
+          have hs := gDrainStep_inv ops bs d occ prot S q prog h
+          cases hst : gDrainStep ops occ prot S q prog with
+          | mk S1 rest =>
+              cases rest with
+              | mk q1 prog1 =>
+                  rw [hst] at hs
+                  dsimp only
+                  exact ih S1 q1 prog1 hs
+
+theorem gWakeGo_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (cs : Array (DenseExpr p))
+    (hcs : ∀ (j : Nat) (c : DenseExpr p), cs[j]? = some c → c ∈ d.algebraicConstraints) :
+    ∀ (k : Nat) (S : GSt p) (q : GQueue) (prog : Bool), GInv bs d S →
+      GInv bs d (gWakeGo ops cs k S q prog).1 := by
+  intro k
+  induction k with
+  | zero => intro S q prog h; exact h
+  | succ k ih =>
+      intro S q prog h
+      rw [gWakeGo]
+      split
+      · cases hc : cs[cs.size - (k + 1)]? with
+        | none => simpa using ih _ _ _ (h.clearWoken _)
+        | some c =>
+            dsimp only
+            have hcm : c ∈ d.algebraicConstraints := hcs _ c hc
+            have h' : GInv bs d (S.clearWoken (cs.size - (k + 1))) := h.clearWoken _
+            cases hg : gRoot ops (S.clearWoken (cs.size - (k + 1))).sol c with
+            | blocked ws => simpa using ih _ _ _ (h'.addWatch _ ws)
+            | row l =>
+                have hl : GEnt bs d l ∧ GCl d l := by
+                  refine ⟨?_, ?_⟩
+                  · intro denv hsat
+                    have hσ : ∀ (j : VarId) (t : DenseLinExpr p),
+                        gSolFn (S.clearWoken (cs.size - (k + 1))).sol j = some t →
+                        denv j = t.eval denv :=
+                      fun j t hj => (h'.sol j t hj).1 denv hsat
+                    rw [← gRoot_eval ops _ denv hσ c l hg]
+                    exact hsat.1 c hcm
+                  · refine gRoot_terms ops _ (· ∈ d.occ) (fun j t hj => (h'.sol j t hj).2) c l hg ?_
+                    intro z hz
+                    exact DenseConstraintSystem.mem_occ_of_constraint hcm hz
+                dsimp only
+                split
+                · exact ih _ _ _ (h'.setStatus _ 2)
+                · exact ih _ _ _ (h'.setPending _ l hl)
+      · exact ih _ _ _ h
+
+theorem gRoundsGo_inv (ops : DenseZModOps p) (bs : BusSemantics p) (d : DenseConstraintSystem p)
+    (occ : Array Nat) (prot : Array Bool) (cs : Array (DenseExpr p))
+    (hcs : ∀ (j : Nat) (c : DenseExpr p), cs[j]? = some c → c ∈ d.algebraicConstraints) :
+    ∀ (round : Nat) (S : GSt p) (q : GQueue), GInv bs d S →
+      GInv bs d (gRoundsGo ops occ prot cs round S q) := by
+  intro round
+  induction round with
+  | zero => intro S q h; exact h
+  | succ round ih =>
+      intro S q h
+      rw [gRoundsGo]
+      have hd := gDrainGo_inv ops bs d occ prot ((gMaxBucket + 2) * cs.size + 8) S q false h
+      cases hdd : gDrainGo ops occ prot ((gMaxBucket + 2) * cs.size + 8) S q false with
+      | mk S1 rest1 =>
+          cases rest1 with
+          | mk q1 prog1 =>
+              rw [hdd] at hd
+              cases hww : gWakeGo ops cs cs.size S1 q1 false with
+              | mk S2 rest2 =>
+                  cases rest2 with
+                  | mk q2 prog2 =>
+                      have hw := gWakeGo_inv ops bs d cs hcs cs.size S1 q1 false hd
+                      rw [hww] at hw
+                      simp only [hww]
+                      split
+                      · exact ih _ _ hw
+                      · exact hw
+
+theorem GSt_empty_inv (bs : BusSemantics p) (d : DenseConstraintSystem p) (nc nv : Nat) :
+    GInv bs d (GSt.empty nc nv : GSt p) := by
+  constructor
+  · intro i l hi
+    rw [GSt.empty] at hi
+    rw [gRows_replicate nc _ i l hi]
+    refine ⟨?_, GCl_nil d _⟩
+    intro denv _
+    simp [DenseLinExpr.eval, zmodZeroP_eq]
+  · intro x t hx
+    rw [GSt.empty] at hx
+    unfold gSolFn at hx
+    by_cases hlt : x.index < nv
+    · rw [show (Array.replicate nv (none : Option (DenseLinExpr p)))[x.index]? = some none by
+        simp [hlt]] at hx
+      exact absurd hx (by simp)
+    · rw [show (Array.replicate nv (none : Option (DenseLinExpr p)))[x.index]? = none by
+        simp [hlt]] at hx
+      exact absurd hx (by simp)
+
+/-! ## The solved map -/
+
+theorem gSolveSystem_inv (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+    GInv bs d (gSolveSystem bs d) := by
+  have hcs : ∀ (j : Nat) (c : DenseExpr p),
+      d.algebraicConstraints.toArray[j]? = some c → c ∈ d.algebraicConstraints := by
+    intro j c hj
+    rw [List.getElem?_toArray] at hj
+    exact List.mem_of_getElem? hj
+  rw [gSolveSystem]
+  cases hp : gPrepare bs d with
+  | mk occ prot =>
+      dsimp only
+      split
+      · rw [gRun]
+        exact gSweepGo_inv _ bs d occ prot _ hcs _ _
+          (gSweepGo_inv _ bs d occ prot _ hcs _ _
+            (gBuildGo_inv _ bs d _ hcs _ _ (GSt_empty_inv bs d _ _)))
+      · rw [gRunFill]
+        exact gRoundsGo_inv _ bs d occ prot _ hcs _ _ _
+          (gBuildGo_inv _ bs d _ hcs _ _ (GSt_empty_inv bs d _ _))
+
+theorem gOutFn_set (out : Array (Option (DenseExpr p))) (i : Nat) (v : Option (DenseExpr p))
+    (x : VarId) :
+    (i = x.index ∧ gOutFn (out.setIfInBounds i v) x = v) ∨
+      gOutFn (out.setIfInBounds i v) x = gOutFn out x := by
+  unfold gOutFn
+  by_cases hx : i = x.index
+  · subst hx
+    by_cases hi : x.index < out.size
+    · exact Or.inl ⟨rfl, by simp [hi]⟩
+    · exact Or.inr (by
+        simp [hi])
+  · right; simp [hx]
+
+/-- Every entry the output array carries is a stored solution's expression. -/
+theorem gOutGo_spec (S : GSt p) :
+    ∀ (k : Nat) (out : Array (Option (DenseExpr p))),
+      (∀ (i : VarId) (e : DenseExpr p), gOutFn out i = some e →
+        ∃ l, gSolFn S.sol i = some l ∧ e = l.toExpr) →
+      ∀ (i : VarId) (e : DenseExpr p), gOutFn (gOutGo S k out) i = some e →
+        ∃ l, gSolFn S.sol i = some l ∧ e = l.toExpr := by
+  intro k
+  induction k with
+  | zero => intro out hout i e h; exact hout i e h
+  | succ k ih =>
+      intro out hout i e h
+      rw [gOutGo] at h
+      refine ih _ ?_ i e h
+      cases hx : S.order[S.order.size - (k + 1)]? with
+      | none => simpa [hx] using hout
+      | some x =>
+          dsimp only
+          cases hs : gSolFn S.sol x with
+          | none => simpa using hout
+          | some l =>
+              dsimp only
+              intro j e' hj
+              rcases gOutFn_set out x.index (some l.toExpr) j with ⟨hix, hset⟩ | hset
+              · rw [hset] at hj
+                have he : l.toExpr = e' := Option.some.inj hj
+                have hxj : x = j := by cases x; cases j; simp_all
+                subst hxj; subst he
+                exact ⟨l, hs, rfl⟩
+              · rw [hset] at hj
+                exact hout j e' hj
+
+theorem gOutOf_spec (S : GSt p) (i : VarId) (e : DenseExpr p) (h : gOutFn (gOutOf S) i = some e) :
+    ∃ l, gSolFn S.sol i = some l ∧ e = l.toExpr := by
+  refine gOutGo_spec S S.order.size _ ?_ i e h
+  intro j e' hj
+  unfold gOutFn at hj
+  by_cases hlt : j.index < S.sol.size
+  · rw [show (Array.replicate S.sol.size (none : Option (DenseExpr p)))[j.index]? = some none by
+      simp [hlt]] at hj
+    exact absurd hj (by simp)
+  · rw [show (Array.replicate S.sol.size (none : Option (DenseExpr p)))[j.index]? = none by
+      simp [hlt]] at hj
+    exact absurd hj (by simp)
+
+/-- The two facts the spec asks of a substitution pass: the map is entailed and closed. -/
+theorem denseGaussElimF_map (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+    (∀ denv, d.satisfies bs denv → ∀ (i : VarId) (e : DenseExpr p),
+        gOutFn (gOutOf (gSolveSystem bs d)) i = some e → denv i = e.eval denv) ∧
+    (∀ (i : VarId) (e : DenseExpr p), gOutFn (gOutOf (gSolveSystem bs d)) i = some e →
+        ∀ z ∈ e.vars, z ∈ d.occ) := by
+  have hinv := gSolveSystem_inv bs d
+  refine ⟨?_, ?_⟩
+  · intro denv hsat i e he
+    obtain ⟨l, hl, rfl⟩ := gOutOf_spec _ i e he
+    rw [DenseLinExpr.toExpr_eval]
+    exact (hinv.sol i l hl).1 denv hsat
+  · intro i e he z hz
+    obtain ⟨l, hl, rfl⟩ := gOutOf_spec _ i e he
+    exact (hinv.sol i l hl).2 z (DenseLinExpr.toExpr_vars l z hz)
+
+/-! ## The pass -/
+
+theorem denseGaussElimF_eq (bs : BusSemantics p) (d : DenseConstraintSystem p) :
+    denseGaussElimF bs d =
+      if (gSolveSystem bs d).order.isEmpty then d
+      else d.substF (gOutFn (gOutOf (gSolveSystem bs d))) := rfl
+
+theorem denseGaussElimF_covered (reg : VarRegistry) (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) : (denseGaussElimF bs d).CoveredBy reg := by
+  rw [denseGaussElimF_eq]
   split_ifs with hempty
   · exact hcov
   · refine DenseConstraintSystem.substF_covered hcov ?_
     intro i _ t hti z hz
-    exact DenseConstraintSystem.occ_valid hcov z
-      ((denseGaussElim_loop_invariant bs d).2 i t hti z hz)
+    exact DenseConstraintSystem.occ_valid hcov z ((denseGaussElimF_map bs d).2 i t hti z hz)
 
-/-- **Correctness of `denseGaussElim`.** The empty-map branch is the identity (`refl`); the
-    substitution branch is `substF_denseCorrect`, fed the entailment and occurrence-closure of the
-    final solution map. -/
-theorem denseGaussElim_correct (reg : VarRegistry) (bs : BusSemantics p)
-    (d : DenseConstraintSystem p) :
-    DensePassCorrect reg.isInput d (denseGaussElim bs d) [] bs := by
-  have hinv := denseGaussElim_loop_invariant bs d
-  rw [denseGaussElim_eq]
+/-- **Correctness of `denseGaussElimF`.** The empty-map branch is the identity; the substitution
+    branch is `substF_denseCorrect`, fed the entailment and occurrence closure of the solved map. -/
+theorem denseGaussElimF_correct (reg : VarRegistry) (bs : BusSemantics p)
+    (d : DenseConstraintSystem p) : DensePassCorrect reg.isInput d (denseGaussElimF bs d) [] bs := by
+  have hmap := denseGaussElimF_map bs d
+  rw [denseGaussElimF_eq]
   split_ifs with hempty
   · exact DensePassCorrect.refl reg.isInput d bs
   · exact DenseConstraintSystem.substF_denseCorrect d _ bs reg.isInput
-      (fun denv hsat i t hti => hinv.1 denv hsat i t hti)
-      (fun i t hti z hz => hinv.2 i t hti z hz)
+      (fun denv hsat i t hti => hmap.1 denv hsat i t hti)
+      (fun i t hti z hz => hmap.2 i t hti z hz)
 
-/-- The wired dense Gauss-elimination pass (transform `denseGaussElim`, `Gauss.lean`). -/
-def denseGaussElimPass : DenseVerifiedPassW p :=
+/-- The wired dense Gauss-elimination pass (transform `denseGaussElimF`, `Gauss.lean`). -/
+def denseGaussElimFPass : DenseVerifiedPassW p :=
   DenseVerifiedPassW.of
-    (fun bs _ d => denseGaussElim bs d)
+    (fun bs _ d => denseGaussElimF bs d)
     (fun _ _ _ => [])
-    (fun reg bs _ d hcov => denseGaussElim_covered reg bs d hcov)
+    (fun reg bs _ d hcov => denseGaussElimF_covered reg bs d hcov)
     (fun _ _ _ _ _ => by intro x hx; simp at hx)
-    (fun reg bs _ d _ => denseGaussElim_correct reg bs d)
+    (fun reg bs _ d _ => denseGaussElimF_correct reg bs d)
 
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -581,56 +581,42 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      Preflight's `T.doms xs` is 6.8 % on sha256, all `Std.HashMap VarId` probes: the R12 array-indexed
      prototype belongs here first.
 
-### gauss residual after entry 158 (arrays for the scheduler indexes)  ·  *runtime, sha256*
+### gauss residual after entry 160 (the sparse engine)  ·  *runtime, sha256*
 
-Measured on sha256 `apc_001` (gauss 11.3 s of 102.0 s on CI, 8 676 ms of 99 256 on this container —
-still the top pass either way), LBR shares of the post-entry-158 pass; the **shares** transfer
-between boxes, the ms estimates below are this container's. Ranked by size ÷ effort; **the whole Markowitz scheduler is planning data that
-appears in no correctness theorem, so 1–4 need no proof at all** — only value equality if the change
-is to stay byte-identical.
+Entry 160 replaced the pass with a watch-driven sparse engine: **gauss 8.8 → 3.7 s on sha256
+`apc_001` (0.42x), run total 0.87x**, −3 vars / −931 bus there, and `Gauss.lean` 958 → 200 lines.
+Items 1–5 of the old residual list are all gone with it (`fromExpr`'s double walk, the per-row
+`HashMap`, the index delta updates, the rekey fan-out, and the eager back-substitution's exponent).
+What is left, LBR shares of the *new* pass on sha256:
 
-1. **One walk in `DenseGaussReduced.fromExpr`** (16.9 % + 3.8 % = the whole of `denseMarkowitzBuild`,
-   ~1.8 s). It calls `denseLinearize e`; on failure `e.normalize` — a full tree rebuild — and
-   `denseLinearize` again, per constraint per invocation (11 of them). The retry can only succeed
-   where a *merged* linear form cancels to a constant (`denseLinearize`'s `mul` branch tests
-   `la.terms.isEmpty` on the **unmerged** list, so `(x - x) * y` fails before normalization and
-   linearizes after). `denseNormalizeResWith` (`Normalize.lean:665`) already carries each node's
-   linear form; a variant whose `mul` branch tests `la.norm.terms.isEmpty` answers both questions in
-   one walk. **Not obviously byte-identical** (term order after merging may differ) — count both
-   verdicts side by side over cycles 0–1 first. ~0.8–1.2 s.
-2. **`denseMarkowitzPivots` without its per-row `HashMap`** (6.3 %). It builds `denseCoeffIdx l.terms`
-   plus a `seen` set, but **every affine row in gauss is `norm`-alized** (`fromExpr`, `denseLinSubstF`,
-   `denseLinAdd`, `denseLinScale` and the fused walk all end in `.norm`), so each variable occurs once
-   with a nonzero coefficient: `coeff = t.2`, `count = 1`, `rhsNnz = terms.length - 1`, the `±1` and
-   unit descriptor lists are disjoint and the dedup is a no-op. One pass, no hash structure, gated on
-   `terms.length ≤ 32` with the current code above the gate (as `denseMergeTermsWith` does).
-   Byte-identical by construction, ~25 lines. ~0.3–0.5 s.
-3. **Delta index/degree updates in `denseMarkowitzRefreshRows`** (index 6.6 % + `refreshRow` 6.7 %).
-   It unindexes every variable of the old row and re-indexes every variable of the new one, when the
-   delta is "drop the pivot, add what the substituted row brought in" — ~1.4 M redundant index
-   operations per big invocation. Byte-identical (`degrees` is exact, so sub-then-add on a shared
-   variable is a no-op and `Nat` truncation cannot bite). ~0.3–0.6 s.
-4. **The rekey fan-out**: 257 515 re-keys for 52 194 adoptions in cycle 1, because `changed` includes
-   every variable of every rewritten stored solution (307 948 of them) although those only move the
-   *third* lexicographic key (`rewrite`). Dropping them would cut re-keys ~5× and with them the entry
-   allocations behind the `pop` phase (10.4 %, of which Batteries' heap code is only 2.1 % — the rest
-   is refcounting and allocating entry records). **Not byte-identical** → CI matrix. ~0.8 s.
-5. **Defer the back-substitution into stored solutions** (`denseLinSubst` 6.2 % + `insertAll` 1.1 % +
-   `adoptPairs`, and the fan-out grows with circuit size — the only idea here that changes gauss's
-   *exponent*). `denseMarkowitzAdoptPairs` eagerly rewrites every stored solution mentioning the new
-   pivot; a triangular store resolved once at `materialize` is `O(total)` instead of
-   `O(chain × total)`. Blocked on the loop needing a **fully resolved** σ for
-   `denseSparseSubstF dσ.fn c` (a triangular one would let pivots be chosen for already-solved
-   variables and leave them in the output), so it needs an on-demand memoized resolver — whose term
-   order differs from step-by-step rewriting, i.e. output changes and `insertAll_preserves`' argument
-   must be redone. Largest and riskiest; open it last.
-
-**Measured sub-bar / do not re-propose** (also in the dead-end list below): reusing
-`st.rows[rowId].reduced` instead of re-substituting the source constraint on selection is 2.2 % of the
-pass (~0.27 s) and would dissolve the pass's untrusted-metadata story; the `ZMod` angle is 1.3 % (both
-`Gauss.c` sweep hits are dead `csimp` originals); a different heap is worth 2.1 %.
+- **output `substF` 28.5 %** — the levers are an unchanged-node-preserving `DenseExpr.substF` twin
+  (return the input node when no descendant changed; most constraints contain no solved variable) and
+  the array-backed lookup the engine already builds. **Cross-cutting**: domainBatch, flagUnify,
+  fxSubst and rootPairUnify all call `substF`, so this is worth more than its gauss share.
+- **the constraint walk 23.8 %** — one fail-fast pass over every constraint tree; irreducible unless
+  the prologue is fused into it (next item).
+- **`occ`/`prot` prologue 21.9 %** — two array passes over the whole system; fuse into the build walk.
+- scheduler 7.4 %, merge 6.6 %, pick/solve 5.3 %, σ upkeep 0.8 %. The elimination algebra is ~13 % of
+  the pass; the rest is three whole-system traversals.
+- **An array-backed row type is worth 0.42x → 0.27x on sha256** (measured with the unproven
+  prototype) but each array primitive then needs its own `toList`-correspondence proof; rows stayed
+  `DenseLinExpr` so the affine-layer lemmas apply unchanged. Open if the pass ever tops the list again.
+- **Reproducing Markowitz's exact key** above the gate would remove the one per-case effectiveness
+  loss (wasm-eth `apc_006`, +1 bus) at the cost of sha256's −931 bus; it needs the per-variable
+  active-degree index back. The scheduler is 7.4 % of the pass, so it is affordable — but measure the
+  bus trade before doing it.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **Dropping gauss's second source-order sweep** (entry 160): looks provably fruitless over a prime
+  field, and measures openvm-eth `apc_037` gauss **170 → 317 ms** with changed output — 35 % of that
+  case's pivots come from it, all nonlinear→affine transitions.
+- **Source order at every system size in gauss** (entry 160): **1.88x slower** on wasm-eth `apc_012`,
+  98 % of the pass in the like-term merge, because eagerly maintaining a reduced σ in source order
+  inflates a stored solution to 586 terms before it cancels back to 7.
+- **Removing gauss's 8192 gate** (entry 160): runtime-neutral on OpenVM (corpus 1.006x) and slightly
+  better there, but **regresses 8 of 100 SP1 `rsp` cases by +88 variables** — the primary axis. Entry
+  134's warning, now measured.
 
 - **Indexing `densePdKeep`'s re-verification** (flagFold part C): `findIdx?` deep-equality scans and
   `List.take` prefixes replaced by a `densePdValHash` position index over an array — **0.98x on
@@ -737,6 +723,11 @@ pass (~0.27 s) and would dissolve the pass's untrusted-metadata story; the `ZMod
   busPairCancel's remaining cost in "per-drop `alive` copies, `denseCheckCancel`, `denseFirstMatchAt`";
   measured in entry 153 those are 2.1 %, ~0 % and ~0 % — the cost had never left the region scans, it
   had only moved from "every prefix position" to "every same-key-or-symbolic prefix position".
+- **`Array` sharing hygiene decides whether array indexes are fast at all** (entry 160, measured on
+  keccak): `{ S with f := g S.f }` leaves `S.f` shared, so the write copies the whole array — **7x on
+  the pass** when the array is per-variable — and projecting `.1`/`.2` out of a returned tuple does the
+  same. Destructure the record (or the tuple) first, update the local, then rebuild. A profile showing
+  `lean_copy_expand_array` next to `lean_dec_ref_cold` is this bug, not real work.
 - **Check open PRs / recent `claude/*` branches for duplicates before implementing.**
 
 ## Runtime ideas (2026-07-27 session, entry 148)

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -581,29 +581,30 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      Preflight's `T.doms xs` is 6.8 % on sha256, all `Std.HashMap VarId` probes: the R12 array-indexed
      prototype belongs here first.
 
-### gauss residual after entry 160 (the sparse engine)  ·  *runtime, sha256*
+### gauss residual after entries 160–161 (the sparse engine)  ·  *runtime, sha256*
 
-Entry 160 replaced the pass with a watch-driven sparse engine: **gauss 8.8 → 3.7 s on sha256
-`apc_001` (0.42x), run total 0.87x**, −3 vars / −931 bus there, and `Gauss.lean` 958 → 200 lines.
-Items 1–5 of the old residual list are all gone with it (`fromExpr`'s double walk, the per-row
-`HashMap`, the index delta updates, the rekey fan-out, and the eager back-substitution's exponent).
-What is left, LBR shares of the *new* pass on sha256:
+Entry 160 replaced the pass with a watch-driven sparse engine and entry 161 removed a pointer-sharing
+copy from its scheduler: **gauss 8.8 → 2.5 s on sha256 `apc_001` (0.29x)**, −3 vars / −931 bus there,
+and `Gauss.lean` 958 → 200 lines. Items 1–5 of the old residual list are all gone with it
+(`fromExpr`'s double walk, the per-row `HashMap`, the index delta updates, the rekey fan-out, and the
+eager back-substitution's exponent). What is left, LBR shares of the *new* pass on sha256:
 
-- **output `substF` 28.5 %** — the levers are an unchanged-node-preserving `DenseExpr.substF` twin
+- **the constraint walk 28.0 %** — one fail-fast pass over every constraint tree; irreducible unless
+  the prologue is fused into it.
+- **output `substF` 28.0 %** — the levers are an unchanged-node-preserving `DenseExpr.substF` twin
   (return the input node when no descendant changed; most constraints contain no solved variable) and
   the array-backed lookup the engine already builds. **Cross-cutting**: domainBatch, flagUnify,
   fxSubst and rootPairUnify all call `substF`, so this is worth more than its gauss share.
-- **the constraint walk 23.8 %** — one fail-fast pass over every constraint tree; irreducible unless
-  the prologue is fused into it (next item).
-- **`occ`/`prot` prologue 21.9 %** — two array passes over the whole system; fuse into the build walk.
-- scheduler 7.4 %, merge 6.6 %, pick/solve 5.3 %, σ upkeep 0.8 %. The elimination algebra is ~13 % of
-  the pass; the rest is three whole-system traversals.
-- **An array-backed row type is worth 0.42x → 0.27x on sha256** (measured with the unproven
-  prototype) but each array primitive then needs its own `toList`-correspondence proof; rows stayed
-  `DenseLinExpr` so the affine-layer lemmas apply unchanged. Open if the pass ever tops the list again.
+- **`occ`/`prot` prologue 21.8 %** — two array passes over the whole system; fuse into the build walk.
+- develop/merge 6.8 %, adopt 4.9 %, scheduler 3.8 %, pick/solve 1.7 %. The elimination algebra is
+  ~13 % of the pass; the rest is three whole-system traversals.
+- **An array-backed row type is worth only 2 525 → 2 375 ms on sha256** (~6 %, measured with a
+  `sorry`-ed prototype, identical output on four representatives) — *not* the 0.42x → 0.27x that entry
+  160 recorded, which was this scheduler copy misattributed to the row representation. Each array
+  primitive would need its own `toList`-correspondence proof, so rows stay `DenseLinExpr`. Below bar.
 - **Reproducing Markowitz's exact key** above the gate would remove the one per-case effectiveness
   loss (wasm-eth `apc_006`, +1 bus) at the cost of sha256's −931 bus; it needs the per-variable
-  active-degree index back. The scheduler is 7.4 % of the pass, so it is affordable — but measure the
+  active-degree index back. The scheduler is 3.8 % of the pass, so it is affordable — but measure the
   bus trade before doing it.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
@@ -723,10 +724,14 @@ What is left, LBR shares of the *new* pass on sha256:
   busPairCancel's remaining cost in "per-drop `alive` copies, `denseCheckCancel`, `denseFirstMatchAt`";
   measured in entry 153 those are 2.1 %, ~0 % and ~0 % — the cost had never left the region scans, it
   had only moved from "every prefix position" to "every same-key-or-symbolic prefix position".
-- **`Array` sharing hygiene decides whether array indexes are fast at all** (entry 160, measured on
-  keccak): `{ S with f := g S.f }` leaves `S.f` shared, so the write copies the whole array — **7x on
-  the pass** when the array is per-variable — and projecting `.1`/`.2` out of a returned tuple does the
-  same. Destructure the record (or the tuple) first, update the local, then rebuild. A profile showing
+- **`Array` sharing hygiene decides whether array indexes are fast at all** (entries 160–161, measured
+  on keccak and sha256). Three traps, all the same cause: `{ S with f := g S.f }` leaves `S.f` shared,
+  so the write copies the whole array (**7x on the pass** when the array is per-variable); projecting
+  `.1`/`.2` out of a returned tuple does the same; and **reading a field for a before/after comparison
+  across a call that updates it** keeps it shared for the whole call — `let n := S.order.size; let S :=
+  gTake … S …; S.order.size != n` cost **34 % of gauss on sha256**, one O(|order|) copy plus
+  element-wise free per adoption. Destructure the record (or the tuple) first; derive "did it change?"
+  from state read *after* the call, never from a value captured before it. A profile showing
   `lean_copy_expand_array` next to `lean_dec_ref_cold` is this bug, not real work.
 - **Check open PRs / recent `claude/*` branches for duplicates before implementing.**
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5700,3 +5700,87 @@ must hash everything the test behind it compares, unless that test is semantic r
 syntactic.**
 **Worked: yes (rootPairUnify 0.217x on its worst case, 0.925x end-to-end, output byte-identical,
 zero proof work).**
+
+### 160. Runtime: Gauss rebuilt as a watch-driven sparse engine (0.33–0.46x on the pass, sha256 total 0.87x)
+
+Full redesign of the Gauss pass (`gaussRedesign.md` has the design, the attribution and the rejected
+alternatives). The old pass re-derived every constraint's reduced form **from its source expression**
+at every visit, and above the 8192-row gate additionally maintained a *substituted expression tree*
+for every nonlinear row, refreshing it once per incident pivot. On sha256 `apc_001` (the worst case,
+gauss 8.8 s of 93 s) that was: 13 % of the pass rebuilding trees for rows that, in cycles 1–2,
+**never once turned affine** (`sigma = naff` exactly there); 28 % in the per-row build (`fromExpr`
+linearizes, and on failure runs a whole `DenseExpr.normalize` rebuild and linearizes *again*, plus
+`uniqueVars` and a per-row `HashMap` — for a 1.2-term row); 13.5 % in the heap; 8 % keeping σ
+back-substituted through the one `denseLinSubst` call site that the `@[csimp]` twin never reached
+(`Gauss.c`: `ZMod.commRing` + three projections rebuilt at the head of a `goto _start` loop).
+
+WHAT REPLACED IT (`Gauss.lean`; correctness in `Proofs/Gauss.lean`):
+1. **A three-valued fail-fast walk** (`gEval`): each constraint is walked once into a constant, an
+   affine row, or `blocked` carrying the variables to watch. Both `add` and `mul` propagate blocking
+   unconditionally, so the walk **stops at the first surviving variable×variable product** and
+   allocates nothing on that path. The verdict is exactly the old `denseSparseSubstF`'s: a product is
+   affine iff one side's *merged substituted* form is constant.
+2. **Two-watched-literal wake-up**: a blocked constraint is re-walked only when a variable of its
+   blocking product's substituted factors is solved — the only way that product can collapse. Untrusted:
+   a missed wake-up loses a pivot, never soundness.
+3. **Rows developed on arrival, not re-derived**: a pending row is substituted against σ when the
+   scheduler reaches it (one pass, one merge — `denseLinSubstF`), never re-walked from the source tree.
+4. **A lazy bucket queue** replaces the Markowitz heap above the gate: shortest row first, a row that
+   outgrew its bucket is re-filed instead of pivoted, FIFO within a bucket. No eager key maintenance,
+   no generations, no rekey fan-out.
+5. **Arrays for every per-variable index** (`sol`, `solRev`, `watch`, `occ`, `prot`, `status`) and a
+   one-scan pivot selection: on a merged row `denseGaussScore` is `(occ[v]-1)·|terms|`, so the choice
+   is min-occ with `±1` preferred — no per-row `HashMap`, no descriptor lists, no `argmin`.
+
+NUMBERS (this 20-core box, serial, interleaved, 3 reps; sha256 2 alternating runs):
+**sha256 `apc_001` gauss 8 816 → 3 734 ms (0.42x), run total 92.8 → 81.1 s (0.87x)**; wasm-eth
+`apc_006` 489 → 163 (0.33x, total 0.91x); wasm-eth `apc_012` 920 → 311 (0.34x, total 0.94x); keccak
+`apc_001` 677 → 255 (0.38x, total 0.93x); openvm-eth `apc_037` 171 → 79 (0.46x, total 0.94x). The
+end-to-end win on sha256 is twice gauss's own, because the new basis leaves cycle 1 with 72 324
+constraints instead of 87 000 (`tupleRange` 0.44x, `subsumedRange` 0.31x, `dedup` 0.78x).
+
+EFFECTIVENESS: **sha256 `apc_001` −3 vars and −931 bus interactions** (constraints equal); every other
+case identical except wasm-eth `apc_006`, which ends **+1 bus** — see the note below. Verified per case
+over openvm-eth (100), wasm-eth (100), OpenVM keccak, SP1 rsp (100) and SP1 keccak.
+
+THREE THINGS THE MEASUREMENTS OVERTURNED, each of which would have been a wrong design:
+- **The second sweep is not dead work.** It looks provably fruitless (over a prime field every
+  non-empty affine row pivots on first visit, so only nonlinear-source constraints can fire later) —
+  but deleting it measured openvm-eth `apc_037` gauss **170 → 317 ms** with changed output: 35 % of
+  that case's pivots come from the second sweep, all from nonlinear→affine transitions.
+- **Source order alone is not viable above the gate.** The first prototype used it everywhere and was
+  **1.88x slower** on wasm-eth `apc_012`, 98 % of the pass in the like-term merge: eagerly maintaining
+  a reduced σ in source order inflates a stored solution to **586 terms** before it cancels back to 7,
+  where the Markowitz baseline never builds a row above 32 in that whole run. Fill-aware selection is
+  load-bearing; being *Markowitz* is not.
+- **The 8192 gate must stay.** Removing it (bucket queue at every size) is runtime-neutral on OpenVM
+  (corpus aggregate 1.006x) and slightly better there — and regresses **8 of 100 SP1 `rsp` cases by
+  +88 variables**, the primary axis. That is entry 134's warning, measured: below the gate the
+  source-order basis is what the later syntactic-cleanup passes want.
+
+THE ONE REGRESSION, PINNED DOWN: wasm-eth `apc_006` +1 bus interaction. Digest-comparing the solution
+map invocation by invocation shows the new source-order path is **faithful variable-for-variable** (all
+ten invocations identical when both engines are forced to source order), and the **baseline itself**,
+forced to source order, also ends at 1359. So the +1 is the price of not reproducing Markowitz's exact
+key above the gate — the same substitution that buys sha256 its −931 bus. Reproducing Markowitz exactly
+would need the per-variable active-degree index back (the scheduler is only 7.4 % of the new pass, so
+it is affordable) but would give up the sha256 gain.
+
+PROOF SHAPE (why this cost ~1 000 lines and not 3 000): the pass's obligations are only *entailment*
+and *occurrence closure* of the final map, so the scheduler, buckets, watch lists and `occ`/`prot`
+appear in no theorem. The invariant is two lines — pending rows are entailed and closed, stored
+solutions are entailed assignments and closed — preserved by `gAdopt` alone, and every step of that is
+an affine-layer lemma the old pass already had (`denseSparseSolveAt_sound`, `denseLinSubst_eval`,
+`denseLinSubstF_terms_closed`, …). Rows stayed `DenseLinExpr` for exactly this reason. Net: **−1 553
+lines deleted** (all of `DenseGaussReduced`, the fused walk, the Markowitz scheduler and their ~450
+lines of proofs) against +1 540 added, and `Gauss.lean` shrinks 958 → 200 lines.
+
+WHAT THIS COST IN SPEED, AND WHERE THE NEXT WIN IS: an array-backed row type measured **0.27x** on
+sha256 against the list-backed one's 0.42x, but every array primitive would then need its own
+`toList`-correspondence proof. Two `Array`-hygiene traps are worth remembering, both measured on
+keccak: `{ S with f := g S.f }` leaves `S.f` shared and copies the whole array (7x on the pass), and
+so does projecting `.1`/`.2` out of a returned tuple — destructure instead. Residual on sha256 (LBR,
+gauss-gated): output `substF` 28.5 %, the constraint walk 23.8 %, the `occ`/`prot` prologue 21.9 %,
+scheduler 7.4 %, merge 6.6 %. The elimination algebra is ~13 % of the pass; the rest is three
+whole-system traversals, so the next levers are an unchanged-node-preserving `substF` twin (helps four
+other passes) and fusing the prologue into the build walk.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5784,3 +5784,48 @@ gauss-gated): output `substF` 28.5 %, the constraint walk 23.8 %, the `occ`/`pro
 scheduler 7.4 %, merge 6.6 %. The elimination algebra is ~13 % of the pass; the rest is three
 whole-system traversals, so the next levers are an unchanged-node-preserving `substF` twin (helps four
 other passes) and fusing the prologue into the build walk.
+
+## Entry 161 — gauss: the "list rows cost 55 %" finding was a pointer-sharing bug (sha256 gauss 3.7 → 2.5 s)
+
+Entry 160 recorded that an array-backed row type measured 0.27x on sha256 against the landed
+list-backed 0.42x, and attributed the 1.3 s gap to the row representation. That was wrong. Rebuilding
+the engine over `Array (VarId × ZMod p)` rows (a `sorry`-ed prototype: `gRowNorm`/`gRowSubstF`/
+`gRowSolveAt` mirroring the affine layer, in-place merge via `Array.modify` at refcount 1) recovered
+**almost nothing**: sha256 gauss 3 761 → 3 707 ms. The gap was somewhere else.
+
+LBR attribution of the two binaries, gated on a gauss frame, found it in one line. The landed version
+spends **19 % of the pass in `lean_copy_expand_array` under `GSt.pushOrder`** and **31 % in
+`lean_dec_ref_cold` under `gDrainAt`**; the old prototype spends 1.3 % and 17 %. `gDrainAt` measured
+progress as
+
+    let n := S.order.size;  let S := gTake … S i l;  (S, q, prog || S.order.size != n)
+
+so `order` is *shared* for the whole `gTake` call, and `gAdopt`'s `pushOrder` copies the entire array
+on every adoption — O(|order|) memcpy plus an element-wise free of the old copy, ~50 k times on
+sha256. In the generated C the pre-call read is visible as a fourth `lean_ctor_get(S, 6)` in
+`gDrainAt`'s prologue that the fixed version does not emit. `gTake` retires slot `i` exactly when it
+pivots, so `(S.status[i]?).getD 1 == 2` read *after* the call decides progress identically while
+holding nothing.
+
+MEASURED (this box, serial, interleaved, 2 reps, gauss ms; all four outputs byte-identical):
+
+| variant | sha256 apc_001 | wasm apc_012 | keccak apc_001 | eth apc_006 |
+|---|---|---|---|---|
+| entry 160 as landed (list rows) | 3 761 | 305 | 265 | 39 |
+| **+ this fix (list rows)** | **2 525** | **284** | **228** | 40 |
+| array rows + this fix | 2 375 | 273 | 224 | 39 |
+
+So against the pre-redesign 8 816 ms the pass is now **0.29x** on sha256, and the row representation
+is worth a further ~6 % — not 55 %. `apc_006` is below the 8192 gate and never reaches this
+scheduler, which is why the four-case set hid the bug: it only bites where `gDrainAt` runs.
+The array prototype stays unbuilt: 6 % does not pay for a `toList`-correspondence proof per primitive.
+
+`prog` is scheduling data occurring in no theorem, so `gDrainAt_inv` and the rest of the ~1 000-line
+proof compile unchanged. Residual on sha256 after the fix: constraint walk 28.0 %, output `substF`
+28.0 %, `occ`/`prot` prologue 21.8 %, develop/merge 6.8 %, adopt 4.9 %, scheduler 3.8 %, pick 1.7 %.
+
+THE GENERAL LESSON (third form of the same trap, now in `ideas.md`): a before/after comparison on a
+field of a linear structure — `let n := S.f.size; …; S.f.size != n` — is as destructive as
+`{ S with f := g S.f }`. Derive "did it change?" from state read after the call. And when a variant
+measures much faster, attribute the difference before believing the explanation you had in mind: the
+first two A/B tables here were consistent with a story that was simply false.


### PR DESCRIPTION
Full redesign of the Gauss pass. Design, attribution and rejected alternatives: `agent-docs/log.md` entries 160–161.

## What was slow

The old pass re-derived every constraint's reduced form **from its source expression** at every visit, and above the 8192-row gate additionally maintained a *substituted expression tree* for every nonlinear row, refreshing it once per incident pivot. On sha256 `apc_001` (worst case, gauss 8.8 s of 93 s), LBR shares of the pass:

| phase | % of pass | what it is |
|---|---:|---|
| nonlinear-row refresh | 13.1 | rebuilding substituted trees for rows that, in cycles 1–2, **never once turned affine** (`sigma = naff` exactly there) |
| per-row build | 28.1 | `fromExpr` linearizes, and on failure runs a whole `DenseExpr.normalize` rebuild and linearizes *again*, plus `uniqueVars` and a per-row `HashMap` — for a 1.2-term row |
| heap pop + rekey | 13.5 | entry records, generations, adoption fan-out |
| eager σ back-substitution | 7.9 | through the one `denseLinSubst` call site the `@[csimp]` twin never reached |

Rows are 1–2.2 terms and solutions ~1 term across every corpus: there is no fill to reduce, so the cost was per-constraint traversal and allocation at 200 k constraints.

## The engine

- **A three-valued fail-fast walk.** Each constraint is walked once into a constant, an affine row, or `blocked` carrying the variables to watch. Both `add` and `mul` propagate blocking unconditionally, so the walk **stops at the first surviving variable×variable product** and allocates nothing on that path. The verdict is exactly `denseSparseSubstF`'s.
- **Two-watched-literal wake-up.** A blocked constraint is re-walked only when a variable of its blocking product's substituted factors is solved — the only way that product can collapse.
- **Rows developed on arrival**, against the solution map, never re-derived from the source tree.
- **A lazy bucket queue** above the gate instead of the Markowitz heap: shortest row first, a row that outgrew its bucket is re-filed rather than pivoted, FIFO within a bucket. No eager keys, no generations, no rekey fan-out.
- **Arrays for every per-variable index**, and one-scan pivot selection: on a merged row `denseGaussScore` is `(occ[v]-1)·|terms|`, so the choice is min-occ with `±1` preferred.

**The 8192 gate stays.** Running the fill-aware scheduler below it is runtime-neutral on OpenVM and slightly better there, and regresses **8 of 100 SP1 `rsp` cases by +88 variables** — entry 134's warning, measured.

## Runtime

This box, serial, interleaved, 3 reps (sha256 2); the `engine` column is the first commit, `+ fix` adds the second.

| case | gauss base | engine | + fix | ratio | run total | ratio |
|---|---:|---:|---:|---:|---|---:|
| **sha256 apc_001** | 8 816 ms | 3 750 ms | **2 525 ms** | **0.29×** | 92.8 → **81 s** | **0.87×** |
| wasm-eth apc_006 | 489 | 170 | 160 | 0.33× | 6 101 → 5 640 | 0.92× |
| wasm-eth apc_012 | 920 | 305 | 284 | 0.31× | 11 170 → 10 400 | 0.93× |
| keccak apc_001 | 677 | 265 | 228 | 0.34× | 8 491 → 7 980 | 0.94× |
| openvm-eth apc_037 | 171 | 84 | 79 | 0.46× | 1 634 → 1 550 | 0.95× |

The second commit's 1.2 s on sha256 is below the run-total noise floor (±2 s across reps), so the
end-to-end ratio is reported unchanged.

sha256's end-to-end win is twice gauss's own: the new basis leaves cycle 1 with 72 324 constraints instead of 87 000 (`tupleRange` 0.44×, `subsumedRange` 0.31×, `dedup` 0.78×).

## Effectiveness (per case, 302 local cases)

| corpus | cases | identical | differing |
|---|---:|---:|---|
| openvm-eth | 100 | 100 | — |
| wasm-eth | 100 | 99 | `apc_006`: **+1 bus** (vars, constraints equal) |
| OpenVM keccak | 1 | 1 | — |
| SP1 rsp | 100 | 100 | — |
| SP1 keccak | 1 | 1 | — |
| sha256 apc_001 | 1 | 0 | **−3 vars, −931 bus**, constraints equal |

The one loss is pinned down: digest-comparing the solution map invocation by invocation shows the new source-order path is **faithful variable-for-variable**, and the **baseline itself**, forced to source order everywhere, also ends at 1359 bus on that case. So the +1 is the price of not reproducing Markowitz's exact key above the gate — the same substitution that buys sha256 its −931. Reproducing it exactly needs the per-variable active-degree index back (the scheduler is 3.8 % of the new pass, so it is affordable) but would give up the sha256 gain. Flagging it for the matrix rather than deciding it here.

## Proof and size

Correctness rides on the same two facts as before — the solution map is **entailed** and **occurrence-closed** — so the scheduler, buckets, watch lists and `occ`/`prot` appear in no theorem. The invariant is two lines (pending rows entailed and closed; stored solutions entailed assignments and closed), preserved by `gAdopt` alone, and every step of that is an affine-layer lemma the old pass already had. Rows stayed `DenseLinExpr` for exactly that reason, and a `sorry`-ed array-backed row prototype measures that choice at **~6 %** (2 525 → 2 375 ms on sha256, identical output) — not enough to pay for a `toList`-correspondence proof per primitive.

No new files: the engine replaces the old one inside `Gauss.lean`, its proof inside `Proofs/Gauss.lean`, per the two-files-per-pass convention. Deleted with the old pass: all of `DenseGaussReduced`, the fused walk, the Markowitz scheduler and ~450 lines of their proofs, plus three `@[csimp]` twins the engine no longer routes through (it calls the `…With` versions directly, so `denseLinSubstF` / `denseLinScale` / `denseSparseSolveAt` are now specifications only). Net **+1 623 / −1 599** across 6 files.

`lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` passes (propext / Classical.choice / Quot.sound, no unused theorems).

## Follow-up commit: the scheduler was copying `order` per adoption

Chasing the row-representation question found a pointer-sharing bug in the first commit's scheduler. `gDrainAt` measured progress as

```lean
let n := S.order.size;  let S := gTake … S i l;  (S, q, prog || S.order.size != n)
```

The pre-call read keeps `order` live across `gTake`, so `gAdopt`'s `pushOrder` finds the array shared and copies it on **every** adoption — an O(|order|) memcpy plus an element-wise free of the old copy, ~50 k times on sha256. LBR shares of the pass: **19 % in `lean_copy_expand_array` under `GSt.pushOrder`** and **31 % in `lean_dec_ref_cold` under `gDrainAt`**, against 1.3 % / 17 % for a variant without the read; in the generated C it is a fourth `lean_ctor_get(S, 6)` in `gDrainAt`'s prologue. `gTake` retires slot `i` exactly when it pivots, so `(S.status[i]?).getD 1 == 2` read *after* the call decides progress identically while holding nothing.

`prog` is scheduling data occurring in no theorem, so `gDrainAt_inv` and the rest of the proof are unchanged. Output verified identical on the five cases above plus **100/100 openvm-eth** and **100/100 SP1 `rsp`**. `openvm-eth apc_006` is below the 8192 gate and never reaches this scheduler, which is why the small-case set hid it.

Draft: opened for the CI effectiveness matrix on the sets I cannot run locally, and for a second opinion on the `apc_006` +1 bus before undrafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

