### PR TITLE
perf(reencode): rebuild the pass as an array-backed engine over stable positions (0.32–0.42x on the pass, sha256 total 0.93x)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -2035,6 +2035,1313 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx
 
+/-! ## The array engine
+
+The engine of `Reencode.lean` keeps the system on stable array positions with `VarId`-keyed indexes.
+Everything it computes off those indexes is *untrusted*: the certificate below is the audited
+`denseCheckReencode` on the covered set the index gathered, and the accept's edits are re-derived
+from each position's current content, so an index that over-reports costs a decision and never
+soundness. Two facts carry the correctness: the gathered covered set *is* the filter
+(`denseRncEs_eq`, from anchor completeness), and the written state's view *is*
+`denseReencodeOut` of the old view with trivially-true constraints dropped (`denseRncWrite_view`) —
+the same two facts the list engine established with `denseWorkView_check` and `denseWorkOut_view`. -/
+
+/-! ### Expression predicate characterisations -/
+
+theorem denseHasVar_iff (e : DenseExpr p) : e.hasVar = true ↔ e.vars ≠ [] := by
+  induction e with
+  | const n => simp [DenseExpr.hasVar, DenseExpr.vars]
+  | var y => simp [DenseExpr.hasVar, DenseExpr.vars]
+  | add a b iha ihb | mul a b iha ihb =>
+      simp only [DenseExpr.hasVar, DenseExpr.vars, Bool.or_eq_true, iha, ihb,
+        ne_eq, List.append_eq_nil_iff, not_and_or]
+
+theorem denseVarsInF_iff (xs : List VarId) (e : DenseExpr p) :
+    e.varsInF xs = true ↔ ∀ v ∈ e.vars, v ∈ xs := by
+  induction e with
+  | const n => simp [DenseExpr.varsInF, DenseExpr.vars]
+  | var y =>
+      simp only [DenseExpr.varsInF, DenseExpr.vars, List.mem_cons, List.not_mem_nil, or_false]
+      constructor
+      · intro h v hv; rw [hv]; exact denseContainsFast_sound xs y h
+      · intro h; exact denseContainsFast_of_mem xs y (h y rfl)
+  | add a b iha ihb | mul a b iha ihb =>
+      simp only [DenseExpr.varsInF, DenseExpr.vars, Bool.and_eq_true, iha, ihb, List.mem_append]
+      exact ⟨fun ⟨ha, hb⟩ v hv => hv.elim (ha v) (hb v),
+        fun h => ⟨fun v hv => h v (Or.inl hv), fun v hv => h v (Or.inr hv)⟩⟩
+
+theorem denseSharesVarIn_iff (xs : List VarId) (e : DenseExpr p) :
+    e.sharesVarIn xs = true ↔ ∃ v ∈ e.vars, v ∈ xs := by
+  induction e with
+  | const n => simp [DenseExpr.sharesVarIn, DenseExpr.vars]
+  | var y =>
+      simp only [DenseExpr.sharesVarIn, DenseExpr.vars, List.mem_cons, List.not_mem_nil, or_false]
+      constructor
+      · intro h; exact ⟨y, rfl, denseContainsFast_sound xs y h⟩
+      · rintro ⟨v, hv, hx⟩; rw [hv] at hx; exact denseContainsFast_of_mem xs y hx
+  | add a b iha ihb | mul a b iha ihb =>
+      simp only [DenseExpr.sharesVarIn, DenseExpr.vars, Bool.or_eq_true, iha, ihb, List.mem_append]
+      constructor
+      · rintro (⟨v, hv, hx⟩ | ⟨v, hv, hx⟩)
+        · exact ⟨v, Or.inl hv, hx⟩
+        · exact ⟨v, Or.inr hv, hx⟩
+      · rintro ⟨v, hv | hv, hx⟩
+        · exact Or.inl ⟨v, hv, hx⟩
+        · exact Or.inr ⟨v, hv, hx⟩
+
+/-! ### The capped variable arrays
+
+`denseRncCapVars` stops at nine distinct variables, so it is exact below the cap; every consumer
+either stays below it or falls back to the tree walk. -/
+
+theorem denseRncCapGo_mono (cap : Nat) :
+    ∀ (e : DenseExpr p) (acc : Array VarId),
+      (∀ v ∈ acc, v ∈ denseRncCapGo cap e acc) ∧ acc.size ≤ (denseRncCapGo cap e acc).size := by
+  intro e
+  induction e with
+  | const n => intro acc; exact ⟨fun v hv => hv, Nat.le_refl _⟩
+  | var y =>
+      intro acc
+      rw [denseRncCapGo]
+      split
+      · exact ⟨fun v hv => hv, Nat.le_refl _⟩
+      · exact ⟨fun v hv => by simp [hv], by simp⟩
+  | add a b iha ihb | mul a b iha ihb =>
+      intro acc
+      rw [denseRncCapGo]
+      obtain ⟨hma, hsa⟩ := iha acc
+      split
+      · exact ⟨hma, hsa⟩
+      · obtain ⟨hmb, hsb⟩ := ihb (denseRncCapGo cap a acc)
+        exact ⟨fun v hv => hmb v (hma v hv), Nat.le_trans hsa hsb⟩
+
+theorem denseRncCapGo_sound (cap : Nat) :
+    ∀ (e : DenseExpr p) (acc : Array VarId) (v : VarId),
+      v ∈ denseRncCapGo cap e acc → v ∈ acc ∨ v ∈ e.vars := by
+  intro e
+  induction e with
+  | const n => intro acc v hv; exact Or.inl hv
+  | var y =>
+      intro acc v hv
+      rw [denseRncCapGo] at hv
+      split at hv
+      · exact Or.inl hv
+      · rcases Array.mem_push.1 hv with h | h
+        · exact Or.inl h
+        · exact Or.inr (by simp [DenseExpr.vars, h])
+  | add a b iha ihb | mul a b iha ihb =>
+      intro acc v hv
+      rw [denseRncCapGo] at hv
+      split at hv
+      · rcases iha acc v hv with h | h
+        · exact Or.inl h
+        · exact Or.inr (by simp [DenseExpr.vars, h])
+      · rcases ihb _ v hv with h | h
+        · rcases iha acc v h with h' | h'
+          · exact Or.inl h'
+          · exact Or.inr (by simp [DenseExpr.vars, h'])
+        · exact Or.inr (by simp [DenseExpr.vars, h])
+
+/-- Below the cap the walk never bailed out, so every variable of the expression is present. -/
+theorem denseRncCapGo_complete (cap : Nat) :
+    ∀ (e : DenseExpr p) (acc : Array VarId),
+      (denseRncCapGo cap e acc).size < cap → ∀ v ∈ e.vars, v ∈ denseRncCapGo cap e acc := by
+  intro e
+  induction e with
+  | const n => intro acc _ v hv; simp [DenseExpr.vars] at hv
+  | var y =>
+      intro acc hlt v hv
+      have hy : v = y := by simpa [DenseExpr.vars] using hv
+      subst hy
+      rw [denseRncCapGo] at hlt ⊢
+      split at hlt
+      · next hc =>
+          rw [if_pos hc]
+          have hc' : cap ≤ acc.size ∨ acc.contains v = true := by simpa using hc
+          rcases hc' with h | h
+          · omega
+          · exact Array.mem_of_contains_eq_true h
+      · next hc =>
+          rw [if_neg hc]
+          simp
+  | add a b iha ihb | mul a b iha ihb =>
+      intro acc hlt v hv
+      rw [denseRncCapGo] at hlt ⊢
+      split at hlt
+      · next hsplit => rw [if_pos hsplit]; omega
+      · next hsplit =>
+        rw [if_neg hsplit]
+        have hva : ∀ w ∈ a.vars, w ∈ denseRncCapGo cap a acc := iha acc (by omega)
+        have hmono := (denseRncCapGo_mono cap b (denseRncCapGo cap a acc)).1
+        rcases List.mem_append.1 (by simpa [DenseExpr.vars] using hv) with h | h
+        · exact hmono v (hva v h)
+        · exact ihb _ hlt v h
+
+/-- The capped array is exact when it stayed below the cap. -/
+theorem denseRncCapVars_mem_iff {c : DenseExpr p} (h : (denseRncCapVars c).size ≤ 8) (v : VarId) :
+    v ∈ denseRncCapVars c ↔ v ∈ c.vars := by
+  constructor
+  · intro hv
+    rcases denseRncCapGo_sound 9 c #[] v hv with h' | h'
+    · simp at h'
+    · exact h'
+  · intro hv
+    exact denseRncCapGo_complete 9 c #[] (by simpa [denseRncCapVars] using Nat.lt_succ_of_le h) v hv
+
+theorem denseRncCapVars_size_pos_iff {c : DenseExpr p} (h : (denseRncCapVars c).size ≤ 8) :
+    1 ≤ (denseRncCapVars c).size ↔ c.hasVar = true := by
+  rw [denseHasVar_iff]
+  constructor
+  · intro hpos hnil
+    have hmem : (denseRncCapVars c)[0] ∈ denseRncCapVars c := Array.getElem_mem (by omega)
+    rw [denseRncCapVars_mem_iff h, hnil] at hmem
+    simp at hmem
+  · intro hne
+    obtain ⟨v, hv⟩ := List.exists_mem_of_ne_nil _ hne
+    have hmem : v ∈ denseRncCapVars c := (denseRncCapVars_mem_iff h v).2 hv
+    simpa using Array.size_pos_of_mem hmem
+
+theorem denseRncSubset_eq {xs : List VarId} {c : DenseExpr p}
+    (h : (denseRncCapVars c).size ≤ 8) :
+    denseRncSubset xs (denseRncCapVars c) = c.varsInF xs := by
+  unfold denseRncSubset
+  cases hv : c.varsInF xs with
+  | true =>
+      have hall := (denseVarsInF_iff xs c).1 hv
+      refine Array.all_eq_true'.2 (fun w hw => ?_)
+      exact denseContainsFast_of_mem xs w (hall w ((denseRncCapVars_mem_iff h w).1 hw))
+  | false =>
+      have hnot : ¬ (∀ w ∈ c.vars, w ∈ xs) := fun hall => by
+        rw [(denseVarsInF_iff xs c).2 hall] at hv; exact Bool.noConfusion hv
+      by_contra hcon
+      rw [Bool.not_eq_false] at hcon
+      exact hnot (fun w hw => denseContainsFast_sound xs w
+        (Array.all_eq_true'.1 hcon w ((denseRncCapVars_mem_iff h w).2 hw)))
+
+/-- The array-level covered test is `denseCoveredBy`. -/
+theorem denseRncCovered_eq (xs : List VarId) (c : DenseExpr p) :
+    denseRncCovered xs (denseRncCapVars c) c = denseCoveredBy xs c := by
+  unfold denseRncCovered
+  split
+  · next h =>
+      rw [denseCoveredBy, denseRncSubset_eq h]
+      cases hv : c.hasVar with
+      | true => simp [(denseRncCapVars_size_pos_iff h).2 hv]
+      | false =>
+          have hz : ¬ (1 ≤ (denseRncCapVars c).size) := fun hpos => by
+            rw [(denseRncCapVars_size_pos_iff h).1 hpos] at hv; exact Bool.noConfusion hv
+          simp [hz]
+  · rfl
+
+/-- The array-level `sharesVarIn` test. -/
+theorem denseRncShares_eq (xs : List VarId) (c : DenseExpr p) :
+    denseRncShares xs (denseRncCapVars c) c = c.sharesVarIn xs := by
+  unfold denseRncShares
+  split
+  · next h =>
+      cases hs : c.sharesVarIn xs with
+      | true =>
+          obtain ⟨w, hw, hx⟩ := (denseSharesVarIn_iff xs c).1 hs
+          exact Array.any_eq_true'.2
+            ⟨w, (denseRncCapVars_mem_iff h w).2 hw, denseContainsFast_of_mem xs w hx⟩
+      | false =>
+          by_contra hcon
+          rw [Bool.not_eq_false] at hcon
+          obtain ⟨w, hw, hx⟩ := Array.any_eq_true'.1 hcon
+          have := (denseSharesVarIn_iff xs c).2
+            ⟨w, (denseRncCapVars_mem_iff h w).1 hw, denseContainsFast_sound xs w hx⟩
+          rw [hs] at this
+          exact Bool.noConfusion this
+  · rfl
+
+/-! ### State invariants
+
+Each says the index over-approximates nothing it must find. All are maintained by the write and
+consumed either by the covered gather or by the accept's edit list. -/
+
+/-- `cvs` mirrors `cs` positionwise. -/
+def DenseRncCvsOk (st : DenseRncState p) : Prop :=
+  ∀ (i : Nat) (c : DenseExpr p), st.cs[i]? = some c → st.cvs[i]? = some (denseRncCapVars c)
+
+/-- Every position is listed under its first variable. -/
+def DenseRncAnchorOk (st : DenseRncState p) : Prop :=
+  ∀ (i : Nat) (c : DenseExpr p), st.cs[i]? = some c →
+    ∀ v ∈ denseRncAnchorVars c, i ∈ st.anchor.buckets.getD v []
+
+/-- Every position is listed under each of its variables, and every foldable one is recorded. -/
+def DenseRncUseOk (st : DenseRncState p) : Prop :=
+  (∀ m, st.useCs = some m → ∀ (i : Nat) (c : DenseExpr p), st.cs[i]? = some c →
+    ∀ v ∈ c.vars, i ∈ denseRncBGet m v) ∧
+  (∀ s, st.foldCs = some s → ∀ (i : Nat) (c : DenseExpr p), st.cs[i]? = some c →
+    denseRncHasFold c = true → s.contains i = true)
+
+def DenseRncBusOk (st : DenseRncState p) : Prop :=
+  (∀ m, st.useBis = some m → ∀ (i : Nat) (bi : BusInteraction (DenseExpr p)),
+    st.bis[i]? = some bi → ∀ v ∈ denseBIVars bi, i ∈ denseRncBGet m v) ∧
+  (∀ s, st.foldBis = some s → ∀ (i : Nat) (bi : BusInteraction (DenseExpr p)),
+    st.bis[i]? = some bi → denseRncBiHasFold bi = true → s.contains i = true)
+
+/-- Every live variable is `denseRncSeen` — what decides bit freshness in `O(|bits|)`. -/
+def DenseRncVarsOk (st : DenseRncState p) : Prop :=
+  ∀ v ∈ (denseRncView st).occ, denseRncSeen st v = true
+
+/-! ### The gathered covered set is the filter -/
+
+theorem denseCoveredIdxPos_map_snd (idx : DenseCovIndex) (arr : Array (DenseExpr p))
+    (xs : List VarId) :
+    (denseCoveredIdxPos idx arr xs).map Prod.snd
+      = denseCoveredIdx idx arr (denseCoveredBy xs) xs := by
+  unfold denseCoveredIdxPos denseCoveredIdx
+  rw [List.map_filterMap]
+  refine List.filterMap_congr (fun i _ => ?_)
+  by_cases h : i < arr.size
+  · simp only [dif_pos h]
+    by_cases hq : denseCoveredBy xs arr[i] = true <;> simp [hq]
+  · simp only [dif_neg h, Option.map_none]
+
+/-- A constraint with a variable has a first capped variable, so it is anchored. -/
+theorem denseRncAnchorVars_of_hasVar {c : DenseExpr p} (h : c.hasVar = true) :
+    ∃ v, denseRncAnchorVars c = [v] ∧ v ∈ c.vars := by
+  have hpos : 0 < (denseRncCapVars c).size := by
+    by_cases hcap : (denseRncCapVars c).size ≤ 8
+    · exact (denseRncCapVars_size_pos_iff hcap).2 h
+    · omega
+  refine ⟨(denseRncCapVars c)[0], ?_, ?_⟩
+  · unfold denseRncAnchorVars
+    rw [Array.getElem?_eq_getElem hpos]
+  · rcases denseRncCapGo_sound 9 c #[] _ (Array.getElem_mem hpos) with h' | h'
+    · simp at h'
+    · exact h'
+
+/-- The covered constraints the index gathers are exactly the covered constraints of the view. -/
+theorem denseRncEs_eq {st : DenseRncState p} (hanchor : DenseRncAnchorOk st) (xs : List VarId) :
+    (denseCoveredIdxPos st.anchor st.cs xs).map Prod.snd
+      = denseCoveredCsOf (denseRncView st) xs := by
+  rw [denseCoveredIdxPos_map_snd]
+  have hcomplete : ∀ (i : Nat) (hi : i < st.cs.toList.length),
+      denseCoveredBy xs st.cs.toList[i] = true → i ∈ denseCandidates st.anchor xs := by
+    intro i hi hcov
+    have hget : st.cs[i]? = some st.cs.toList[i] := by
+      rw [← Array.getElem?_toList, List.getElem?_eq_getElem hi]
+    have hhv : (st.cs.toList[i]).hasVar = true := by
+      rw [denseCoveredBy, Bool.and_eq_true] at hcov; exact hcov.1
+    obtain ⟨v, hav, hvmem⟩ := denseRncAnchorVars_of_hasVar hhv
+    have hvxs : v ∈ xs := by
+      rw [denseCoveredBy, Bool.and_eq_true] at hcov
+      exact (denseVarsInF_iff xs _).1 hcov.2 v hvmem
+    exact denseMem_candidates st.anchor xs v i hvxs
+      (hanchor i _ hget v (by rw [hav]; exact List.mem_singleton_self v))
+  have hfilter := denseCoveredIdx_eq_filter_of_complete st.anchor st.cs.toList
+    (denseCoveredBy xs) xs hcomplete
+  rw [Array.toArray_toList] at hfilter
+  rw [hfilter]
+  show st.cs.toList.filter (denseCoveredBy xs) = _
+  unfold denseCoveredCsOf denseRncView
+  show _ = ((st.cs.filter (fun c => !denseIsZero c)).toList).filter (denseCoveredBy xs)
+  rw [Array.toList_filter]
+  exact (List.filter_filter_of st.cs.toList _ _
+    (fun c _ hz => denseIsZero_not_covered (by simpa using hz))).symm
+
+/-- The one-pass `(hasVar, hasConstFoldableNode)` walk computes both. -/
+theorem denseRncFoldPair_eq (e : DenseExpr p) :
+    denseRncFoldPair e = (e.hasVar, e.hasConstFoldableNode) := by
+  induction e with
+  | const n => rfl
+  | var y => rfl
+  | add a b iha ihb | mul a b iha ihb =>
+      simp only [denseRncFoldPair, iha, ihb, DenseExpr.hasVar, DenseExpr.hasConstFoldableNode]
+
+theorem denseRncHasFold_eq (e : DenseExpr p) : denseRncHasFold e = e.hasConstFoldableNode := by
+  rw [denseRncHasFold, denseRncFoldPair_eq]
+
+theorem denseRncBiHasFold_eq (bi : BusInteraction (DenseExpr p)) :
+    denseRncBiHasFold bi = denseBiHasFold bi := by
+  unfold denseRncBiHasFold denseBiHasFold
+  rw [denseRncHasFold_eq]
+  have : ∀ (l : List (DenseExpr p)), l.any denseRncHasFold
+      = l.any (fun e => e.hasConstFoldableNode) := by
+    intro l
+    induction l with
+    | nil => rfl
+    | cons e rest ih => rw [List.any_cons, List.any_cons, denseRncHasFold_eq, ih]
+  rw [this]
+
+/-! ### The certificate
+
+`denseRncCert` is the audited `denseCheckReencode` with two substitutions: the covered set comes from
+the index (`denseRncEs_eq`) and freshness from `varSeen` (the invariant plus
+`denseFreshScan_of_notMemOcc`). -/
+
+theorem denseRncCert_sound {st : DenseRncState p} {xs : List VarId} {cd : DenseRncCand p}
+    (hanchor : DenseRncAnchorOk st) (hvars : DenseRncVarsOk st)
+    (hes : cd.es = (denseCoveredIdxPos st.anchor st.cs xs).map Prod.snd)
+    (h : denseRncCert st xs cd = true) :
+    denseCheckReencode (denseRncView st) xs cd.bits cd.hm.get = true := by
+  rw [denseRncCert, Bool.and_eq_true] at h
+  obtain ⟨hfresh, hchk⟩ := h
+  refine denseCheckReencode_of_parts _ xs cd.bits cd.hm.get ?_ ?_
+  · rw [denseCheckReencodeNoFresh_eq_Es, ← denseRncEs_eq hanchor xs, ← hes]
+    exact hchk
+  · refine denseFreshScan_of_notMemOcc _ cd.bits ?_
+    intro b hb hmem
+    have hseen := hvars b hmem
+    have hnb := List.all_eq_true.mp hfresh b hb
+    rw [hseen] at hnb
+    exact Bool.noConfusion hnb
+
+/-! ### Writing a list of positional edits into an array
+
+The accept installs its edits by folding `Array.setIfInBounds` over distinct positions. These three
+lemmas are what turn that fold into a positionwise map. -/
+
+section ArrFold
+variable {α : Type}
+
+def denseArrSet (a : Array α) (q : Nat × α) : Array α := a.setIfInBounds q.1 q.2
+
+theorem denseArrFold_size (l : List (Nat × α)) :
+    ∀ (a : Array α), (l.foldl denseArrSet a).size = a.size := by
+  induction l with
+  | nil => intro a; rfl
+  | cons q rest ih => intro a; rw [List.foldl_cons, ih]; simp [denseArrSet]
+
+theorem denseArrFold_stable (l : List (Nat × α)) :
+    ∀ (a : Array α) (j : Nat), j ∉ l.map Prod.fst → (l.foldl denseArrSet a)[j]? = a[j]? := by
+  induction l with
+  | nil => intro a j _; rfl
+  | cons q rest ih =>
+      intro a j hj
+      simp only [List.map_cons, List.mem_cons, not_or] at hj
+      rw [List.foldl_cons, ih _ j hj.2, denseArrSet,
+        Array.getElem?_setIfInBounds_ne (fun h => hj.1 h.symm)]
+
+theorem denseArrFold_hit (l : List (Nat × α)) :
+    ∀ (a : Array α) (i : Nat) (x : α), (l.map Prod.fst).Nodup → (i, x) ∈ l → i < a.size →
+      (l.foldl denseArrSet a)[i]? = some x := by
+  induction l with
+  | nil => intro a i x _ hmem _; simp at hmem
+  | cons q rest ih =>
+      intro a i x hnd hmem hlt
+      rw [List.map_cons, List.nodup_cons] at hnd
+      rcases List.mem_cons.1 hmem with heq | hmem'
+      · subst heq
+        rw [List.foldl_cons, denseArrFold_stable rest _ i hnd.1, denseArrSet,
+          Array.getElem?_setIfInBounds_self_of_lt hlt]
+      · rw [List.foldl_cons]
+        exact ih _ i x hnd.2 hmem' (by rw [denseArrSet]; simpa using hlt)
+
+end ArrFold
+
+/-! ### The accept's write
+
+`denseRncWrite` installs the constraint edits, the bus edits and the booleanity constraints. Each
+setter touches one field at one position, so the fold is the positionwise `denseTombify` map — and
+from there `denseTombify_filter` (the list engine's lemma) finishes the view. -/
+
+theorem denseRncCsStep_cs (ctx : DenseRncCtx p) (st : DenseRncState p) (e : DenseRncCsEdit p) :
+    (denseRncCsStep ctx st e).cs = st.cs.setIfInBounds e.pos (e.content ctx) := by
+  cases e <;> rfl
+
+theorem denseRncCsFold_cs (ctx : DenseRncCtx p) :
+    ∀ (es : List (DenseRncCsEdit p)) (st : DenseRncState p),
+      (es.foldl (denseRncCsStep ctx) st).cs
+        = (es.map (fun e => (e.pos, e.content ctx))).foldl denseArrSet st.cs := by
+  intro es
+  induction es with
+  | nil => intro st; rfl
+  | cons e rest ih =>
+      intro st
+      rw [List.foldl_cons, ih, List.map_cons, List.foldl_cons, denseRncCsStep_cs]
+      rfl
+
+theorem denseRncBiFold_bis :
+    ∀ (es : List (Nat × BusInteraction (DenseExpr p))) (st : DenseRncState p),
+      (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st).bis = es.foldl denseArrSet st.bis := by
+  intro es
+  induction es with
+  | nil => intro st; rfl
+  | cons e rest ih => intro st; rw [List.foldl_cons, ih, List.foldl_cons]; rfl
+
+theorem denseRncCsFold_bis (ctx : DenseRncCtx p) :
+    ∀ (es : List (DenseRncCsEdit p)) (st : DenseRncState p),
+      (es.foldl (denseRncCsStep ctx) st).bis = st.bis := by
+  intro es
+  induction es with
+  | nil => intro st; rfl
+  | cons e rest ih => intro st; rw [List.foldl_cons, ih]; cases e <;> rfl
+
+theorem denseRncBiFold_cs :
+    ∀ (es : List (Nat × BusInteraction (DenseExpr p))) (st : DenseRncState p),
+      (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st).cs = st.cs := by
+  intro es
+  induction es with
+  | nil => intro st; rfl
+  | cons e rest ih => intro st; rw [List.foldl_cons, ih]; rfl
+
+theorem denseRncBoolFold_cs :
+    ∀ (bits : List VarId) (st : DenseRncState p),
+      (bits.foldl (fun st b => st.pushBool b) st).cs
+        = st.cs ++ (bits.map (denseBoolConstraint (p := p))).toArray := by
+  intro bits
+  induction bits with
+  | nil => intro st; simp
+  | cons b rest ih =>
+      intro st
+      rw [List.foldl_cons, ih, List.map_cons]
+      show (st.cs.push (denseBoolConstraint b)) ++ _ = _
+      simp
+
+theorem denseRncBoolFold_bis :
+    ∀ (bits : List VarId) (st : DenseRncState p),
+      (bits.foldl (fun st b => st.pushBool b) st).bis = st.bis := by
+  intro bits
+  induction bits with
+  | nil => intro st; rfl
+  | cons b rest ih => intro st; rw [List.foldl_cons, ih]; rfl
+
+/-! ### What the edit builders produce
+
+Three facts per builder: the positions are a sublist of the (duplicate-free) candidate list, each
+edit installs the positionwise `denseTombify` (resp. the gated bus rewrite), and every position the
+rewrite can change is listed. -/
+
+theorem denseRncPosList_nodup (bs : Array (Array Nat)) (xs : List VarId) (extra : List Nat) :
+    (denseRncPosList bs xs extra).Nodup :=
+  Std.HashSet.distinct_toList.imp (fun {a b} h => by simpa using h)
+
+theorem denseRncPosList_mem (bs : Array (Array Nat)) (xs : List VarId) (extra : List Nat)
+    (i : Nat) (h : (∃ v ∈ xs, i ∈ denseRncBGet bs v) ∨ i ∈ extra) :
+    i ∈ denseRncPosList bs xs extra := by
+  rw [denseRncPosList, Std.HashSet.mem_toList, mem_foldl_insert]
+  refine Or.inr ?_
+  rw [List.mem_append]
+  rcases h with ⟨v, hv, hi⟩ | hi
+  · exact Or.inl (List.mem_flatMap.2 ⟨v, hv, by simpa using hi⟩)
+  · exact Or.inr hi
+
+section CsEdits
+variable (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId) (cd : DenseRncCand p)
+
+/-- The builder's per-position body, as a standalone function so the three lemmas share it. -/
+private def csBody (i : Nat) (acc : List (DenseRncCsEdit p) × Bool) :
+    List (DenseRncCsEdit p) × Bool :=
+  match st.cs[i]?, st.cvs[i]? with
+  | some c, some vs =>
+    if denseRncCovered xs vs c then (.tomb i :: acc.1, acc.2)
+    else if denseRncShares xs vs c || denseRncHasFold c then
+      let c' := denseGroupRewrite xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get c
+      let cv' := denseRncCapVars c'
+      (.cst i c' cv' (denseRncFullVars c' cv') :: acc.1,
+        acc.2 && decide (c'.degree ≤ ctx.dmaxC))
+    else acc
+  | _, _ => acc
+
+private theorem csEdits_eq_foldr :
+    (denseRncCsEdits ctx st xs cd).1
+      = ((denseRncPosList (match st.useCs with | some m => m | none => #[]) xs
+          (match st.foldCs with | some s => s | none => ∅).toList).foldr (csBody ctx st xs cd)
+          ([], true)).1 := rfl
+
+private theorem csBody_sublist (l : List Nat) :
+    ((l.foldr (csBody ctx st xs cd) ([], true)).1.map DenseRncCsEdit.pos).Sublist l := by
+  induction l with
+  | nil => exact List.Sublist.refl []
+  | cons i rest ih =>
+      rw [List.foldr_cons]
+      cases hc : st.cs[i]? with
+      | none => simpa only [csBody, hc] using ih.trans (List.sublist_cons_self i rest)
+      | some c =>
+        cases hvs : st.cvs[i]? with
+        | none => simpa only [csBody, hc, hvs] using ih.trans (List.sublist_cons_self i rest)
+        | some vs =>
+          simp only [csBody, hc, hvs]
+          by_cases hcov : denseRncCovered xs vs c = true
+          · rw [if_pos hcov]
+            simpa only [List.map_cons, DenseRncCsEdit.pos] using List.cons_sublist_cons.2 ih
+          · rw [if_neg hcov]
+            by_cases hg : denseRncShares xs vs c || denseRncHasFold c
+            · rw [if_pos hg]
+              simpa only [List.map_cons, DenseRncCsEdit.pos] using List.cons_sublist_cons.2 ih
+            · rw [if_neg hg]
+              exact ih.trans (List.sublist_cons_self i rest)
+
+private theorem csBody_content (hcvs : DenseRncCvsOk st)
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p)) (l : List Nat) :
+    ∀ e ∈ (l.foldr (csBody ctx st xs cd) ([], true)).1, ∃ c, st.cs[e.pos]? = some c ∧
+      e.content ctx
+        = denseTombify xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get c := by
+  induction l with
+  | nil => intro e he; simp at he
+  | cons i rest ih =>
+      intro e he
+      rw [List.foldr_cons] at he
+      cases hc : st.cs[i]? with
+      | none => exact ih e (by simpa only [csBody, hc] using he)
+      | some c =>
+        have hvs : st.cvs[i]? = some (denseRncCapVars c) := hcvs i c hc
+        simp only [csBody, hc, hvs] at he
+        rw [denseRncCovered_eq] at he
+        by_cases hcov : denseCoveredBy xs c = true
+        · rw [if_pos hcov] at he
+          rcases List.mem_cons.1 he with rfl | he'
+          · exact ⟨c, by simpa [DenseRncCsEdit.pos] using hc,
+              by simp [DenseRncCsEdit.content, hzero, denseTombify, hcov]⟩
+          · exact ih e he'
+        · rw [if_neg hcov] at he
+          by_cases hg : denseRncShares xs (denseRncCapVars c) c || denseRncHasFold c
+          · rw [if_pos hg] at he
+            rcases List.mem_cons.1 he with rfl | he'
+            · refine ⟨c, by simpa [DenseRncCsEdit.pos] using hc, ?_⟩
+              have hcov' : denseCoveredBy xs c = false := by simpa using hcov
+              simp only [DenseRncCsEdit.content, denseTombify, hcov', if_false,
+                Bool.false_eq_true]
+            · exact ih e he'
+          · rw [if_neg hg] at he
+            exact ih e he
+
+private theorem csBody_complete (hcvs : DenseRncCvsOk st) (l : List Nat) (j : Nat)
+    (c : DenseExpr p) (hj : j ∈ l) (hc : st.cs[j]? = some c)
+    (hfires : denseCoveredBy xs c = true ∨ c.sharesVarIn xs = true ∨
+      c.hasConstFoldableNode = true) :
+    j ∈ (l.foldr (csBody ctx st xs cd) ([], true)).1.map DenseRncCsEdit.pos := by
+  induction l with
+  | nil => simp at hj
+  | cons i rest ih =>
+      rw [List.foldr_cons]
+      rcases List.mem_cons.1 hj with rfl | hj'
+      · have hvs : st.cvs[j]? = some (denseRncCapVars c) := hcvs j c hc
+        simp only [csBody, hc, hvs]
+        rw [denseRncCovered_eq]
+        by_cases hcov : denseCoveredBy xs c = true
+        · rw [if_pos hcov]; simp [DenseRncCsEdit.pos]
+        · rw [if_neg hcov, denseRncShares_eq, denseRncHasFold_eq]
+          have hg : (c.sharesVarIn xs || c.hasConstFoldableNode) = true := by
+            rcases hfires with h | h | h
+            · exact absurd h hcov
+            · simp [h]
+            · simp [h]
+          rw [if_pos hg]
+          simp [DenseRncCsEdit.pos]
+      · have hrec := ih hj'
+        cases hc0 : st.cs[i]? with
+        | none => simpa only [csBody, hc0] using hrec
+        | some c0 =>
+          cases hvs0 : st.cvs[i]? with
+          | none => simpa only [csBody, hc0, hvs0] using hrec
+          | some vs0 =>
+            simp only [csBody, hc0, hvs0]
+            by_cases hcov : denseRncCovered xs vs0 c0 = true
+            · rw [if_pos hcov]; simpa using Or.inr hrec
+            · rw [if_neg hcov]
+              by_cases hg : denseRncShares xs vs0 c0 || denseRncHasFold c0
+              · rw [if_pos hg]; simpa using Or.inr hrec
+              · rw [if_neg hg]; exact hrec
+
+end CsEdits
+
+section BiEdits
+variable (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId) (cd : DenseRncCand p)
+
+private def biBody (i : Nat) (acc : List (Nat × BusInteraction (DenseExpr p)) × Bool) :
+    List (Nat × BusInteraction (DenseExpr p)) × Bool :=
+  match st.bis[i]? with
+  | some bi =>
+    if bi.multiplicity.sharesVarIn xs || denseRncHasFold bi.multiplicity
+        || bi.payload.any (fun e => e.sharesVarIn xs || denseRncHasFold e) then
+      let bi' : BusInteraction (DenseExpr p) :=
+        { bi with
+          multiplicity := denseGroupRewrite xs cd.bits (denseGroupSubst xs cd.hm.get)
+            cd.patts.get bi.multiplicity,
+          payload := bi.payload.map
+            (denseGroupRewrite xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get) }
+      ((i, bi') :: acc.1,
+        acc.2 && decide (bi'.multiplicity.degree ≤ ctx.dmaxB)
+          && bi'.payload.all (fun e => decide (e.degree ≤ ctx.dmaxB)))
+    else acc
+  | none => acc
+
+private theorem biEdits_eq_foldr :
+    (denseRncBiEdits ctx st xs cd).1
+      = ((denseRncPosList (match st.useBis with | some m => m | none => #[]) xs
+          (match st.foldBis with | some s => s | none => ∅).toList).foldr (biBody ctx st xs cd)
+          ([], true)).1 := rfl
+
+/-- The gate test the builder uses is `denseBiGateFires`. -/
+private theorem biBody_fires (bi : BusInteraction (DenseExpr p)) :
+    (bi.multiplicity.sharesVarIn xs || denseRncHasFold bi.multiplicity
+      || bi.payload.any (fun e => e.sharesVarIn xs || denseRncHasFold e))
+      = denseBiGateFires xs bi := by
+  unfold denseBiGateFires
+  rw [denseRncHasFold_eq]
+  have hp : ∀ (l : List (DenseExpr p)),
+      l.any (fun e => e.sharesVarIn xs || denseRncHasFold e)
+        = l.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) := by
+    intro l
+    induction l with
+    | nil => rfl
+    | cons e rest ih => rw [List.any_cons, List.any_cons, denseRncHasFold_eq, ih]
+  rw [hp]
+
+private theorem biBody_sublist (l : List Nat) :
+    ((l.foldr (biBody ctx st xs cd) ([], true)).1.map Prod.fst).Sublist l := by
+  induction l with
+  | nil => exact List.Sublist.refl []
+  | cons i rest ih =>
+      rw [List.foldr_cons]
+      cases hb : st.bis[i]? with
+      | none => simpa only [biBody, hb] using ih.trans (List.sublist_cons_self i rest)
+      | some bi =>
+        simp only [biBody, hb]
+        split
+        · simpa only [List.map_cons] using List.cons_sublist_cons.2 ih
+        · exact ih.trans (List.sublist_cons_self i rest)
+
+private theorem biBody_content (l : List Nat) :
+    ∀ q ∈ (l.foldr (biBody ctx st xs cd) ([], true)).1, ∃ bi, st.bis[q.1]? = some bi ∧
+      q.2 = denseBIRewriteGate xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get bi := by
+  induction l with
+  | nil => intro q hq; simp at hq
+  | cons i rest ih =>
+      intro q hq
+      rw [List.foldr_cons] at hq
+      cases hb : st.bis[i]? with
+      | none => exact ih q (by simpa only [biBody, hb] using hq)
+      | some bi =>
+        simp only [biBody, hb] at hq
+        split at hq
+        · next hgate =>
+            rcases List.mem_cons.1 hq with rfl | hq'
+            · refine ⟨bi, hb, ?_⟩
+              have hgate' : (bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
+                  || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode)) = true := by
+                rw [biBody_fires (p := p) xs bi] at hgate
+                simpa [denseBiGateFires] using hgate
+              unfold denseBIRewriteGate
+              rw [if_pos (by simpa using hgate')]
+              simp only [denseGroupRewriteGate_eq]
+            · exact ih q hq'
+        · exact ih q hq
+
+private theorem biBody_complete (l : List Nat) (j : Nat) (bi : BusInteraction (DenseExpr p))
+    (hj : j ∈ l) (hb : st.bis[j]? = some bi) (hfires : denseBiGateFires xs bi = true) :
+    j ∈ (l.foldr (biBody ctx st xs cd) ([], true)).1.map Prod.fst := by
+  induction l with
+  | nil => simp at hj
+  | cons i rest ih =>
+      rw [List.foldr_cons]
+      rcases List.mem_cons.1 hj with rfl | hj'
+      · simp only [biBody, hb]
+        rw [if_pos (by rw [biBody_fires]; exact hfires)]
+        simp
+      · have hrec := ih hj'
+        cases hb0 : st.bis[i]? with
+        | none => simpa only [biBody, hb0] using hrec
+        | some bi0 =>
+          simp only [biBody, hb0]
+          split
+          · simpa using Or.inr hrec
+          · exact hrec
+
+end BiEdits
+
+/-! ### The write installs the positionwise `denseTombify` -/
+
+theorem denseRncCsEdits_nodup (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : ((denseRncCsEdits ctx st xs cd).1.map DenseRncCsEdit.pos).Nodup := by
+  rw [csEdits_eq_foldr]
+  exact (denseRncPosList_nodup _ xs _).sublist (csBody_sublist ctx st xs cd _)
+
+theorem denseRncBiEdits_nodup (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : ((denseRncBiEdits ctx st xs cd).1.map Prod.fst).Nodup := by
+  rw [biEdits_eq_foldr]
+  exact (denseRncPosList_nodup _ xs _).sublist (biBody_sublist ctx st xs cd _)
+
+theorem denseRncCsEdits_complete {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m : Array (Array Nat)} {sf : Std.HashSet Nat}
+    (hcvs : DenseRncCvsOk st) (huse : DenseRncUseOk st)
+    (hm : st.useCs = some m) (hs : st.foldCs = some sf) :
+    ∀ (j : Nat) (c : DenseExpr p), st.cs[j]? = some c →
+      (denseCoveredBy xs c = true ∨ c.sharesVarIn xs = true ∨ c.hasConstFoldableNode = true) →
+      j ∈ (denseRncCsEdits ctx st xs cd).1.map DenseRncCsEdit.pos := by
+  intro j c hc hfires
+  rw [csEdits_eq_foldr]
+  refine csBody_complete ctx st xs cd hcvs _ j c ?_ hc hfires
+  rw [hm, hs]
+  refine denseRncPosList_mem _ _ _ j ?_
+  rcases hfires with hcov | hsh | hfd
+  · obtain ⟨v, hv, hx⟩ := (denseSharesVarIn_iff xs c).1 (denseCoveredBy_sharesVarIn hcov)
+    exact Or.inl ⟨v, hx, huse.1 m hm j c hc v hv⟩
+  · obtain ⟨v, hv, hx⟩ := (denseSharesVarIn_iff xs c).1 hsh
+    exact Or.inl ⟨v, hx, huse.1 m hm j c hc v hv⟩
+  · refine Or.inr ?_
+    have hcontains := huse.2 sf hs j c hc (by rw [denseRncHasFold_eq]; exact hfd)
+    rw [Std.HashSet.mem_toList, Std.HashSet.mem_iff_contains]
+    exact hcontains
+
+theorem denseRncBiEdits_complete {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m : Array (Array Nat)} {sf : Std.HashSet Nat}
+    (hbus : DenseRncBusOk st) (hm : st.useBis = some m) (hs : st.foldBis = some sf) :
+    ∀ (j : Nat) (bi : BusInteraction (DenseExpr p)), st.bis[j]? = some bi →
+      denseBiGateFires xs bi = true → j ∈ (denseRncBiEdits ctx st xs cd).1.map Prod.fst := by
+  intro j bi hb hfires
+  rw [biEdits_eq_foldr]
+  refine biBody_complete ctx st xs cd _ j bi ?_ hb hfires
+  rw [hm, hs]
+  refine denseRncPosList_mem _ _ _ j ?_
+  rw [denseBiGateFires, Bool.or_eq_true, Bool.or_eq_true] at hfires
+  rcases hfires with (hmul | hfd) | hpl
+  · obtain ⟨v, hv, hx⟩ := (denseSharesVarIn_iff xs _).1 hmul
+    exact Or.inl ⟨v, hx, hbus.1 m hm j bi hb v (by simp [denseBIVars, hv])⟩
+  · refine Or.inr ?_
+    have hcontains := hbus.2 sf hs j bi hb (by
+      rw [denseRncBiHasFold_eq]; simp [denseBiHasFold, hfd])
+    rw [Std.HashSet.mem_toList, Std.HashSet.mem_iff_contains]
+    exact hcontains
+  · rw [List.any_eq_true] at hpl
+    obtain ⟨e, he, hor⟩ := hpl
+    rw [Bool.or_eq_true] at hor
+    rcases hor with hsh | hfd
+    · obtain ⟨v, hv, hx⟩ := (denseSharesVarIn_iff xs e).1 hsh
+      refine Or.inl ⟨v, hx, hbus.1 m hm j bi hb v ?_⟩
+      simp only [denseBIVars, List.mem_append, List.mem_flatMap]
+      exact Or.inr ⟨e, he, hv⟩
+    · refine Or.inr ?_
+      have hcontains := hbus.2 sf hs j bi hb (by
+        rw [denseRncBiHasFold_eq]
+        simp only [denseBiHasFold, Bool.or_eq_true, List.any_eq_true]
+        exact Or.inr ⟨e, he, hfd⟩)
+      rw [Std.HashSet.mem_toList, Std.HashSet.mem_iff_contains]
+      exact hcontains
+
+/-- The constraint array after the write: the positionwise tombify, then the booleanity
+    constraints. -/
+theorem denseRncWrite_cs_toList {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m : Array (Array Nat)} {sf : Std.HashSet Nat}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p))
+    (hcvs : DenseRncCvsOk st) (huse : DenseRncUseOk st)
+    (hm : st.useCs = some m) (hs : st.foldCs = some sf) :
+    (denseRncWrite ctx st cd.bits (denseRncCsEdits ctx st xs cd).1
+        (denseRncBiEdits ctx st xs cd).1).cs.toList
+      = st.cs.toList.map (denseTombify xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get)
+        ++ cd.bits.map denseBoolConstraint := by
+  set σ := denseGroupSubst xs cd.hm.get with hσ
+  set patts := cd.patts.get with hpatts
+  set es := (denseRncCsEdits ctx st xs cd).1 with hes
+  have hcs : (denseRncWrite ctx st cd.bits es (denseRncBiEdits ctx st xs cd).1).cs
+      = (es.map (fun e => (e.pos, e.content ctx))).foldl denseArrSet st.cs
+        ++ (cd.bits.map (denseBoolConstraint (p := p))).toArray := by
+    show ((cd.bits.foldl (fun st b => st.pushBool b)
+      (((denseRncBiEdits ctx st xs cd).1).foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+        (es.foldl (denseRncCsStep ctx) st))).domReset).cs = _
+    show (cd.bits.foldl (fun st b => st.pushBool b)
+      (((denseRncBiEdits ctx st xs cd).1).foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+        (es.foldl (denseRncCsStep ctx) st))).cs = _
+    rw [denseRncBoolFold_cs, denseRncBiFold_cs, denseRncCsFold_cs]
+  rw [hcs]
+  have hlen : ((es.map (fun e => (e.pos, e.content ctx))).foldl denseArrSet st.cs).size
+      = st.cs.size := denseArrFold_size _ _
+  rw [Array.toList_append, List.toList_toArray]
+  refine congrArg (· ++ cd.bits.map denseBoolConstraint) ?_
+  refine List.ext_getElem? (fun j => ?_)
+  rw [Array.getElem?_toList, List.getElem?_map, Array.getElem?_toList]
+  by_cases hj : j < st.cs.size
+  · have hcget : st.cs[j]? = some st.cs[j] := Array.getElem?_eq_getElem hj
+    rw [hcget, Option.map_some]
+    by_cases hedit : j ∈ es.map DenseRncCsEdit.pos
+    · obtain ⟨e, hemem, hepos⟩ := List.mem_map.1 hedit
+      obtain ⟨c0, hc0, hcontent⟩ := csBody_content ctx st xs cd hcvs hzero _ e
+        (by rwa [hes, csEdits_eq_foldr] at hemem)
+      have hc0' : c0 = st.cs[j] := by rw [hepos] at hc0; rw [hcget] at hc0; exact (Option.some.inj hc0).symm
+      subst hc0'
+      have := denseArrFold_hit (es.map (fun e => (e.pos, e.content ctx))) st.cs e.pos
+        (e.content ctx)
+        (by simpa [List.map_map, Function.comp_def] using denseRncCsEdits_nodup ctx st xs cd)
+        (List.mem_map.2 ⟨e, hemem, rfl⟩) (by rw [hepos]; exact hj)
+      rw [hepos] at this
+      rw [this, hcontent]
+    · have hstable := denseArrFold_stable (es.map (fun e => (e.pos, e.content ctx))) st.cs j
+        (by simpa [List.map_map, Function.comp_def] using hedit)
+      rw [hstable, hcget]
+      have hnf : ¬ (denseCoveredBy xs st.cs[j] = true ∨ st.cs[j].sharesVarIn xs = true ∨
+          st.cs[j].hasConstFoldableNode = true) := fun hfires =>
+        hedit (denseRncCsEdits_complete hcvs huse hm hs j st.cs[j] hcget hfires)
+      rw [not_or, not_or] at hnf
+      obtain ⟨h1, h2, h3⟩ := hnf
+      simp only [denseTombify, Bool.not_eq_true] at *
+      rw [if_neg (by simpa using h1),
+        denseGroupRewrite_eq_self (by simpa using h2) (by simpa using h3)]
+  · have hnone : st.cs[j]? = none := Array.getElem?_eq_none (by omega)
+    rw [hnone, Option.map_none, Array.getElem?_eq_none (by omega)]
+
+/-- The interaction array after the write: the positionwise gated rewrite. -/
+theorem denseRncWrite_bis_toList {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m : Array (Array Nat)} {sf : Std.HashSet Nat}
+    (hbus : DenseRncBusOk st) (hm : st.useBis = some m) (hs : st.foldBis = some sf) :
+    (denseRncWrite ctx st cd.bits (denseRncCsEdits ctx st xs cd).1
+        (denseRncBiEdits ctx st xs cd).1).bis.toList
+      = st.bis.toList.map
+          (denseBIRewriteGate xs cd.bits (denseGroupSubst xs cd.hm.get) cd.patts.get) := by
+  set es := (denseRncBiEdits ctx st xs cd).1 with hes
+  have hbis : (denseRncWrite ctx st cd.bits (denseRncCsEdits ctx st xs cd).1 es).bis
+      = es.foldl denseArrSet st.bis := by
+    show (cd.bits.foldl (fun st b => st.pushBool b)
+      (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+        ((denseRncCsEdits ctx st xs cd).1.foldl (denseRncCsStep ctx) st))).bis = _
+    rw [denseRncBoolFold_bis, denseRncBiFold_bis, denseRncCsFold_bis]
+  rw [hbis]
+  refine List.ext_getElem? (fun j => ?_)
+  rw [Array.getElem?_toList, List.getElem?_map, Array.getElem?_toList]
+  by_cases hj : j < st.bis.size
+  · have hbget : st.bis[j]? = some st.bis[j] := Array.getElem?_eq_getElem hj
+    rw [hbget, Option.map_some]
+    by_cases hedit : j ∈ es.map Prod.fst
+    · obtain ⟨q, hqmem, hqpos⟩ := List.mem_map.1 hedit
+      obtain ⟨bi0, hb0, hcontent⟩ := biBody_content ctx st xs cd _ q
+        (by rwa [hes, biEdits_eq_foldr] at hqmem)
+      have hb0' : bi0 = st.bis[j] := by
+        rw [hqpos] at hb0; rw [hbget] at hb0; exact (Option.some.inj hb0).symm
+      subst hb0'
+      have := denseArrFold_hit es st.bis q.1 q.2 (denseRncBiEdits_nodup ctx st xs cd)
+        (by simpa using hqmem) (by rw [hqpos]; exact hj)
+      rw [hqpos] at this
+      rw [this, hcontent]
+    · rw [denseArrFold_stable es st.bis j (by simpa using hedit), hbget]
+      have hnf : denseBiGateFires xs st.bis[j] = false := by
+        cases hf : denseBiGateFires xs st.bis[j] with
+        | false => rfl
+        | true => exact absurd (denseRncBiEdits_complete hbus hm hs j st.bis[j] hbget hf) hedit
+      unfold denseBIRewriteGate
+      rw [if_neg (by simpa [denseBiGateFires] using hnf)]
+  · have hsz : (es.foldl denseArrSet st.bis).size = st.bis.size := denseArrFold_size _ _
+    rw [Array.getElem?_eq_none (by omega), Array.getElem?_eq_none (by omega), Option.map_none]
+
+/-- The written state's view is the re-encoded system with trivially-true constraints dropped —
+    the array engine's counterpart of `denseWorkOut_view`. -/
+theorem denseRncWrite_view {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m mB : Array (Array Nat)} {sf sfB : Std.HashSet Nat}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p))
+    (hpatts : cd.patts.get = denseAssignments (denseBitBox cd.bits))
+    (hcvs : DenseRncCvsOk st) (huse : DenseRncUseOk st) (hbus : DenseRncBusOk st)
+    (hm : st.useCs = some m) (hs : st.foldCs = some sf)
+    (hmB : st.useBis = some mB) (hsB : st.foldBis = some sfB) :
+    denseRncView (denseRncWrite ctx st cd.bits (denseRncCsEdits ctx st xs cd).1
+        (denseRncBiEdits ctx st xs cd).1)
+      = (denseReencodeOut (denseRncView st) xs cd.bits cd.hm.get).filterConstraints
+          (fun c => !denseIsZero c) := by
+  have hcsL := denseRncWrite_cs_toList (xs := xs) (cd := cd) hzero hcvs huse hm hs
+  have hbisL := denseRncWrite_bis_toList (ctx := ctx) (xs := xs) (cd := cd) hbus hmB hsB
+  rw [hpatts] at hcsL hbisL
+  unfold denseRncView DenseConstraintSystem.filterConstraints denseReencodeOut
+  dsimp only
+  refine congrArg₂ DenseConstraintSystem.mk ?_ ?_
+  · rw [Array.toList_filter, hcsL, List.filter_append, denseBoolConstraints_not_zero,
+      List.filter_append, denseBoolConstraints_not_zero, Array.toList_filter, denseTombify_filter]
+  · rw [hbisL, denseBIRewriteGate_eq]
+
+/-! ### The indexes survive the write
+
+Every setter writes one position of one array and only ever *adds* index entries, so each invariant
+is preserved pointwise. The bundled `DenseRncOk` is what the loop threads. -/
+
+structure DenseRncOk (st : DenseRncState p) : Prop where
+  sizes : st.cvs.size = st.cs.size
+  cvs : DenseRncCvsOk st
+  anchor : DenseRncAnchorOk st
+  use : DenseRncUseOk st
+  bus : DenseRncBusOk st
+
+theorem denseRncCapVars_const_zero : denseRncCapVars (DenseExpr.const 0 : DenseExpr p) = #[] := rfl
+
+theorem denseRncCapVars_bool (b : VarId) :
+    denseRncCapVars (denseBoolConstraint b : DenseExpr p) = #[b] := by
+  simp [denseRncCapVars, denseRncCapGo, denseBoolConstraint]
+
+theorem denseRncAnchorVars_const_zero :
+    denseRncAnchorVars (DenseExpr.const 0 : DenseExpr p) = [] := rfl
+
+/-- Growing an array does not change any existing entry. -/
+theorem denseArrEnsure_getD {α : Type} (a : Array α) (i j : Nat) (d : α) :
+    (denseArrEnsure a i d).getD j d = a.getD j d := by
+  unfold denseArrEnsure
+  split
+  · rfl
+  · rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?]
+    by_cases hj : j < a.size
+    · rw [Array.getElem?_append_left hj]
+    · have hR : a[j]? = none := Array.getElem?_eq_none (by omega)
+      have hL : ((a ++ Array.replicate (max (i + 1) (2 * a.size) - a.size) d)[j]?).getD d = d := by
+        rw [Array.getElem?_append_right (by omega), Array.getElem?_replicate]
+        split <;> rfl
+      rw [hL, hR]
+      rfl
+
+theorem denseArrEnsure_size {α : Type} (a : Array α) (i : Nat) (d : α) :
+    i < (denseArrEnsure a i d).size := by
+  unfold denseArrEnsure
+  split
+  · omega
+  · rw [Array.size_append, Array.size_replicate]
+    omega
+
+theorem denseRncBAdd_mono (m : Array (Array Nat)) (w : VarId) (i j : Nat) (v : VarId)
+    (h : j ∈ denseRncBGet m v) : j ∈ denseRncBGet (denseRncBAdd m w i) v := by
+  have hkeep : (denseArrEnsure m w.index #[]).getD v.index #[] = m.getD v.index #[] :=
+    denseArrEnsure_getD m w.index v.index #[]
+  unfold denseRncBGet denseRncBAdd at *
+  rw [← hkeep] at h
+  rw [Array.getD_eq_getD_getElem?, Array.getElem?_modify]
+  rw [Array.getD_eq_getD_getElem?] at h
+  by_cases hw : w.index = v.index
+  · rw [if_pos hw]
+    cases hget : (denseArrEnsure m w.index #[])[v.index]? with
+    | none => rw [hget] at h; simp at h
+    | some a =>
+        rw [hget] at h
+        simp only [Option.map_some, Option.getD_some] at h ⊢
+        exact Array.mem_push.2 (Or.inl h)
+  · rw [if_neg hw]
+    exact h
+
+theorem denseRncBAdd_self (m : Array (Array Nat)) (w : VarId) (i : Nat) :
+    i ∈ denseRncBGet (denseRncBAdd m w i) w := by
+  unfold denseRncBGet denseRncBAdd
+  rw [Array.getD_eq_getD_getElem?, Array.getElem?_modify, if_pos rfl,
+    Array.getElem?_eq_getElem (denseArrEnsure_size m w.index #[])]
+  simp
+
+theorem denseRncAnchorAdd_mono (idx : DenseCovIndex) (ks : List VarId) (i j : Nat) (v : VarId)
+    (h : j ∈ idx.buckets.getD v []) : j ∈ (denseRncAnchorAdd idx ks i).buckets.getD v [] := by
+  unfold denseRncAnchorAdd
+  cases ks with
+  | nil => exact h
+  | cons w rest =>
+      by_cases hw : v = w
+      · subst hw
+        show j ∈ (idx.buckets.insert v (i :: idx.buckets.getD v [])).getD v []
+        rw [Std.HashMap.getD_insert_self]
+        exact List.mem_cons_of_mem i h
+      · show j ∈ (idx.buckets.insert w (i :: idx.buckets.getD w [])).getD v []
+        rw [Std.HashMap.getD_insert, if_neg (by simpa using fun hh => hw hh.symm)]
+        exact h
+
+theorem denseRncAnchorAdd_self (idx : DenseCovIndex) (v : VarId) (rest : List VarId) (i : Nat) :
+    i ∈ (denseRncAnchorAdd idx (v :: rest) i).buckets.getD v [] := by
+  show i ∈ (idx.buckets.insert v (i :: idx.buckets.getD v [])).getD v []
+  rw [Std.HashMap.getD_insert_self]
+  exact List.mem_cons_self
+
+theorem denseRncBFoldL_mono (i : Nat) :
+    ∀ (vs : List VarId) (m : Array (Array Nat)) (v : VarId) (j : Nat), j ∈ denseRncBGet m v →
+      j ∈ denseRncBGet (vs.foldl (fun m w => denseRncBAdd m w i) m) v := by
+  intro vs
+  induction vs with
+  | nil => intro m v j h; exact h
+  | cons w rest ih => intro m v j h; exact ih _ v j (denseRncBAdd_mono m w i j v h)
+
+theorem denseRncBFoldL_self (i : Nat) :
+    ∀ (vs : List VarId) (m : Array (Array Nat)) (v : VarId), v ∈ vs →
+      i ∈ denseRncBGet (vs.foldl (fun m w => denseRncBAdd m w i) m) v := by
+  intro vs
+  induction vs with
+  | nil => intro m v hv; simp at hv
+  | cons w rest ih =>
+      intro m v hv
+      rcases List.mem_cons.1 hv with rfl | hv'
+      · exact denseRncBFoldL_mono i rest _ v i (denseRncBAdd_self m v i)
+      · exact ih _ v hv'
+
+theorem denseRncFullVars_mem {c : DenseExpr p} {v : VarId} (h : v ∈ c.vars) :
+    v ∈ denseRncFullVars c (denseRncCapVars c) := by
+  unfold denseRncFullVars
+  split
+  · next hle => exact (denseRncCapVars_mem_iff hle v).2 h
+  · rw [HashedDedup.hashedDedup_eq]
+    simpa using List.mem_dedup.2 h
+
+theorem denseRncSet_getElem?_ne {α : Type} (a : Array α) (i j : Nat) (x : α) (h : i ≠ j) :
+    (a.setIfInBounds i x)[j]? = a[j]? := Array.getElem?_setIfInBounds_ne h
+
+theorem denseRncSet_getElem?_self {α : Type} (a : Array α) (i : Nat) (x y : α)
+    (h : (a.setIfInBounds i x)[i]? = some y) : i < a.size ∧ y = x := by
+  by_cases hlt : i < a.size
+  · rw [Array.getElem?_setIfInBounds_self_of_lt hlt] at h
+    exact ⟨hlt, (Option.some.inj h).symm⟩
+  · rw [Array.getElem?_eq_none (by rw [Array.size_setIfInBounds]; omega)] at h
+    exact absurd h (by simp)
+
+/-- The constraint write preserves every index invariant: it only ever adds bucket entries, and it
+    keeps `cvs`, the anchor and the use index in step with the new content. -/
+theorem denseRncOk_rewriteAt {st : DenseRncState p} {i : Nat} {c' : DenseExpr p}
+    {cv' full : Array VarId} (h : DenseRncOk st) (hcv : cv' = denseRncCapVars c')
+    (hfull : ∀ v ∈ c'.vars, v ∈ full) : DenseRncOk (st.rewriteAt i c' cv' full) := by
+  have hcs : (st.rewriteAt i c' cv' full).cs = st.cs.setIfInBounds i c' := rfl
+  have hcvs : (st.rewriteAt i c' cv' full).cvs = st.cvs.setIfInBounds i cv' := rfl
+  have hanch : (st.rewriteAt i c' cv' full).anchor
+      = denseRncAnchorAdd st.anchor (denseRncAnchorVars c') i := rfl
+  have huse : (st.rewriteAt i c' cv' full).useCs
+      = st.useCs.map (fun m => full.foldl (fun m v => denseRncBAdd m v i) m) := rfl
+  have hfold : (st.rewriteAt i c' cv' full).foldCs
+      = st.foldCs.map (fun s => if denseRncHasFold c' then s.insert i else s.erase i) := rfl
+  refine ⟨?_, ?_, ?_, ⟨?_, ?_⟩, ?_⟩
+  · rw [hcs, hcvs, Array.size_setIfInBounds, Array.size_setIfInBounds]; exact h.sizes
+  · intro j c hj
+    rw [hcs] at hj
+    rw [hcvs]
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨hlt, hcc⟩ := denseRncSet_getElem?_self st.cs i c' c hj
+      subst hcc
+      rw [Array.getElem?_setIfInBounds_self_of_lt (by rw [h.sizes]; exact hlt), hcv]
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      rw [denseRncSet_getElem?_ne _ _ _ _ hij]
+      exact h.cvs j c hj
+  · intro j c hj v hv
+    rw [hcs] at hj
+    rw [hanch]
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨_, hcc⟩ := denseRncSet_getElem?_self st.cs i c' c hj
+      subst hcc
+      cases hav : denseRncAnchorVars c with
+      | nil => rw [hav] at hv; simp at hv
+      | cons w rest =>
+          have hvw : v = w := by
+            rw [hav] at hv
+            rcases List.mem_cons.1 hv with h1 | h1
+            · exact h1
+            · exact absurd h1 (by
+                unfold denseRncAnchorVars at hav
+                split at hav <;> simp_all)
+          subst hvw
+          exact denseRncAnchorAdd_self st.anchor v rest i
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      exact denseRncAnchorAdd_mono _ _ i j v (h.anchor j c hj v hv)
+  · intro m hm j c hj v hv
+    rw [huse] at hm
+    obtain ⟨m0, hm0, rfl⟩ := Option.map_eq_some_iff.1 hm
+    rw [hcs] at hj
+    have hfl : full.foldl (fun m v => denseRncBAdd m v i) m0
+        = full.toList.foldl (fun m v => denseRncBAdd m v i) m0 := by
+      conv_lhs => rw [← Array.toArray_toList (xs := full)]
+      rw [List.foldl_toArray]
+    rw [hfl]
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨_, hcc⟩ := denseRncSet_getElem?_self st.cs i c' c hj
+      subst hcc
+      exact denseRncBFoldL_self i full.toList m0 v (by simpa using hfull v hv)
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      exact denseRncBFoldL_mono i full.toList m0 v j (h.use.1 m0 hm0 j c hj v hv)
+  · intro sf hsf j c hj hfd
+    rw [hfold] at hsf
+    obtain ⟨s0, hs0, rfl⟩ := Option.map_eq_some_iff.1 hsf
+    rw [hcs] at hj
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨_, hcc⟩ := denseRncSet_getElem?_self st.cs i c' c hj
+      subst hcc
+      rw [if_pos hfd]
+      simp
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      have hmem := h.use.2 s0 hs0 j c hj hfd
+      split
+      · rw [Std.HashSet.contains_insert]; simp [hmem]
+      · rw [Std.HashSet.contains_erase]; simp [hmem, hij]
+  · exact h.bus
+
+theorem denseRncHasFold_bool (b : VarId) :
+    denseRncHasFold (denseBoolConstraint b : DenseExpr p) = false := rfl
+
+theorem denseBoolConstraint_vars (b : VarId) :
+    ∀ v ∈ (denseBoolConstraint b : DenseExpr p).vars, v = b := by
+  intro v hv
+  simpa [denseBoolConstraint, DenseExpr.vars] using hv
+
+theorem denseRncAnchorVars_bool (b : VarId) :
+    denseRncAnchorVars (denseBoolConstraint b : DenseExpr p) = [b] := by
+  unfold denseRncAnchorVars
+  rw [denseRncCapVars_bool]
+  rfl
+
+/-- Appending a booleanity constraint preserves every index invariant. -/
+theorem denseRncOk_pushBool {st : DenseRncState p} (h : DenseRncOk st) (b : VarId) :
+    DenseRncOk (st.pushBool b) := by
+  have hcs : (st.pushBool b).cs = st.cs.push (denseBoolConstraint b) := rfl
+  have hcvs : (st.pushBool b).cvs = st.cvs.push #[b] := rfl
+  have hanch : (st.pushBool b).anchor = denseRncAnchorAdd st.anchor [b] st.cs.size := rfl
+  have huse : (st.pushBool b).useCs = st.useCs.map (fun m => denseRncBAdd m b st.cs.size) := rfl
+  have hfold : (st.pushBool b).foldCs = st.foldCs := rfl
+  refine ⟨?_, ?_, ?_, ⟨?_, ?_⟩, ?_⟩
+  · rw [hcs, hcvs, Array.size_push, Array.size_push, h.sizes]
+  · intro j c hj
+    rw [hcs, Array.getElem?_push] at hj
+    rw [hcvs, Array.getElem?_push, h.sizes]
+    by_cases heq : j = st.cs.size
+    · rw [if_pos heq] at hj ⊢
+      rw [← Option.some.inj hj, denseRncCapVars_bool]
+    · rw [if_neg heq] at hj ⊢
+      exact h.cvs j c hj
+  · intro j c hj v hv
+    rw [hcs, Array.getElem?_push] at hj
+    rw [hanch]
+    by_cases heq : j = st.cs.size
+    · rw [if_pos heq] at hj
+      have hc : c = denseBoolConstraint b := (Option.some.inj hj).symm
+      subst hc
+      rw [denseRncAnchorVars_bool] at hv
+      have hvb : v = b := by simpa using hv
+      subst hvb
+      subst heq
+      exact denseRncAnchorAdd_self st.anchor v [] st.cs.size
+    · rw [if_neg heq] at hj
+      exact denseRncAnchorAdd_mono _ _ _ j v (h.anchor j c hj v hv)
+  · intro m hm j c hj v hv
+    rw [huse] at hm
+    obtain ⟨m0, hm0, rfl⟩ := Option.map_eq_some_iff.1 hm
+    rw [hcs, Array.getElem?_push] at hj
+    by_cases heq : j = st.cs.size
+    · rw [if_pos heq] at hj
+      have hc : c = denseBoolConstraint b := (Option.some.inj hj).symm
+      subst hc
+      have hvb : v = b := denseBoolConstraint_vars b v hv
+      subst hvb
+      subst heq
+      exact denseRncBAdd_self m0 v st.cs.size
+    · rw [if_neg heq] at hj
+      exact denseRncBAdd_mono m0 b st.cs.size j v (h.use.1 m0 hm0 j c hj v hv)
+  · intro sf hsf j c hj hfd
+    rw [hfold] at hsf
+    rw [hcs, Array.getElem?_push] at hj
+    by_cases heq : j = st.cs.size
+    · rw [if_pos heq] at hj
+      have hc : c = denseBoolConstraint b := (Option.some.inj hj).symm
+      subst hc
+      rw [denseRncHasFold_bool] at hfd
+      exact absurd hfd (by simp)
+    · rw [if_neg heq] at hj
+      exact h.use.2 sf hsf j c hj hfd
+  · exact h.bus
+
+/-- The bus write preserves the invariants: the constraint side is untouched and the bus index only
+    grows. -/
+theorem denseRncOk_rewriteBiAt {st : DenseRncState p} (h : DenseRncOk st) (i : Nat)
+    (bi' : BusInteraction (DenseExpr p)) : DenseRncOk (st.rewriteBiAt i bi') := by
+  have hbis : (st.rewriteBiAt i bi').bis = st.bis.setIfInBounds i bi' := rfl
+  have huse : (st.rewriteBiAt i bi').useBis
+      = st.useBis.map (fun m => (denseBIVars bi').foldl (fun m v => denseRncBAdd m v i) m) := rfl
+  have hfold : (st.rewriteBiAt i bi').foldBis
+      = st.foldBis.map (fun s => if denseRncBiHasFold bi' then s.insert i else s.erase i) := rfl
+  refine ⟨h.sizes, h.cvs, h.anchor, h.use, ⟨?_, ?_⟩⟩
+  · intro m hm j bi hj v hv
+    rw [huse] at hm
+    obtain ⟨m0, hm0, rfl⟩ := Option.map_eq_some_iff.1 hm
+    rw [hbis] at hj
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨_, hbb⟩ := denseRncSet_getElem?_self st.bis i bi' bi hj
+      subst hbb
+      exact denseRncBFoldL_self i (denseBIVars bi) m0 v hv
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      exact denseRncBFoldL_mono i (denseBIVars bi') m0 v j (h.bus.1 m0 hm0 j bi hj v hv)
+  · intro sf hsf j bi hj hfd
+    rw [hfold] at hsf
+    obtain ⟨s0, hs0, rfl⟩ := Option.map_eq_some_iff.1 hsf
+    rw [hbis] at hj
+    by_cases hij : i = j
+    · subst hij
+      obtain ⟨_, hbb⟩ := denseRncSet_getElem?_self st.bis i bi' bi hj
+      subst hbb
+      rw [if_pos hfd]
+      simp
+    · rw [denseRncSet_getElem?_ne _ _ _ _ hij] at hj
+      have hmem := h.bus.2 s0 hs0 j bi hj hfd
+      split
+      · rw [Std.HashSet.contains_insert]; simp [hmem]
+      · rw [Std.HashSet.contains_erase]; simp [hmem, hij]
+
+theorem denseRncOk_domReset {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk st.domReset := ⟨h.sizes, h.cvs, h.anchor, h.use, h.bus⟩
+
+/-- What the constraint-edit builder guarantees about each edit's payload. -/
+def DenseRncEditOk : DenseRncCsEdit p → Prop
+  | .tomb _ => True
+  | .cst _ c' cv' full => cv' = denseRncCapVars c' ∧ ∀ v ∈ c'.vars, v ∈ full
+
+theorem denseRncOk_csStep {ctx : DenseRncCtx p} {st : DenseRncState p} {e : DenseRncCsEdit p}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p))
+    (h : DenseRncOk st) (he : DenseRncEditOk e) : DenseRncOk (denseRncCsStep ctx st e) := by
+  cases e with
+  | tomb i =>
+      refine denseRncOk_rewriteAt h ?_ ?_
+      · rw [hzero, denseRncCapVars_const_zero]
+      · intro v hv; rw [hzero] at hv; simp [DenseExpr.vars] at hv
+  | cst i c' cv' full => exact denseRncOk_rewriteAt h he.1 he.2
+
+theorem denseRncOk_csFold {ctx : DenseRncCtx p}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p)) :
+    ∀ (es : List (DenseRncCsEdit p)) (st : DenseRncState p), DenseRncOk st →
+      (∀ e ∈ es, DenseRncEditOk e) → DenseRncOk (es.foldl (denseRncCsStep ctx) st) := by
+  intro es
+  induction es with
+  | nil => intro st h _; exact h
+  | cons e rest ih =>
+      intro st h he
+      exact ih _ (denseRncOk_csStep hzero h (he e List.mem_cons_self))
+        (fun e' he' => he e' (List.mem_cons_of_mem e he'))
+
+theorem denseRncOk_biFold :
+    ∀ (es : List (Nat × BusInteraction (DenseExpr p))) (st : DenseRncState p), DenseRncOk st →
+      DenseRncOk (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st) := by
+  intro es
+  induction es with
+  | nil => intro st h; exact h
+  | cons e rest ih => intro st h; exact ih _ (denseRncOk_rewriteBiAt h e.1 e.2)
+
+theorem denseRncOk_boolFold :
+    ∀ (bits : List VarId) (st : DenseRncState p), DenseRncOk st →
+      DenseRncOk (bits.foldl (fun st b => st.pushBool b) st) := by
+  intro bits
+  induction bits with
+  | nil => intro st h; exact h
+  | cons b rest ih => intro st h; exact ih _ (denseRncOk_pushBool h b)
+
+/-- The whole write preserves the index invariants. -/
+theorem denseRncOk_write {ctx : DenseRncCtx p} {st : DenseRncState p} {bits : List VarId}
+    {csEdits : List (DenseRncCsEdit p)} {biEdits : List (Nat × BusInteraction (DenseExpr p))}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p)) (h : DenseRncOk st)
+    (he : ∀ e ∈ csEdits, DenseRncEditOk e) :
+    DenseRncOk (denseRncWrite ctx st bits csEdits biEdits) :=
+  denseRncOk_domReset (denseRncOk_boolFold bits _
+    (denseRncOk_biFold biEdits _ (denseRncOk_csFold hzero csEdits st h he)))
+
+/-- The builder's edits carry the payload the invariants need. -/
+theorem denseRncCsEdits_editOk (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : ∀ e ∈ (denseRncCsEdits ctx st xs cd).1, DenseRncEditOk e := by
+  rw [csEdits_eq_foldr]
+  generalize (denseRncPosList (match st.useCs with | some m => m | none => #[]) xs
+    (match st.foldCs with | some s => s | none => ∅).toList) = l
+  induction l with
+  | nil => intro e he; simp at he
+  | cons i rest ih =>
+      intro e he
+      rw [List.foldr_cons] at he
+      cases hc : st.cs[i]? with
+      | none => exact ih e (by simpa only [csBody, hc] using he)
+      | some c =>
+        cases hvs : st.cvs[i]? with
+        | none => exact ih e (by simpa only [csBody, hc, hvs] using he)
+        | some vs =>
+          simp only [csBody, hc, hvs] at he
+          split at he
+          · rcases List.mem_cons.1 he with rfl | he'
+            · trivial
+            · exact ih e he'
+          · split at he
+            · rcases List.mem_cons.1 he with rfl | he'
+              · exact ⟨rfl, fun v hv => denseRncFullVars_mem hv⟩
+              · exact ih e he'
+            · exact ih e he
+
 /-- **Unproven on this branch (measurement).** The array-backed engine's obligations, in the shape
     `denseReencodeF_props` discharges for the list engine. -/
 theorem denseRncF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -1132,41 +1132,8 @@ theorem denseRegisterBits_props (reg : VarRegistry) (fb : String) (k : Nat) :
   registerBits_fold_inv fb reg (List.range k) reg [] (VarRegistry.Extends.refl reg)
     (fun _ => rfl) (by intro b hb; simp at hb)
 
-theorem denseRegisterBits_extends_of_eq {reg r : VarRegistry} {fb : String} {k : Nat}
-    {bs : List VarId} (h : denseRegisterBits reg fb k = (r, bs)) : reg.Extends r := by
-  have := (denseRegisterBits_props reg fb k).1; rw [h] at this; exact this
 
-theorem denseRegisterBits_isInput_of_eq {reg r : VarRegistry} {fb : String} {k : Nat}
-    {bs : List VarId} (h : denseRegisterBits reg fb k = (r, bs)) (i : VarId) :
-    r.isInput i = reg.isInput i := by
-  have := (denseRegisterBits_props reg fb k).2.1 i; rw [h] at this; exact this
 
-theorem denseRegisterBits_valid_of_eq {reg r : VarRegistry} {fb : String} {k : Nat}
-    {bs : List VarId} (h : denseRegisterBits reg fb k = (r, bs)) : ∀ b ∈ bs, r.Valid b := by
-  have := (denseRegisterBits_props reg fb k).2.2; rw [h] at this; exact this
-
-theorem denseBuildReencodeCached_props (reg : VarRegistry)
-    (csIdx : DenseCovIndex) (arrCs : Array (DenseExpr p))
-    (cache : DenseReencodeRootCache p) (xs : List VarId) (freshBase : String) :
-    reg.Extends (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1
-    ∧ (∀ i, (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1.isInput i
-        = reg.isInput i)
-    ∧ (∀ bits hm,
-        (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).2.1
-          = some (bits, hm) →
-        ∀ b ∈ bits,
-          (denseBuildReencodeCached reg csIdx arrCs cache xs freshBase).1.Valid b) := by
-  fun_cases denseBuildReencodeCached reg csIdx arrCs cache xs freshBase <;>
-    first
-      | exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl,
-          by intro bits hm h; simp at h⟩
-      | (refine ⟨denseRegisterBits_extends_of_eq (by assumption),
-                fun i => denseRegisterBits_isInput_of_eq (by assumption) i, ?_⟩
-         intro bits hm heq b hb
-         dsimp only at heq
-         rw [Option.some.injEq, Prod.mk.injEq] at heq
-         obtain ⟨rfl, -⟩ := heq
-         exact denseRegisterBits_valid_of_eq (by assumption) b hb)
 
 
 theorem coveredBy_of_occ {r : VarRegistry} {d : DenseConstraintSystem p}
@@ -1214,18 +1181,6 @@ theorem denseBitCM_covered (reg1 : VarRegistry) (xs bits : List VarId)
   exact ⟨hbits b hb, denseCM_coveredBy_of_vars _
     (fun i hi => hxsValid i (denseBitCM_vars _ xs hm b i hi))⟩
 
-
-/-- `stepIdentityPost` for the cached step, which does not carry the variable-set invariant
-    (its `varSet` over-approximates the live variables; see `DenseReencodeCacheState`). -/
-theorem stepIdentityPostC (reg reg' : VarRegistry) (d : DenseConstraintSystem p)
-    (bs : BusSemantics p)
-    (hext : reg.Extends reg') (hii : ∀ i, reg'.isInput i = reg.isInput i)
-    (hcov : d.CoveredBy reg) :
-    reg.Extends reg' ∧ (∀ i, reg'.isInput i = reg.isInput i) ∧ d.CoveredBy reg'
-    ∧ DenseDerivations.CoveredBy reg' ([] : DenseDerivations p)
-    ∧ DensePassCorrect reg'.isInput d d ([] : DenseDerivations p) bs :=
-  ⟨hext, hii, csCoveredBy_mono hext hcov, (by intro x hx; simp at hx),
-   DensePassCorrect.refl reg'.isInput d bs⟩
 
 /-! ## Group variables occur in `d`, straight from the certificate
 
@@ -1298,39 +1253,8 @@ theorem denseCheckReencode_polyVars (d : DenseConstraintSystem p) (xs bits : Lis
     ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs hm)).vars, v ∈ bits := by
   grind [denseCheckReencode, List.contains_iff_mem]
 
-theorem denseBuildReencodeCached_ext_of_eq {reg reg1 : VarRegistry}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
-    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
-    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
-      (reg1, o, cache1)) : reg.Extends reg1 := by
-  have := (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).1
-  rw [h] at this
-  exact this
 
-theorem denseBuildReencodeCached_isInput_of_eq {reg reg1 : VarRegistry}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
-    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
-    {o : Option (List VarId × Std.HashMap VarId (DenseExpr p))}
-    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
-      (reg1, o, cache1)) (i : VarId) :
-    reg1.isInput i = reg.isInput i := by
-  have :=
-    (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).2.1 i
-  rw [h] at this
-  exact this
 
-theorem denseBuildReencodeCached_bits_valid_of_eq {reg reg1 : VarRegistry}
-    {csIdx : DenseCovIndex} {arrCs : Array (DenseExpr p)}
-    {cache cache1 : DenseReencodeRootCache p} {xs : List VarId} {freshBase : String}
-    {bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
-    (h : denseBuildReencodeCached reg csIdx arrCs cache xs freshBase =
-      (reg1, some (bits, hm), cache1)) :
-    ∀ bb ∈ bits, reg1.Valid bb := by
-  have := (denseBuildReencodeCached_props reg csIdx arrCs cache xs freshBase).2.2
-    bits hm (by rw [h])
-  rw [h] at this
-  exact this
 
 set_option maxHeartbeats 1000000 in
 theorem denseFilterConstraints_coveredBy {d : DenseConstraintSystem p} {reg : VarRegistry}
@@ -1345,31 +1269,6 @@ licenses that is `DenseWorkVarsOk`: every variable occurring in the working syst
 The seed satisfies it by construction (`varSet = ofList d.occ`), and an accept preserves it because
 the rewritten system's variables are old variables or fresh bits
 (`denseReencodeOut_vars_subset`), and the fresh bits are exactly what the state update inserts. -/
-
-/-- Every variable of the working system is recorded in `vs`. -/
-def DenseWorkVarsOk (vs : Std.HashSet VarId) (w : DenseReencodeWork p) : Prop :=
-  ∀ v ∈ (denseWorkView w).occ, vs.contains v = true
-
-theorem denseIsZero_vars {c : DenseExpr p} (h : denseIsZero c = true) : c.vars = [] := by
-  cases c <;> simp_all [denseIsZero, DenseExpr.vars]
-
-/-- The raw working pieces have no variable the view lacks: the view only drops `.const 0`
-    tombstones, which carry none. -/
-theorem denseWorkRaw_occ_sub (w : DenseReencodeWork p) :
-    ∀ v ∈ ({ algebraicConstraints := w.cs,
-             busInteractions := w.bis } : DenseConstraintSystem p).occ,
-      v ∈ (denseWorkView w).occ := by
-  intro v hv
-  simp only [DenseConstraintSystem.occ, List.mem_append, List.mem_flatMap] at hv
-  rcases hv with ⟨c, hc, hcv⟩ | ⟨bi, hbi, hbiv⟩
-  · have hkeep : (!denseIsZero c) = true := by
-      cases hz : denseIsZero c with
-      | false => rfl
-      | true => rw [denseIsZero_vars hz] at hcv; simp at hcv
-    refine DenseConstraintSystem.mem_occ_of_constraint (c := c) ?_ hcv
-    show c ∈ w.cs.filter (fun c => !denseIsZero c) ++ w.bools
-    exact List.mem_append.2 (Or.inl (List.mem_filter.2 ⟨hc, hkeep⟩))
-  · exact DenseConstraintSystem.mem_occ_of_bi (bi := bi) hbi hbiv
 
 /-- Filtering constraints cannot introduce a variable. -/
 theorem denseFilterConstraints_occ_sub (d : DenseConstraintSystem p)
@@ -1403,25 +1302,6 @@ theorem denseFreshScan_of_notMemOcc (d : DenseConstraintSystem p) (bits : List V
       simp only [denseBIVars, List.mem_append, List.mem_flatMap]
       exact Or.inr ⟨e, he, hv⟩)
 
-/-- The step's certificate: the `varSet` test plus the remaining conjuncts give the full
-    certificate, on the strength of the invariant. -/
-theorem denseCheckReencodeVS_sound {w : DenseReencodeWork p}
-    {state : DenseReencodeCacheState p} {xs bits : List VarId}
-    {hm : Std.HashMap VarId (DenseExpr p)} (hvs : DenseWorkVarsOk state.varSet w)
-    (h : denseCheckReencodeVS state
-      { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm = true) :
-    denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm
-      = true := by
-  rw [denseCheckReencodeVS, Bool.and_eq_true] at h
-  obtain ⟨hnv, hnf⟩ := h
-  refine denseCheckReencode_of_parts _ xs bits hm hnf (denseFreshScan_of_notMemOcc _ bits ?_)
-  intro b hb hmem
-  have hcontains : state.varSet.contains b = true :=
-    hvs b (denseWorkRaw_occ_sub w b hmem)
-  have := List.all_eq_true.mp hnv b hb
-  rw [hcontains] at this
-  exact Bool.noConfusion this
-
 /-! ### The bus-side index invariant
 
 `denseWorkOut` rewrites the bus list only at the positions it is handed, so it needs those positions
@@ -1430,610 +1310,15 @@ to cover everywhere `denseBIRewriteGate` could fire. `DenseBusIdxOk` is what sup
 carrying a variable-free composite node. Both hold at the seed by construction and are maintained by
 the state update, which folds over the very list the splice consumed. -/
 
-/-- Insert-folding into a set never loses a member. -/
-theorem denseNatFold_mono (l : List Nat) :
-    ∀ (s : Std.HashSet Nat) (v : Nat), s.contains v = true →
-      (l.foldl (·.insert ·) s).contains v = true := by
-  intro s v
-  induction l generalizing s with
-  | nil => intro h; exact h
-  | cons a rest ih => intro h; exact ih _ (by simp [Std.HashSet.contains_insert, h])
+set_option maxHeartbeats 1000000 in
 
-/-- A member of the folded list ends up in the set. -/
-theorem denseNatFold_mem (l : List Nat) :
-    ∀ (s : Std.HashSet Nat) (v : Nat), v ∈ l → (l.foldl (·.insert ·) s).contains v = true := by
-  intro s v
-  induction l generalizing s with
-  | nil => intro h; simp at h
-  | cons a rest ih =>
-      intro h
-      rcases List.mem_cons.1 h with rfl | h
-      · exact denseNatFold_mono rest _ v (by simp [Std.HashSet.contains_insert])
-      · exact ih _ h
 
-/-- `denseBuild_complete` in the `getElem?` form the invariant uses. -/
-theorem denseBuild_complete' {α : Type} (varsOf : α → List VarId) (items : List α) (i : Nat)
-    (a : α) (hi : items[i]? = some a) (v : VarId) (hv : v ∈ varsOf a) :
-    i ∈ (denseCovBuild varsOf items).buckets.getD v [] := by
-  obtain ⟨hlt, hget⟩ := List.getElem?_eq_some_iff.1 hi
-  subst hget
-  exact denseBuild_complete varsOf items i hlt v hv
 
-/-- The seed's fold-position scan lists every interaction carrying a variable-free composite node. -/
-theorem denseFoldBisSeed_complete (bis : List (BusInteraction (DenseExpr p))) :
-    ∀ (n : Nat) (s : Std.HashSet Nat) (k : Nat) (bi : BusInteraction (DenseExpr p)),
-      bis[k]? = some bi → denseBiHasFold bi = true →
-      ((bis.zipIdx n).foldl
-        (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s) s).contains (n + k) = true := by
-  have hmono : ∀ (l : List (BusInteraction (DenseExpr p) × Nat)) (s : Std.HashSet Nat) (j : Nat),
-      s.contains j = true →
-      (l.foldl (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s) s).contains j = true := by
-    intro l
-    induction l with
-    | nil => intro s j h; exact h
-    | cons a rest ih =>
-        intro s j h
-        refine ih _ j ?_
-        by_cases hf : denseBiHasFold a.1 = true
-        · simp [hf, Std.HashSet.contains_insert, h]
-        · simp [hf, h]
-  intro n s k bi
-  induction bis generalizing n s k with
-  | nil => intro h; simp at h
-  | cons a rest ih =>
-      intro hk hfold
-      cases k with
-      | zero =>
-          simp only [List.getElem?_cons_zero, Option.some.injEq] at hk
-          subst hk
-          simp only [List.zipIdx_cons, List.foldl_cons]
-          refine hmono _ _ _ ?_
-          simp [hfold, Std.HashSet.contains_insert]
-      | succ k =>
-          simp only [List.getElem?_cons_succ] at hk
-          simp only [List.zipIdx_cons, List.foldl_cons]
-          have := ih (n + 1) (if denseBiHasFold a then s.insert n else s) k hk hfold
-          have heq : n + 1 + k = n + (k + 1) := by omega
-          rwa [heq] at this
-
-/-- Every position of the system whose interaction is listed by its variables, and every position
-    carrying a variable-free composite node. -/
-def DenseBusIdxOk (state : DenseReencodeCacheState p) (w : DenseReencodeWork p) : Prop :=
-  (∀ (i : Nat) (bi : BusInteraction (DenseExpr p)), w.bis[i]? = some bi →
-      ∀ v ∈ denseBIVars bi, i ∈ state.useBis.buckets.getD v [])
-  ∧ (∀ (i : Nat) (bi : BusInteraction (DenseExpr p)), w.bis[i]? = some bi →
-      denseBiHasFold bi = true → state.foldBis.get.contains i = true)
-
-/-- The position list the step builds. -/
-def denseBusPosList (state : DenseReencodeCacheState p) (xs : List VarId) : List Nat :=
-  ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).toList.mergeSort (· ≤ ·)
-
-theorem denseBusPosList_sorted (state : DenseReencodeCacheState p) (xs : List VarId) :
-    (denseBusPosList state xs).Pairwise (· ≤ ·) :=
-  List.pairwise_mergeSort' (fun a b => a ≤ b) _
-
-/-- The invariant makes the position list complete for the gate. -/
-theorem denseBusPosList_cover {state : DenseReencodeCacheState p} {w : DenseReencodeWork p}
-    (xs : List VarId) (hidx : DenseBusIdxOk state w) :
-    ∀ k bi, w.bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ denseBusPosList state xs := by
-  intro k bi hk hf
-  have hset : ((denseCandidates state.useBis xs).foldl (·.insert ·)
-      state.foldBis.get).contains k = true := by
-    have hvar : ∀ (e : DenseExpr p), e.sharesVarIn xs = true → (∀ v ∈ e.vars, v ∈ denseBIVars bi) →
-        ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).contains k = true := by
-      intro e he hsub
-      obtain ⟨v, hv, hvxs⟩ := denseSharesVarIn_exists he
-      exact denseNatFold_mem _ _ k
-        (denseMem_candidates state.useBis xs v k hvxs (hidx.1 k bi hk v (hsub v hv)))
-    have hfold : denseBiHasFold bi = true →
-        ((denseCandidates state.useBis xs).foldl (·.insert ·) state.foldBis.get).contains k = true :=
-      fun h => denseNatFold_mono _ _ k (hidx.2 k bi hk h)
-    simp only [denseBiGateFires, Bool.or_eq_true, List.any_eq_true] at hf
-    rcases hf with (hm | hm) | ⟨e, he, hee⟩
-    · exact hvar bi.multiplicity hm (fun v hv => by
-        simp only [denseBIVars, List.mem_append]; exact Or.inl hv)
-    · exact hfold (by simp [denseBiHasFold, hm])
-    · rcases hee with h | h
-      · exact hvar e h (fun v hv => by
-          simp only [denseBIVars, List.mem_append, List.mem_flatMap]
-          exact Or.inr ⟨e, he, hv⟩)
-      · exact hfold (by
-          simp only [denseBiHasFold, Bool.or_eq_true, List.any_eq_true]
-          exact Or.inr ⟨e, he, h⟩)
-  rw [denseBusPosList, List.mem_mergeSort]
-  simpa [Std.HashSet.mem_toList] using hset
-
-/-- Bucket inserts never lose a member. -/
-theorem denseBucketFold_mono (vs : List VarId) (i : Nat) :
-    ∀ (m : Std.HashMap VarId (List Nat)) (v : VarId) (k : Nat), k ∈ m.getD v [] →
-      k ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD v [] := by
-  intro m v k
-  induction vs generalizing m with
-  | nil => intro h; exact h
-  | cons a rest ih =>
-      intro h
-      refine ih _ ?_
-      by_cases hva : v = a
-      · subst hva
-        rw [Std.HashMap.getD_insert_self]
-        exact List.mem_cons_of_mem _ h
-      · have hne : (m.insert a (i :: m.getD a [])).getD v [] = m.getD v [] := by
-          rw [Std.HashMap.getD_insert]
-          rw [if_neg (show ¬((a == v) = true) by simpa using Ne.symm hva)]
-        rw [hne]; exact h
-
-/-- A variable of the inserted list gets the position. -/
-theorem denseBucketFold_mem (vs : List VarId) (i : Nat) :
-    ∀ (m : Std.HashMap VarId (List Nat)) (v : VarId), v ∈ vs →
-      i ∈ (vs.foldl (fun m v => m.insert v (i :: m.getD v [])) m).getD v [] := by
-  intro m v
-  induction vs generalizing m with
-  | nil => intro h; simp at h
-  | cons a rest ih =>
-      intro h
-      rcases List.mem_cons.1 h with rfl | h
-      · refine denseBucketFold_mono rest i _ _ i ?_
-        rw [Std.HashMap.getD_insert_self]
-        exact List.mem_cons_self ..
-      · exact ih _ h
-
-/-- Positions the fold does not visit keep their fold-set membership. -/
-theorem denseBusIdxFold_keep_of_not_mem (arrB : Array (BusInteraction (DenseExpr p))) :
-    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat), i ∉ ps →
-      acc.2.contains i = true → (denseBusIdxFold arrB ps acc).2.contains i = true := by
-  intro ps
-  induction ps with
-  | nil => intro acc i _ h; rw [denseBusIdxFold]; exact h
-  | cons j rest ih =>
-      intro acc i hni h
-      have hij : i ≠ j := fun hh => hni (hh ▸ List.mem_cons_self ..)
-      rw [denseBusIdxFold]
-      split
-      · refine ih _ i (fun hmem => hni (List.mem_cons_of_mem _ hmem)) ?_
-        show (if denseBiHasFold _ then acc.2.insert j else acc.2.erase j).contains i = true
-        split
-        · simp [Std.HashSet.contains_insert, h]
-        · simp [Std.HashSet.contains_erase, h, Ne.symm hij]
-      · exact ih _ i (fun hmem => hni (List.mem_cons_of_mem _ hmem)) h
-
-/-- A position whose interaction carries a fold node keeps its membership through the fold: every
-    visit to it re-inserts it, since the decision is a function of the (unchanging) content. -/
-theorem denseBusIdxFold_keep_of_hasFold (arrB : Array (BusInteraction (DenseExpr p))) :
-    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat) (h : i < arrB.size),
-      denseBiHasFold arrB[i] = true → acc.2.contains i = true →
-      (denseBusIdxFold arrB ps acc).2.contains i = true := by
-  intro ps
-  induction ps with
-  | nil => intro acc i _ _ h; rw [denseBusIdxFold]; exact h
-  | cons j rest ih =>
-      intro acc i hlt hfold h
-      rw [denseBusIdxFold]
-      split
-      · refine ih _ i hlt hfold ?_
-        show (if denseBiHasFold _ then acc.2.insert j else acc.2.erase j).contains i = true
-        by_cases hij : i = j
-        · subst hij; rw [if_pos hfold]; simp [Std.HashSet.contains_insert]
-        · split
-          · simp [Std.HashSet.contains_insert, h]
-          · simp [Std.HashSet.contains_erase, h, Ne.symm hij]
-      · exact ih _ i hlt hfold h
-
-/-- Visited in-range positions get their interaction's variables into the buckets. -/
-theorem denseBusIdxFold_buckets (arrB : Array (BusInteraction (DenseExpr p))) :
-    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat),
-      (∀ v k, k ∈ acc.1.buckets.getD v [] →
-        k ∈ (denseBusIdxFold arrB ps acc).1.buckets.getD v [])
-      ∧ (∀ i, i ∈ ps → ∀ (h : i < arrB.size), ∀ v ∈ denseBIVars arrB[i],
-          i ∈ (denseBusIdxFold arrB ps acc).1.buckets.getD v []) := by
-  intro ps
-  induction ps with
-  | nil =>
-      intro acc
-      exact ⟨fun v k h => by rw [denseBusIdxFold]; exact h, fun i h => absurd h (by simp)⟩
-  | cons j rest ih =>
-      intro acc
-      rw [denseBusIdxFold]
-      split
-      · next hj =>
-        obtain ⟨ih1, ih2⟩ := ih (⟨(HashedDedup.hashedDedup (hash ·)
-            (denseBIVars arrB[j])).foldl (fun m v => m.insert v (j :: m.getD v [])) acc.1.buckets,
-            acc.1.varless⟩,
-          if denseBiHasFold arrB[j] then acc.2.insert j else acc.2.erase j)
-        refine ⟨fun v k h => ih1 v k (denseBucketFold_mono _ _ _ v k h), ?_⟩
-        intro i hi h v hv
-        rcases List.mem_cons.1 hi with rfl | hi
-        · refine ih1 v i (denseBucketFold_mem _ _ _ v ?_)
-          rw [HashedDedup.hashedDedup_eq]
-          exact List.mem_dedup.2 (by simpa using hv)
-        · exact ih2 i hi h v hv
-      · next hj =>
-        obtain ⟨ih1, ih2⟩ := ih acc
-        refine ⟨ih1, ?_⟩
-        intro i hi h v hv
-        rcases List.mem_cons.1 hi with rfl | hi
-        · exact absurd h hj
-        · exact ih2 i hi h v hv
-
-/-- A visited in-range position carrying a fold node ends up in the fold set. -/
-theorem denseBusIdxFold_mem_of_hasFold (arrB : Array (BusInteraction (DenseExpr p))) :
-    ∀ (ps : List Nat) (acc : DenseCovIndex × Std.HashSet Nat) (i : Nat) (h : i < arrB.size),
-      i ∈ ps → denseBiHasFold arrB[i] = true →
-      (denseBusIdxFold arrB ps acc).2.contains i = true := by
-  intro ps
-  induction ps with
-  | nil => intro _ i _ hi _; exact absurd hi (by simp)
-  | cons j rest ih =>
-      intro acc i hlt hi hfold
-      rcases List.mem_cons.1 hi with rfl | hi
-      · rw [denseBusIdxFold, dif_pos hlt]
-        refine denseBusIdxFold_keep_of_hasFold arrB rest _ i hlt hfold ?_
-        show (if denseBiHasFold arrB[i] then acc.2.insert i else acc.2.erase i).contains i = true
-        rw [if_pos hfold]
-        simp [Std.HashSet.contains_insert]
-      · rw [denseBusIdxFold]
-        split
-        · exact ih _ i hlt hi hfold
-        · exact ih _ i hlt hi hfold
-
-/-- The index invariant survives an accept: the update folds over the positions the rewrite visited,
-    recording the new interactions' variables, and every other position kept its content. -/
-theorem denseBusIdxOk_update {state : DenseReencodeCacheState p} {w w' : DenseReencodeWork p}
-    {xs bits : List VarId} {hm : Std.HashMap VarId (DenseExpr p)}
-    (hidx : DenseBusIdxOk state w)
-    (hnew : ∀ i bi, w'.bis[i]? = some bi → i ∉ denseBusPosList state xs →
-      w.bis[i]? = some bi) :
-    DenseBusIdxOk
-      (denseReencodeStateUpdate state (denseBusPosList state xs) w'.bis xs bits hm) w' := by
-  set ps := denseBusPosList state xs with hps
-  have hproj : (denseReencodeStateUpdate state ps w'.bis xs bits hm).useBis
-      = (denseBusIdxFold w'.bis.toArray ps (state.useBis, state.foldBis.get)).1 := rfl
-  have hprojF : (denseReencodeStateUpdate state ps w'.bis xs bits hm).foldBis.get
-      = (denseBusIdxFold w'.bis.toArray ps (state.useBis, state.foldBis.get)).2 := rfl
-  obtain ⟨hb1, hb2⟩ :=
-    denseBusIdxFold_buckets w'.bis.toArray ps (state.useBis, state.foldBis.get)
-  constructor
-  · intro i bi hi v hv
-    obtain ⟨hlt', hget⟩ := List.getElem?_eq_some_iff.1 hi
-    have hlt : i < w'.bis.toArray.size := by simpa using hlt'
-    have hidx' : w'.bis.toArray[i] = bi := by simpa using hget
-    rw [hproj]
-    by_cases hmem : i ∈ ps
-    · exact hb2 i hmem hlt v (by rw [hidx']; exact hv)
-    · exact hb1 v i (hidx.1 i bi (hnew i bi hi hmem) v hv)
-  · intro i bi hi hfold
-    obtain ⟨hlt', hget⟩ := List.getElem?_eq_some_iff.1 hi
-    have hlt : i < w'.bis.toArray.size := by simpa using hlt'
-    have hidx' : w'.bis.toArray[i] = bi := by simpa using hget
-    rw [hprojF]
-    by_cases hmem : i ∈ ps
-    · exact denseBusIdxFold_mem_of_hasFold w'.bis.toArray ps _ i hlt hmem
-        (by rw [hidx']; exact hfold)
-    · exact denseBusIdxFold_keep_of_not_mem w'.bis.toArray ps _ i hmem
-        (hidx.2 i bi (hnew i bi hi hmem) hfold)
 
 set_option maxHeartbeats 1000000 in
-theorem denseWorkStep_correct [Fact p.Prime] (b : DegreeBound)
-    (reg : VarRegistry) (w : DenseReencodeWork p) (state : DenseReencodeCacheState p)
-    (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
-    (hcov : (denseWorkView w).CoveredBy reg)
-    (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hvs : DenseWorkVarsOk state.varSet w)
-    (hidxB : DenseBusIdxOk state w) :
-    reg.Extends (denseWorkStep b reg w state xs freshBase).1
-    ∧ (∀ i, (denseWorkStep b reg w state xs freshBase).1.isInput i = reg.isInput i)
-    ∧ (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1).CoveredBy
-        (denseWorkStep b reg w state xs freshBase).1
-    ∧ DenseDerivations.CoveredBy (denseWorkStep b reg w state xs freshBase).1
-        (denseWorkStep b reg w state xs freshBase).2.2.1
-    ∧ DensePassCorrect (denseWorkStep b reg w state xs freshBase).1.isInput (denseWorkView w)
-        (denseWorkView (denseWorkStep b reg w state xs freshBase).2.1)
-        (denseWorkStep b reg w state xs freshBase).2.2.1 bs := by
-  fun_cases denseWorkStep b reg w state xs freshBase
-  all_goals first
-    | exact stepIdentityPostC reg reg (denseWorkView w) bs (VarRegistry.Extends.refl reg)
-        (fun _ => rfl) hcov
-    | exact stepIdentityPostC reg _ (denseWorkView w) bs
-        (denseBuildReencodeCached_ext_of_eq (by assumption))
-        (fun i => denseBuildReencodeCached_isInput_of_eq (by assumption) i) hcov
-    | skip
-  rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
-  have hbext : reg.Extends reg1 := denseBuildReencodeCached_ext_of_eq hbeq
-  have hbii : ∀ i, reg1.isInput i = reg.isInput i := fun i =>
-    denseBuildReencodeCached_isInput_of_eq hbeq i
-  have hbval : ∀ bb ∈ bits, reg1.Valid bb := denseBuildReencodeCached_bits_valid_of_eq hbeq
-  have hxsB' : ∀ x ∈ xs, w.bitSet.contains x = false := by simpa using hbit
-  have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
-  have hchkView : denseCheckReencode (denseWorkView w) xs bits hm = true := by
-    rw [denseWorkView_check hm hbools hxsB' hbitsB']
-    exact denseCheckReencodeVS_sound hvs hD
-  have hview : denseWorkView ro.1
-      = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
-          (fun c => !denseIsZero c) := by
-    have h := denseWorkOut_view (usePosB := denseBusPosList state1 xs)
-        b (denseWorkEnsureBounded w) xs bits hm
-      (denseWorkEnsureBounded_posOk hpos)
-      (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
-      (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
-      (denseBusPosList_sorted state1 xs)
-      (by
-        intro k bi hk hf
-        exact denseBusPosList_cover xs hidxB k bi (by rwa [denseWorkEnsureBounded_bis] at hk) hf)
-    rwa [denseWorkEnsureBounded_view] at h
-  have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
-  have hxsInput : ∀ x ∈ xs, reg1.isInput x = true := fun x hx => by
-    rw [hbii x]
-    exact List.all_eq_true.mp hgate x hx
-  have hxsOcc : ∀ x ∈ xs, x ∈ (denseWorkView w).occ :=
-    denseCheckReencode_xsOcc (denseWorkView w) xs bits hm hchkView
-  have hxsBits : ∀ x ∈ xs, x ∉ bits := fun x hx =>
-    of_decide_eq_true (List.all_eq_true.mp hB x hx)
-  have hbnInput : ∀ bb ∈ bits, reg1.isInput bb = false := fun bb hbb => by
-    have hpd : (reg1.resolve bb).powdrId? = none :=
-      of_decide_eq_true (List.all_eq_true.mp hC bb hbb)
-    show (reg1.resolve bb).powdrId?.isSome = false
-    rw [hpd]
-    rfl
-  have hxsValid : ∀ x ∈ xs, reg1.Valid x := fun x hx =>
-    hbext.valid (DenseConstraintSystem.occ_valid hcov x (hxsOcc x hx))
-  refine ⟨hbext, hbii, ?_, ?_, ?_⟩
-  · rw [hview]
-    exact denseFilterConstraints_coveredBy
-      (denseReencodeOut_covered reg1 (denseWorkView w) xs bits hm
-        (csCoveredBy_mono hbext hcov) hbval hpolyVars)
-  · exact denseBitCM_covered reg1 xs bits hm hxsValid hbval
-  · rw [hview]
-    have h1 := denseCheckReencode_sound (denseWorkView w) bs reg1.isInput xs bits hm
-      hxsInput hxsOcc hxsBits hbnInput hchkView
-    have h2 := DensePassCorrect.denseFilterConstraintsEntailed
-      (denseReencodeOut (denseWorkView w) xs bits hm) bs reg1.isInput (fun c => !denseIsZero c)
-      (fun c _ hk => denseIsZero_eval (by simpa using hk))
-    simpa using h1.andThen h2
 
-theorem denseBitSetFold_mono (bits : List VarId) :
-    ∀ (s : Std.HashSet VarId) (v : VarId), s.contains v = true →
-      (bits.foldl (·.insert ·) s).contains v = true := by
-  intro s v
-  induction bits generalizing s with
-  | nil => intro h; exact h
-  | cons bb rest ih =>
-      intro h
-      exact ih _ (by simp [Std.HashSet.contains_insert, h])
-
-theorem denseBitSetFold_mem (bits : List VarId) :
-    ∀ (s : Std.HashSet VarId) (v : VarId), v ∈ bits →
-      (bits.foldl (·.insert ·) s).contains v = true := by
-  intro s v
-  induction bits generalizing s with
-  | nil => intro h; simp at h
-  | cons bb rest ih =>
-      intro h
-      rcases List.mem_cons.mp h with rfl | h
-      · exact denseBitSetFold_mono rest _ v (by simp [Std.HashSet.contains_insert])
-      · exact ih _ h
-
-theorem denseWorkStep_inv (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
-    (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String)
-    (hpos : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs)
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hvs : DenseWorkVarsOk state.varSet w)
-    (hidxB : DenseBusIdxOk state w) :
-    ((denseWorkStep b reg w state xs freshBase).2.1.bounded = true →
-      DenseWorkPosOk (denseWorkStep b reg w state xs freshBase).2.1.lastPos
-        (denseWorkStep b reg w state xs freshBase).2.1.lastFold
-        (denseWorkStep b reg w state xs freshBase).2.1.cs)
-    ∧ DenseWorkBoolsOk (denseWorkStep b reg w state xs freshBase).2.1.bitSet
-        (denseWorkStep b reg w state xs freshBase).2.1.bools
-    ∧ DenseWorkVarsOk (denseWorkStep b reg w state xs freshBase).2.2.2.varSet
-        (denseWorkStep b reg w state xs freshBase).2.1
-    ∧ DenseBusIdxOk (denseWorkStep b reg w state xs freshBase).2.2.2
-        (denseWorkStep b reg w state xs freshBase).2.1 := by
-  fun_cases denseWorkStep b reg w state xs freshBase
-  all_goals try exact ⟨hpos, hbools, hvs, hidxB⟩
-  rename_i hgate hbit hcoll reg1 bits hm rootCache hbeq state1 hbits hdpr hA hB hC hD ro hwd
-  have hxsB' : ∀ x ∈ xs, w.bitSet.contains x = false := by simpa using hbit
-  have hbitsB' : ∀ bb ∈ bits, w.bitSet.contains bb = false := by simpa using hbits
-  refine ⟨?_, ?_, ?_, ?_⟩
-  · intro _
-    show DenseWorkPosOk _ _ _
-    rw [densePosOk_from0]
-    set w' := denseWorkEnsureBounded w with hw'
-    exact denseWorkSpliceCs_posOk b.identities xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w'.lastPos w'.lastFold xs)
-      w'.cs 0 [] w'.lastPos w'.lastFold true rfl (by intro j c hj; simp at hj)
-      (densePosOk_from0.mp (denseWorkEnsureBounded_posOk hpos))
-  · show DenseWorkBoolsOk (bits.foldl (·.insert ·) (denseWorkEnsureBounded w).bitSet)
-      ((denseWorkEnsureBounded w).bools ++ bits.map (denseBoolConstraint (p := p)))
-    rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]
-    intro c hc
-    rcases List.mem_append.mp hc with hc | hc
-    · obtain ⟨bb, rfl, hbb⟩ := hbools c hc
-      exact ⟨bb, rfl, denseBitSetFold_mono bits w.bitSet bb hbb⟩
-    · obtain ⟨bb, hbb, rfl⟩ := List.mem_map.1 hc
-      exact ⟨bb, rfl, denseBitSetFold_mem bits w.bitSet bb hbb⟩
-  · -- the variable superset survives an accept: the rewritten system's variables are old ones or
-    -- fresh bits, and the fresh bits are exactly what the state update inserts
-    have hchkView : denseCheckReencode (denseWorkView w) xs bits hm = true := by
-      rw [denseWorkView_check hm hbools hxsB' hbitsB']
-      exact denseCheckReencodeVS_sound hvs hD
-    have hpolyVars := denseCheckReencode_polyVars (denseWorkView w) xs bits hm hchkView
-    have hview : denseWorkView ro.1
-        = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
-            (fun c => !denseIsZero c) := by
-      have h := denseWorkOut_view (usePosB := denseBusPosList state1 xs)
-          b (denseWorkEnsureBounded w) xs bits hm
-        (denseWorkEnsureBounded_posOk hpos)
-        (by rw [denseWorkEnsureBounded_bitSet, denseWorkEnsureBounded_bools]; exact hbools)
-        (by rw [denseWorkEnsureBounded_bitSet]; exact hxsB')
-        (denseBusPosList_sorted state1 xs)
-        (by
-          intro k bi hk hf
-          exact denseBusPosList_cover (w := w) xs hidxB k bi
-            (by rwa [denseWorkEnsureBounded_bis] at hk) hf)
-      rwa [denseWorkEnsureBounded_view] at h
-    intro v hv
-    show (bits.foldl (·.insert ·) state.varSet).contains v = true
-    rw [hview] at hv
-    rcases denseReencodeOut_vars_subset (denseWorkView w) xs bits hm hpolyVars v
-        (denseFilterConstraints_occ_sub _ _ v hv) with h | h
-    · exact denseBitSetFold_mono bits state.varSet v (hvs v h)
-    · exact denseBitSetFold_mem bits state.varSet v h
-  · -- the bus index invariant survives an accept
-    have hcov : ∀ k bi, (denseWorkEnsureBounded w).bis[k]? = some bi →
-        denseBiGateFires xs bi = true → k ∈ denseBusPosList state1 xs := by
-      intro k bi hk hf
-      exact denseBusPosList_cover (w := w) xs hidxB k bi
-        (by rwa [denseWorkEnsureBounded_bis] at hk) hf
-    have hnew : ∀ i bi, ro.1.bis[i]? = some bi → i ∉ denseBusPosList state1 xs →
-        w.bis[i]? = some bi := by
-      intro i bi hi hni
-      have hro : ro.1.bis = (denseGateBisPos b.busInteractions xs bits (denseGroupSubst xs hm)
-          (denseAssignments (denseBitBox bits)) (denseBusPosList state1 xs) 0
-          (denseWorkEnsureBounded w).bis [] true).1 := rfl
-      rw [hro] at hi
-      have := denseGateBisPos_untouched b.busInteractions xs bits (denseGroupSubst xs hm)
-        (denseAssignments (denseBitBox bits)) (denseBusPosList state1 xs)
-        (denseWorkEnsureBounded w).bis (denseBusPosList_sorted state1 xs) hcov i bi hi hni
-      rwa [denseWorkEnsureBounded_bis] at this
-    exact denseBusIdxOk_update hidxB hnew
 
 set_option maxHeartbeats 1000000 in
-theorem denseWorkLoop_correct [Fact p.Prime] (b : DegreeBound) (bs : BusSemantics p) :
-    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (w : DenseReencodeWork p)
-      (state : DenseReencodeCacheState p) (nc nb : Nat),
-      (denseWorkView w).CoveredBy reg →
-      (w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) →
-      DenseWorkBoolsOk w.bitSet w.bools →
-      DenseWorkVarsOk state.varSet w →
-      DenseBusIdxOk state w →
-      reg.Extends (denseWorkLoop b targets idx reg w state nc nb).1
-      ∧ (∀ i, (denseWorkLoop b targets idx reg w state nc nb).1.isInput i = reg.isInput i)
-      ∧ (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1).CoveredBy
-          (denseWorkLoop b targets idx reg w state nc nb).1
-      ∧ DenseDerivations.CoveredBy (denseWorkLoop b targets idx reg w state nc nb).1
-          (denseWorkLoop b targets idx reg w state nc nb).2.2
-      ∧ DensePassCorrect (denseWorkLoop b targets idx reg w state nc nb).1.isInput
-          (denseWorkView w) (denseWorkView (denseWorkLoop b targets idx reg w state nc nb).2.1)
-          (denseWorkLoop b targets idx reg w state nc nb).2.2 bs := by
-  intro targets
-  induction targets with
-  | nil =>
-      intro idx reg w state nc nb hcov _ _ _ _
-      show reg.Extends reg ∧ (∀ i, reg.isInput i = reg.isInput i)
-        ∧ (denseWorkView w).CoveredBy reg
-        ∧ DenseDerivations.CoveredBy reg ([] : DenseDerivations p)
-        ∧ DensePassCorrect reg.isInput (denseWorkView w) (denseWorkView w)
-            ([] : DenseDerivations p) bs
-      exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
-        (by intro x hx; simp at hx), DensePassCorrect.refl reg.isInput (denseWorkView w) bs⟩
-  | cons xs rest ih =>
-      intro idx reg w state nc nb hcov hpos hbools hvs hidxB
-      simp only [denseWorkLoop]
-      rcases hstep : denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
-          with ⟨reg1, w1, derivs1, state1⟩
-      have hsp := denseWorkStep_correct b reg w state xs s!"rnc{nc}_{nb}_{idx}" bs hcov hpos hbools
-        hvs hidxB
-      have hinv := denseWorkStep_inv b reg w state xs s!"rnc{nc}_{nb}_{idx}" hpos hbools hvs hidxB
-      simp only [hstep] at hsp hinv
-      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct⟩ := hsp
-      obtain ⟨hi_pos, hi_bools, hi_vs, hi_idxB⟩ := hinv
-      rcases hrec : denseWorkLoop b rest (idx + 1) reg1 w1 state1
-          (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
-          (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
-          with ⟨reg2, w2, derivs2⟩
-      have hih := ih (idx + 1) reg1 w1 state1
-          (denseWorkNameCountsS derivs1 w1 state1 nc nb).1
-          (denseWorkNameCountsS derivs1 w1 state1 nc nb).2
-          hs_cov hi_pos hi_bools hi_vs hi_idxB
-      simp only [hrec] at hih
-      obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct⟩ := hih
-      refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_⟩
-      · exact DenseDerivations.coveredBy_append
-          (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
-      · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
-        have hstepcert : DensePassCorrect reg2.isInput (denseWorkView w) (denseWorkView w1)
-            derivs1 bs := by rw [hfe]; exact hs_correct
-        exact hstepcert.andThen hr_correct
-
-theorem denseWorkSeed_view (d : DenseConstraintSystem p) :
-    denseWorkView (denseWorkSeed d) = d.filterConstraints (fun c => !denseIsZero c) := by
-  simp [denseWorkView, denseWorkSeed, DenseConstraintSystem.filterConstraints]
-
-set_option maxHeartbeats 1000000 in
-theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
-    (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
-    (hcov : d.CoveredBy reg) :
-    reg.Extends (denseReencodeF pw b reg bs facts d).1
-    ∧ (denseReencodeF pw b reg bs facts d).2.1.CoveredBy (denseReencodeF pw b reg bs facts d).1
-    ∧ DenseDerivations.CoveredBy (denseReencodeF pw b reg bs facts d).1
-        (denseReencodeF pw b reg bs facts d).2.2
-    ∧ DensePassCorrect (denseReencodeF pw b reg bs facts d).1.isInput d
-        (denseReencodeF pw b reg bs facts d).2.1 (denseReencodeF pw b reg bs facts d).2.2 bs := by
-  unfold denseReencodeF
-  by_cases hpr : pw.isPrime = true
-  · rw [if_pos hpr]
-    haveI : Fact p.Prime := ⟨pw.correct hpr⟩
-    extract_lets csVs svSet targets
-    have hseedCov : (denseWorkView (denseWorkSeed d)).CoveredBy reg := by
-      rw [denseWorkSeed_view]
-      exact denseFilterConstraints_coveredBy hcov
-    have hseedPos : (denseWorkSeed d).bounded = true →
-        DenseWorkPosOk (denseWorkSeed d).lastPos (denseWorkSeed d).lastFold
-          (denseWorkSeed d).cs := by intro hb; simp [denseWorkSeed] at hb
-    have hseedBools : DenseWorkBoolsOk (denseWorkSeed d).bitSet (denseWorkSeed d).bools := by
-      intro c hc; simp [denseWorkSeed] at hc
-    set st : DenseReencodeCacheState p :=
-      { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
-        arrCs := d.algebraicConstraints.toArray
-        rootCache := ∅
-        varSet := Std.HashSet.ofList d.occ
-        useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
-        useBis := denseCovBuild denseBIVars d.busInteractions
-        arrBis := d.busInteractions.toArray
-        foldCs := d.algebraicConstraints.zipIdx.foldl
-          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
-        foldBis := Thunk.mk (fun _ => d.busInteractions.zipIdx.foldl
-          (fun s bi => if denseBiHasFold bi.1 then s.insert bi.2 else s) ∅)
-        liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
-        bisN := d.busInteractions.length
-        dWithin := false } with hst
-    have hseedVars : DenseWorkVarsOk st.varSet (denseWorkSeed d) := by
-      intro v hv
-      rw [denseWorkSeed_view] at hv
-      have hd := denseFilterConstraints_occ_sub d (fun c => !denseIsZero c) v hv
-      rw [hst]
-      show (Std.HashSet.ofList d.occ).contains v = true
-      simpa [Std.HashSet.contains_ofList, List.contains_iff_mem] using hd
-    have hseedIdxB : DenseBusIdxOk st (denseWorkSeed d) := by
-      constructor
-      · intro i bi hi v hv
-        rw [hst]
-        show i ∈ (denseCovBuild denseBIVars d.busInteractions).buckets.getD v []
-        exact denseBuild_complete' denseBIVars d.busInteractions i bi (by simpa using hi) v hv
-      · intro i bi hi hfold
-        rw [hst]
-        show ((d.busInteractions.zipIdx).foldl
-          (fun s x => if denseBiHasFold x.1 then s.insert x.2 else s)
-          (∅ : Std.HashSet Nat)).contains i = true
-        simpa using denseFoldBisSeed_complete d.busInteractions 0 ∅ i bi (by simpa using hi) hfold
-    obtain ⟨he, _, hc, hd, hcorr⟩ :=
-      denseWorkLoop_correct b bs targets 0 reg (denseWorkSeed d) st
-        (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
-        hseedCov hseedPos hseedBools hseedVars hseedIdxB
-    refine ⟨he, hc, hd, ?_⟩
-    -- the seed drops trivially-true constraints, itself a verified step
-    have hpre : DensePassCorrect
-        (denseWorkLoop b targets 0 reg (denseWorkSeed d) st
-          (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
-          d.busInteractions.length).1.isInput d (denseWorkView (denseWorkSeed d))
-        ([] : DenseDerivations p) bs := by
-      rw [denseWorkSeed_view]
-      exact DensePassCorrect.denseFilterConstraintsEntailed d bs _
-        (fun c => !denseIsZero c) (fun c _ hk => denseIsZero_eval (by simpa using hk))
-    simpa using hpre.andThen hcorr
-  · rw [if_neg hpr]
-    refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
-    intro x hx; simp at hx
 
 /-! ## The array engine
 
@@ -2956,8 +2241,6 @@ theorem denseRncCapVars_bool (b : VarId) :
     denseRncCapVars (denseBoolConstraint b : DenseExpr p) = #[b] := by
   simp [denseRncCapVars, denseRncCapGo, denseBoolConstraint]
 
-theorem denseRncAnchorVars_const_zero :
-    denseRncAnchorVars (DenseExpr.const 0 : DenseExpr p) = [] := rfl
 
 /-- Growing an array does not change any existing entry. -/
 theorem denseArrEnsure_getD {α : Type} (a : Array α) (i j : Nat) (d : α) :
@@ -3342,8 +2625,1421 @@ theorem denseRncCsEdits_editOk (ctx : DenseRncCtx p) (st : DenseRncState p) (xs 
               · exact ih e he'
             · exact ih e he
 
-/-- **Unproven on this branch (measurement).** The array-backed engine's obligations, in the shape
-    `denseReencodeF_props` discharges for the list engine. -/
+/-! ### The lazily built indexes are complete
+
+Each builder walks the positions once; the two facts per builder are that it lists what it must and
+that it only adds. -/
+
+theorem denseRncUseGo_mono (cs : Array (DenseExpr p)) (cvs : Array (Array VarId)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Array (Array Nat)) (v : VarId) (j : Nat),
+      j ∈ denseRncBGet acc v → j ∈ denseRncBGet (denseRncUseGo cs cvs i acc) v := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc v j hj
+      rw [denseRncUseGo, dif_neg (by omega)]
+      exact hj
+  | succ n ih =>
+      intro i hn acc v j hj
+      rw [denseRncUseGo]
+      split
+      · next hlt =>
+          refine ih (i + 1) (by omega) _ v j ?_
+          have hfl : (denseRncFullVars cs[i] (cvs.getD i #[])).foldl
+              (fun m w => denseRncBAdd m w i) acc
+              = (denseRncFullVars cs[i] (cvs.getD i #[])).toList.foldl
+                (fun m w => denseRncBAdd m w i) acc := by
+            conv_lhs => rw [← Array.toArray_toList (xs := denseRncFullVars cs[i] (cvs.getD i #[]))]
+            rw [List.foldl_toArray]
+          rw [hfl]
+          exact denseRncBFoldL_mono i _ acc v j hj
+      · exact hj
+
+theorem denseRncUseGo_complete (cs : Array (DenseExpr p)) (cvs : Array (Array VarId))
+    (hcvs : ∀ (k : Nat) (c : DenseExpr p), cs[k]? = some c → cvs[k]? = some (denseRncCapVars c)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Array (Array Nat)) (j : Nat) (c : DenseExpr p),
+      i ≤ j → cs[j]? = some c →
+      ∀ v ∈ c.vars, j ∈ denseRncBGet (denseRncUseGo cs cvs i acc) v := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j c hij hj v hv
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j c hij hj v hv
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      rw [denseRncUseGo]
+      split
+      · next hlt =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : cs[i] = c := by
+              rw [Array.getElem?_eq_getElem hlt] at hj
+              exact Option.some.inj hj
+            refine denseRncUseGo_mono cs cvs (n + 1) (i + 1) (by omega) _ v i ?_
+            have hfl : (denseRncFullVars cs[i] (cvs.getD i #[])).foldl
+                (fun m w => denseRncBAdd m w i) acc
+                = (denseRncFullVars cs[i] (cvs.getD i #[])).toList.foldl
+                  (fun m w => denseRncBAdd m w i) acc := by
+              conv_lhs =>
+                rw [← Array.toArray_toList (xs := denseRncFullVars cs[i] (cvs.getD i #[]))]
+              rw [List.foldl_toArray]
+            rw [hfl]
+            refine denseRncBFoldL_self i _ acc v ?_
+            have hcv : cvs.getD i #[] = denseRncCapVars cs[i] := by
+              have hh := hcvs i cs[i] (by rw [Array.getElem?_eq_getElem hlt])
+              rw [Array.getD_eq_getD_getElem?, hh]
+              rfl
+            rw [hcv, hc]
+            simpa using denseRncFullVars_mem hv
+          · exact ih (i + 1) (by omega) _ j c (by omega) hj v hv
+      · omega
+
+theorem denseRncUseBisGo_mono (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Array (Array Nat)) (v : VarId) (j : Nat),
+      j ∈ denseRncBGet acc v → j ∈ denseRncBGet (denseRncUseBisGo bis i acc) v := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc v j hj
+      rw [denseRncUseBisGo, dif_neg (by omega)]
+      exact hj
+  | succ n ih =>
+      intro i hn acc v j hj
+      rw [denseRncUseBisGo]
+      split
+      · next hlt => exact ih (i + 1) (by omega) _ v j (denseRncBFoldL_mono i _ acc v j hj)
+      · exact hj
+
+theorem denseRncUseBisGo_complete (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Array (Array Nat)) (j : Nat)
+      (bi : BusInteraction (DenseExpr p)), i ≤ j → bis[j]? = some bi →
+      ∀ v ∈ denseBIVars bi, j ∈ denseRncBGet (denseRncUseBisGo bis i acc) v := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j bi hij hj v hv
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j bi hij hj v hv
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      rw [denseRncUseBisGo]
+      split
+      · next hlt =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : bis[i] = bi := by
+              rw [Array.getElem?_eq_getElem hlt] at hj
+              exact Option.some.inj hj
+            refine denseRncUseBisGo_mono bis (n + 1) (i + 1) (by omega) _ v i ?_
+            rw [hc]
+            exact denseRncBFoldL_self i _ acc v hv
+          · exact ih (i + 1) (by omega) _ j bi (by omega) hj v hv
+      · omega
+
+theorem denseRncFoldCsGo_mono (cs : Array (DenseExpr p)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Std.HashSet Nat) (j : Nat), acc.contains j = true →
+      (denseRncFoldCsGo cs i acc).contains j = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j hj
+      rw [denseRncFoldCsGo, dif_neg (by omega)]
+      exact hj
+  | succ n ih =>
+      intro i hn acc j hj
+      rw [denseRncFoldCsGo]
+      split
+      · next hlt =>
+          refine ih (i + 1) (by omega) _ j ?_
+          split
+          · rw [Std.HashSet.contains_insert]; simp [hj]
+          · exact hj
+      · exact hj
+
+theorem denseRncFoldCsGo_complete (cs : Array (DenseExpr p)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Std.HashSet Nat) (j : Nat) (c : DenseExpr p),
+      i ≤ j → cs[j]? = some c → denseRncHasFold c = true →
+      (denseRncFoldCsGo cs i acc).contains j = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j c hij hj _
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j c hij hj hfd
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      rw [denseRncFoldCsGo]
+      split
+      · next hlt =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : cs[i] = c := by
+              rw [Array.getElem?_eq_getElem hlt] at hj
+              exact Option.some.inj hj
+            rw [hc, if_pos hfd]
+            refine denseRncFoldCsGo_mono cs (n + 1) (i + 1) (by omega) _ i ?_
+            rw [Std.HashSet.contains_insert]; simp
+          · exact ih (i + 1) (by omega) _ j c (by omega) hj hfd
+      · omega
+
+theorem denseRncFoldBisGo_mono (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Std.HashSet Nat) (j : Nat), acc.contains j = true →
+      (denseRncFoldBisGo bis i acc).contains j = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j hj
+      rw [denseRncFoldBisGo, dif_neg (by omega)]
+      exact hj
+  | succ n ih =>
+      intro i hn acc j hj
+      rw [denseRncFoldBisGo]
+      split
+      · next hlt =>
+          refine ih (i + 1) (by omega) _ j ?_
+          split
+          · rw [Std.HashSet.contains_insert]; simp [hj]
+          · exact hj
+      · exact hj
+
+theorem denseRncFoldBisGo_complete (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Std.HashSet Nat) (j : Nat)
+      (bi : BusInteraction (DenseExpr p)), i ≤ j → bis[j]? = some bi →
+      denseRncBiHasFold bi = true → (denseRncFoldBisGo bis i acc).contains j = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j bi hij hj _
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j bi hij hj hfd
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      rw [denseRncFoldBisGo]
+      split
+      · next hlt =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : bis[i] = bi := by
+              rw [Array.getElem?_eq_getElem hlt] at hj
+              exact Option.some.inj hj
+            rw [hc, if_pos hfd]
+            refine denseRncFoldBisGo_mono bis (n + 1) (i + 1) (by omega) _ i ?_
+            rw [Std.HashSet.contains_insert]; simp
+          · exact ih (i + 1) (by omega) _ j bi (by omega) hj hfd
+      · omega
+
+theorem denseRncOk_ensureUse {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk (denseRncEnsureUse st) ∧ (denseRncEnsureUse st).useCs.isSome = true := by
+  unfold denseRncEnsureUse
+  split
+  · next hsome => exact ⟨h, by rw [hsome]; rfl⟩
+  · refine ⟨⟨h.sizes, h.cvs, h.anchor, ⟨?_, h.use.2⟩, h.bus⟩, rfl⟩
+    intro m hm j c hj v hv
+    have hm' : m = denseRncUseGo st.cs st.cvs 0 (Array.replicate st.nVar #[]) :=
+      Option.some.inj hm.symm ▸ rfl
+    subst hm'
+    exact denseRncUseGo_complete st.cs st.cvs h.cvs st.cs.size 0 (by omega) _ j c
+      (Nat.zero_le j) hj v hv
+
+theorem denseRncOk_ensureUseBis {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk (denseRncEnsureUseBis st) ∧ (denseRncEnsureUseBis st).useBis.isSome = true := by
+  unfold denseRncEnsureUseBis
+  split
+  · next hsome => exact ⟨h, by rw [hsome]; rfl⟩
+  · refine ⟨⟨h.sizes, h.cvs, h.anchor, h.use, ⟨?_, h.bus.2⟩⟩, rfl⟩
+    intro m hm j bi hj v hv
+    have hm' : m = denseRncUseBisGo st.bis 0 (Array.replicate st.nVar #[]) :=
+      Option.some.inj hm.symm ▸ rfl
+    subst hm'
+    exact denseRncUseBisGo_complete st.bis st.bis.size 0 (by omega) _ j bi (Nat.zero_le j) hj v hv
+
+theorem denseRncOk_ensureFoldCs {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk (denseRncEnsureFoldCs st) ∧ (denseRncEnsureFoldCs st).foldCs.isSome = true := by
+  unfold denseRncEnsureFoldCs
+  split
+  · next hsome => exact ⟨h, by rw [hsome]; rfl⟩
+  · refine ⟨⟨h.sizes, h.cvs, h.anchor, ⟨h.use.1, ?_⟩, h.bus⟩, rfl⟩
+    intro sf hsf j c hj hfd
+    have hsf' : sf = denseRncFoldCsGo st.cs 0 ∅ := Option.some.inj hsf.symm ▸ rfl
+    subst hsf'
+    exact denseRncFoldCsGo_complete st.cs st.cs.size 0 (by omega) ∅ j c (Nat.zero_le j) hj hfd
+
+theorem denseRncOk_ensureFoldBis {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk (denseRncEnsureFoldBis st) ∧ (denseRncEnsureFoldBis st).foldBis.isSome = true := by
+  unfold denseRncEnsureFoldBis
+  split
+  · next hsome => exact ⟨h, by rw [hsome]; rfl⟩
+  · refine ⟨⟨h.sizes, h.cvs, h.anchor, h.use, ⟨h.bus.1, ?_⟩⟩, rfl⟩
+    intro sf hsf j bi hj hfd
+    have hsf' : sf = denseRncFoldBisGo st.bis 0 ∅ := Option.some.inj hsf.symm ▸ rfl
+    subst hsf'
+    exact denseRncFoldBisGo_complete st.bis st.bis.size 0 (by omega) ∅ j bi (Nat.zero_le j) hj hfd
+
+/-! ### The seed state
+
+`denseRncScan` mirrors `cvs` on `cs` by construction, and the anchor builder lists every position
+under its first variable. The remaining indexes start as `none`, so their invariants hold
+vacuously. -/
+
+theorem denseRncMark_size (m : Array Bool) (v : VarId) : (denseRncMark m v).size = m.size :=
+  Array.size_setIfInBounds ..
+
+theorem denseRncMark_mono {m : Array Bool} {v w : VarId} (h : denseRncGetB m v = true) :
+    denseRncGetB (denseRncMark m w) v = true := by
+  unfold denseRncGetB denseRncMark at *
+  rw [Array.getD_eq_getD_getElem?] at h ⊢
+  by_cases hvw : w.index = v.index
+  · rw [hvw, Array.getElem?_setIfInBounds_self_of_lt (by
+      by_contra hcon
+      rw [Array.getElem?_eq_none (by omega)] at h
+      exact absurd h (by simp))]
+    rfl
+  · rw [Array.getElem?_setIfInBounds_ne hvw]; exact h
+
+theorem denseRncMark_self {m : Array Bool} {v : VarId} (h : v.index < m.size) :
+    denseRncGetB (denseRncMark m v) v = true := by
+  unfold denseRncGetB denseRncMark
+  rw [Array.getD_eq_getD_getElem?, Array.getElem?_setIfInBounds_self_of_lt h]
+  rfl
+
+theorem denseRncFoldVars_size (c : DenseExpr p) :
+    ∀ (m : Array Bool), (c.foldVars (fun m v => denseRncMark m v) m).size = m.size := by
+  induction c with
+  | const n => intro m; rfl
+  | var y => intro m; exact denseRncMark_size m y
+  | add a b iha ihb | mul a b iha ihb =>
+      intro m
+      show (b.foldVars _ (a.foldVars _ m)).size = m.size
+      rw [ihb, iha]
+
+theorem denseRncFoldVars_mono (c : DenseExpr p) :
+    ∀ (m : Array Bool) (v : VarId), denseRncGetB m v = true →
+      denseRncGetB (c.foldVars (fun m w => denseRncMark m w) m) v = true := by
+  induction c with
+  | const n => intro m v h; exact h
+  | var y => intro m v h; exact denseRncMark_mono h
+  | add a b iha ihb | mul a b iha ihb =>
+      intro m v h
+      show denseRncGetB (b.foldVars _ (a.foldVars _ m)) v = true
+      exact ihb _ v (iha _ v h)
+
+theorem denseRncFoldVars_mark (c : DenseExpr p) :
+    ∀ (m : Array Bool) (v : VarId), v ∈ c.vars → v.index < m.size →
+      denseRncGetB (c.foldVars (fun m w => denseRncMark m w) m) v = true := by
+  induction c with
+  | const n => intro m v hv; simp [DenseExpr.vars] at hv
+  | var y =>
+      intro m v hv hlt
+      have : v = y := by simpa [DenseExpr.vars] using hv
+      subst this
+      exact denseRncMark_self hlt
+  | add a b iha ihb | mul a b iha ihb =>
+      intro m v hv hlt
+      show denseRncGetB (b.foldVars _ (a.foldVars _ m)) v = true
+      rcases List.mem_append.1 (by simpa [DenseExpr.vars] using hv) with h | h
+      · exact denseRncFoldVars_mono b _ v (iha _ v h hlt)
+      · exact ihb _ v h (by rw [denseRncFoldVars_size a m]; exact hlt)
+
+theorem denseRncSeenCsGo_size (cs : Array (DenseExpr p)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Array Bool),
+      (denseRncSeenCsGo cs i acc).size = acc.size := by
+  intro n
+  induction n with
+  | zero => intro i hn acc; rw [denseRncSeenCsGo, dif_neg (by omega)]
+  | succ n ih =>
+      intro i hn acc
+      rw [denseRncSeenCsGo]
+      split
+      · next hlt => rw [ih (i + 1) (by omega), denseRncFoldVars_size]
+      · rfl
+
+theorem denseRncSeenCsGo_mono (cs : Array (DenseExpr p)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Array Bool) (v : VarId), denseRncGetB acc v = true →
+      denseRncGetB (denseRncSeenCsGo cs i acc) v = true := by
+  intro n
+  induction n with
+  | zero => intro i hn acc v h; rw [denseRncSeenCsGo, dif_neg (by omega)]; exact h
+  | succ n ih =>
+      intro i hn acc v h
+      rw [denseRncSeenCsGo]
+      split
+      · next hlt => exact ih (i + 1) (by omega) _ v (denseRncFoldVars_mono _ acc v h)
+      · exact h
+
+theorem denseRncSeenCsGo_mark (cs : Array (DenseExpr p)) :
+    ∀ (n i : Nat), cs.size - i ≤ n → ∀ (acc : Array Bool) (j : Nat) (c : DenseExpr p),
+      i ≤ j → cs[j]? = some c → ∀ v ∈ c.vars, v.index < acc.size →
+      denseRncGetB (denseRncSeenCsGo cs i acc) v = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j c hij hj v hv _
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j c hij hj v hv hlt
+      have hjlt : j < cs.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      rw [denseRncSeenCsGo]
+      split
+      · next hltc =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : cs[i] = c := by
+              rw [Array.getElem?_eq_getElem hltc] at hj
+              exact Option.some.inj hj
+            refine denseRncSeenCsGo_mono cs (n + 1) (i + 1) (by omega) _ v ?_
+            rw [hc]
+            exact denseRncFoldVars_mark c acc v hv hlt
+          · refine ih (i + 1) (by omega) _ j c (by omega) hj v hv ?_
+            rw [denseRncFoldVars_size]
+            exact hlt
+      · omega
+
+theorem denseRncSeenBisGo_mono (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Array Bool) (v : VarId), denseRncGetB acc v = true →
+      denseRncGetB (denseRncSeenBisGo bis i acc) v = true := by
+  intro n
+  induction n with
+  | zero => intro i hn acc v h; rw [denseRncSeenBisGo, dif_neg (by omega)]; exact h
+  | succ n ih =>
+      intro i hn acc v h
+      rw [denseRncSeenBisGo]
+      split
+      · next hlt =>
+          refine ih (i + 1) (by omega) _ v ?_
+          have hstep : ∀ (l : List (DenseExpr p)) (m : Array Bool), denseRncGetB m v = true →
+              denseRncGetB (l.foldl (fun m e => e.foldVars (fun m w => denseRncMark m w) m) m) v
+                = true := by
+            intro l
+            induction l with
+            | nil => intro m hm; exact hm
+            | cons e rest ihl => intro m hm; exact ihl _ (denseRncFoldVars_mono e m v hm)
+          exact hstep _ _ (denseRncFoldVars_mono _ acc v h)
+      · exact h
+
+/-- Every variable of the system is either an entry variable (bucketed by index) or a minted bit. -/
+def DenseRncNVarOk (st : DenseRncState p) : Prop :=
+  ∀ v ∈ (denseRncView st).occ, v.index < st.nVar ∨ st.minted.contains v = true
+
+theorem denseRncPayloadFold_mark (l : List (DenseExpr p)) :
+    ∀ (m : Array Bool) (v : VarId) (e : DenseExpr p), e ∈ l → v ∈ e.vars → v.index < m.size →
+      denseRncGetB (l.foldl (fun m e => e.foldVars (fun m w => denseRncMark m w) m) m) v = true := by
+  induction l with
+  | nil => intro m v e he; simp at he
+  | cons e0 rest ih =>
+      intro m v e he hv hlt
+      have hstep : ∀ (l' : List (DenseExpr p)) (m' : Array Bool), denseRncGetB m' v = true →
+          denseRncGetB (l'.foldl (fun m e => e.foldVars (fun m w => denseRncMark m w) m) m') v
+            = true := by
+        intro l'
+        induction l' with
+        | nil => intro m' hm'; exact hm'
+        | cons e1 rest1 ihl => intro m' hm'; exact ihl _ (denseRncFoldVars_mono e1 m' v hm')
+      rcases List.mem_cons.1 he with rfl | he'
+      · exact hstep rest _ (denseRncFoldVars_mark e m v hv hlt)
+      · exact ih _ v e he' hv (by rw [denseRncFoldVars_size]; exact hlt)
+
+theorem denseRncSeenBisGo_mark (bis : Array (BusInteraction (DenseExpr p))) :
+    ∀ (n i : Nat), bis.size - i ≤ n → ∀ (acc : Array Bool) (j : Nat)
+      (bi : BusInteraction (DenseExpr p)), i ≤ j → bis[j]? = some bi →
+      ∀ v ∈ denseBIVars bi, v.index < acc.size →
+      denseRncGetB (denseRncSeenBisGo bis i acc) v = true := by
+  intro n
+  induction n with
+  | zero =>
+      intro i hn acc j bi hij hj v hv _
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      omega
+  | succ n ih =>
+      intro i hn acc j bi hij hj v hv hlt
+      have hjlt : j < bis.size := by
+        by_contra hcon
+        rw [Array.getElem?_eq_none (by omega)] at hj
+        exact absurd hj (by simp)
+      have hsz : ∀ (l' : List (DenseExpr p)) (m' : Array Bool),
+          (l'.foldl (fun m e => e.foldVars (fun m w => denseRncMark m w) m) m').size = m'.size := by
+        intro l'
+        induction l' with
+        | nil => intro m'; rfl
+        | cons e1 rest1 ihl => intro m'; rw [List.foldl_cons, ihl, denseRncFoldVars_size]
+      rw [denseRncSeenBisGo]
+      split
+      · next hltb =>
+          by_cases heq : i = j
+          · subst heq
+            have hc : bis[i] = bi := by
+              rw [Array.getElem?_eq_getElem hltb] at hj
+              exact Option.some.inj hj
+            refine denseRncSeenBisGo_mono bis (n + 1) (i + 1) (by omega) _ v ?_
+            rw [hc]
+            rw [denseBIVars, List.mem_append] at hv
+            rcases hv with h | h
+            · have hstep : ∀ (l' : List (DenseExpr p)) (m' : Array Bool),
+                  denseRncGetB m' v = true →
+                  denseRncGetB (l'.foldl
+                    (fun m e => e.foldVars (fun m w => denseRncMark m w) m) m') v = true := by
+                intro l'
+                induction l' with
+                | nil => intro m' hm'; exact hm'
+                | cons e1 rest1 ihl => intro m' hm'; exact ihl _ (denseRncFoldVars_mono e1 m' v hm')
+              exact hstep _ _ (denseRncFoldVars_mark bi.multiplicity acc v h hlt)
+            · obtain ⟨e, he, hve⟩ := List.mem_flatMap.1 h
+              exact denseRncPayloadFold_mark bi.payload _ v e he hve
+                (by rw [denseRncFoldVars_size]; exact hlt)
+          · refine ih (i + 1) (by omega) _ j bi (by omega) hj v hv ?_
+            rw [hsz, denseRncFoldVars_size]
+            exact hlt
+      · omega
+
+/-- `denseRncEnsureSeen` establishes the freshness invariant. -/
+theorem denseRncVarsOk_ensureSeen {st : DenseRncState p} (hvo : DenseRncVarsOk st)
+    (hnv : DenseRncNVarOk st) : DenseRncVarsOk (denseRncEnsureSeen st) := by
+  unfold denseRncEnsureSeen
+  split
+  · exact hvo
+  · next hnone =>
+    intro v hv
+    have hview : (denseRncView { st with varSeen := some (denseRncSeenBisGo st.bis 0
+        (denseRncSeenCsGo st.cs 0 (Array.replicate st.nVar false))) }) = denseRncView st := rfl
+    rw [hview] at hv
+    rcases hnv v hv with hlt | hmint
+    · refine Bool.or_eq_true_iff.2 (Or.inl ?_)
+      show denseRncGetB (denseRncSeenBisGo st.bis 0
+        (denseRncSeenCsGo st.cs 0 (Array.replicate st.nVar false))) v = true
+      have hszcs : (denseRncSeenCsGo st.cs 0 (Array.replicate st.nVar false)).size = st.nVar := by
+        rw [denseRncSeenCsGo_size st.cs st.cs.size 0 (by omega), Array.size_replicate]
+      rw [DenseConstraintSystem.occ, List.mem_append] at hv
+      rcases hv with hc | hb
+      · obtain ⟨c, hcmem, hvc⟩ := List.mem_flatMap.1 hc
+        have hcs : c ∈ st.cs := by
+          have hmem : c ∈ (st.cs.filter (fun c => !denseIsZero c)) := by
+            rw [Array.mem_def]
+            simpa [denseRncView] using hcmem
+          exact Array.mem_of_mem_filter hmem
+        obtain ⟨jc, hjc⟩ := Array.mem_iff_getElem?.1 hcs
+        refine denseRncSeenBisGo_mono st.bis st.bis.size 0 (by omega) _ v ?_
+        exact denseRncSeenCsGo_mark st.cs st.cs.size 0 (by omega) _ jc c (Nat.zero_le jc) hjc v hvc
+          (by rw [Array.size_replicate]; exact hlt)
+      · obtain ⟨bi, hbimem, hvb⟩ := List.mem_flatMap.1 hb
+        have hbis : bi ∈ st.bis := by
+          rw [Array.mem_def]
+          simpa [denseRncView] using hbimem
+        obtain ⟨jb, hjb⟩ := Array.mem_iff_getElem?.1 hbis
+        exact denseRncSeenBisGo_mark st.bis st.bis.size 0 (by omega) _ jb bi (Nat.zero_le jb) hjb
+          v hvb (by rw [hszcs]; exact hlt)
+    · exact Bool.or_eq_true_iff.2 (Or.inr hmint)
+
+theorem denseRncScanFold (l : List (DenseExpr p)) :
+    ∀ (a : Array (Array VarId)) (n : Nat),
+      (l.foldl (fun (acc : Array (Array VarId) × Nat) c =>
+        (acc.1.push (denseRncCapVars c), if denseIsZero c then acc.2 else acc.2 + 1)) (a, n)).1
+        = a ++ (l.map denseRncCapVars).toArray := by
+  induction l with
+  | nil => intro a n; simp
+  | cons c rest ih =>
+      intro a n
+      rw [List.foldl_cons, ih, List.map_cons]
+      show a.push (denseRncCapVars c) ++ _ = _
+      simp
+
+theorem denseRncScan_cvs (cs : Array (DenseExpr p)) :
+    (denseRncScan cs).1 = (cs.toList.map denseRncCapVars).toArray := by
+  unfold denseRncScan
+  conv_lhs => rw [← Array.toArray_toList (xs := cs)]
+  rw [List.foldl_toArray, denseRncScanFold]
+  simp
+
+theorem denseRncScan_cvsOk (cs : Array (DenseExpr p)) :
+    (∀ (i : Nat) (c : DenseExpr p), cs[i]? = some c →
+      ((denseRncScan cs).1)[i]? = some (denseRncCapVars c)) ∧
+    (denseRncScan cs).1.size = cs.size := by
+  rw [denseRncScan_cvs]
+  refine ⟨fun i c hi => ?_, by simp⟩
+  rw [← Array.getElem?_toList, List.toList_toArray, List.getElem?_map, Array.getElem?_toList, hi]
+  rfl
+
+theorem denseRncAnchorFold_complete :
+    ∀ (l : List (DenseExpr p × Nat)) (c : DenseExpr p) (i : Nat), (c, i) ∈ l →
+      ∀ v ∈ denseRncAnchorVars c,
+        i ∈ (l.foldr (fun ai idx => denseRncAnchorAdd idx (denseRncAnchorVars ai.1) ai.2)
+          ⟨∅, []⟩).buckets.getD v [] := by
+  intro l
+  induction l with
+  | nil => intro c i hi; simp at hi
+  | cons ai rest ih =>
+      intro c i hi v hv
+      rw [List.foldr_cons]
+      rcases List.mem_cons.1 hi with heq | hmem
+      · rw [← heq]
+        cases hav : denseRncAnchorVars c with
+        | nil => rw [hav] at hv; simp at hv
+        | cons w tail =>
+            have hvw : v = w := by
+              rw [hav] at hv
+              rcases List.mem_cons.1 hv with h1 | h1
+              · exact h1
+              · exact absurd h1 (by
+                  unfold denseRncAnchorVars at hav
+                  split at hav <;> simp_all)
+            subst hvw
+            exact denseRncAnchorAdd_self _ v tail i
+      · exact denseRncAnchorAdd_mono _ _ _ i v (ih c i hmem v hv)
+
+theorem denseRncAnchorBuild_complete (cs : List (DenseExpr p)) :
+    ∀ (i : Nat) (c : DenseExpr p), cs[i]? = some c →
+      ∀ v ∈ denseRncAnchorVars c, i ∈ (denseRncAnchorBuild cs).buckets.getD v [] := by
+  intro i c hi v hv
+  refine denseRncAnchorFold_complete cs.zipIdx c i ?_ v hv
+  refine List.mem_of_getElem? (i := i) ?_
+  rw [List.getElem?_zipIdx, hi]
+  simp
+
+theorem denseRncWrite_occ_sub {ctx : DenseRncCtx p} {st : DenseRncState p} {xs : List VarId}
+    {cd : DenseRncCand p} {m mB : Array (Array Nat)} {sf sfB : Std.HashSet Nat}
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p))
+    (hpatts : cd.patts.get = denseAssignments (denseBitBox cd.bits))
+    (hcvs : DenseRncCvsOk st) (huse : DenseRncUseOk st) (hbus : DenseRncBusOk st)
+    (hm : st.useCs = some m) (hs : st.foldCs = some sf)
+    (hmB : st.useBis = some mB) (hsB : st.foldBis = some sfB)
+    (hσ : ∀ y ∈ xs, ∀ v ∈ ((DenseExpr.var y).substF (denseGroupSubst xs cd.hm.get)).vars,
+      v ∈ cd.bits) :
+    ∀ v ∈ (denseRncView (denseRncWrite ctx st cd.bits (denseRncCsEdits ctx st xs cd).1
+        (denseRncBiEdits ctx st xs cd).1)).occ,
+      v ∈ (denseRncView st).occ ∨ v ∈ cd.bits := by
+  intro v hv
+  rw [denseRncWrite_view hzero hpatts hcvs huse hbus hm hs hmB hsB] at hv
+  exact denseReencodeOut_vars_subset _ xs cd.bits cd.hm.get hσ v
+    (denseFilterConstraints_occ_sub _ _ v hv)
+
+/-! ### The bits' derivations
+
+The engine reads each group variable's image at a pattern from the shared table; `denseBitCM`
+re-evaluates the interpolation polynomial per (bit, pattern, variable). Same tree. -/
+
+theorem denseRncMatchCM_eq (img : Array (ZMod p)) (imgFn : VarId → ZMod p)
+    (thenM elseM : DenseComputationMethod p) :
+    ∀ (ys : List VarId) (j : Nat),
+      (∀ (k : Nat) (y : VarId), ys[k]? = some y → img.getD (j + k) (zmodZeroP p) = imgFn y) →
+      denseRncMatchCM img thenM elseM ys j = denseMatchCM ys imgFn thenM elseM := by
+  intro ys
+  induction ys with
+  | nil => intro j _; rfl
+  | cons y rest ih =>
+      intro j hval
+      have hy : img.getD j (zmodZeroP p) = imgFn y := by
+        have h0 := hval 0 y rfl
+        simpa using h0
+      rw [denseRncMatchCM, denseMatchCM, hy, zmodNegP_eq,
+        ih (j + 1) (fun k z hz => by
+          have h1 := hval (k + 1) z (by simpa using hz)
+          rw [show j + 1 + k = j + (k + 1) by omega]
+          exact h1)]
+
+theorem denseRncBitCM_eq {ctx : DenseRncCtx p} {cd : DenseRncCand p} {xs : List VarId} {b : VarId}
+    (hzero : ctx.ops.zero = (0 : ZMod p))
+    (himgs : cd.imgs.get = cd.pattsA.get.map (fun aβ =>
+      (xs.toArray).map (fun x => ((cd.hm.get[x]?).getD (.var x)).evalFast (denseEnvOfFast aβ)))) :
+    ∀ (n t : Nat), cd.pattsA.get.size - t ≤ n → denseRncBitCMGo ctx cd xs b t
+      = denseBitCM (cd.pattsA.get.toList.drop t) xs cd.hm.get b := by
+  intro n
+  induction n with
+  | zero =>
+      intro t hn
+      rw [denseRncBitCMGo, dif_neg (by omega),
+        List.drop_eq_nil_of_le (by rw [Array.length_toList]; omega), denseBitCM, hzero]
+  | succ n ih =>
+      intro t hn
+      rw [denseRncBitCMGo]
+      split
+      · next hlt =>
+          have hlt' : t < cd.pattsA.get.toList.length := by
+            rw [Array.length_toList]
+            exact hlt
+          rw [List.drop_eq_getElem_cons hlt', denseBitCM, ih (t + 1) (by omega)]
+          have hpt : cd.pattsA.get.toList[t] = cd.pattsA.get[t] := Array.getElem_toList ..
+          rw [hpt]
+          have hrow : cd.imgs.get.getD t #[]
+              = (xs.toArray).map (fun x =>
+                  ((cd.hm.get[x]?).getD (.var x)).evalFast (denseEnvOfFast cd.pattsA.get[t])) := by
+            rw [himgs, Array.getD_eq_getD_getElem?, Array.getElem?_map,
+              Array.getElem?_eq_getElem hlt]
+            rfl
+          rw [hrow]
+          refine denseRncMatchCM_eq _ _ _ _ xs 0 (fun k y hk => ?_)
+          have hklt : k < xs.length := by
+            by_contra hcon
+            rw [List.getElem?_eq_none (by omega)] at hk
+            exact absurd hk (by simp)
+          rw [Array.getD_eq_getD_getElem?, Array.getElem?_map,
+            Array.getElem?_eq_getElem (by simpa using hklt)]
+          have hxk : (xs.toArray)[k] = y := by
+            have hg : xs[k]? = some xs[k] := List.getElem?_eq_getElem hklt
+            rw [hg] at hk
+            have hy : xs[k] = y := Option.some.inj hk
+            simpa using hy
+          simp only [Nat.zero_add, hxk, denseImgVal, DenseExpr.substF]
+          have hσ : denseGroupSubst xs cd.hm.get y = cd.hm.get[y]? := by
+            unfold denseGroupSubst
+            rw [if_pos (denseContainsFast_of_mem xs y (by
+              rw [← hxk]; exact List.getElem_mem (by simpa using hklt)))]
+          rw [hσ]
+          simp only [Option.map_some, Option.getD_some]
+          cases cd.hm.get[y]? <;> rfl
+      · next hge =>
+          rw [List.drop_eq_nil_of_le (by rw [Array.length_toList]; omega), denseBitCM, hzero]
+
+/-! ### States that differ only in the domain memo
+
+The build touches the memo, never the system; the `ensure*` helpers build one index each. -/
+
+structure DenseRncCore (st st' : DenseRncState p) : Prop where
+  cs : st'.cs = st.cs
+  cvs : st'.cvs = st.cvs
+  bis : st'.bis = st.bis
+  anchor : st'.anchor = st.anchor
+  useCs : st'.useCs = st.useCs
+  useBis : st'.useBis = st.useBis
+  foldCs : st'.foldCs = st.foldCs
+  foldBis : st'.foldBis = st.foldBis
+  varSeen : st'.varSeen = st.varSeen
+  minted : st'.minted = st.minted
+  nVar : st'.nVar = st.nVar
+
+theorem DenseRncCore.refl (st : DenseRncState p) : DenseRncCore st st :=
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem DenseRncCore.trans {st st' st'' : DenseRncState p} (h1 : DenseRncCore st st')
+    (h2 : DenseRncCore st' st'') : DenseRncCore st st'' :=
+  ⟨h2.cs.trans h1.cs, h2.cvs.trans h1.cvs, h2.bis.trans h1.bis, h2.anchor.trans h1.anchor,
+   h2.useCs.trans h1.useCs, h2.useBis.trans h1.useBis, h2.foldCs.trans h1.foldCs,
+   h2.foldBis.trans h1.foldBis, h2.varSeen.trans h1.varSeen, h2.minted.trans h1.minted,
+   h2.nVar.trans h1.nVar⟩
+
+theorem DenseRncCore.view {st st' : DenseRncState p} (h : DenseRncCore st st') :
+    denseRncView st' = denseRncView st := by
+  unfold denseRncView; rw [h.cs, h.bis]
+
+theorem DenseRncCore.ok {st st' : DenseRncState p} (h : DenseRncCore st st') (hok : DenseRncOk st) :
+    DenseRncOk st' := by
+  refine ⟨?_, ?_, ?_, ⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
+  · rw [h.cvs, h.cs]; exact hok.sizes
+  · intro i c hi; rw [h.cvs]; rw [h.cs] at hi; exact hok.cvs i c hi
+  · intro i c hi v hv; rw [h.anchor]; rw [h.cs] at hi; exact hok.anchor i c hi v hv
+  · intro m hm i c hi v hv
+    rw [h.useCs] at hm; rw [h.cs] at hi
+    exact hok.use.1 m hm i c hi v hv
+  · intro sf hsf i c hi hfd
+    rw [h.foldCs] at hsf; rw [h.cs] at hi
+    exact hok.use.2 sf hsf i c hi hfd
+  · intro m hm i bi hi v hv
+    rw [h.useBis] at hm; rw [h.bis] at hi
+    exact hok.bus.1 m hm i bi hi v hv
+  · intro sf hsf i bi hi hfd
+    rw [h.foldBis] at hsf; rw [h.bis] at hi
+    exact hok.bus.2 sf hsf i bi hi hfd
+
+/-- The weaker relation the `ensure*` helpers satisfy: they build indexes, but the system, the
+    freshness data and the index-array size are untouched. -/
+structure DenseRncSysSame (st st' : DenseRncState p) : Prop where
+  cs : st'.cs = st.cs
+  bis : st'.bis = st.bis
+  anchor : st'.anchor = st.anchor
+  varSeen : st'.varSeen = st.varSeen
+  minted : st'.minted = st.minted
+  nVar : st'.nVar = st.nVar
+
+theorem DenseRncCore.sysSame {st st' : DenseRncState p} (h : DenseRncCore st st') :
+    DenseRncSysSame st st' := ⟨h.cs, h.bis, h.anchor, h.varSeen, h.minted, h.nVar⟩
+
+theorem DenseRncSysSame.view {st st' : DenseRncState p} (h : DenseRncSysSame st st') :
+    denseRncView st' = denseRncView st := by unfold denseRncView; rw [h.cs, h.bis]
+
+theorem DenseRncSysSame.varsOk {st st' : DenseRncState p} (h : DenseRncSysSame st st')
+    (hv : DenseRncVarsOk st) : DenseRncVarsOk st' := by
+  intro v hvm
+  show ((match st'.varSeen with | some m => denseRncGetB m v | none => true)
+    || st'.minted.contains v) = true
+  rw [h.varSeen, h.minted]
+  exact hv v (by rwa [h.view] at hvm)
+
+theorem DenseRncSysSame.nVarOk {st st' : DenseRncState p} (h : DenseRncSysSame st st')
+    (hn : DenseRncNVarOk st) : DenseRncNVarOk st' := by
+  intro v hvm
+  rw [h.minted, h.nVar]
+  exact hn v (by rwa [h.view] at hvm)
+
+theorem denseRncCore_setDom (st : DenseRncState p) (v : VarId)
+    (r : Option (Nat × List (ZMod p))) : DenseRncCore st (st.setDom v r) :=
+  ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+/-- The bundle of facts the step threads about a state that only had indexes built. -/
+structure DenseRncFacts (st0 st : DenseRncState p) : Prop where
+  view : denseRncView st = denseRncView st0
+  ok : DenseRncOk st
+  vo : DenseRncVarsOk st
+  nv : DenseRncNVarOk st
+
+theorem denseRncCore_domOf (ops : DenseZModOps p) (st : DenseRncState p) (v : VarId) :
+    DenseRncCore st (denseRncDomOf ops st v).2 := by
+  unfold denseRncDomOf
+  split
+  · exact DenseRncCore.refl st
+  · exact denseRncCore_setDom st v _
+
+theorem denseRncCore_doms (ops : DenseZModOps p) :
+    ∀ (ys : List VarId) (st : DenseRncState p) (acc : Array (Array (ZMod p))),
+      DenseRncCore st (denseRncDoms ops st ys acc).2 := by
+  intro ys
+  induction ys with
+  | nil => intro st acc; exact DenseRncCore.refl st
+  | cons y rest ih =>
+      intro st acc
+      rw [denseRncDoms]
+      split
+      · next ds st' hd =>
+          have h1 : DenseRncCore st st' := by
+            have hh := denseRncCore_domOf ops st y
+            rw [hd] at hh
+            exact hh
+          exact h1.trans (ih st' _)
+      · next st' hd =>
+          have hh := denseRncCore_domOf ops st y
+          rw [hd] at hh
+          exact hh
+
+theorem denseRncSysSame_ensureUse (st : DenseRncState p) :
+    DenseRncSysSame st (denseRncEnsureUse st) := by
+  unfold denseRncEnsureUse; split <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem denseRncSysSame_ensureUseBis (st : DenseRncState p) :
+    DenseRncSysSame st (denseRncEnsureUseBis st) := by
+  unfold denseRncEnsureUseBis; split <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem denseRncSysSame_ensureFoldCs (st : DenseRncState p) :
+    DenseRncSysSame st (denseRncEnsureFoldCs st) := by
+  unfold denseRncEnsureFoldCs; split <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem denseRncSysSame_ensureFoldBis (st : DenseRncState p) :
+    DenseRncSysSame st (denseRncEnsureFoldBis st) := by
+  unfold denseRncEnsureFoldBis; split <;> exact ⟨rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem denseRncSysSame_ensureSeen (st : DenseRncState p) :
+    (denseRncEnsureSeen st).cs = st.cs ∧ (denseRncEnsureSeen st).bis = st.bis ∧
+    (denseRncEnsureSeen st).anchor = st.anchor ∧ (denseRncEnsureSeen st).minted = st.minted ∧
+    (denseRncEnsureSeen st).nVar = st.nVar := by
+  unfold denseRncEnsureSeen; split <;> exact ⟨rfl, rfl, rfl, rfl, rfl⟩
+
+theorem denseRncEnsureUseBis_useCs (st : DenseRncState p) :
+    (denseRncEnsureUseBis st).useCs = st.useCs := by
+  unfold denseRncEnsureUseBis; split <;> rfl
+
+theorem denseRncEnsureFoldCs_useCs (st : DenseRncState p) :
+    (denseRncEnsureFoldCs st).useCs = st.useCs := by
+  unfold denseRncEnsureFoldCs; split <;> rfl
+
+theorem denseRncEnsureFoldCs_useBis (st : DenseRncState p) :
+    (denseRncEnsureFoldCs st).useBis = st.useBis := by
+  unfold denseRncEnsureFoldCs; split <;> rfl
+
+theorem denseRncEnsureFoldBis_useCs (st : DenseRncState p) :
+    (denseRncEnsureFoldBis st).useCs = st.useCs := by
+  unfold denseRncEnsureFoldBis; split <;> rfl
+
+theorem denseRncEnsureFoldBis_useBis (st : DenseRncState p) :
+    (denseRncEnsureFoldBis st).useBis = st.useBis := by
+  unfold denseRncEnsureFoldBis; split <;> rfl
+
+theorem denseRncEnsureFoldBis_foldCs (st : DenseRncState p) :
+    (denseRncEnsureFoldBis st).foldCs = st.foldCs := by
+  unfold denseRncEnsureFoldBis; split <;> rfl
+
+theorem denseRncEnsureSeen_useCs (st : DenseRncState p) :
+    (denseRncEnsureSeen st).useCs = st.useCs := by
+  unfold denseRncEnsureSeen; split <;> rfl
+
+theorem denseRncEnsureSeen_useBis (st : DenseRncState p) :
+    (denseRncEnsureSeen st).useBis = st.useBis := by
+  unfold denseRncEnsureSeen; split <;> rfl
+
+theorem denseRncEnsureSeen_view (st : DenseRncState p) :
+    denseRncView (denseRncEnsureSeen st) = denseRncView st := by
+  unfold denseRncView
+  obtain ⟨h1, h2, _, _, _⟩ := denseRncSysSame_ensureSeen st
+  rw [h1, h2]
+
+theorem denseRncEnsureSeen_nVarOk {st : DenseRncState p} (hn : DenseRncNVarOk st) :
+    DenseRncNVarOk (denseRncEnsureSeen st) := by
+  intro v hvm
+  obtain ⟨_, _, _, h3, h4⟩ := denseRncSysSame_ensureSeen st
+  rw [h3, h4]
+  exact hn v (by rwa [denseRncEnsureSeen_view] at hvm)
+
+theorem denseRncOk_ensureSeen {st : DenseRncState p} (h : DenseRncOk st) :
+    DenseRncOk (denseRncEnsureSeen st) := by
+  unfold denseRncEnsureSeen
+  split
+  · exact h
+  · exact ⟨h.sizes, h.cvs, h.anchor, h.use, h.bus⟩
+
+/-! ### What the candidate builder guarantees -/
+
+theorem denseRncBuild_state (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (xs : List VarId) (fb : String) :
+    (denseRncBuild ctx reg st xs fb).2.2 = (denseRncDoms ctx.ops st xs #[]).2 := by
+  unfold denseRncBuild
+  split <;> next h => rw [h]
+
+theorem denseRncBuild_core (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (xs : List VarId) (fb : String) : DenseRncCore st (denseRncBuild ctx reg st xs fb).2.2 := by
+  rw [denseRncBuild_state]
+  exact denseRncCore_doms ctx.ops xs st #[]
+
+theorem denseRncBuildCand_spec (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (planned : List (Nat × DenseExpr p)) (doms : Array (Array (ZMod p))) (xs : List VarId)
+    (fb : String) :
+    reg.Extends (denseRncBuildCand ctx reg st planned doms xs fb).1
+    ∧ (∀ i, (denseRncBuildCand ctx reg st planned doms xs fb).1.isInput i = reg.isInput i)
+    ∧ ∀ cd, (denseRncBuildCand ctx reg st planned doms xs fb).2 = some cd →
+        cd.es = planned.map Prod.snd
+        ∧ cd.patts.get = denseAssignments (denseBitBox cd.bits)
+        ∧ cd.pattsA.get = cd.patts.get.toArray
+        ∧ cd.imgs.get = cd.pattsA.get.map (fun aβ =>
+            (xs.toArray).map (fun x => ((cd.hm.get[x]?).getD (.var x)).evalFast
+              (denseEnvOfFast aβ)))
+        ∧ (∀ b ∈ cd.bits, (denseRncBuildCand ctx reg st planned doms xs fb).1.Valid b) := by
+  fun_cases denseRncBuildCand ctx reg st planned doms xs fb <;>
+    first
+      | exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, fun cd hcd => absurd hcd (by simp)⟩
+      | refine ⟨(denseRegisterBits_props reg fb _).1,
+          (denseRegisterBits_props reg fb _).2.1, fun cd hcd => ?_⟩
+  have hcd' := Option.some.inj hcd
+  subst hcd'
+  exact ⟨rfl, rfl, rfl, rfl, (denseRegisterBits_props reg fb _).2.2⟩
+
+theorem denseRncBuild_spec (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (xs : List VarId) (fb : String) :
+    reg.Extends (denseRncBuild ctx reg st xs fb).1
+    ∧ (∀ i, (denseRncBuild ctx reg st xs fb).1.isInput i = reg.isInput i)
+    ∧ ∀ cd, (denseRncBuild ctx reg st xs fb).2.1 = some cd →
+        cd.es = (denseCoveredIdxPos st.anchor st.cs xs).map Prod.snd
+        ∧ cd.patts.get = denseAssignments (denseBitBox cd.bits)
+        ∧ cd.pattsA.get = cd.patts.get.toArray
+        ∧ cd.imgs.get = cd.pattsA.get.map (fun aβ =>
+            (xs.toArray).map (fun x => ((cd.hm.get[x]?).getD (.var x)).evalFast
+              (denseEnvOfFast aβ)))
+        ∧ (∀ b ∈ cd.bits, (denseRncBuild ctx reg st xs fb).1.Valid b) := by
+  unfold denseRncBuild
+  split
+  · exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, fun cd hcd => absurd hcd (by simp)⟩
+  · next doms st' hd =>
+      obtain ⟨hext, hii, hcd⟩ := denseRncBuildCand_spec ctx reg st'
+        (denseCoveredIdxPos st.anchor st.cs xs) doms xs fb
+      exact ⟨hext, hii, hcd⟩
+
+/-! ### The write's freshness fields
+
+`varSeen` and the index-array size are untouched; `minted` gains exactly the new bits. -/
+
+theorem denseRncCsFold_varSeen (ctx : DenseRncCtx p) :
+    ∀ (es : List (DenseRncCsEdit p)) (st : DenseRncState p),
+      (es.foldl (denseRncCsStep ctx) st).varSeen = st.varSeen
+      ∧ (es.foldl (denseRncCsStep ctx) st).minted = st.minted
+      ∧ (es.foldl (denseRncCsStep ctx) st).nVar = st.nVar := by
+  intro es
+  induction es with
+  | nil => intro st; exact ⟨rfl, rfl, rfl⟩
+  | cons e rest ih =>
+      intro st
+      rw [List.foldl_cons]
+      obtain ⟨h1, h2, h3⟩ := ih (denseRncCsStep ctx st e)
+      refine ⟨h1.trans ?_, h2.trans ?_, h3.trans ?_⟩ <;> cases e <;> rfl
+
+theorem denseRncBiFold_varSeen :
+    ∀ (es : List (Nat × BusInteraction (DenseExpr p))) (st : DenseRncState p),
+      (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st).varSeen = st.varSeen
+      ∧ (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st).minted = st.minted
+      ∧ (es.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st).nVar = st.nVar := by
+  intro es
+  induction es with
+  | nil => intro st; exact ⟨rfl, rfl, rfl⟩
+  | cons e rest ih =>
+      intro st
+      rw [List.foldl_cons]
+      obtain ⟨h1, h2, h3⟩ := ih (st.rewriteBiAt e.1 e.2)
+      exact ⟨h1, h2, h3⟩
+
+theorem denseRncBoolFold_fields :
+    ∀ (bits : List VarId) (st : DenseRncState p),
+      (bits.foldl (fun st b => st.pushBool b) st).varSeen = st.varSeen
+      ∧ (bits.foldl (fun st b => st.pushBool b) st).nVar = st.nVar
+      ∧ (∀ v, st.minted.contains v = true →
+          (bits.foldl (fun st b => st.pushBool b) st).minted.contains v = true)
+      ∧ (∀ v ∈ bits, (bits.foldl (fun st b => st.pushBool b) st).minted.contains v = true) := by
+  intro bits
+  induction bits with
+  | nil => intro st; exact ⟨rfl, rfl, fun _ h => h, fun v hv => by simp at hv⟩
+  | cons b rest ih =>
+      intro st
+      rw [List.foldl_cons]
+      obtain ⟨h1, h2, h3, h4⟩ := ih (st.pushBool b)
+      refine ⟨h1, h2, ?_, ?_⟩
+      · intro v hv
+        refine h3 v ?_
+        show (st.minted.insert b).contains v = true
+        rw [Std.HashSet.contains_insert]; simp [hv]
+      · intro v hv
+        rcases List.mem_cons.1 hv with rfl | hv'
+        · refine h3 v ?_
+          show (st.minted.insert v).contains v = true
+          rw [Std.HashSet.contains_insert]; simp
+        · exact h4 v hv'
+
+theorem denseRncWrite_fields (ctx : DenseRncCtx p) (st : DenseRncState p) (bits : List VarId)
+    (csE : List (DenseRncCsEdit p)) (biE : List (Nat × BusInteraction (DenseExpr p))) :
+    (denseRncWrite ctx st bits csE biE).varSeen = st.varSeen
+    ∧ (denseRncWrite ctx st bits csE biE).nVar = st.nVar
+    ∧ (∀ v, st.minted.contains v = true →
+        (denseRncWrite ctx st bits csE biE).minted.contains v = true)
+    ∧ (∀ v ∈ bits, (denseRncWrite ctx st bits csE biE).minted.contains v = true) := by
+  obtain ⟨hc1, hc2, hc3⟩ := denseRncCsFold_varSeen ctx csE st
+  obtain ⟨hb1, hb2, hb3⟩ := denseRncBiFold_varSeen biE (csE.foldl (denseRncCsStep ctx) st)
+  obtain ⟨hp1, hp2, hp3, hp4⟩ := denseRncBoolFold_fields bits
+    (biE.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) (csE.foldl (denseRncCsStep ctx) st))
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [show ((denseRncWrite ctx st bits csE biE)).varSeen
+      = (bits.foldl (fun st b => st.pushBool b)
+          (biE.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+            (csE.foldl (denseRncCsStep ctx) st))).varSeen from rfl, hp1, hb1, hc1]
+  · rw [show ((denseRncWrite ctx st bits csE biE)).nVar
+      = (bits.foldl (fun st b => st.pushBool b)
+          (biE.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+            (csE.foldl (denseRncCsStep ctx) st))).nVar from rfl, hp2, hb3, hc3]
+  · intro v hv
+    show (bits.foldl (fun st b => st.pushBool b)
+      (biE.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+        (csE.foldl (denseRncCsStep ctx) st))).minted.contains v = true
+    refine hp3 v ?_
+    rw [hb2, hc2]
+    exact hv
+  · intro v hv
+    show (bits.foldl (fun st b => st.pushBool b)
+      (biE.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2)
+        (csE.foldl (denseRncCsStep ctx) st))).minted.contains v = true
+    exact hp4 v hv
+
+theorem denseRncWrite_seen {ctx : DenseRncCtx p} {st : DenseRncState p} {bits : List VarId}
+    {csE : List (DenseRncCsEdit p)} {biE : List (Nat × BusInteraction (DenseExpr p))} (v : VarId)
+    (h : denseRncSeen st v = true ∨ v ∈ bits) :
+    denseRncSeen (denseRncWrite ctx st bits csE biE) v = true := by
+  obtain ⟨h1, _, h3, h4⟩ := denseRncWrite_fields ctx st bits csE biE
+  unfold denseRncSeen
+  rw [h1]
+  rcases h with h | h
+  · unfold denseRncSeen at h
+    rcases Bool.or_eq_true_iff.1 h with h' | h'
+    · exact Bool.or_eq_true_iff.2 (Or.inl h')
+    · exact Bool.or_eq_true_iff.2 (Or.inr (h3 v h'))
+  · exact Bool.or_eq_true_iff.2 (Or.inr (h4 v h))
+
+/-! ### The step
+
+Everything the accept branch needs is in place: the certificate gives the audited
+`denseCheckReencode` on the view, the write gives `denseReencodeOut` of that view, and the
+derivations are `denseBitCM`'s. The reject branches only ever build indexes. -/
+
+/-- The step's post-condition: the pass-level obligations plus the threaded invariants. -/
+def DenseRncPost (bs : BusSemantics p) (reg : VarRegistry) (st : DenseRncState p)
+    (r : VarRegistry × DenseRncState p × DenseDerivations p) : Prop :=
+  reg.Extends r.1 ∧ (∀ i, r.1.isInput i = reg.isInput i)
+  ∧ (denseRncView r.2.1).CoveredBy r.1
+  ∧ DenseDerivations.CoveredBy r.1 r.2.2
+  ∧ DensePassCorrect r.1.isInput (denseRncView st) (denseRncView r.2.1) r.2.2 bs
+  ∧ DenseRncOk r.2.1 ∧ DenseRncVarsOk r.2.1 ∧ DenseRncNVarOk r.2.1
+
+theorem denseRncPost_reject {bs : BusSemantics p} {reg reg' : VarRegistry}
+    {st st' : DenseRncState p} (hext : reg.Extends reg')
+    (hii : ∀ i, reg'.isInput i = reg.isInput i) (hview : denseRncView st' = denseRncView st)
+    (hcov : (denseRncView st).CoveredBy reg) (hok : DenseRncOk st') (hvo : DenseRncVarsOk st')
+    (hnv : DenseRncNVarOk st') : DenseRncPost bs reg st (reg', st', []) := by
+  refine ⟨hext, hii, ?_, (by intro x hx; cases hx), ?_, hok, hvo, hnv⟩
+  · rw [hview]; exact csCoveredBy_mono hext hcov
+  · rw [hview]; exact DensePassCorrect.refl reg'.isInput (denseRncView st) bs
+
+/-- The name guard only builds `varSeen`. -/
+theorem denseRncNameTaken_props (reg : VarRegistry) (st : DenseRncState p) (fb : String)
+    (hok : DenseRncOk st) (hvo : DenseRncVarsOk st) (hnv : DenseRncNVarOk st) :
+    denseRncView (denseRncNameTaken reg st fb).2 = denseRncView st
+    ∧ DenseRncOk (denseRncNameTaken reg st fb).2
+    ∧ DenseRncVarsOk (denseRncNameTaken reg st fb).2
+    ∧ DenseRncNVarOk (denseRncNameTaken reg st fb).2 := by
+  unfold denseRncNameTaken
+  split
+  · exact ⟨denseRncEnsureSeen_view st, denseRncOk_ensureSeen hok,
+      denseRncVarsOk_ensureSeen hvo hnv, denseRncEnsureSeen_nVarOk hnv⟩
+  · exact ⟨rfl, hok, hvo, hnv⟩
+
+theorem denseRncFacts_nameTaken {st0 st : DenseRncState p} (reg : VarRegistry) (fb : String)
+    (h : DenseRncFacts st0 st) : DenseRncFacts st0 (denseRncNameTaken reg st fb).2 := by
+  obtain ⟨hv1, hok1, hvo1, hnv1⟩ := denseRncNameTaken_props reg st fb h.ok h.vo h.nv
+  exact ⟨hv1.trans h.view, hok1, hvo1, hnv1⟩
+
+theorem denseRncFacts_build {st0 st : DenseRncState p} (ctx : DenseRncCtx p) (reg : VarRegistry)
+    (xs : List VarId) (fb : String) (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncBuild ctx reg st xs fb).2.2 :=
+  let hc := denseRncBuild_core ctx reg st xs fb
+  ⟨hc.view.trans h.view, hc.ok h.ok, hc.sysSame.varsOk h.vo, hc.sysSame.nVarOk h.nv⟩
+
+theorem denseRncFacts_ensureUse {st0 st : DenseRncState p} (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncEnsureUse st) :=
+  let hs := denseRncSysSame_ensureUse st
+  ⟨hs.view.trans h.view, (denseRncOk_ensureUse h.ok).1, hs.varsOk h.vo, hs.nVarOk h.nv⟩
+
+theorem denseRncFacts_ensureUseBis {st0 st : DenseRncState p} (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncEnsureUseBis st) :=
+  let hs := denseRncSysSame_ensureUseBis st
+  ⟨hs.view.trans h.view, (denseRncOk_ensureUseBis h.ok).1, hs.varsOk h.vo, hs.nVarOk h.nv⟩
+
+theorem denseRncFacts_ensureFoldCs {st0 st : DenseRncState p} (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncEnsureFoldCs st) :=
+  let hs := denseRncSysSame_ensureFoldCs st
+  ⟨hs.view.trans h.view, (denseRncOk_ensureFoldCs h.ok).1, hs.varsOk h.vo, hs.nVarOk h.nv⟩
+
+theorem denseRncFacts_ensureFoldBis {st0 st : DenseRncState p} (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncEnsureFoldBis st) :=
+  let hs := denseRncSysSame_ensureFoldBis st
+  ⟨hs.view.trans h.view, (denseRncOk_ensureFoldBis h.ok).1, hs.varsOk h.vo, hs.nVarOk h.nv⟩
+
+theorem denseRncFacts_ensureSeen {st0 st : DenseRncState p} (h : DenseRncFacts st0 st) :
+    DenseRncFacts st0 (denseRncEnsureSeen st) :=
+  ⟨(denseRncEnsureSeen_view st).trans h.view, denseRncOk_ensureSeen h.ok,
+   denseRncVarsOk_ensureSeen h.vo h.nv, denseRncEnsureSeen_nVarOk h.nv⟩
+
+set_option maxHeartbeats 4000000 in
+theorem denseRncStep_correct [Fact p.Prime] (ctx : DenseRncCtx p) (reg : VarRegistry)
+    (st : DenseRncState p) (xs : List VarId) (freshBase : String) (bs : BusSemantics p)
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p)) (hopz : ctx.ops.zero = (0 : ZMod p))
+    (hcov : (denseRncView st).CoveredBy reg) (hok : DenseRncOk st) (hvo : DenseRncVarsOk st)
+    (hnv : DenseRncNVarOk st) :
+    DenseRncPost bs reg st (denseRncStep ctx reg st xs freshBase) := by
+  have hF0 : DenseRncFacts st st := ⟨rfl, hok, hvo, hnv⟩
+  set st1 := (denseRncNameTaken reg st freshBase).2 with hst1def
+  have hF1 : DenseRncFacts st st1 := denseRncFacts_nameTaken reg freshBase hF0
+  set rB := denseRncBuild ctx reg st1 xs freshBase with hrB
+  obtain ⟨hbext, hbii, hbcd⟩ := denseRncBuild_spec ctx reg st1 xs freshBase
+  have hFb : DenseRncFacts st rB.2.2 := denseRncFacts_build ctx reg xs freshBase hF1
+  have hF3 : DenseRncFacts st (denseRncEnsureUseBis (denseRncEnsureUse rB.2.2)) :=
+    denseRncFacts_ensureUseBis (denseRncFacts_ensureUse hFb)
+  have hF4 : DenseRncFacts st
+      (denseRncEnsureSeen (denseRncEnsureUseBis (denseRncEnsureUse rB.2.2))) :=
+    denseRncFacts_ensureSeen hF3
+  have hF5 : DenseRncFacts st (denseRncEnsureFoldBis (denseRncEnsureFoldCs
+      (denseRncEnsureSeen (denseRncEnsureUseBis (denseRncEnsureUse rB.2.2))))) :=
+    denseRncFacts_ensureFoldBis (denseRncFacts_ensureFoldCs hF4)
+  fun_cases denseRncStep ctx reg st xs freshBase <;>
+    first
+      | exact denseRncPost_reject (VarRegistry.Extends.refl reg) (fun _ => rfl) rfl hcov hok hvo hnv
+      | exact denseRncPost_reject (VarRegistry.Extends.refl reg) (fun _ => rfl) hF1.view hcov
+          hF1.ok hF1.vo hF1.nv
+      | exact denseRncPost_reject hbext hbii hFb.view hcov hFb.ok hFb.vo hFb.nv
+      | exact denseRncPost_reject hbext hbii hF3.view hcov hF3.ok hF3.vo hF3.nv
+      | exact denseRncPost_reject hbext hbii hF4.view hcov hF4.ok hF4.vo hF4.nv
+      | exact denseRncPost_reject hbext hbii hF5.view hcov hF5.ok hF5.vo hF5.nv
+      | skip
+  -- the accept
+  case case11 =>
+    rename_i cd hcd _ _ _ _ _ _ _ hcertN _ _ _ _ _
+    set st3 := denseRncEnsureUseBis (denseRncEnsureUse rB.2.2) with hst3
+    set st4 := denseRncEnsureSeen st3 with hst4
+    set st0 := denseRncEnsureFoldBis (denseRncEnsureFoldCs st4) with hst0
+    obtain ⟨hes, hpatts, hpattsA, himgs, hbval⟩ := hbcd cd hcd
+    have hcert : denseRncCert st4 xs cd = true := by simpa using hcertN
+    have hUse : st0.useCs.isSome = true := by
+      rw [hst0, denseRncEnsureFoldBis_useCs, denseRncEnsureFoldCs_useCs, hst4,
+        denseRncEnsureSeen_useCs, hst3, denseRncEnsureUseBis_useCs]
+      exact (denseRncOk_ensureUse hFb.ok).2
+    have hUseB : st0.useBis.isSome = true := by
+      rw [hst0, denseRncEnsureFoldBis_useBis, denseRncEnsureFoldCs_useBis, hst4,
+        denseRncEnsureSeen_useBis]
+      exact (denseRncOk_ensureUseBis (denseRncOk_ensureUse hFb.ok).1).2
+    have hFold : st0.foldCs.isSome = true := by
+      rw [hst0, denseRncEnsureFoldBis_foldCs]
+      exact (denseRncOk_ensureFoldCs (denseRncOk_ensureSeen hF3.ok)).2
+    have hFoldB : st0.foldBis.isSome = true :=
+      (denseRncOk_ensureFoldBis (denseRncOk_ensureFoldCs (denseRncOk_ensureSeen hF3.ok)).1).2
+    obtain ⟨m, hm⟩ := Option.isSome_iff_exists.1 hUse
+    obtain ⟨mB, hmB⟩ := Option.isSome_iff_exists.1 hUseB
+    obtain ⟨sf, hsf⟩ := Option.isSome_iff_exists.1 hFold
+    obtain ⟨sfB, hsfB⟩ := Option.isSome_iff_exists.1 hFoldB
+    have hanchor : st0.anchor = st1.anchor := by
+      rw [hst0, (denseRncSysSame_ensureFoldBis _).anchor, (denseRncSysSame_ensureFoldCs _).anchor,
+        hst4, (denseRncSysSame_ensureSeen st3).2.2.1, hst3,
+        (denseRncSysSame_ensureUseBis _).anchor, (denseRncSysSame_ensureUse _).anchor,
+        (denseRncBuild_core ctx reg st1 xs freshBase).anchor]
+    have hcs : st0.cs = st1.cs := by
+      rw [hst0, (denseRncSysSame_ensureFoldBis _).cs, (denseRncSysSame_ensureFoldCs _).cs,
+        hst4, (denseRncSysSame_ensureSeen st3).1, hst3,
+        (denseRncSysSame_ensureUseBis _).cs, (denseRncSysSame_ensureUse _).cs,
+        (denseRncBuild_core ctx reg st1 xs freshBase).cs]
+    have hcert0 : denseRncCert st0 xs cd = true := by
+      rw [denseRncCert, Bool.and_eq_true]
+      rw [denseRncCert, Bool.and_eq_true] at hcert
+      refine ⟨?_, hcert.2⟩
+      refine List.all_eq_true.2 (fun b hb => ?_)
+      have h4 := List.all_eq_true.mp hcert.1 b hb
+      show (!denseRncSeen st0 b) = true
+      have hseen : denseRncSeen st0 b = denseRncSeen st4 b := by
+        unfold denseRncSeen
+        rw [hst0, (denseRncSysSame_ensureFoldBis _).varSeen,
+          (denseRncSysSame_ensureFoldCs _).varSeen, (denseRncSysSame_ensureFoldBis _).minted,
+          (denseRncSysSame_ensureFoldCs _).minted]
+      rw [hseen]
+      exact h4
+    have hchk : denseCheckReencode (denseRncView st0) xs cd.bits cd.hm.get = true := by
+      refine denseRncCert_sound hF5.ok.anchor hF5.vo ?_ hcert0
+      rw [hes, hanchor, hcs]
+    have hview : denseRncView (denseRncWrite ctx st0 cd.bits
+        (denseRncCsEdits ctx st0 xs cd).1 (denseRncBiEdits ctx st0 xs cd).1)
+        = (denseReencodeOut (denseRncView st0) xs cd.bits cd.hm.get).filterConstraints
+            (fun c => !denseIsZero c) :=
+      denseRncWrite_view hzero hpatts hF5.ok.cvs hF5.ok.use hF5.ok.bus hm hsf hmB hsfB
+    have hpolyVars := denseCheckReencode_polyVars (denseRncView st0) xs cd.bits cd.hm.get hchk
+    have hxsInput : ∀ x ∈ xs, rB.1.isInput x = true := by
+      intro x hx
+      rw [hbii x]
+      have hg : xs.all (fun x => reg.isInput x) = true := by
+        simpa using ‹¬(!xs.all fun x => reg.isInput x) = true›
+      exact List.all_eq_true.mp hg x hx
+    have hxsOcc : ∀ x ∈ xs, x ∈ (denseRncView st0).occ :=
+      denseCheckReencode_xsOcc (denseRncView st0) xs cd.bits cd.hm.get hchk
+    have hxsBits : ∀ x ∈ xs, x ∉ cd.bits := by
+      intro x hx
+      have hg : xs.all (fun x => decide (x ∉ cd.bits)) = true := by
+        simpa using ‹¬(!xs.all fun x => decide (x ∉ cd.bits)) = true›
+      exact of_decide_eq_true (List.all_eq_true.mp hg x hx)
+    have hbnInput : ∀ b ∈ cd.bits, rB.1.isInput b = false := by
+      intro b hb
+      have hg : cd.bits.all (fun b => decide ((rB.1.resolve b).powdrId? = none)) = true := by
+        simpa using ‹¬(!cd.bits.all fun b => decide ((rB.1.resolve b).powdrId? = none)) = true›
+      have hpd : (rB.1.resolve b).powdrId? = none :=
+        of_decide_eq_true (List.all_eq_true.mp hg b hb)
+      show (rB.1.resolve b).powdrId?.isSome = false
+      rw [hpd]; rfl
+    have hcov0 : (denseRncView st0).CoveredBy reg := by rw [hF5.view]; exact hcov
+    have hcovOut := csCoveredBy_mono hbext hcov0
+    have hxsValid : ∀ x ∈ xs, rB.1.Valid x := fun x hx =>
+      hbext.valid (DenseConstraintSystem.occ_valid hcov0 x (hxsOcc x hx))
+    have hderiv : (cd.bits.map (fun b => (b, denseRncBitCMGo ctx cd xs b 0)))
+        = cd.bits.map (fun b => (b, denseBitCM (denseAssignments (denseBitBox cd.bits)) xs
+            cd.hm.get b)) := by
+      refine List.map_congr_left (fun b _ => ?_)
+      rw [denseRncBitCM_eq hopz himgs cd.pattsA.get.size 0 (by omega)]
+      rw [List.drop_zero, hpattsA, List.toList_toArray, hpatts]
+    refine ⟨hbext, hbii, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    · rw [hview]
+      exact denseFilterConstraints_coveredBy
+        (denseReencodeOut_covered rB.1 (denseRncView st0) xs cd.bits cd.hm.get hcovOut hbval
+          hpolyVars)
+    · rw [hderiv]
+      exact denseBitCM_covered rB.1 xs cd.bits cd.hm.get hxsValid hbval
+    · rw [hview, hderiv, ← hF5.view]
+      have h1 := denseCheckReencode_sound (denseRncView st0) bs rB.1.isInput xs cd.bits cd.hm.get
+        hxsInput hxsOcc hxsBits hbnInput hchk
+      have h2 := DensePassCorrect.denseFilterConstraintsEntailed
+        (denseReencodeOut (denseRncView st0) xs cd.bits cd.hm.get) bs rB.1.isInput
+        (fun c => !denseIsZero c) (fun c _ hk => denseIsZero_eval (by simpa using hk))
+      simpa using h1.andThen h2
+    · exact denseRncOk_write hzero hF5.ok (denseRncCsEdits_editOk ctx st0 xs cd)
+    · intro v hv
+      rcases denseRncWrite_occ_sub hzero hpatts hF5.ok.cvs hF5.ok.use hF5.ok.bus hm hsf hmB hsfB
+        hpolyVars v hv with h | h
+      · exact denseRncWrite_seen v (Or.inl (hF5.vo v h))
+      · exact denseRncWrite_seen v (Or.inr h)
+    · intro v hv
+      rcases denseRncWrite_occ_sub hzero hpatts hF5.ok.cvs hF5.ok.use hF5.ok.bus hm hsf hmB hsfB
+        hpolyVars v hv with h | h
+      · obtain ⟨_, h2, h3, _⟩ := denseRncWrite_fields ctx st0 cd.bits
+          (denseRncCsEdits ctx st0 xs cd).1 (denseRncBiEdits ctx st0 xs cd).1
+        rcases hF5.nv v h with h1 | h1
+        · exact Or.inl (by rw [h2]; exact h1)
+        · exact Or.inr (h3 v h1)
+      · obtain ⟨_, _, _, h4⟩ := denseRncWrite_fields ctx st0 cd.bits
+          (denseRncCsEdits ctx st0 xs cd).1 (denseRncBiEdits ctx st0 xs cd).1
+        exact Or.inr (h4 v h)
+
+/-! ### The loop -/
+
+theorem denseRncLoop_correct [Fact p.Prime] (ctx : DenseRncCtx p) (bs : BusSemantics p)
+    (hzero : ctx.zeroE = (DenseExpr.const 0 : DenseExpr p)) (hopz : ctx.ops.zero = (0 : ZMod p)) :
+    ∀ (targets : List (List VarId)) (idx : Nat) (reg : VarRegistry) (st : DenseRncState p)
+      (pre : String),
+      (denseRncView st).CoveredBy reg → DenseRncOk st → DenseRncVarsOk st → DenseRncNVarOk st →
+      DenseRncPost bs reg st (denseRncLoop ctx targets idx reg st pre) := by
+  intro targets
+  induction targets with
+  | nil =>
+      intro idx reg st pre hcov hok hvo hnv
+      exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, hcov,
+        (by intro x hx; cases hx),
+        DensePassCorrect.refl reg.isInput (denseRncView st) bs, hok, hvo, hnv⟩
+  | cons xs rest ih =>
+      intro idx reg st pre hcov hok hvo hnv
+      simp only [denseRncLoop]
+      rcases hstep : denseRncStep ctx reg st xs (pre ++ toString idx) with ⟨reg1, st1, derivs1⟩
+      have hsp := denseRncStep_correct ctx reg st xs (pre ++ toString idx) bs hzero hopz hcov hok
+        hvo hnv
+      simp only [DenseRncPost, hstep] at hsp
+      obtain ⟨hs_ext, hs_ii, hs_cov, hs_dcov, hs_correct, hs_ok, hs_vo, hs_nv⟩ := hsp
+      rcases hrec : denseRncLoop ctx rest (idx + 1) reg1 st1
+          (if derivs1.isEmpty then pre else s!"rnc{st1.live}_{st1.bisN}_") with ⟨reg2, st2, derivs2⟩
+      have hih := ih (idx + 1) reg1 st1
+        (if derivs1.isEmpty then pre else s!"rnc{st1.live}_{st1.bisN}_") hs_cov hs_ok hs_vo hs_nv
+      simp only [DenseRncPost, hrec] at hih
+      obtain ⟨hr_ext, hr_ii, hr_cov, hr_dcov, hr_correct, hr_ok, hr_vo, hr_nv⟩ := hih
+      refine ⟨hs_ext.trans hr_ext, fun i => (hr_ii i).trans (hs_ii i), hr_cov, ?_, ?_, hr_ok,
+        hr_vo, hr_nv⟩
+      · exact DenseDerivations.coveredBy_append
+          (DenseDerivations.CoveredBy.mono hr_ext hs_dcov) hr_dcov
+      · have hfe : reg2.isInput = reg1.isInput := funext hr_ii
+        have hstepcert : DensePassCorrect reg2.isInput (denseRncView st) (denseRncView st1)
+            derivs1 bs := by rw [hfe]; exact hs_correct
+        exact hstepcert.andThen hr_correct
+
+/-! ### The pass
+
+The seed's view is `d` with trivially-true constraints dropped — itself a verified step
+(`DensePassCorrect.denseFilterConstraintsEntailed`) — and its invariants come from the scan, the
+anchor builder and coverage; the lazily built indexes start as `none`, so their invariants hold
+vacuously. -/
+
+theorem denseRncRun_props [Fact p.Prime] (b : DegreeBound) (reg : VarRegistry)
+    (bs : BusSemantics p) (d : DenseConstraintSystem p) (targets : List (List VarId))
+    (hcov : d.CoveredBy reg)
+    (hcvs : ∀ (i : Nat) (c : DenseExpr p), d.algebraicConstraints.toArray[i]? = some c →
+      (denseRncScan d.algebraicConstraints.toArray).1[i]? = some (denseRncCapVars c))
+    (hsize : (denseRncScan d.algebraicConstraints.toArray).1.size
+      = d.algebraicConstraints.toArray.size) :
+    reg.Extends (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).1
+    ∧ (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).2.1.CoveredBy
+      (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).1
+    ∧ DenseDerivations.CoveredBy (denseRncRun b reg d
+        (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).1
+      (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).2.2
+    ∧ DensePassCorrect (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).1.isInput d
+      (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).2.1
+      (denseRncRun b reg d (denseRncScan d.algebraicConstraints.toArray).1
+        (denseRncScan d.algebraicConstraints.toArray).2 targets).2.2 bs := by
+  unfold denseRncRun
+  split
+  · exact ⟨VarRegistry.Extends.refl reg, hcov, (by intro x hx; cases hx),
+      DensePassCorrect.refl reg.isInput d bs⟩
+  · have hfilter : DensePassCorrect reg.isInput d (d.filterConstraints (fun c => !denseIsZero c))
+        ([] : DenseDerivations p) bs :=
+      DensePassCorrect.denseFilterConstraintsEntailed d bs _ (fun c => !denseIsZero c)
+        (fun c _ hk => denseIsZero_eval (by simpa using hk))
+    set cvs := (denseRncScan d.algebraicConstraints.toArray).1 with hcvsdef
+    set live := (denseRncScan d.algebraicConstraints.toArray).2 with hlivedef
+    set st := denseRncSeed reg.byId.size d cvs live with hst
+    have hseedCs : st.cs = d.algebraicConstraints.toArray := by rw [hst]; rfl
+    have hseedBis : st.bis = d.busInteractions.toArray := by rw [hst]; rfl
+    have hseedView : denseRncView st = d.filterConstraints (fun c => !denseIsZero c) := by
+      unfold denseRncView DenseConstraintSystem.filterConstraints
+      rw [hseedCs, hseedBis, Array.toList_filter, List.toList_toArray, List.toList_toArray]
+    have hseedCov : (denseRncView st).CoveredBy reg := by
+      rw [hseedView]; exact denseFilterConstraints_coveredBy hcov
+    have hseedOk : DenseRncOk st := by
+      refine ⟨?_, ?_, ?_, ⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
+      · rw [hseedCs]; show cvs.size = _; exact hsize
+      · intro i c hi
+        rw [hseedCs] at hi
+        show cvs[i]? = some (denseRncCapVars c)
+        exact hcvs i c hi
+      · intro i c hi v hv
+        rw [hseedCs] at hi
+        show i ∈ (denseRncAnchorBuild d.algebraicConstraints).buckets.getD v []
+        refine denseRncAnchorBuild_complete d.algebraicConstraints i c ?_ v hv
+        rw [← Array.getElem?_toList (xs := d.algebraicConstraints.toArray),
+          List.toList_toArray] at hi
+        exact hi
+      · intro m hm; rw [hst] at hm; exact absurd hm (by simp [denseRncSeed])
+      · intro sf hsf; rw [hst] at hsf; exact absurd hsf (by simp [denseRncSeed])
+      · intro m hm; rw [hst] at hm; exact absurd hm (by simp [denseRncSeed])
+      · intro sf hsf; rw [hst] at hsf; exact absurd hsf (by simp [denseRncSeed])
+    have hseedVo : DenseRncVarsOk st := by
+      intro v _
+      show ((match st.varSeen with | some m => denseRncGetB m v | none => true)
+        || st.minted.contains v) = true
+      rw [hst]
+      simp [denseRncSeed]
+    have hseedNv : DenseRncNVarOk st := by
+      intro v hv
+      refine Or.inl ?_
+      have hd : v ∈ d.occ := by
+        rw [hseedView] at hv
+        exact denseFilterConstraints_occ_sub d (fun c => !denseIsZero c) v hv
+      show v.index < st.nVar
+      rw [hst]
+      exact DenseConstraintSystem.occ_valid hcov v hd
+    obtain ⟨hext, hii, hcovOut, hdcov, hcorr, _, _, _⟩ :=
+      denseRncLoop_correct (denseRncCtxOf b) bs (by
+        show DenseExpr.const (denseZModOps (p := p)).zero = DenseExpr.const 0
+        rw [show (denseZModOps (p := p)).zero = (0 : ZMod p) from zmodZeroP_eq])
+        (show (denseRncCtxOf (p := p) b).ops.zero = (0 : ZMod p) from zmodZeroP_eq)
+        targets 0 reg st (s!"rnc{live}_{d.busInteractions.length}_") hseedCov hseedOk hseedVo
+        hseedNv
+    refine ⟨hext, hcovOut, hdcov, ?_⟩
+    have hfe : (denseRncLoop (denseRncCtxOf b) targets 0 reg st
+        (s!"rnc{live}_{d.busInteractions.length}_")).1.isInput = reg.isInput := funext hii
+    have hpre : DensePassCorrect (denseRncLoop (denseRncCtxOf b) targets 0 reg st
+        (s!"rnc{live}_{d.busInteractions.length}_")).1.isInput d (denseRncView st)
+        ([] : DenseDerivations p) bs := by
+      rw [hfe, hseedView]; exact hfilter
+    simpa using hpre.andThen hcorr
+
 theorem denseRncF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
     (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
     (hcov : d.CoveredBy reg) :
@@ -3353,7 +4049,14 @@ theorem denseRncF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegist
         (denseRncF pw b reg bs facts d).2.2
     ∧ DensePassCorrect (denseRncF pw b reg bs facts d).1.isInput d
         (denseRncF pw b reg bs facts d).2.1 (denseRncF pw b reg bs facts d).2.2 bs := by
-  sorry
+  unfold denseRncF
+  split
+  · next hpr =>
+      haveI : Fact p.Prime := ⟨pw.correct hpr⟩
+      obtain ⟨hcvs, hsize⟩ := denseRncScan_cvsOk d.algebraicConstraints.toArray
+      exact denseRncRun_props b reg bs d _ hcov hcvs hsize
+  · refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
+    intro x hx; cases hx
 
 /-- The registered witness re-encoding pass (see `denseRncF` in `Reencode.lean`). -/
 def denseReencodePass (pw : PrimeWitness p) (b : DegreeBound) : DenseVerifiedPassW p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -2035,12 +2035,25 @@ theorem denseReencodeF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarR
     refine ⟨VarRegistry.Extends.refl reg, hcov, ?_, DensePassCorrect.refl reg.isInput d bs⟩
     intro x hx; simp at hx
 
-/-- The registered witness re-encoding pass (see `denseReencodeF` in `Reencode.lean`). -/
+/-- **Unproven on this branch (measurement).** The array-backed engine's obligations, in the shape
+    `denseReencodeF_props` discharges for the list engine. -/
+theorem denseRncF_props (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
+    (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
+    (hcov : d.CoveredBy reg) :
+    reg.Extends (denseRncF pw b reg bs facts d).1
+    ∧ (denseRncF pw b reg bs facts d).2.1.CoveredBy (denseRncF pw b reg bs facts d).1
+    ∧ DenseDerivations.CoveredBy (denseRncF pw b reg bs facts d).1
+        (denseRncF pw b reg bs facts d).2.2
+    ∧ DensePassCorrect (denseRncF pw b reg bs facts d).1.isInput d
+        (denseRncF pw b reg bs facts d).2.1 (denseRncF pw b reg bs facts d).2.2 bs := by
+  sorry
+
+/-- The registered witness re-encoding pass (see `denseRncF` in `Reencode.lean`). -/
 def denseReencodePass (pw : PrimeWitness p) (b : DegreeBound) : DenseVerifiedPassW p :=
-  DenseVerifiedPassW.ofExtending (denseReencodeF pw b)
-    (fun reg bs facts d hcov => (denseReencodeF_props pw b reg bs facts d hcov).1)
-    (fun reg bs facts d hcov => (denseReencodeF_props pw b reg bs facts d hcov).2.1)
-    (fun reg bs facts d hcov => (denseReencodeF_props pw b reg bs facts d hcov).2.2.1)
-    (fun reg bs facts d hcov => (denseReencodeF_props pw b reg bs facts d hcov).2.2.2)
+  DenseVerifiedPassW.ofExtending (denseRncF pw b)
+    (fun reg bs facts d hcov => (denseRncF_props pw b reg bs facts d hcov).1)
+    (fun reg bs facts d hcov => (denseRncF_props pw b reg bs facts d hcov).2.1)
+    (fun reg bs facts d hcov => (denseRncF_props pw b reg bs facts d hcov).2.2.1)
+    (fun reg bs facts d hcov => (denseRncF_props pw b reg bs facts d hcov).2.2.2)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1903,12 +1903,760 @@ def denseWorkSeed (d : DenseConstraintSystem p) : DenseReencodeWork p :=
   { cs := d.algebraicConstraints, bis := d.busInteractions, bools := [], bitSet := ∅,
     lastPos := ∅, lastFold := 0, bounded := false }
 
+/-! ## The array-backed engine
+
+One position-stable `Array` per item list, `VarId.index`-keyed buckets, and per-invocation memos for
+the quantities that are provably target-independent. Everything here is untrusted: the certificate
+(`denseRncCert`) re-verifies
+each candidate, so an index that over- or under-reports only costs a decision. -/
+
+/-- Distinct variables of `e` appended to `acc`, abandoning the walk once `cap` are known — so a
+    result of size `cap` means "at least `cap` distinct variables". Every consumer of the cheap path
+    only distinguishes counts below 9: a constraint covered by an ≤ 8-variable group has ≤ 8
+    variables. -/
+def denseRncCapGo (cap : Nat) : DenseExpr p → Array VarId → Array VarId
+  | .const _, acc => acc
+  | .var y, acc => if cap ≤ acc.size || acc.contains y then acc else acc.push y
+  | .add a b, acc =>
+      let acc := denseRncCapGo cap a acc
+      if cap ≤ acc.size then acc else denseRncCapGo cap b acc
+  | .mul a b, acc =>
+      let acc := denseRncCapGo cap a acc
+      if cap ≤ acc.size then acc else denseRncCapGo cap b acc
+
+def denseRncCapVars (c : DenseExpr p) : Array VarId := denseRncCapGo 9 c #[]
+
+/-- All distinct variables, reusing the capped array when it is already exact. -/
+def denseRncFullVars (c : DenseExpr p) (vs : Array VarId) : Array VarId :=
+  if vs.size ≤ 8 then vs else (HashedDedup.hashedDedup (hash ·) c.vars).toArray
+
+/-- `(hasVar, hasConstFoldableNode)` in one walk. `DenseExpr.hasConstFoldableNode` re-derives
+    `hasVar` at every composite node, so it is quadratic in the depth. -/
+def denseRncFoldPair : DenseExpr p → Bool × Bool
+  | .const _ => (false, false)
+  | .var _ => (true, false)
+  | .add a b =>
+      let (va, fa) := denseRncFoldPair a
+      let (vb, fb) := denseRncFoldPair b
+      (va || vb, !(va || vb) || fa || fb)
+  | .mul a b =>
+      let (va, fa) := denseRncFoldPair a
+      let (vb, fb) := denseRncFoldPair b
+      (va || vb, !(va || vb) || fa || fb)
+
+def denseRncHasFold (e : DenseExpr p) : Bool := (denseRncFoldPair e).2
+
+def denseRncBiHasFold (bi : BusInteraction (DenseExpr p)) : Bool :=
+  denseRncHasFold bi.multiplicity || bi.payload.any denseRncHasFold
+
+def denseRncBGet (bs : Array (Array Nat)) (v : VarId) : Array Nat := bs.getD v.index #[]
+
+def denseRncBAdd (bs : Array (Array Nat)) (v : VarId) (i : Nat) : Array (Array Nat) :=
+  bs.modify v.index (fun a => a.push i)
+
+def denseRncMark (bs : Array Bool) (v : VarId) : Array Bool := bs.setIfInBounds v.index true
+
+def denseRncGetB (bs : Array Bool) (v : VarId) : Bool := bs.getD v.index false
+
+/-- Drop adjacent duplicates; the input is sorted (`denseRncSortPos`). -/
+def denseRncDedup (a : Array Nat) : Array Nat :=
+  (a.foldl (fun (acc : Array Nat × Option Nat) x =>
+    if acc.2 == some x then acc else (acc.1.push x, some x)) (#[], none)).1
+
+def denseRncSortPos (a : Array Nat) : Array Nat := denseRncDedup (a.qsort Nat.blt)
+
+/-- The union of the buckets of `xs`, ascending and duplicate-free. -/
+def denseRncUnion (bs : Array (Array Nat)) (xs : List VarId) (extra : Array Nat) : Array Nat :=
+  denseRncSortPos (xs.foldl (fun acc x => acc ++ denseRncBGet bs x) extra)
+
+/-- Whether every variable of the capped array lies in `xs` (exact for sizes below 9). -/
+def denseRncSubset (xs : List VarId) (vs : Array VarId) : Bool :=
+  vs.all (fun v => denseContainsFast xs v)
+
+/-- `denseCoveredBy` off the capped variable array: a covered constraint has a variable and at most
+    `|xs| ≤ 8` of them. -/
+def denseRncCovered (xs : List VarId) (vs : Array VarId) : Bool :=
+  1 ≤ vs.size && vs.size ≤ 8 && denseRncSubset xs vs
+
+/-- `DenseExpr.sharesVarIn` off the capped array where it is exact, by tree walk otherwise. -/
+def denseRncShares (xs : List VarId) (vs : Array VarId) (c : DenseExpr p) : Bool :=
+  if vs.size ≤ 8 then vs.any (fun v => denseContainsFast xs v) else c.sharesVarIn xs
+
+/-! ### The threaded state -/
+
+/-- Per-invocation immutable context: the dictionary-free field operations and the shared `.const 0`
+    tombstone (the plain literal rebuilds the whole `CommRing (ZMod p)` chain per tombstoned
+    position — visible in the generated C of the list splice this engine replaces). -/
+structure DenseRncCtx (p : ℕ) where
+  ops : DenseZModOps p
+  zeroE : DenseExpr p
+  b : DegreeBound
+
+def DenseRncCtx.dmaxC (ctx : DenseRncCtx p) : Nat := ctx.b.identities
+def DenseRncCtx.dmaxB (ctx : DenseRncCtx p) : Nat := ctx.b.busInteractions
+
+/-- `f` holds at some position of the buckets of `xs`; short-circuits. -/
+def denseRncBucketAny (bs : Array (Array Nat)) (xs : List VarId) (f : Nat → Bool) : Bool :=
+  xs.any (fun x => (denseRncBGet bs x).any f)
+
+/-- `f` holds at every `i < n`, without materialising the range. -/
+def denseRncAllLt (n : Nat) (f : Nat → Bool) : Bool :=
+  let rec go (i : Nat) : Bool :=
+    if h : i < n then (if f i then go (i + 1) else false) else true
+    termination_by n - i
+    decreasing_by omega
+  go 0
+
+/-- The working system and its indexes, on stable positions. Dropped constraints become the shared
+    `.const 0`; the booleanity constraints of every accept are pushed onto `cs`, so the output list
+    is one filtered pass over it. Structures that only the near-accept path reads are `Option`s,
+    built on first use (`denseRncEnsure*`). -/
+structure DenseRncState (p : ℕ) where
+  cs : Array (DenseExpr p)
+  /-- Per position, its distinct variables capped at 9 (`denseRncCapVars`). -/
+  cvs : Array (Array VarId)
+  bis : Array (BusInteraction (DenseExpr p))
+  /-- Non-tombstone entries of `cs` (feeds the fresh-name prefix only). -/
+  live : Nat
+  bisN : Nat
+  /-- Each ≤ 8-variable position under its *first* variable only: `vars c ⊆ xs` implies the first
+      variable is in `xs`, so this is complete for the covered query, and no position is listed
+      twice under one target. -/
+  anchor : Array (Array Nat)
+  /-- Each position under *every* variable it mentions — what the rewrite and the degree pre-gate
+      need. -/
+  useCs : Option (Array (Array Nat))
+  useBis : Option (Array (Array Nat))
+  foldCs : Option (Std.HashSet Nat)
+  foldBis : Option (Std.HashSet Nat)
+  /-- Variables occurring in the system at pass entry; with `minted`, an over-approximation of the
+      live variables, which is what decides bit freshness in `O(|bits|)`. -/
+  varSeen : Option (Array Bool)
+  minted : Std.HashSet VarId
+  /-- Per-variable domain memo. A variable's domain is the roots of the lowest-positioned constraint
+      whose variable set is exactly `{v}` and whose root plan resolves; a root plan resolves for `v`
+      only for such a constraint, and such a constraint is covered by *every* group containing `v`,
+      so the answer does not depend on the target. Computed once per invocation, dropped on each
+      accept (a rewrite can change which constraint is lowest). -/
+  domVal : Array (Option (List (ZMod p)))
+  domKnown : Array Bool
+  /-- Per variable, `position + 1` of the constraint its domain came from (`0` if unknown). Such a
+      constraint vanishes on every point of the variable's own domain — the plan's roots *are* its
+      factors' roots — so the enumeration below never tests it. -/
+  domSrc : Array Nat
+  domTouched : List VarId
+  dWithin : Bool
+  nVar : Nat
+
+/-! ### Field updates
+
+Every write destructures the state first, so the array being written is uniquely owned:
+`{ st with f := g st.f }` leaves `st.f` shared and copies the whole array (the same trap
+`Gauss.lean` documents, measured at 7× there and at ~10× on the accept path here). -/
+
+def DenseRncState.setDom (st : DenseRncState p) (v : VarId)
+    (r : Option (Nat × List (ZMod p))) : DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
+  { cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+    domVal := domVal.setIfInBounds v.index (r.map Prod.snd),
+    domKnown := domKnown.setIfInBounds v.index true,
+    domSrc := domSrc.setIfInBounds v.index (match r with | some (q, _) => q + 1 | none => 0),
+    domTouched := v :: domTouched, dWithin, nVar }
+
+/-- Drop the memo (an accept rewrites positions, so a memoized domain may no longer be the lowest
+    one); only the entries actually filled are reset. -/
+def DenseRncState.domReset (st : DenseRncState p) : DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
+  { cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted, domVal,
+    domKnown := domTouched.foldl (fun m v => m.setIfInBounds v.index false) domKnown, domSrc,
+    domTouched := [], dWithin, nVar }
+
+/-- Drop the constraint at `i`: covered by the group, so the re-encoding replaces it. -/
+def DenseRncState.tombstone (st : DenseRncState p) (zeroE : DenseExpr p) (i : Nat) :
+    DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
+  { cs := cs.setIfInBounds i zeroE, cvs := cvs.setIfInBounds i #[], bis, live := live - 1, bisN,
+    anchor, useCs, useBis, foldCs := foldCs.map (·.erase i), foldBis, varSeen, minted,
+    domVal, domKnown, domSrc, domTouched, dWithin, nVar }
+
+/-- Install the rewritten constraint at `i` and extend the indexes for its new variables. -/
+def DenseRncState.rewriteAt (st : DenseRncState p) (i : Nat) (c' : DenseExpr p)
+    (cv' full : Array VarId) : DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
+  { cs := cs.setIfInBounds i c', cvs := cvs.setIfInBounds i cv', bis,
+    live := if denseIsZero c' then live - 1 else live, bisN,
+    anchor := if 1 ≤ cv'.size && cv'.size ≤ 8 then
+        (match cv'[0]? with | some v => denseRncBAdd anchor v i | none => anchor)
+      else anchor,
+    useCs := useCs.map (fun m => full.foldl (fun m v => denseRncBAdd m v i) m), useBis,
+    foldCs := foldCs.map (fun s => if denseRncHasFold c' then s.insert i else s.erase i),
+    foldBis, varSeen, minted, domVal, domKnown, domSrc, domTouched, dWithin, nVar }
+
+def DenseRncState.rewriteBiAt (st : DenseRncState p) (i : Nat)
+    (bi' : BusInteraction (DenseExpr p)) : DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
+  { cs, cvs, bis := bis.setIfInBounds i bi', live, bisN, anchor, useCs,
+    useBis := useBis.map (fun m => (denseBIVars bi').foldl (fun m v => denseRncBAdd m v i) m),
+    foldCs, foldBis := foldBis.map (fun s => if denseRncBiHasFold bi' then s.insert i else s.erase i),
+    varSeen, minted, domVal, domKnown, domSrc, domTouched, dWithin, nVar }
+
+/-- Append one booleanity constraint. -/
+def DenseRncState.pushBool (st : DenseRncState p) (b : VarId) : DenseRncState p :=
+  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
+        domVal, domKnown, domSrc, domTouched, _, nVar⟩ := st
+  { cs := cs.push (denseBoolConstraint b), cvs := cvs.push #[b], bis, live := live + 1, bisN,
+    anchor, useCs, useBis, foldCs, foldBis, varSeen, minted := minted.insert b,
+    domVal, domKnown, domSrc, domTouched, dWithin := true, nVar }
+
+def denseRncEnsureUse (st : DenseRncState p) : DenseRncState p :=
+  match st.useCs with
+  | some _ => st
+  | none =>
+    let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
+      if h : i < st.cs.size then
+        let vs := denseRncFullVars st.cs[i] (st.cvs.getD i #[])
+        go (i + 1) (vs.foldl (fun m v => denseRncBAdd m v i) acc)
+      else acc
+      termination_by st.cs.size - i
+      decreasing_by omega
+    { st with useCs := some (go 0 (Array.replicate st.nVar #[])) }
+
+def denseRncEnsureUseBis (st : DenseRncState p) : DenseRncState p :=
+  match st.useBis with
+  | some _ => st
+  | none =>
+    let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
+      if h : i < st.bis.size then
+        go (i + 1) ((denseBIVars st.bis[i]).foldl (fun m v => denseRncBAdd m v i) acc)
+      else acc
+      termination_by st.bis.size - i
+      decreasing_by omega
+    { st with useBis := some (go 0 (Array.replicate st.nVar #[])) }
+
+def denseRncEnsureFoldCs (st : DenseRncState p) : DenseRncState p :=
+  match st.foldCs with
+  | some _ => st
+  | none =>
+    let rec go (i : Nat) (acc : Std.HashSet Nat) : Std.HashSet Nat :=
+      if h : i < st.cs.size then
+        go (i + 1) (if denseRncHasFold st.cs[i] then acc.insert i else acc)
+      else acc
+      termination_by st.cs.size - i
+      decreasing_by omega
+    { st with foldCs := some (go 0 ∅) }
+
+def denseRncEnsureFoldBis (st : DenseRncState p) : DenseRncState p :=
+  match st.foldBis with
+  | some _ => st
+  | none =>
+    let rec go (i : Nat) (acc : Std.HashSet Nat) : Std.HashSet Nat :=
+      if h : i < st.bis.size then
+        go (i + 1) (if denseRncBiHasFold st.bis[i] then acc.insert i else acc)
+      else acc
+      termination_by st.bis.size - i
+      decreasing_by omega
+    { st with foldBis := some (go 0 ∅) }
+
+def denseRncEnsureSeen (st : DenseRncState p) : DenseRncState p :=
+  match st.varSeen with
+  | some _ => st
+  | none =>
+    let m := st.cs.foldl (fun m c => c.foldVars (fun m v => denseRncMark m v) m)
+      (Array.replicate st.nVar false)
+    let m := st.bis.foldl (fun m bi =>
+      bi.payload.foldl (fun m e => e.foldVars (fun m v => denseRncMark m v) m)
+        (bi.multiplicity.foldVars (fun m v => denseRncMark m v) m)) m
+    { st with varSeen := some m }
+
+/-- Whether `v` may still occur in the system (over-approximate: entry occurrences plus minted
+    bits). Assumes `denseRncEnsureSeen`. -/
+def denseRncSeen (st : DenseRncState p) (v : VarId) : Bool :=
+  (match st.varSeen with | some m => denseRncGetB m v | none => true) || st.minted.contains v
+
+/-! ### Domains
+
+The affine root `-(a⁻¹ · c)` costs a field inversion, and the plan of a booleanity or range
+constraint asks for one per factor. At `a = ±1` — which is every constraint the domains actually
+come from — the inverse is `a` itself, so the root is `∓c` with no inversion; the general case keeps
+`denseRootsOfTerms`. -/
+
+def denseRncRootsOfTerms (ops : DenseZModOps p) (i : VarId) (c : ZMod p) :
+    List (VarId × ZMod p) → Option (List (ZMod p))
+  | [] => if zmodIsZero c then none else some []
+  | [(j, a)] =>
+      if j == i && (zmodIsOne a || zmodIsZero (ops.add a ops.one)) then
+        let r := if zmodIsOne a then zmodNegP c else c
+        if zmodIsZero (ops.add (ops.mul a r) c) then some [r] else none
+      else denseRootsOfTerms i c [(j, a)]
+  | _ :: _ :: _ => none
+
+def denseRncRootPlan (ops : DenseZModOps p) : DenseExpr p → Option (DenseReencodeRootPlan p)
+  | .mul a b =>
+      match denseRncRootPlan ops a, denseRncRootPlan ops b with
+      | some left, some right => denseReencodeRootPlanMul left right
+      | _, _ => none
+  | e =>
+      match denseLinearize e with
+      | none => none
+      | some l =>
+          let l := l.norm
+          match l.terms with
+          | [] => if zmodIsZero l.const then none else some (.any [])
+          | [(i, a)] => (denseRncRootsOfTerms ops i l.const [(i, a)]).map (.one i)
+          | _ => none
+
+/-- The first single-variable position resolving a root plan for `v`, scanning ascending. -/
+def denseRncFirstRoots (ops : DenseZModOps p) (cs : Array (DenseExpr p)) (v : VarId)
+    (cands : Array Nat) (i : Nat) : Option (Nat × List (ZMod p)) :=
+  if h : i < cands.size then
+    match cs[cands[i]]? with
+    | some c =>
+      match (denseRncRootPlan ops c).bind (denseReencodeRootPlanLookup v) with
+      | some roots => some (cands[i], roots)
+      | none => denseRncFirstRoots ops cs v cands (i + 1)
+    | none => denseRncFirstRoots ops cs v cands (i + 1)
+  else none
+  termination_by cands.size - i
+  decreasing_by omega
+
+/-- `v`'s domain: the roots of the lowest-positioned constraint whose variable set is exactly `{v}`
+    and whose root plan resolves. Memoized per variable. -/
+def denseRncDomOf (ops : DenseZModOps p) (st : DenseRncState p) (v : VarId) :
+    Option (List (ZMod p)) × DenseRncState p :=
+  if denseRncGetB st.domKnown v then (st.domVal.getD v.index none, st)
+  else
+    let cands := denseRncSortPos ((denseRncBGet st.anchor v).filter (fun q =>
+      match st.cvs[q]? with
+      | some vs => vs.size == 1
+      | none => false))
+    let r := denseRncFirstRoots ops st.cs v cands 0
+    (r.map Prod.snd, st.setDom v r)
+
+/-- Every group variable's domain, in group order; `none` if any is missing. -/
+def denseRncDoms (ops : DenseZModOps p) (st : DenseRncState p) :
+    List VarId → Array (Array (ZMod p)) →
+    Option (Array (Array (ZMod p))) × DenseRncState p
+  | [], acc => (some acc, st)
+  | v :: rest, acc =>
+    match denseRncDomOf ops st v with
+    | (some ds, st) => denseRncDoms ops st rest (acc.push ds.toArray)
+    | (none, st) => (none, st)
+
+/-! ### Enumeration
+
+Points are `Array (ZMod p)` in group order; compiled constraints are evaluated by index. Each
+constraint is filed under the *smallest* group index it mentions, and the DFS assigns indices
+`n-1 … 0` — which is `denseAssignments`' order (its head variable varies fastest) — so a constraint
+is tested as soon as its last variable is assigned and a violation prunes the whole subtree. -/
+
+def denseRncEvalA (zero : ZMod p) (env : Array (ZMod p)) : IExpr p → ZMod p
+  | .const n => n
+  | .ix i => env.getD i zero
+  | .add a b => zmodAddP (denseRncEvalA zero env a) (denseRncEvalA zero env b)
+  | .mul a b => zmodMulP (denseRncEvalA zero env a) (denseRncEvalA zero env b)
+
+def denseRncIxMin : IExpr p → Nat → Nat
+  | .const _, m => m
+  | .ix i, m => min i m
+  | .add a b, m => denseRncIxMin b (denseRncIxMin a m)
+  | .mul a b, m => denseRncIxMin b (denseRncIxMin a m)
+
+/-- Whether the constraint at `i` is the domain source of its (single) variable, hence zero at every
+    point of the box. -/
+def denseRncIsDomSrc (st : DenseRncState p) (i : Nat) : Bool :=
+  match st.cvs[i]? with
+  | some vs =>
+    vs.size == 1 && (match vs[0]? with
+      | some v => st.domSrc.getD v.index 0 == i + 1
+      | none => false)
+  | none => false
+
+/-- The compiled covered constraints filed by the smallest group index they mention, dropping the
+    domain sources. -/
+def denseRncChecks (st : DenseRncState p) (n : Nat) (pos : Array Nat) (ces : List (IExpr p)) :
+    Array (Array (IExpr p)) :=
+  (ces.toArray.zip pos).foldl (fun acc iep =>
+    if denseRncIsDomSrc st iep.2 then acc
+    else
+      let m := denseRncIxMin iep.1 n
+      acc.modify (if m < n then m else 0) (fun a => a.push iep.1)) (Array.replicate n #[])
+
+/-- Enumerate the box depth-first, keeping the points that zero every constraint; `none` as soon as
+    a `cap + 1`-st survivor appears (mirroring `denseFilterCap`: above the cap the `k < |xs|` gate
+    must fail anyway). -/
+def denseRncDfs (zero : ZMod p) (doms : Array (Array (ZMod p)))
+    (checks : Array (Array (IExpr p))) (cap : Nat) :
+    Nat → Array (ZMod p) → Option (Array (Array (ZMod p))) →
+      Array (ZMod p) × Option (Array (Array (ZMod p)))
+  | 0, env, acc? => (env, acc?)
+  | 1, env, acc? =>
+      -- the innermost level emits directly: recursing per point would cost a call and a tuple each
+      let chk := checks.getD 0 #[]
+      (doms.getD 0 #[]).foldl (fun ea v =>
+        match ea with
+        | (env, none) => (env, none)
+        | (env, some acc) =>
+          let env := env.setIfInBounds 0 v
+          if chk.all (fun ie => zmodIsZero (denseRncEvalA zero env ie)) then
+            (if acc.size < cap then (env, some (acc.push (env.extract 0 env.size)))
+             else (env, none))
+          else (env, some acc)) (env, acc?)
+  | i + 1, env, acc? =>
+      let chk := checks.getD i #[]
+      (doms.getD i #[]).foldl (fun ea v =>
+        match ea with
+        | (env, none) => (env, none)
+        | (env, some acc) =>
+          let env := env.setIfInBounds i v
+          if chk.all (fun ie => zmodIsZero (denseRncEvalA zero env ie)) then
+            denseRncDfs zero doms checks cap i env (some acc)
+          else (env, some acc)) (env, acc?)
+
+/-! ### The candidate -/
+
+/-- Everything an accept needs about a candidate group, computed once. -/
+structure DenseRncCand (p : ℕ) where
+  bits : List VarId
+  hm : Std.HashMap VarId (DenseExpr p)
+  patts : List (List (VarId × ZMod p))
+  pattsA : Array (List (VarId × ZMod p))
+  /-- Per pattern, the interpolation image of each group variable (group order). A `Thunk`: only the
+      certificate and the derivations read it, and nearly every candidate is rejected by the degree
+      pre-gate before that. -/
+  imgs : Thunk (Array (Array (ZMod p)))
+  /-- The covered constraints compiled over the group (`.ix` = group index), in position order. -/
+  ces : List (IExpr p)
+  survs : Array (Array (ZMod p))
+
+/-- The covered constraints of `xs`, ascending by position, off the anchor index. -/
+def denseRncGather (st : DenseRncState p) (xs : List VarId) : Array Nat × Array (DenseExpr p) :=
+  (denseRncUnion st.anchor xs #[]).foldl
+    (fun (acc : Array Nat × Array (DenseExpr p)) i =>
+      match st.cs[i]?, st.cvs[i]? with
+      | some c, some vs => if denseRncCovered xs vs then (acc.1.push i, acc.2.push c) else acc
+      | _, _ => acc) (#[], #[])
+
+/-- The interpolation polynomial of the group variable at index `j`: `Σ_t indicator_t · value_t`,
+    with the per-pattern indicators shared across the group (they depend only on the bits). -/
+def denseRncInterp (ctx : DenseRncCtx p) (inds : Array (DenseExpr p))
+    (vals : Array (Array (ZMod p))) (j : Nat) : DenseExpr p :=
+  let rec go (t : Nat) (acc : DenseExpr p) : DenseExpr p :=
+    if h : t < inds.size then
+      go (t + 1) (.add acc (.mul inds[t] (.const ((vals.getD t #[]).getD j ctx.ops.zero))))
+    else acc
+    termination_by inds.size - t
+    decreasing_by omega
+  (go 0 (.const ctx.ops.zero)).fold
+
+/-- Build the candidate: covered set, domains, box, survivors, bits, interpolations, images.
+    Proof-free — `denseRncCert` re-verifies. -/
+def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (xs : List VarId) (freshBase : String) :
+    VarRegistry × Option (DenseRncCand p) × DenseRncState p :=
+  let (pos, es) := denseRncGather st xs
+  match denseRncDoms ctx.ops st xs #[] with
+  | (none, st) => (reg, none, st)
+  | (some doms, st) =>
+    let boxSize := doms.foldl (fun n dd => n * dd.size) 1
+    if boxSize > 256 then (reg, none, st)
+    else if es.size == xs.length
+        && pos.all (fun i => (st.cvs.getD i #[]).size == 1)
+        && xs.length ≤ Nat.clog 2 boxSize then (reg, none, st)
+    else
+      match denseCompileEs xs es.toList with
+      | none => (reg, none, st)
+      | some ces =>
+        let n := doms.size
+        match (denseRncDfs ctx.ops.zero doms (denseRncChecks st n pos ces) (2 ^ (xs.length - 1)) n
+            (Array.replicate n ctx.ops.zero) (some #[])).2 with
+        | none => (reg, none, st)
+        | some survs =>
+          if survs.size < 2 then (reg, none, st)
+          else
+            let k := Nat.clog 2 survs.size
+            if k ≥ xs.length then (reg, none, st)
+            else
+              let (reg1, bits) := denseRegisterBits reg freshBase k
+              let patts := denseAssignments (denseBitBox bits)
+              let pattsA := patts.toArray
+              let vals := survs ++ Array.replicate (pattsA.size - survs.size) (survs.getD 0 #[])
+              let inds := pattsA.map denseIndicatorExpr
+              let hm := Std.HashMap.ofList (xs.zipIdx.map
+                (fun xj => (xj.1, denseRncInterp ctx inds vals xj.2)))
+              let imgs := Thunk.mk (fun _ => pattsA.map (fun aβ =>
+                let env := denseEnvOfFast aβ
+                (xs.toArray).map (fun x => ((hm[x]?).getD (.var x)).evalFast env)))
+              (reg1, some { bits := bits, hm := hm, patts := patts, pattsA := pattsA, imgs := imgs,
+                            ces := ces, survs := survs }, st)
+
+/-! ### The checked certificate
+
+Same conjuncts as `denseCheckReencode`, read off the candidate: the covered set the build step
+gathered (index completeness is what makes it the filter), the survivors it enumerated, and the
+per-pattern image table. Freshness is the `O(|bits|)` `varSeen` test. -/
+def denseRncCert (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : Bool :=
+  let n := xs.length
+  decide (cd.bits.length < n) &&
+  decide (cd.bits.Nodup) &&
+  xs.all (fun x => ((cd.hm[x]?).getD (.var x)).vars.all (fun v => cd.bits.contains v)) &&
+  -- completeness: every survivor is the image of some bit pattern
+  cd.survs.all (fun s => cd.imgs.get.any (fun img =>
+    denseRncAllLt n (fun j =>
+      zmodIsZero (ctx.ops.add (img.getD j ctx.ops.zero)
+        (zmodNegP (s.getD j ctx.ops.zero)))))) &&
+  -- soundness: every pattern's image satisfies the covered constraints
+  cd.imgs.get.all (fun img =>
+    cd.ces.all (fun ie => zmodIsZero (denseRncEvalA ctx.ops.zero img ie))) &&
+  -- freshness
+  cd.bits.all (fun b => !denseRncSeen st b)
+
+/-! ### The degree pre-gate -/
+
+/-- Untrusted degree pre-gate: fire when a candidate position's rewrite already exceeds the bound.
+    Only positions mentioning a group variable are visited (the buckets are complete), and each
+    position's current content is re-tested, so stale bucket entries are harmless. -/
+def denseRncDegPre (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : Bool :=
+  let σ := denseGroupSubst xs cd.hm
+  let useC := (match st.useCs with | some m => m | none => #[])
+  let useB := (match st.useBis with | some m => m | none => #[])
+  (denseRncBucketAny useC xs (fun i =>
+    match st.cs[i]?, st.cvs[i]? with
+    | some c, some vs =>
+      denseRncShares xs vs c && !denseRncCovered xs vs &&
+        decide (ctx.dmaxC < (denseGroupRewrite xs cd.bits σ cd.patts c).degree)
+    | _, _ => false)) ||
+  (denseRncBucketAny useB xs (fun i =>
+    match st.bis[i]? with
+    | some bi =>
+      (bi.multiplicity.sharesVarIn xs &&
+        decide (ctx.dmaxB
+          < (denseGroupRewrite xs cd.bits σ cd.patts bi.multiplicity).degree)) ||
+      bi.payload.any (fun e =>
+        e.sharesVarIn xs &&
+          decide (ctx.dmaxB < (denseGroupRewrite xs cd.bits σ cd.patts e).degree))
+    | none => false))
+
+/-! ### The accept
+
+Computing the rewrite and writing it are separate steps: the degree decision is taken on the
+computed edits, so the write consumes the state linearly (a rejected candidate never touches it, and
+an accepted one never needs the old copy alive). -/
+
+/-- One position's new content. -/
+inductive DenseRncEdit (p : ℕ) where
+  | tomb (i : Nat)
+  | cst (i : Nat) (c : DenseExpr p) (cv full : Array VarId)
+  | bus (i : Nat) (bi : BusInteraction (DenseExpr p))
+
+/-- The accepted rewrite's edits, over the only positions it can touch — the group's `useCs`/`useBis`
+    buckets plus the recorded foldable positions — paired with whether every rewritten item stayed
+    within the degree bound. Read-only in `st`. -/
+def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : Array (DenseRncEdit p) × Bool :=
+  let σ := denseGroupSubst xs cd.hm
+  let foldC := (match st.foldCs with | some s => s | none => ∅)
+  let useC := (match st.useCs with | some m => m | none => #[])
+  let rc := (denseRncUnion useC xs foldC.toArray).foldl
+    (fun (acc : Array (DenseRncEdit p) × Bool) i =>
+      match st.cs[i]?, st.cvs[i]? with
+      | some c, some vs =>
+        if denseRncCovered xs vs then (acc.1.push (.tomb i), acc.2)
+        else if denseRncShares xs vs c || denseRncHasFold c then
+          let c' := denseGroupRewrite xs cd.bits σ cd.patts c
+          let cv' := denseRncCapVars c'
+          (acc.1.push (.cst i c' cv' (denseRncFullVars c' cv')),
+           acc.2 && decide (c'.degree ≤ ctx.dmaxC))
+        else acc
+      | _, _ => acc) (#[], true)
+  let foldB := (match st.foldBis with | some s => s | none => ∅)
+  let useB := (match st.useBis with | some m => m | none => #[])
+  (denseRncUnion useB xs foldB.toArray).foldl
+    (fun (acc : Array (DenseRncEdit p) × Bool) i =>
+      match st.bis[i]? with
+      | some bi =>
+        if bi.multiplicity.sharesVarIn xs || denseRncHasFold bi.multiplicity
+            || bi.payload.any (fun e => e.sharesVarIn xs || denseRncHasFold e) then
+          let bi' : BusInteraction (DenseExpr p) :=
+            { bi with multiplicity := denseGroupRewrite xs cd.bits σ cd.patts bi.multiplicity,
+                      payload := bi.payload.map (denseGroupRewrite xs cd.bits σ cd.patts) }
+          (acc.1.push (.bus i bi'),
+           acc.2 && decide (bi'.multiplicity.degree ≤ ctx.dmaxB)
+             && bi'.payload.all (fun e => decide (e.degree ≤ ctx.dmaxB)))
+        else acc
+      | none => acc) rc
+
+/-- Install the edits and the booleanity constraints. Consumes `st`. -/
+def denseRncWrite (ctx : DenseRncCtx p) (st : DenseRncState p) (bits : List VarId)
+    (edits : Array (DenseRncEdit p)) : DenseRncState p :=
+  let st := edits.foldl (fun st e =>
+    match e with
+    | .tomb i => st.tombstone ctx.zeroE i
+    | .cst i c' cv' full => st.rewriteAt i c' cv' full
+    | .bus i bi' => st.rewriteBiAt i bi') st
+  (bits.foldl (fun st b => st.pushBool b) st).domReset
+
+/-- Whether the current system is within the degree bound. Discharges the side condition that makes
+    the edit-level degree test agree with measuring the rewritten system outright; the pipeline's
+    degree guard makes it true at every pass entry, so it is computed once per invocation. -/
+def denseRncWithinNow (ctx : DenseRncCtx p) (st : DenseRncState p) : Bool :=
+  st.cs.all (fun c => decide (c.degree ≤ ctx.dmaxC)) &&
+    st.bis.all (fun bi => decide (bi.multiplicity.degree ≤ ctx.dmaxB) &&
+      bi.payload.all (fun e => decide (e.degree ≤ ctx.dmaxB)))
+
+/-! ### The bits' derivations
+
+`denseBitCM`'s decision tree, with the group's per-pattern image values read from the shared table
+instead of re-evaluating an interpolation polynomial per (bit, pattern, variable). -/
+
+def denseRncMatchCM (img : Array (ZMod p)) (thenM elseM : DenseComputationMethod p) :
+    List VarId → Nat → DenseComputationMethod p
+  | [], _ => thenM
+  | x :: rest, j =>
+      .ifEqZero (.add (.var x) (.const (zmodNegP (img.getD j (zmodZeroP p)))))
+        (denseRncMatchCM img thenM elseM rest (j + 1)) elseM
+
+def denseRncBitCMGo (ctx : DenseRncCtx p) (cd : DenseRncCand p) (xs : List VarId) (b : VarId)
+    (t : Nat) : DenseComputationMethod p :=
+  if h : t < cd.pattsA.size then
+    denseRncMatchCM (cd.imgs.get.getD t #[])
+      (.const (denseEnvOfFast cd.pattsA[t] b))
+      (denseRncBitCMGo ctx cd xs b (t + 1)) xs 0
+  else .const ctx.ops.zero
+  termination_by cd.pattsA.size - t
+  decreasing_by omega
+
+/-! ### The step, loop and pass -/
+
+def denseRncView (st : DenseRncState p) : DenseConstraintSystem p :=
+  { algebraicConstraints := (st.cs.filter (fun c => !denseIsZero c)).toList,
+    busInteractions := st.bis.toList }
+
+/-- One checked re-encoding step on the array state. Same gate sequence as `denseWorkStep`. -/
+def denseRncStep (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (xs : List VarId) (freshBase : String) :
+    VarRegistry × DenseRncState p × DenseDerivations p :=
+  if !xs.all (fun x => reg.isInput x) then (reg, st, [])
+  else if xs.any (fun x => st.minted.contains x) then (reg, st, [])
+  else
+    let (skip, st) :=
+      match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
+      | some i => let st := denseRncEnsureSeen st; (denseRncSeen st i, st)
+      | none => (false, st)
+    if skip then (reg, st, [])
+    else
+      match denseRncBuild ctx reg st xs freshBase with
+      | (reg1, none, st) => (reg1, st, [])
+      | (reg1, some cd, st) =>
+        if cd.bits.any (fun b => st.minted.contains b) then (reg1, st, [])
+        else
+          let st := denseRncEnsureUseBis (denseRncEnsureUse st)
+          if denseRncDegPre ctx st xs cd then (reg1, st, [])
+          else
+            let st := denseRncEnsureSeen st
+            if !xs.all (fun x => denseRncSeen st x) then (reg1, st, [])
+            else if !xs.all (fun x => decide (x ∉ cd.bits)) then (reg1, st, [])
+            else if !cd.bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
+              (reg1, st, [])
+            else if !denseRncCert ctx st xs cd then (reg1, st, [])
+            else
+              let st0 := denseRncEnsureFoldBis (denseRncEnsureFoldCs st)
+              let (edits, ok) := denseRncEdits ctx st0 xs cd
+              if (if st0.dWithin then ok else ok && denseRncWithinNow ctx st0) then
+                (reg1, denseRncWrite ctx st0 cd.bits edits,
+                 cd.bits.map (fun b => (b, denseRncBitCMGo ctx cd xs b 0)))
+              else (reg1, st0, [])
+
+/-- The fresh-name prefix depends only on the item counts, which change only on an accept, so it is
+    threaded rather than rebuilt per target (`Nat.toString` twice per target otherwise). -/
+def denseRncLoop (ctx : DenseRncCtx p) :
+    List (List VarId) → Nat → VarRegistry → DenseRncState p → String →
+      VarRegistry × DenseRncState p × DenseDerivations p
+  | [], _, reg, st, _ => (reg, st, [])
+  | xs :: rest, idx, reg, st, pre =>
+    let (reg1, st1, derivs1) := denseRncStep ctx reg st xs (pre ++ toString idx)
+    let pre1 := if derivs1.isEmpty then pre else s!"rnc{st1.live}_{st1.bisN}_"
+    let (reg2, st2, derivs2) := denseRncLoop ctx rest (idx + 1) reg1 st1 pre1
+    (reg2, st2, derivs1 ++ derivs2)
+
+/-! ### The setup walk
+
+One walk over the constraint array yields every position's capped variable array, the live count and
+the single-variable set; the targets follow from that array alone. Nothing else is built when there
+are no targets, and the remaining structures are `Option`s built on the path that reads them. -/
+
+/-- Per-position capped variables, and the number of non-tombstone positions. -/
+def denseRncScan (cs : Array (DenseExpr p)) : Array (Array VarId) × Nat :=
+  cs.foldl (fun (acc : Array (Array VarId) × Nat) c =>
+    (acc.1.push (denseRncCapVars c), if denseIsZero c then acc.2 else acc.2 + 1)) (#[], 0)
+
+/-- Variables carrying a single-variable constraint. -/
+def denseRncSvSet (nVar : Nat) (cvs : Array (Array VarId)) : Array Bool :=
+  cvs.foldl (fun s vs =>
+    if vs.size == 1 then (match vs[0]? with | some v => denseRncMark s v | none => s) else s)
+    (Array.replicate nVar false)
+
+/-- The candidate groups: the variable sets of size 2–8 all of whose members carry a
+    single-variable constraint, sorted by the resolved `Variable` (the accept sequence is greedy and
+    order-sensitive, so the group order is part of the result) and deduped. -/
+def denseRncTargets (reg : VarRegistry) (sv : Array Bool) (cvs : Array (Array VarId)) :
+    List (List VarId) :=
+  dedupHash (cvs.toList.filterMap (fun vs =>
+    if 2 ≤ vs.size && vs.size ≤ 8 && vs.all (fun v => denseRncGetB sv v) then
+      some (vs.toList.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
+    else none))
+
+/-- Each ≤ 8-variable position under its first variable, ascending. -/
+def denseRncAnchorBuild (nVar : Nat) (cvs : Array (Array VarId)) : Array (Array Nat) :=
+  let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
+    if h : i < cvs.size then
+      let vs := cvs[i]
+      go (i + 1)
+        (if 1 ≤ vs.size && vs.size ≤ 8 then
+          (match vs[0]? with | some v => denseRncBAdd acc v i | none => acc)
+         else acc)
+    else acc
+    termination_by cvs.size - i
+    decreasing_by omega
+  go 0 (Array.replicate nVar #[])
+
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
     combinations survive, mint `Nat.clog 2 #survivors` fresh boolean bits, rewrite each group
     variable as an interpolation polynomial over the bits, drop the now-covered constraints, and add
     booleanity constraints — e.g. a group with 3 surviving combinations becomes 2 bits, cutting the
     variable count. The transform is shaped for `DenseVerifiedPassW.ofExtending`; `facts` is unused
     (reencode is fact-free). -/
+def denseRncF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
+    (bsem : BusSemantics p) (_facts : BusFacts p bsem) (d : DenseConstraintSystem p) :
+    VarRegistry × DenseConstraintSystem p × DenseDerivations p :=
+  if pw.isPrime = true then
+    let csArr := d.algebraicConstraints.toArray
+    let (cvs, live) := denseRncScan csArr
+    let nVar := reg.byId.size
+    let targets := denseRncTargets reg (denseRncSvSet nVar cvs) cvs
+    match targets with
+    | [] => (reg, d, [])
+    | _ :: _ =>
+      let ops : DenseZModOps p := denseZModOps
+      let ctx : DenseRncCtx p := { ops := ops, zeroE := .const ops.zero, b := b }
+      let bisArr := d.busInteractions.toArray
+      let st : DenseRncState p :=
+        { cs := csArr, cvs := cvs, bis := bisArr, live := live, bisN := bisArr.size,
+          anchor := denseRncAnchorBuild nVar cvs,
+          useCs := none, useBis := none, foldCs := none, foldBis := none, varSeen := none,
+          minted := ∅,
+          domVal := Array.replicate nVar none, domKnown := Array.replicate nVar false,
+          domSrc := Array.replicate nVar 0, domTouched := [], dWithin := false, nVar := nVar }
+      let r := denseRncLoop ctx targets 0 reg st s!"rnc{live}_{bisArr.size}_" 
+      (r.1, denseRncView r.2.1, r.2.2)
+  else (reg, d, [])
+
 def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
     (bsem : BusSemantics p) (_facts : BusFacts p bsem) (d : DenseConstraintSystem p) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1949,34 +1949,42 @@ def denseRncHasFold (e : DenseExpr p) : Bool := (denseRncFoldPair e).2
 def denseRncBiHasFold (bi : BusInteraction (DenseExpr p)) : Bool :=
   denseRncHasFold bi.multiplicity || bi.payload.any denseRncHasFold
 
+/-- The single bucket key of a position: its first variable. A constraint covered by a group has all
+    its variables — in particular this one — in the group, which is what makes one bucket per
+    position complete for the covered query. -/
+def denseRncAnchorVars (c : DenseExpr p) : List VarId :=
+  match (denseRncCapVars c)[0]? with
+  | some v => [v]
+  | none => []
+
+def denseRncAnchorAdd (idx : DenseCovIndex) (ks : List VarId) (i : Nat) : DenseCovIndex :=
+  match ks with
+  | [] => idx
+  | v :: _ => ⟨idx.buckets.insert v (i :: idx.buckets.getD v []), idx.varless⟩
+
 def denseRncBGet (bs : Array (Array Nat)) (v : VarId) : Array Nat := bs.getD v.index #[]
 
+/-- Grow-then-add, so a variable minted after the arrays were sized still gets a bucket. -/
 def denseRncBAdd (bs : Array (Array Nat)) (v : VarId) (i : Nat) : Array (Array Nat) :=
-  bs.modify v.index (fun a => a.push i)
+  (denseArrEnsure bs v.index #[]).modify v.index (fun a => a.push i)
 
 def denseRncMark (bs : Array Bool) (v : VarId) : Array Bool := bs.setIfInBounds v.index true
 
 def denseRncGetB (bs : Array Bool) (v : VarId) : Bool := bs.getD v.index false
 
-/-- Drop adjacent duplicates; the input is sorted (`denseRncSortPos`). -/
-def denseRncDedup (a : Array Nat) : Array Nat :=
-  (a.foldl (fun (acc : Array Nat × Option Nat) x =>
-    if acc.2 == some x then acc else (acc.1.push x, some x)) (#[], none)).1
-
-def denseRncSortPos (a : Array Nat) : Array Nat := denseRncDedup (a.qsort Nat.blt)
-
-/-- The union of the buckets of `xs`, ascending and duplicate-free. -/
-def denseRncUnion (bs : Array (Array Nat)) (xs : List VarId) (extra : Array Nat) : Array Nat :=
-  denseRncSortPos (xs.foldl (fun acc x => acc ++ denseRncBGet bs x) extra)
+/-- The positions the group rewrite can touch, deduplicated: applying it twice at one position is
+    not the identity, and `Std.HashSet` is what makes the list provably duplicate-free. -/
+def denseRncPosList (bs : Array (Array Nat)) (xs : List VarId) (extra : List Nat) : List Nat :=
+  ((xs.flatMap (fun x => (denseRncBGet bs x).toList) ++ extra).foldl (·.insert ·)
+    (∅ : Std.HashSet Nat)).toList
 
 /-- Whether every variable of the capped array lies in `xs` (exact for sizes below 9). -/
 def denseRncSubset (xs : List VarId) (vs : Array VarId) : Bool :=
   vs.all (fun v => denseContainsFast xs v)
 
-/-- `denseCoveredBy` off the capped variable array: a covered constraint has a variable and at most
-    `|xs| ≤ 8` of them. -/
-def denseRncCovered (xs : List VarId) (vs : Array VarId) : Bool :=
-  1 ≤ vs.size && vs.size ≤ 8 && denseRncSubset xs vs
+/-- `denseCoveredBy` off the capped variable array where it is exact, by tree walk otherwise. -/
+def denseRncCovered (xs : List VarId) (vs : Array VarId) (c : DenseExpr p) : Bool :=
+  if vs.size ≤ 8 then 1 ≤ vs.size && denseRncSubset xs vs else denseCoveredBy xs c
 
 /-- `DenseExpr.sharesVarIn` off the capped array where it is exact, by tree walk otherwise. -/
 def denseRncShares (xs : List VarId) (vs : Array VarId) (c : DenseExpr p) : Bool :=
@@ -2020,9 +2028,9 @@ structure DenseRncState (p : ℕ) where
   live : Nat
   bisN : Nat
   /-- Each ≤ 8-variable position under its *first* variable only: `vars c ⊆ xs` implies the first
-      variable is in `xs`, so this is complete for the covered query, and no position is listed
-      twice under one target. -/
-  anchor : Array (Array Nat)
+      variable is in `xs`, so this is complete for the covered query (`denseCoveredIdx`), and no
+      position is listed twice under one target. -/
+  anchor : DenseCovIndex
   /-- Each position under *every* variable it mentions — what the rewrite and the degree pre-gate
       need. -/
   useCs : Option (Array (Array Nat))
@@ -2073,15 +2081,6 @@ def DenseRncState.domReset (st : DenseRncState p) : DenseRncState p :=
     domKnown := domTouched.foldl (fun m v => m.setIfInBounds v.index false) domKnown, domSrc,
     domTouched := [], dWithin, nVar }
 
-/-- Drop the constraint at `i`: covered by the group, so the re-encoding replaces it. -/
-def DenseRncState.tombstone (st : DenseRncState p) (zeroE : DenseExpr p) (i : Nat) :
-    DenseRncState p :=
-  let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
-        domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
-  { cs := cs.setIfInBounds i zeroE, cvs := cvs.setIfInBounds i #[], bis, live := live - 1, bisN,
-    anchor, useCs, useBis, foldCs := foldCs.map (·.erase i), foldBis, varSeen, minted,
-    domVal, domKnown, domSrc, domTouched, dWithin, nVar }
-
 /-- Install the rewritten constraint at `i` and extend the indexes for its new variables. -/
 def DenseRncState.rewriteAt (st : DenseRncState p) (i : Nat) (c' : DenseExpr p)
     (cv' full : Array VarId) : DenseRncState p :=
@@ -2089,9 +2088,7 @@ def DenseRncState.rewriteAt (st : DenseRncState p) (i : Nat) (c' : DenseExpr p)
         domVal, domKnown, domSrc, domTouched, dWithin, nVar⟩ := st
   { cs := cs.setIfInBounds i c', cvs := cvs.setIfInBounds i cv', bis,
     live := if denseIsZero c' then live - 1 else live, bisN,
-    anchor := if 1 ≤ cv'.size && cv'.size ≤ 8 then
-        (match cv'[0]? with | some v => denseRncBAdd anchor v i | none => anchor)
-      else anchor,
+    anchor := denseRncAnchorAdd anchor (denseRncAnchorVars c') i,
     useCs := useCs.map (fun m => full.foldl (fun m v => denseRncBAdd m v i) m), useBis,
     foldCs := foldCs.map (fun s => if denseRncHasFold c' then s.insert i else s.erase i),
     foldBis, varSeen, minted, domVal, domKnown, domSrc, domTouched, dWithin, nVar }
@@ -2110,7 +2107,9 @@ def DenseRncState.pushBool (st : DenseRncState p) (b : VarId) : DenseRncState p 
   let ⟨cs, cvs, bis, live, bisN, anchor, useCs, useBis, foldCs, foldBis, varSeen, minted,
         domVal, domKnown, domSrc, domTouched, _, nVar⟩ := st
   { cs := cs.push (denseBoolConstraint b), cvs := cvs.push #[b], bis, live := live + 1, bisN,
-    anchor, useCs, useBis, foldCs, foldBis, varSeen, minted := minted.insert b,
+    anchor := denseRncAnchorAdd anchor [b] cs.size,
+    useCs := useCs.map (fun m => denseRncBAdd m b cs.size), useBis, foldCs, foldBis, varSeen,
+    minted := minted.insert b,
     domVal, domKnown, domSrc, domTouched, dWithin := true, nVar }
 
 def denseRncEnsureUse (st : DenseRncState p) : DenseRncState p :=
@@ -2230,10 +2229,10 @@ def denseRncDomOf (ops : DenseZModOps p) (st : DenseRncState p) (v : VarId) :
     Option (List (ZMod p)) × DenseRncState p :=
   if denseRncGetB st.domKnown v then (st.domVal.getD v.index none, st)
   else
-    let cands := denseRncSortPos ((denseRncBGet st.anchor v).filter (fun q =>
+    let cands := (((st.anchor.buckets.getD v []).filter (fun q =>
       match st.cvs[q]? with
       | some vs => vs.size == 1
-      | none => false))
+      | none => false)).mergeSort (· ≤ ·)).toArray
     let r := denseRncFirstRoots ops st.cs v cands 0
     (r.map Prod.snd, st.setDom v r)
 
@@ -2337,17 +2336,13 @@ structure DenseRncCand (p : ℕ) where
   /-- Per pattern, the interpolation image of each group variable, evaluated from `hm` — the
       certificate checks it against `vals` rather than assuming it. -/
   imgs : Thunk (Array (Array (ZMod p)))
+  /-- The covered constraints, in position order, as the index gathered them: the certificate is the
+      audited predicate on exactly this list (`denseCoveredIdx`-style completeness makes it the
+      filter). -/
+  es : List (DenseExpr p)
   /-- The covered constraints compiled over the group (`.ix` = group index), in position order. -/
   ces : List (IExpr p)
   survs : Array (Array (ZMod p))
-
-/-- The covered constraints of `xs`, ascending by position, off the anchor index. -/
-def denseRncGather (st : DenseRncState p) (xs : List VarId) : Array Nat × Array (DenseExpr p) :=
-  (denseRncUnion st.anchor xs #[]).foldl
-    (fun (acc : Array Nat × Array (DenseExpr p)) i =>
-      match st.cs[i]?, st.cvs[i]? with
-      | some c, some vs => if denseRncCovered xs vs then (acc.1.push i, acc.2.push c) else acc
-      | _, _ => acc) (#[], #[])
 
 /-- The interpolation polynomial of the group variable at index `j`: `Σ_t indicator_t · value_t`,
     with the per-pattern indicators shared across the group (they depend only on the bits). -/
@@ -2366,21 +2361,23 @@ def denseRncInterp (ctx : DenseRncCtx p) (inds : Array (DenseExpr p))
 def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × Option (DenseRncCand p) × DenseRncState p :=
-  let (pos, es) := denseRncGather st xs
+  let planned := denseCoveredIdxPos st.anchor st.cs xs
+  let es := planned.map Prod.snd
   match denseRncDoms ctx.ops st xs #[] with
   | (none, st) => (reg, none, st)
   | (some doms, st) =>
     let boxSize := doms.foldl (fun n dd => n * dd.size) 1
     if boxSize > 256 then (reg, none, st)
-    else if es.size == xs.length
-        && pos.all (fun i => (st.cvs.getD i #[]).size == 1)
+    else if es.length == xs.length
+        && planned.all (fun ic => (st.cvs.getD ic.1 #[]).size == 1)
         && xs.length ≤ Nat.clog 2 boxSize then (reg, none, st)
     else
-      match denseCompileEs xs es.toList with
+      match denseCompileEs xs es with
       | none => (reg, none, st)
       | some ces =>
         let n := doms.size
-        match (denseRncDfs ctx.ops.zero doms (denseRncChecks st n pos ces) (2 ^ (xs.length - 1)) n
+        match (denseRncDfs ctx.ops.zero doms
+            (denseRncChecks st n (planned.map Prod.fst).toArray ces) (2 ^ (xs.length - 1)) n
             (Array.replicate n ctx.ops.zero) (some #[])).2 with
         | none => (reg, none, st)
         | some survs =>
@@ -2403,29 +2400,42 @@ def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState 
                 let env := denseEnvOfFast aβ
                 (xs.toArray).map (fun x => ((hm.get[x]?).getD (.var x)).evalFast env)))
               (reg1, some { bits := bits, k := k, vals := vals, hm := hm, patts := patts,
-                            pattsA := pattsA, imgs := imgs, ces := ces, survs := survs }, st)
+                            pattsA := pattsA, imgs := imgs, es := es, ces := ces,
+                            survs := survs }, st)
 
 /-! ### The checked certificate
 
-Same conjuncts as `denseCheckReencode`, read off the candidate: the covered set the build step
-gathered (index completeness is what makes it the filter), the survivors it enumerated, and the
-per-pattern image table. Freshness is the `O(|bits|)` `varSeen` test. -/
-def denseRncCert (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
-    (cd : DenseRncCand p) : Bool :=
-  let n := xs.length
-  decide (cd.bits.length < n) &&
-  decide (cd.bits.Nodup) &&
-  xs.all (fun x => ((cd.hm.get[x]?).getD (.var x)).vars.all (fun v => cd.bits.contains v)) &&
-  -- completeness: every survivor is the image of some bit pattern
-  cd.survs.all (fun s => cd.imgs.get.any (fun img =>
-    denseRncAllLt n (fun j =>
-      zmodIsZero (ctx.ops.add (img.getD j ctx.ops.zero)
-        (zmodNegP (s.getD j ctx.ops.zero)))))) &&
-  -- soundness: every pattern's image satisfies the covered constraints
-  cd.imgs.get.all (fun img =>
-    cd.ces.all (fun ie => zmodIsZero (denseRncEvalA ctx.ops.zero img ie))) &&
-  -- freshness
-  cd.bits.all (fun b => !denseRncSeen st b)
+`denseCheckReencodeNoFresh` computes the covered set by filtering the whole system; the index has
+already gathered it, and `denseCheckEs` is that same predicate with the list passed in. Freshness
+stays the `O(|bits|)` `varSeen` test. -/
+
+/-- `denseCheckReencodeNoFresh` with the covered set supplied. -/
+def denseCheckEs (es : List (DenseExpr p)) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
+  match denseGroupDoms es xs with
+  | none => false
+  | some doms =>
+    let survs := denseGroupSurvivorsE es doms
+    let patts := denseAssignments (denseBitBox bits)
+    decide ((doms.map (fun yd => yd.2.length)).prod ≤ 256) &&
+    decide (2 ≤ survs.length) &&
+    decide (bits.length < xs.length) &&
+    decide (bits.Nodup) &&
+    xs.all (fun x =>
+      ((DenseExpr.var x).substF (denseGroupSubst xs hm)).vars.all (fun v => bits.contains v)) &&
+    survs.all (fun s => patts.any (fun aβ =>
+      xs.all (fun x =>
+        decide (((DenseExpr.var x).substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ)
+          = denseEnvOfFast s x)))) &&
+    patts.all (fun aβ => es.all (fun c =>
+      decide ((c.substF (denseGroupSubst xs hm)).evalFast (denseEnvOfFast aβ) = 0)))
+
+theorem denseCheckReencodeNoFresh_eq_Es (d : DenseConstraintSystem p) (xs bits : List VarId)
+    (hm : Std.HashMap VarId (DenseExpr p)) :
+    denseCheckReencodeNoFresh d xs bits hm = denseCheckEs (denseCoveredCsOf d xs) xs bits hm := rfl
+
+def denseRncCert (st : DenseRncState p) (xs : List VarId) (cd : DenseRncCand p) : Bool :=
+  cd.bits.all (fun b => !denseRncSeen st b) && denseCheckEs cd.es xs cd.bits cd.hm.get
 
 /-! ### The degree pre-gate
 
@@ -2475,7 +2485,7 @@ def denseRncDegPre (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId
   (denseRncBucketAny useC xs (fun i =>
     match st.cs[i]?, st.cvs[i]? with
     | some c, some vs =>
-      denseRncShares xs vs c && !denseRncCovered xs vs && decide (ctx.dmaxC < deg c)
+      denseRncShares xs vs c && !denseRncCovered xs vs c && decide (ctx.dmaxC < deg c)
     | _, _ => false)) ||
   (denseRncBucketAny useB xs (fun i =>
     match st.bis[i]? with
@@ -2490,37 +2500,47 @@ Computing the rewrite and writing it are separate steps: the degree decision is 
 computed edits, so the write consumes the state linearly (a rejected candidate never touches it, and
 an accepted one never needs the old copy alive). -/
 
-/-- One position's new content. -/
-inductive DenseRncEdit (p : ℕ) where
+/-- One constraint position's new content: the tombstone, or the rewrite with its variable arrays. -/
+inductive DenseRncCsEdit (p : ℕ) where
   | tomb (i : Nat)
   | cst (i : Nat) (c : DenseExpr p) (cv full : Array VarId)
-  | bus (i : Nat) (bi : BusInteraction (DenseExpr p))
 
-/-- The accepted rewrite's edits, over the only positions it can touch — the group's `useCs`/`useBis`
-    buckets plus the recorded foldable positions — paired with whether every rewritten item stayed
-    within the degree bound. Read-only in `st`. -/
-def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
-    (cd : DenseRncCand p) : Array (DenseRncEdit p) × Bool :=
+def DenseRncCsEdit.pos : DenseRncCsEdit p → Nat
+  | .tomb i => i
+  | .cst i _ _ _ => i
+
+/-- The accepted rewrite's constraint edits, over the only positions it can touch: the group's
+    `useCs` buckets plus the recorded foldable positions. Read-only in `st`; the position list is
+    `Std.HashSet`-deduplicated, since applying the rewrite twice at one position is not the
+    identity. -/
+def denseRncCsEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : List (DenseRncCsEdit p) × Bool :=
   let σ := denseGroupSubst xs cd.hm.get
   let patts := cd.patts.get
   let foldC := (match st.foldCs with | some s => s | none => ∅)
   let useC := (match st.useCs with | some m => m | none => #[])
-  let rc := (denseRncUnion useC xs foldC.toArray).foldl
-    (fun (acc : Array (DenseRncEdit p) × Bool) i =>
+  ((denseRncPosList useC xs foldC.toList).foldr
+    (fun i (acc : List (DenseRncCsEdit p) × Bool) =>
       match st.cs[i]?, st.cvs[i]? with
       | some c, some vs =>
-        if denseRncCovered xs vs then (acc.1.push (.tomb i), acc.2)
+        if denseRncCovered xs vs c then (.tomb i :: acc.1, acc.2)
         else if denseRncShares xs vs c || denseRncHasFold c then
           let c' := denseGroupRewrite xs cd.bits σ patts c
           let cv' := denseRncCapVars c'
-          (acc.1.push (.cst i c' cv' (denseRncFullVars c' cv')),
+          (.cst i c' cv' (denseRncFullVars c' cv') :: acc.1,
            acc.2 && decide (c'.degree ≤ ctx.dmaxC))
         else acc
-      | _, _ => acc) (#[], true)
+      | _, _ => acc) ([], true))
+
+/-- The bus half, over its own candidate positions. -/
+def denseRncBiEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
+    (cd : DenseRncCand p) : List (Nat × BusInteraction (DenseExpr p)) × Bool :=
+  let σ := denseGroupSubst xs cd.hm.get
+  let patts := cd.patts.get
   let foldB := (match st.foldBis with | some s => s | none => ∅)
   let useB := (match st.useBis with | some m => m | none => #[])
-  (denseRncUnion useB xs foldB.toArray).foldl
-    (fun (acc : Array (DenseRncEdit p) × Bool) i =>
+  ((denseRncPosList useB xs foldB.toList).foldr
+    (fun i (acc : List (Nat × BusInteraction (DenseExpr p)) × Bool) =>
       match st.bis[i]? with
       | some bi =>
         if bi.multiplicity.sharesVarIn xs || denseRncHasFold bi.multiplicity
@@ -2528,20 +2548,31 @@ def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
           let bi' : BusInteraction (DenseExpr p) :=
             { bi with multiplicity := denseGroupRewrite xs cd.bits σ patts bi.multiplicity,
                       payload := bi.payload.map (denseGroupRewrite xs cd.bits σ patts) }
-          (acc.1.push (.bus i bi'),
+          ((i, bi') :: acc.1,
            acc.2 && decide (bi'.multiplicity.degree ≤ ctx.dmaxB)
              && bi'.payload.all (fun e => decide (e.degree ≤ ctx.dmaxB)))
         else acc
-      | none => acc) rc
+      | none => acc) ([], true))
+
+/-- The content one constraint edit installs. -/
+def DenseRncCsEdit.content (ctx : DenseRncCtx p) : DenseRncCsEdit p → DenseExpr p
+  | .tomb _ => ctx.zeroE
+  | .cst _ c' _ _ => c'
+
+/-- Both edits are the same write: a tombstone is the rewrite to the shared `.const 0`, whose
+    variable arrays are empty and which is not foldable, so the index updates are no-ops. -/
+def denseRncCsStep (ctx : DenseRncCtx p) (st : DenseRncState p) (e : DenseRncCsEdit p) :
+    DenseRncState p :=
+  match e with
+  | .tomb i => st.rewriteAt i ctx.zeroE #[] #[]
+  | .cst i c' cv' full => st.rewriteAt i c' cv' full
 
 /-- Install the edits and the booleanity constraints. Consumes `st`. -/
 def denseRncWrite (ctx : DenseRncCtx p) (st : DenseRncState p) (bits : List VarId)
-    (edits : Array (DenseRncEdit p)) : DenseRncState p :=
-  let st := edits.foldl (fun st e =>
-    match e with
-    | .tomb i => st.tombstone ctx.zeroE i
-    | .cst i c' cv' full => st.rewriteAt i c' cv' full
-    | .bus i bi' => st.rewriteBiAt i bi') st
+    (csEdits : List (DenseRncCsEdit p)) (biEdits : List (Nat × BusInteraction (DenseExpr p))) :
+    DenseRncState p :=
+  let st := csEdits.foldl (denseRncCsStep ctx) st
+  let st := biEdits.foldl (fun st ib => st.rewriteBiAt ib.1 ib.2) st
   (bits.foldl (fun st b => st.pushBool b) st).domReset
 
 /-- Whether the current system is within the degree bound. Discharges the side condition that makes
@@ -2606,12 +2637,15 @@ def denseRncStep (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p
             else if !xs.all (fun x => decide (x ∉ cd.bits)) then (reg1, st, [])
             else if !cd.bits.all (fun b => decide ((reg1.resolve b).powdrId? = none)) then
               (reg1, st, [])
-            else if !denseRncCert ctx st xs cd then (reg1, st, [])
+            else if !denseRncCert st xs cd then (reg1, st, [])
             else
               let st0 := denseRncEnsureFoldBis (denseRncEnsureFoldCs st)
-              let (edits, ok) := denseRncEdits ctx st0 xs cd
+              let (csEdits, okC) := denseRncCsEdits ctx st0 xs cd
+              let (biEdits, okB) := denseRncBiEdits ctx st0 xs cd
+              let ok := okC && okB && cd.bits.all (fun b =>
+                decide ((denseBoolConstraint b : DenseExpr p).degree ≤ ctx.dmaxC))
               if (if st0.dWithin then ok else ok && denseRncWithinNow ctx st0) then
-                (reg1, denseRncWrite ctx st0 cd.bits edits,
+                (reg1, denseRncWrite ctx st0 cd.bits csEdits biEdits,
                  cd.bits.map (fun b => (b, denseRncBitCMGo ctx cd xs b 0)))
               else (reg1, st0, [])
 
@@ -2654,19 +2688,9 @@ def denseRncTargets (reg : VarRegistry) (sv : Array Bool) (cvs : Array (Array Va
       some (vs.toList.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
     else none))
 
-/-- Each ≤ 8-variable position under its first variable, ascending. -/
-def denseRncAnchorBuild (nVar : Nat) (cvs : Array (Array VarId)) : Array (Array Nat) :=
-  let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
-    if h : i < cvs.size then
-      let vs := cvs[i]
-      go (i + 1)
-        (if 1 ≤ vs.size && vs.size ≤ 8 then
-          (match vs[0]? with | some v => denseRncBAdd acc v i | none => acc)
-         else acc)
-    else acc
-    termination_by cvs.size - i
-    decreasing_by omega
-  go 0 (Array.replicate nVar #[])
+/-- Each ≤ 8-variable position under its first variable. -/
+def denseRncAnchorBuild (cs : List (DenseExpr p)) : DenseCovIndex :=
+  cs.zipIdx.foldr (fun ai idx => denseRncAnchorAdd idx (denseRncAnchorVars ai.1) ai.2) ⟨∅, []⟩
 
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
     combinations survive, mint `Nat.clog 2 #survivors` fresh boolean bits, rewrite each group
@@ -2690,7 +2714,7 @@ def denseRncF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
       let bisArr := d.busInteractions.toArray
       let st : DenseRncState p :=
         { cs := csArr, cvs := cvs, bis := bisArr, live := live, bisN := bisArr.size,
-          anchor := denseRncAnchorBuild nVar cvs,
+          anchor := denseRncAnchorBuild d.algebraicConstraints,
           useCs := none, useBis := none, foldCs := none, foldBis := none, varSeen := none,
           minted := ∅,
           domVal := Array.replicate nVar none, domKnown := Array.replicate nVar false,

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -2319,15 +2319,23 @@ def denseRncDfs (zero : ZMod p) (doms : Array (Array (ZMod p)))
 
 /-! ### The candidate -/
 
-/-- Everything an accept needs about a candidate group, computed once. -/
+/-- Everything an accept needs about a candidate group. The interpolation polynomials, the bit
+    patterns and the image table are `Thunk`s: the degree pre-gate rejects nearly every candidate
+    (13.5 k of 13.6 k on sha256 `apc_001`) and decides without them (`denseRncDegRW`), so building
+    them there is the pass's largest piece of wasted work. -/
 structure DenseRncCand (p : ℕ) where
   bits : List VarId
-  hm : Std.HashMap VarId (DenseExpr p)
-  patts : List (List (VarId × ZMod p))
-  pattsA : Array (List (VarId × ZMod p))
-  /-- Per pattern, the interpolation image of each group variable (group order). A `Thunk`: only the
-      certificate and the derivations read it, and nearly every candidate is rejected by the degree
-      pre-gate before that. -/
+  /-- `|bits|`, the degree of every interpolation polynomial. -/
+  k : Nat
+  /-- The padded survivor table: per bit pattern, the group's values in group order. The image of
+      the group under the interpolation at pattern `t` is row `t` (the indicators are `δ` on the
+      patterns), which is what lets the pre-gate work off values alone. -/
+  vals : Array (Array (ZMod p))
+  hm : Thunk (Std.HashMap VarId (DenseExpr p))
+  patts : Thunk (List (List (VarId × ZMod p)))
+  pattsA : Thunk (Array (List (VarId × ZMod p)))
+  /-- Per pattern, the interpolation image of each group variable, evaluated from `hm` — the
+      certificate checks it against `vals` rather than assuming it. -/
   imgs : Thunk (Array (Array (ZMod p)))
   /-- The covered constraints compiled over the group (`.ix` = group index), in position order. -/
   ces : List (IExpr p)
@@ -2353,8 +2361,8 @@ def denseRncInterp (ctx : DenseRncCtx p) (inds : Array (DenseExpr p))
     decreasing_by omega
   (go 0 (.const ctx.ops.zero)).fold
 
-/-- Build the candidate: covered set, domains, box, survivors, bits, interpolations, images.
-    Proof-free — `denseRncCert` re-verifies. -/
+/-- Build the candidate: covered set, domains, box, survivors, bits. Proof-free — `denseRncCert`
+    re-verifies. -/
 def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × Option (DenseRncCand p) × DenseRncState p :=
@@ -2382,17 +2390,20 @@ def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState 
             if k ≥ xs.length then (reg, none, st)
             else
               let (reg1, bits) := denseRegisterBits reg freshBase k
-              let patts := denseAssignments (denseBitBox bits)
-              let pattsA := patts.toArray
-              let vals := survs ++ Array.replicate (pattsA.size - survs.size) (survs.getD 0 #[])
-              let inds := pattsA.map denseIndicatorExpr
-              let hm := Std.HashMap.ofList (xs.zipIdx.map
-                (fun xj => (xj.1, denseRncInterp ctx inds vals xj.2)))
-              let imgs := Thunk.mk (fun _ => pattsA.map (fun aβ =>
+              let vals := survs ++ Array.replicate (2 ^ k - survs.size) (survs.getD 0 #[])
+              let patts : Thunk (List (List (VarId × ZMod p))) :=
+                Thunk.mk (fun _ => denseAssignments (denseBitBox bits))
+              let pattsA : Thunk (Array (List (VarId × ZMod p))) :=
+                Thunk.mk (fun _ => patts.get.toArray)
+              let hm : Thunk (Std.HashMap VarId (DenseExpr p)) := Thunk.mk (fun _ =>
+                let inds := pattsA.get.map denseIndicatorExpr
+                Std.HashMap.ofList (xs.zipIdx.map
+                  (fun xj => (xj.1, denseRncInterp ctx inds vals xj.2))))
+              let imgs := Thunk.mk (fun _ => pattsA.get.map (fun aβ =>
                 let env := denseEnvOfFast aβ
-                (xs.toArray).map (fun x => ((hm[x]?).getD (.var x)).evalFast env)))
-              (reg1, some { bits := bits, hm := hm, patts := patts, pattsA := pattsA, imgs := imgs,
-                            ces := ces, survs := survs }, st)
+                (xs.toArray).map (fun x => ((hm.get[x]?).getD (.var x)).evalFast env)))
+              (reg1, some { bits := bits, k := k, vals := vals, hm := hm, patts := patts,
+                            pattsA := pattsA, imgs := imgs, ces := ces, survs := survs }, st)
 
 /-! ### The checked certificate
 
@@ -2404,7 +2415,7 @@ def denseRncCert (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
   let n := xs.length
   decide (cd.bits.length < n) &&
   decide (cd.bits.Nodup) &&
-  xs.all (fun x => ((cd.hm[x]?).getD (.var x)).vars.all (fun v => cd.bits.contains v)) &&
+  xs.all (fun x => ((cd.hm.get[x]?).getD (.var x)).vars.all (fun v => cd.bits.contains v)) &&
   -- completeness: every survivor is the image of some bit pattern
   cd.survs.all (fun s => cd.imgs.get.any (fun img =>
     denseRncAllLt n (fun j =>
@@ -2416,31 +2427,61 @@ def denseRncCert (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
   -- freshness
   cd.bits.all (fun b => !denseRncSeen st b)
 
-/-! ### The degree pre-gate -/
+/-! ### The degree pre-gate
+
+The gate needs the *degree* of each candidate position's rewrite, not the rewrite. A maximal
+in-group node becomes its interpolation over the bit patterns — `denseCandSelect` always takes it
+(its variables are the bits, and it agrees with the substitution at every pattern because the
+indicators are `δ` there) — and after `DenseExpr.fold` that interpolation is a constant exactly when
+the node takes one value across the padded survivor table, otherwise its surviving terms keep a full
+`|bits|`-factor indicator. So the degree follows from values alone, and the interpolation
+polynomials (and the substitution map they feed) are never built for a rejected candidate. -/
+
+/-- The degree of a maximal in-group node's rewrite: `0` if it is constant across the survivor
+    table, `|bits|` otherwise. -/
+def denseRncCandDeg (zero : ZMod p) (k : Nat) (vals : Array (Array (ZMod p))) (xs : List VarId)
+    (e : DenseExpr p) : Nat :=
+  match denseCompileE xs e with
+  | none => k
+  | some ie =>
+    match vals[0]? with
+    | none => 0
+    | some r0 =>
+      let v0 := denseRncEvalA zero r0 ie
+      if vals.all (fun r => zmodIsZero (zmodAddP (denseRncEvalA zero r ie) (zmodNegP v0)))
+      then 0 else k
+
+/-- `(denseGroupRewrite xs bits σ patts e).degree`, without building the rewrite. -/
+def denseRncDegRW (zero : ZMod p) (k : Nat) (vals : Array (Array (ZMod p))) (xs : List VarId) :
+    DenseExpr p → Nat
+  | .const _ => 0
+  | .var y =>
+      if denseContainsFast xs y then denseRncCandDeg zero k vals xs (.var y) else 1
+  | .add a b =>
+      if (DenseExpr.add a b).varsInF xs then denseRncCandDeg zero k vals xs (.add a b)
+      else max (denseRncDegRW zero k vals xs a) (denseRncDegRW zero k vals xs b)
+  | .mul a b =>
+      if (DenseExpr.mul a b).varsInF xs then denseRncCandDeg zero k vals xs (.mul a b)
+      else denseRncDegRW zero k vals xs a + denseRncDegRW zero k vals xs b
 
 /-- Untrusted degree pre-gate: fire when a candidate position's rewrite already exceeds the bound.
     Only positions mentioning a group variable are visited (the buckets are complete), and each
     position's current content is re-tested, so stale bucket entries are harmless. -/
 def denseRncDegPre (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
     (cd : DenseRncCand p) : Bool :=
-  let σ := denseGroupSubst xs cd.hm
+  let deg : DenseExpr p → Nat := denseRncDegRW ctx.ops.zero cd.k cd.vals xs
   let useC := (match st.useCs with | some m => m | none => #[])
   let useB := (match st.useBis with | some m => m | none => #[])
   (denseRncBucketAny useC xs (fun i =>
     match st.cs[i]?, st.cvs[i]? with
     | some c, some vs =>
-      denseRncShares xs vs c && !denseRncCovered xs vs &&
-        decide (ctx.dmaxC < (denseGroupRewrite xs cd.bits σ cd.patts c).degree)
+      denseRncShares xs vs c && !denseRncCovered xs vs && decide (ctx.dmaxC < deg c)
     | _, _ => false)) ||
   (denseRncBucketAny useB xs (fun i =>
     match st.bis[i]? with
     | some bi =>
-      (bi.multiplicity.sharesVarIn xs &&
-        decide (ctx.dmaxB
-          < (denseGroupRewrite xs cd.bits σ cd.patts bi.multiplicity).degree)) ||
-      bi.payload.any (fun e =>
-        e.sharesVarIn xs &&
-          decide (ctx.dmaxB < (denseGroupRewrite xs cd.bits σ cd.patts e).degree))
+      (bi.multiplicity.sharesVarIn xs && decide (ctx.dmaxB < deg bi.multiplicity)) ||
+      bi.payload.any (fun e => e.sharesVarIn xs && decide (ctx.dmaxB < deg e))
     | none => false))
 
 /-! ### The accept
@@ -2460,7 +2501,8 @@ inductive DenseRncEdit (p : ℕ) where
     within the degree bound. Read-only in `st`. -/
 def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
     (cd : DenseRncCand p) : Array (DenseRncEdit p) × Bool :=
-  let σ := denseGroupSubst xs cd.hm
+  let σ := denseGroupSubst xs cd.hm.get
+  let patts := cd.patts.get
   let foldC := (match st.foldCs with | some s => s | none => ∅)
   let useC := (match st.useCs with | some m => m | none => #[])
   let rc := (denseRncUnion useC xs foldC.toArray).foldl
@@ -2469,7 +2511,7 @@ def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
       | some c, some vs =>
         if denseRncCovered xs vs then (acc.1.push (.tomb i), acc.2)
         else if denseRncShares xs vs c || denseRncHasFold c then
-          let c' := denseGroupRewrite xs cd.bits σ cd.patts c
+          let c' := denseGroupRewrite xs cd.bits σ patts c
           let cv' := denseRncCapVars c'
           (acc.1.push (.cst i c' cv' (denseRncFullVars c' cv')),
            acc.2 && decide (c'.degree ≤ ctx.dmaxC))
@@ -2484,8 +2526,8 @@ def denseRncEdits (ctx : DenseRncCtx p) (st : DenseRncState p) (xs : List VarId)
         if bi.multiplicity.sharesVarIn xs || denseRncHasFold bi.multiplicity
             || bi.payload.any (fun e => e.sharesVarIn xs || denseRncHasFold e) then
           let bi' : BusInteraction (DenseExpr p) :=
-            { bi with multiplicity := denseGroupRewrite xs cd.bits σ cd.patts bi.multiplicity,
-                      payload := bi.payload.map (denseGroupRewrite xs cd.bits σ cd.patts) }
+            { bi with multiplicity := denseGroupRewrite xs cd.bits σ patts bi.multiplicity,
+                      payload := bi.payload.map (denseGroupRewrite xs cd.bits σ patts) }
           (acc.1.push (.bus i bi'),
            acc.2 && decide (bi'.multiplicity.degree ≤ ctx.dmaxB)
              && bi'.payload.all (fun e => decide (e.degree ≤ ctx.dmaxB)))
@@ -2524,12 +2566,12 @@ def denseRncMatchCM (img : Array (ZMod p)) (thenM elseM : DenseComputationMethod
 
 def denseRncBitCMGo (ctx : DenseRncCtx p) (cd : DenseRncCand p) (xs : List VarId) (b : VarId)
     (t : Nat) : DenseComputationMethod p :=
-  if h : t < cd.pattsA.size then
+  if h : t < cd.pattsA.get.size then
     denseRncMatchCM (cd.imgs.get.getD t #[])
-      (.const (denseEnvOfFast cd.pattsA[t] b))
+      (.const (denseEnvOfFast cd.pattsA.get[t] b))
       (denseRncBitCMGo ctx cd xs b (t + 1)) xs 0
   else .const ctx.ops.zero
-  termination_by cd.pattsA.size - t
+  termination_by cd.pattsA.get.size - t
   decreasing_by omega
 
 /-! ### The step, loop and pass -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -199,59 +199,6 @@ def denseGroupSurvivorsEFast (es : List (DenseExpr p)) (doms : List (VarId × Li
   · rw [denseSurvZeroCWZ_eq]
   · rfl
 
-/-- `filter P l` if it keeps at most `cap` elements, `none` as soon as a `cap + 1`-st hit shows
-    up — the tail is not scanned. -/
-def denseFilterCap {α : Type} (P : α → Bool) : Nat → List α → Option (List α)
-  | _, [] => some []
-  | cap, x :: rest =>
-    if P x then
-      match cap with
-      | 0 => none
-      | cap + 1 =>
-        match denseFilterCap P cap rest with
-        | some l => some (x :: l)
-        | none => none
-    else denseFilterCap P cap rest
-
-/-- `denseGroupSurvivorsE`, stopping as soon as more than `cap` survivors exist. The build uses
-    `cap = 2 ^ (xs.length − 1)`: any larger survivor count makes `Nat.clog 2` reach the group
-    size and the `k < xs.length` gate reject, so the outcome is the full enumeration's. -/
-def denseGroupSurvivorsECap (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p)))
-    (cap : Nat) : Option (List (List (VarId × ZMod p))) :=
-  match denseCompileEs (doms.map Prod.fst) es with
-  | some ces =>
-    denseFilterCap
-      (denseSurvZeroCW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul ces)
-      cap (denseAssignments doms)
-  | none =>
-    denseFilterCap (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = 0)))
-      cap (denseAssignments doms)
-
-/-- Boxed twin of `denseGroupSurvivorsECap`; see `denseGroupSurvivorsEW`. -/
-def denseGroupSurvivorsECapW (add mul : ZMod p → ZMod p → ZMod p) (zero : ZMod p)
-    (es : List (DenseExpr p)) (doms : List (VarId × List (ZMod p))) (cap : Nat) :
-    Option (List (List (VarId × ZMod p))) :=
-  match denseCompileEs (doms.map Prod.fst) es with
-  | some ces =>
-    denseFilterCap (denseSurvZeroCWZ add mul zero ces) cap (denseAssignments doms)
-  | none =>
-    denseFilterCap (fun a => es.all (fun c => decide (c.evalFast (denseEnvOfFast a) = zero)))
-      cap (denseAssignments doms)
-
-def denseGroupSurvivorsECapFast (es : List (DenseExpr p))
-    (doms : List (VarId × List (ZMod p))) (cap : Nat) :
-    Option (List (List (VarId × ZMod p))) :=
-  denseGroupSurvivorsECapW (inferInstance : Add (ZMod p)).add (inferInstance : Mul (ZMod p)).mul 0
-    es doms cap
-
-@[csimp] theorem denseGroupSurvivorsECap_eq_fast :
-    @denseGroupSurvivorsECap = @denseGroupSurvivorsECapFast := by
-  funext p es doms cap
-  show denseGroupSurvivorsECap es doms cap = denseGroupSurvivorsECapW _ _ 0 es doms cap
-  unfold denseGroupSurvivorsECap denseGroupSurvivorsECapW
-  split
-  · rw [denseSurvZeroCWZ_eq]
-  · rfl
 
 /-! ## The checked re-encoding certificate -/
 
@@ -561,34 +508,6 @@ the bound, only the items the gate rewrote (and the fresh booleanity constraints
 `denseMapOk` carries the resulting `Bool` alongside the mapped list in one tail-recursive pass;
 `denseReencodeOutOk_snd` is where the input-within-bound side condition is discharged. -/
 
-/-- Per-interaction gate paired with the degree test of the interaction it produced. -/
-def denseBIGateDeg (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
-    BusInteraction (DenseExpr p) × Bool :=
-  if bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode
-      || bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) then
-    let bi' : BusInteraction (DenseExpr p) :=
-      { bi with multiplicity := denseGroupRewriteGate xs bits σfn patts bi.multiplicity,
-                payload := bi.payload.map (denseGroupRewriteGate xs bits σfn patts) }
-    (bi', decide (bi'.multiplicity.degree ≤ dmax) &&
-      bi'.payload.all (fun e => decide (e.degree ≤ dmax)))
-  else (bi, true)
-
-theorem denseBIGateDeg_fst (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (bi : BusInteraction (DenseExpr p)) :
-    (denseBIGateDeg dmax xs bits σfn patts bi).1 = denseBIRewriteGate xs bits σfn patts bi := by
-  unfold denseBIGateDeg denseBIRewriteGate
-  split <;> rfl
-
-/-- Two lists' `all` agree when the predicates agree pointwise on the members. -/
-theorem List.all_congr_mem {α : Type} (l : List α) (f g : α → Bool)
-    (h : ∀ x ∈ l, f x = g x) : l.all f = l.all g := by
-  induction l with
-  | nil => rfl
-  | cons x rest ih =>
-      rw [List.all_cons, List.all_cons, h x List.mem_cons_self,
-        ih (fun y hy => h y (List.mem_cons_of_mem x hy))]
-
 /-- Whether any expression of the interaction carries a variable-free composite node. Independent of
     the group, so it is a property of the interaction and does not need re-deriving per accept. -/
 def denseBiHasFold (bi : BusInteraction (DenseExpr p)) : Bool :=
@@ -600,141 +519,6 @@ def denseBiHasFold (bi : BusInteraction (DenseExpr p)) : Bool :=
 def denseBiGateFires (xs : List VarId) (bi : BusInteraction (DenseExpr p)) : Bool :=
   bi.multiplicity.sharesVarIn xs || bi.multiplicity.hasConstFoldableNode ||
     bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode)
-
-/-- The bus side of an accept, driven by an ascending position list instead of by a gate test at
-    every interaction: `denseBIRewriteGate` is the identity wherever the gate cannot fire
-    (`denseBIRewriteGate_eq` + `denseGroupRewrite_eq_self`), and the positions where it can are the
-    `useBis` bucket candidates for `xs` together with the interactions carrying a variable-free
-    composite node. Once the positions run out the remaining suffix is shared untouched, which is
-    what makes this `O(prefix + candidates)` rather than `O(system)` tree walks. -/
-def denseGateBisPos (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) :
-    List Nat → Nat → List (BusInteraction (DenseExpr p)) →
-      List (BusInteraction (DenseExpr p)) → Bool →
-      List (BusInteraction (DenseExpr p)) × Bool
-  | _, _, [], acc, ok => (acc.reverse, ok)
-  | [], _, rest, acc, ok => (acc.reverse ++ rest, ok)
-  | j :: ps, i, bi :: rest, acc, ok =>
-      if j < i then denseGateBisPos dmax xs bits σfn patts ps i (bi :: rest) acc ok
-      else if j == i then
-        let r := denseBIGateDeg dmax xs bits σfn patts bi
-        denseGateBisPos dmax xs bits σfn patts ps (i + 1) rest (r.1 :: acc) (ok && r.2)
-      else denseGateBisPos dmax xs bits σfn patts (j :: ps) (i + 1) rest (bi :: acc) ok
-
-/-- The gate leaves an interaction it cannot fire on completely alone. -/
-theorem denseBIGateDeg_of_not_fires (dmax : Nat) (xs bits : List VarId)
-    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
-    {bi : BusInteraction (DenseExpr p)} (h : denseBiGateFires xs bi = false) :
-    denseBIGateDeg dmax xs bits σfn patts bi = (bi, true) := by
-  unfold denseBIGateDeg
-  rw [if_neg (by simpa [denseBiGateFires] using h)]
-
-/-- The position-driven bus rewrite equals the dense one, provided every position the gate can fire
-    on is listed. Extra and out-of-range positions are harmless (each visited position is re-tested by
-    `denseBIGateDeg`); the listed positions must be ascending, which is what lets the scan share the
-    suffix once they run out. -/
-theorem denseGateBisPos_eq (dmax : Nat) (xs bits : List VarId)
-    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) :
-    ∀ (bis : List (BusInteraction (DenseExpr p))) (ps : List Nat) (i : Nat)
-      (acc : List (BusInteraction (DenseExpr p))) (ok : Bool),
-      ps.Pairwise (· ≤ ·) →
-      (∀ k bi, bis[k]? = some bi → denseBiGateFires xs bi = true → (i + k) ∈ ps) →
-      denseGateBisPos dmax xs bits σfn patts ps i bis acc ok
-        = (acc.reverse ++ bis.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1),
-           ok && bis.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) := by
-  -- `gid l` : the gate is the identity on every item of `l`
-  have gid : ∀ (l : List (BusInteraction (DenseExpr p))),
-      (∀ bi ∈ l, denseBiGateFires xs bi = false) →
-      l.map (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1) = l ∧
-      (l.all (fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).2)) = true := by
-    intro l hl
-    constructor
-    · have h := List.map_congr_left (l := l)
-        (f := fun bi => (denseBIGateDeg dmax xs bits σfn patts bi).1) (g := id)
-        (fun bi hbi => by
-          simp [denseBIGateDeg_of_not_fires dmax xs bits σfn patts (hl bi hbi)])
-      rwa [List.map_id] at h
-    · rw [List.all_eq_true]
-      intro bi hbi
-      simp only [denseBIGateDeg_of_not_fires dmax xs bits σfn patts (hl bi hbi)]
-  intro bis
-  induction bis with
-  | nil =>
-      intro ps i acc ok _ _
-      cases ps <;> simp [denseGateBisPos]
-  | cons bi rest ih =>
-      intro ps i acc ok hsorted hcov
-      induction ps with
-      | nil =>
-          have hl : ∀ bi' ∈ bi :: rest, denseBiGateFires xs bi' = false := by
-            intro bi' hbi'
-            cases hf : denseBiGateFires xs bi' with
-            | false => rfl
-            | true =>
-                obtain ⟨k, hk⟩ := List.mem_iff_getElem?.1 hbi'
-                exact absurd (hcov k bi' hk hf) (by simp)
-          obtain ⟨hmap, hall⟩ := gid (bi :: rest) hl
-          simp only [denseGateBisPos, hmap, hall, Bool.and_true]
-      | cons j ps' ihps =>
-          have hsorted' : ps'.Pairwise (· ≤ ·) :=
-            List.Pairwise.sublist (List.sublist_cons_self j ps') hsorted
-          rcases Nat.lt_trichotomy j i with hji | hji | hji
-          · -- a position already passed: drop it and keep the same items
-            rw [denseGateBisPos, if_pos hji]
-            refine ihps hsorted' ?_
-            intro k bi' hk hf
-            rcases List.mem_cons.1 (hcov k bi' hk hf) with h | h
-            · omega
-            · exact h
-          · -- the current position: rewrite this item
-            rw [denseGateBisPos, if_neg (by omega), if_pos (show (j == i) = true by simp [hji])]
-            rw [ih ps' (i + 1) _ _ hsorted' ?_]
-            · simp [Bool.and_assoc]
-            · intro k bi' hk hf
-              have h1 := hcov (k + 1) bi' (by simpa using hk) hf
-              rcases List.mem_cons.1 h1 with h | h
-              · omega
-              · have : i + 1 + k = i + (k + 1) := by omega
-                rwa [this]
-          · -- the next listed position is later: this item cannot fire
-            have hni : denseBiGateFires xs bi = false := by
-              cases hf : denseBiGateFires xs bi with
-              | false => rfl
-              | true =>
-                  have h0 := hcov 0 bi (by simp) hf
-                  rcases List.mem_cons.1 (by simpa using h0) with h | h
-                  · omega
-                  · have := (List.pairwise_cons.1 hsorted).1 i h
-                    omega
-            rw [denseGateBisPos, if_neg (by omega),
-              if_neg (show ¬ ((j == i) = true) by simp; omega)]
-            rw [ih (j :: ps') (i + 1) _ _ hsorted ?_]
-            · simp [denseBIGateDeg_of_not_fires dmax xs bits σfn patts hni]
-            · intro k bi' hk hf
-              have h1 := hcov (k + 1) bi' (by simpa using hk) hf
-              have : i + 1 + k = i + (k + 1) := by omega
-              rwa [this]
-
-/-- A position the rewrite did not visit keeps its interaction. -/
-theorem denseGateBisPos_untouched (dmax : Nat) (xs bits : List VarId)
-    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p)))
-    (ps : List Nat) (bis : List (BusInteraction (DenseExpr p)))
-    (hsorted : ps.Pairwise (· ≤ ·))
-    (hcov : ∀ k bi, bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ ps) :
-    ∀ i bi, ((denseGateBisPos dmax xs bits σfn patts ps 0 bis [] true).1)[i]? = some bi →
-      i ∉ ps → bis[i]? = some bi := by
-  intro i bi hi hni
-  rw [denseGateBisPos_eq dmax xs bits σfn patts bis ps 0 [] true hsorted
-    (by simpa using hcov)] at hi
-  simp only [List.reverse_nil, List.nil_append, List.getElem?_map,
-    Option.map_eq_some_iff] at hi
-  obtain ⟨bi0, hbi0, hgate⟩ := hi
-  have hfires : denseBiGateFires xs bi0 = false := by
-    cases hf : denseBiGateFires xs bi0 with
-    | false => rfl
-    | true => exact absurd (hcov i bi0 hbi0 hf) hni
-  rw [denseBIGateDeg_of_not_fires dmax xs bits σfn patts hfires] at hgate
-  rw [hbi0, ← hgate]
 
 /-! ## Deferred materialisation: the loop's working system
 
@@ -752,21 +536,6 @@ appended once, since appending them per accept would copy the whole spine and de
 `lastPos`/`lastFold` are the bound: `DenseWorkBounded` says nothing past `maxPos` can change, which
 is what licenses sharing the tail. They are maintained monotonically by the splice itself. -/
 
-structure DenseReencodeWork (p : ℕ) where
-  cs : List (DenseExpr p)
-  bis : List (BusInteraction (DenseExpr p))
-  bools : List (DenseExpr p)
-  /-- Every bit minted so far. The step refuses a group meeting one, which is what keeps the
-      accumulated `bools` inert (`denseBoolConstraint_inert`). -/
-  bitSet : Std.HashSet VarId
-  /-- For each variable, an upper bound on the positions of `cs` mentioning it. -/
-  lastPos : Std.HashMap VarId Nat
-  /-- An upper bound on the positions of `cs` carrying a variable-free composite node. -/
-  lastFold : Nat
-  /-- Whether `lastPos`/`lastFold` have been computed. They are seeded on the first accept rather than
-      at pass entry (`denseWorkEnsureBounded`): an APC that never accepts would otherwise pay a full
-      variable fold per cleanup cycle for a bound it never consults. -/
-  bounded : Bool
 
 def denseIsZeroImpl : DenseExpr p → Bool
   | .const n => zmodIsZero n
@@ -787,140 +556,15 @@ def denseIsZero : DenseExpr p → Bool
   | add _ _ => rfl
   | mul _ _ => rfl
 
-/-- `denseIsZero` with the field zero as a parameter. The compiler floats the `0`'s whole
-    `ZMod.commRing` chain to the head of `denseIsZero`, *before* the constructor test, so a caller
-    scanning a list pays four dictionary constructions per item; binding the zero in the function
-    that contains the scan hoists it out of the loop. -/
-def denseIsZeroW (zero : ZMod p) : DenseExpr p → Bool
-  | .const n => n == zero
-  | _ => false
 
-theorem denseIsZeroW_zero : denseIsZeroW (0 : ZMod p) = denseIsZero (p := p) := by
-  funext e; cases e <;> rfl
-
-def denseWorkView (w : DenseReencodeWork p) : DenseConstraintSystem p :=
-  { algebraicConstraints := w.cs.filter (fun c => !denseIsZero c) ++ w.bools,
-    busInteractions := w.bis }
-
-/-- Boxed twin: `zero` must be a parameter of the function *containing* the scan. A `let` at the
-    head of `denseWorkViewFast` is floated back into the `filter` body by the compiler (verified in
-    the generated C), which is the whole cost being removed here. -/
-def denseWorkViewW (zero : ZMod p) (w : DenseReencodeWork p) : DenseConstraintSystem p :=
-  { algebraicConstraints := w.cs.filter (fun c => !denseIsZeroW zero c) ++ w.bools,
-    busInteractions := w.bis }
-
-def denseWorkViewFast (w : DenseReencodeWork p) : DenseConstraintSystem p := denseWorkViewW 0 w
-
-@[csimp] theorem denseWorkView_eq_fast : @denseWorkView = @denseWorkViewFast := by
-  funext p w
-  simp only [denseWorkView, denseWorkViewFast, denseWorkViewW, denseIsZeroW_zero]
+theorem denseCoveredBy_const (xs : List VarId) (n : ZMod p) :
+    denseCoveredBy xs (.const n) = false := by
+  simp [denseCoveredBy, DenseExpr.hasVar]
 
 /-- One position's new content: the placeholder if the group covers it, else the gated rewrite. -/
 def denseTombify (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
     (patts : List (List (VarId × ZMod p))) (c : DenseExpr p) : DenseExpr p :=
   if denseCoveredBy xs c then .const 0 else denseGroupRewrite xs bits σfn patts c
-
-/-- No position at or past `i + j` beyond `maxPos` can be touched by the rewrite. -/
-def DenseWorkBounded (xs : List VarId) (maxPos i : Nat) (cs : List (DenseExpr p)) : Prop :=
-  ∀ j c, cs[j]? = some c →
-    (denseCoveredBy xs c = true ∨ c.sharesVarIn xs = true ∨ c.hasConstFoldableNode = true) →
-    i + j ≤ maxPos
-
-theorem denseTombify_id_of_untouched {xs bits : List VarId} {σfn : VarId → Option (DenseExpr p)}
-    {patts : List (List (VarId × ZMod p))} :
-    ∀ (l : List (DenseExpr p)),
-      (∀ c ∈ l, denseCoveredBy xs c = false ∧ c.sharesVarIn xs = false ∧
-        c.hasConstFoldableNode = false) →
-      l.map (denseTombify xs bits σfn patts) = l := by
-  intro l
-  induction l with
-  | nil => intro _; rfl
-  | cons c rest ih =>
-      intro h
-      obtain ⟨hcov, hsh, hfd⟩ := h c (List.mem_cons_self ..)
-      have htf : denseTombify xs bits σfn patts c = c := by
-        simp [denseTombify, hcov, denseGroupRewrite_eq_self hsh hfd]
-      rw [List.map_cons, htf, ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
-
-/-- Rewrite the prefix through `maxPos`, then share the tail. `lastPos`/`lastFold` are extended for
-    every position the rewrite touches, which keeps `DenseWorkBounded` true for the next group. -/
-def denseWorkSpliceCs (dmax : Nat) (xs bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
-    Nat → List (DenseExpr p) → List (DenseExpr p) → Std.HashMap VarId Nat → Nat → Bool →
-      List (DenseExpr p) × Std.HashMap VarId Nat × Nat × Bool
-  | _, [], acc, lp, lf, ok => (acc.reverse, lp, lf, ok)
-  | i, c :: rest, acc, lp, lf, ok =>
-      if maxPos < i then (acc.reverse ++ (c :: rest), lp, lf, ok)
-      else if denseCoveredBy xs c then
-        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest
-          ((.const 0) :: acc) lp lf ok
-      else if c.sharesVarIn xs || c.hasConstFoldableNode then
-        let c' := denseGroupRewrite xs bits σfn patts c
-        let lp' := c'.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) lp
-        let lf' := if c'.hasConstFoldableNode then max lf i else lf
-        denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest (c' :: acc) lp' lf'
-          (ok && decide (c'.degree ≤ dmax))
-      else denseWorkSpliceCs dmax xs bits σfn patts maxPos (i + 1) rest (c :: acc) lp lf ok
-
-/-- The spliced list is the positionwise `denseTombify` of the input: `maxPos` decides *whether to
-    look*, never *what the answer is*, so boundedness makes the two agree. -/
-theorem denseWorkSpliceCs_list (dmax : Nat) (xs bits : List VarId)
-    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
-    ∀ (l : List (DenseExpr p)) (i : Nat) (acc : List (DenseExpr p)) (lp : Std.HashMap VarId Nat)
-      (lf : Nat) (ok : Bool),
-      DenseWorkBounded xs maxPos i l →
-      (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).1
-        = acc.reverse ++ l.map (denseTombify xs bits σfn patts) := by
-  intro l
-  induction l with
-  | nil => intro i acc lp lf ok _; simp [denseWorkSpliceCs]
-  | cons c rest ih =>
-      intro i acc lp lf ok hb
-      have hrest : DenseWorkBounded xs maxPos (i + 1) rest := by
-        intro j c' hj hgate
-        have := hb (j + 1) c' (by simpa using hj) hgate
-        omega
-      rw [denseWorkSpliceCs]
-      by_cases hmp : maxPos < i
-      · rw [if_pos hmp]
-        have hall : ∀ c' ∈ c :: rest, denseCoveredBy xs c' = false ∧ c'.sharesVarIn xs = false ∧
-            c'.hasConstFoldableNode = false := by
-          intro c' hc'
-          obtain ⟨j, hj⟩ := List.getElem?_of_mem hc'
-          by_contra hcon
-          rw [not_and_or, not_and_or] at hcon
-          have hg : denseCoveredBy xs c' = true ∨ c'.sharesVarIn xs = true ∨
-              c'.hasConstFoldableNode = true := by
-            rcases hcon with h | h
-            · exact Or.inl (by simpa using h)
-            · rcases h with h | h
-              · exact Or.inr (Or.inl (by simpa using h))
-              · exact Or.inr (Or.inr (by simpa using h))
-          exact absurd (hb j c' hj hg) (by omega)
-        rw [denseTombify_id_of_untouched _ hall]
-      · rw [if_neg hmp]
-        by_cases hcov : denseCoveredBy xs c = true
-        · rw [if_pos hcov, ih (i + 1) _ _ _ _ hrest]
-          simp only [List.map_cons, denseTombify, if_pos hcov, List.reverse_cons,
-            List.append_assoc, List.cons_append, List.nil_append]
-        · rw [if_neg hcov]
-          rw [Bool.not_eq_true] at hcov
-          by_cases hg : c.sharesVarIn xs || c.hasConstFoldableNode
-          · rw [if_pos hg, ih (i + 1) _ _ _ _ hrest]
-            have htf : denseTombify xs bits σfn patts c
-                = denseGroupRewrite xs bits σfn patts c := by simp [denseTombify, hcov]
-            simp only [List.map_cons, htf, List.reverse_cons, List.append_assoc,
-              List.cons_append, List.nil_append]
-          · rw [if_neg hg, ih (i + 1) _ _ _ _ hrest]
-            rw [Bool.or_eq_true, not_or, Bool.not_eq_true, Bool.not_eq_true] at hg
-            have htf : denseTombify xs bits σfn patts c = c := by
-              simp [denseTombify, hcov, denseGroupRewrite_eq_self hg.1 hg.2]
-            simp only [List.map_cons, htf, List.reverse_cons, List.append_assoc,
-              List.cons_append, List.nil_append]
-
-theorem denseCoveredBy_const (xs : List VarId) (n : ZMod p) :
-    denseCoveredBy xs (.const n) = false := by
-  simp [denseCoveredBy, DenseExpr.hasVar]
 
 /-- Filtering the placeholders out of the tombified list is the same as dropping the covered items
     first and rewriting what is left — the step that lets `denseReencodeOut` reappear. -/
@@ -973,86 +617,6 @@ theorem denseTombify_filter (xs bits : List VarId) (σfn : VarId → Option (Den
 positions mentioning each variable and `lastFold` bounds the foldable ones. The splice maintains it,
 and `denseWorkBounded_of_posOk` turns it into the `DenseWorkBounded` hypothesis the splice needs. -/
 
-theorem denseSharesVarIn_exists {xs : List VarId} :
-    ∀ {c : DenseExpr p}, c.sharesVarIn xs = true → ∃ v ∈ c.vars, v ∈ xs := by
-  intro c
-  induction c with
-  | const n => intro h; simp [DenseExpr.sharesVarIn] at h
-  | var y =>
-      intro h
-      exact ⟨y, by simp [DenseExpr.vars], denseContainsFast_sound xs y (by
-        simpa [DenseExpr.sharesVarIn] using h)⟩
-  | add a b iha ihb =>
-      intro h
-      rw [DenseExpr.sharesVarIn, Bool.or_eq_true] at h
-      rcases h with h | h
-      · obtain ⟨v, hv, hx⟩ := iha h
-        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
-      · obtain ⟨v, hv, hx⟩ := ihb h
-        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
-  | mul a b iha ihb =>
-      intro h
-      rw [DenseExpr.sharesVarIn, Bool.or_eq_true] at h
-      rcases h with h | h
-      · obtain ⟨v, hv, hx⟩ := iha h
-        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
-      · obtain ⟨v, hv, hx⟩ := ihb h
-        exact ⟨v, by simp [DenseExpr.vars, hv], hx⟩
-
-/-- A covered constraint has a variable, and all of them lie in the group, so it shares one. -/
-theorem denseCoveredBy_sharesVarIn {xs : List VarId} {c : DenseExpr p}
-    (h : denseCoveredBy xs c = true) : c.sharesVarIn xs = true := by
-  rw [denseCoveredBy, Bool.and_eq_true] at h
-  by_contra hs
-  rw [Bool.not_eq_true] at hs
-  rw [DenseExpr.varsInF_eq_false h.1 hs] at h
-  exact Bool.noConfusion h.2
-
-def DenseWorkPosOk (lp : Std.HashMap VarId Nat) (lf : Nat) (cs : List (DenseExpr p)) : Prop :=
-  ∀ j c, cs[j]? = some c →
-    (∀ v ∈ c.vars, j ≤ lp.getD v 0) ∧ (c.hasConstFoldableNode = true → j ≤ lf)
-
-def denseWorkMaxPos (lp : Std.HashMap VarId Nat) (lf : Nat) (xs : List VarId) : Nat :=
-  xs.foldl (fun m x => max m (lp.getD x 0)) lf
-
-theorem denseWorkMaxPos_ge_lf (lp : Std.HashMap VarId Nat) (lf : Nat) (xs : List VarId) :
-    lf ≤ denseWorkMaxPos lp lf xs := by
-  unfold denseWorkMaxPos
-  suffices h : ∀ (l : List VarId) (acc : Nat), acc ≤ l.foldl (fun m x => max m (lp.getD x 0)) acc by
-    exact h xs lf
-  intro l
-  induction l with
-  | nil => intro acc; exact Nat.le_refl acc
-  | cons y rest ih => intro acc; exact Nat.le_trans (Nat.le_max_left _ _) (ih _)
-
-theorem denseWorkMaxPos_ge_mem {lp : Std.HashMap VarId Nat} {lf : Nat} {xs : List VarId} {v : VarId}
-    (hv : v ∈ xs) : lp.getD v 0 ≤ denseWorkMaxPos lp lf xs := by
-  unfold denseWorkMaxPos
-  suffices h : ∀ (l : List VarId) (acc : Nat), v ∈ l →
-      lp.getD v 0 ≤ l.foldl (fun m x => max m (lp.getD x 0)) acc by
-    exact h xs lf hv
-  intro l
-  induction l with
-  | nil => intro _ h; simp at h
-  | cons y rest ih =>
-      intro acc h
-      rcases List.mem_cons.mp h with rfl | h
-      · exact Nat.le_trans (Nat.le_max_right acc _)
-          (denseWorkMaxPos_ge_lf lp (max acc (lp.getD v 0)) rest)
-      · exact ih _ h
-
-theorem denseWorkBounded_of_posOk {lp : Std.HashMap VarId Nat} {lf : Nat} {xs : List VarId}
-    {cs : List (DenseExpr p)} (h : DenseWorkPosOk lp lf cs) :
-    DenseWorkBounded xs (denseWorkMaxPos lp lf xs) 0 cs := by
-  intro j c hj hgate
-  rw [Nat.zero_add]
-  obtain ⟨hvars, hfold⟩ := h j c hj
-  rcases hgate with hcov | hsh | hfd
-  · obtain ⟨v, hv, hx⟩ := denseSharesVarIn_exists (denseCoveredBy_sharesVarIn hcov)
-    exact Nat.le_trans (hvars v hv) (denseWorkMaxPos_ge_mem hx)
-  · obtain ⟨v, hv, hx⟩ := denseSharesVarIn_exists hsh
-    exact Nat.le_trans (hvars v hv) (denseWorkMaxPos_ge_mem hx)
-  · exact Nat.le_trans (hfold hfd) (denseWorkMaxPos_ge_lf lp lf xs)
 
 
 /-! ### Maintaining the bound
@@ -1061,152 +625,6 @@ The splice only ever raises `lastPos`/`lastFold`, and raises them at every posit
 `DenseWorkPosOk` survives an accept. `DenseLpLe` is the pointwise order that makes "only raises"
 usable: the already-processed prefix keeps its bound because the map only grew. -/
 
-def DenseLpLe (lp lp' : Std.HashMap VarId Nat) : Prop := ∀ v, lp.getD v 0 ≤ lp'.getD v 0
-
-theorem DenseLpLe.refl (lp : Std.HashMap VarId Nat) : DenseLpLe lp lp := fun _ => Nat.le_refl _
-
-theorem DenseLpLe.trans {a b c : Std.HashMap VarId Nat} (h1 : DenseLpLe a b) (h2 : DenseLpLe b c) :
-    DenseLpLe a c := fun v => Nat.le_trans (h1 v) (h2 v)
-
-theorem denseLpStep_mono (m : Std.HashMap VarId Nat) (v : VarId) (i : Nat) :
-    DenseLpLe m (m.insert v (max (m.getD v 0) i)) := by
-  intro u
-  by_cases h : u = v
-  · subst h
-    rw [Std.HashMap.getD_insert]
-    simp only [beq_self_eq_true, if_true]
-    exact Nat.le_max_left _ _
-  · rw [Std.HashMap.getD_insert, show (v == u) = false from by simpa using (Ne.symm h)]
-    simp
-
-theorem denseLpFold_mono (i : Nat) :
-    ∀ (vs : List VarId) (m : Std.HashMap VarId Nat),
-      DenseLpLe m (vs.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m) := by
-  intro vs
-  induction vs with
-  | nil => intro m; exact DenseLpLe.refl m
-  | cons v rest ih =>
-      intro m
-      exact DenseLpLe.trans (denseLpStep_mono m v i) (ih _)
-
-theorem denseLpFold_ge (i : Nat) :
-    ∀ (vs : List VarId) (m : Std.HashMap VarId Nat) (u : VarId), u ∈ vs →
-      i ≤ (vs.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m).getD u 0 := by
-  intro vs
-  induction vs with
-  | nil => intro _ _ h; simp at h
-  | cons v rest ih =>
-      intro m u h
-      rcases List.mem_cons.mp h with rfl | h
-      · refine Nat.le_trans ?_ (denseLpFold_mono i rest (m.insert u (max (m.getD u 0) i)) u)
-        rw [Std.HashMap.getD_insert]
-        simp only [beq_self_eq_true, if_true]
-        exact Nat.le_max_right _ _
-      · exact ih _ u h
-
-def DenseWorkPosOkFrom (off : Nat) (lp : Std.HashMap VarId Nat) (lf : Nat)
-    (cs : List (DenseExpr p)) : Prop :=
-  ∀ j c, cs[j]? = some c →
-    (∀ v ∈ c.vars, off + j ≤ lp.getD v 0) ∧ (c.hasConstFoldableNode = true → off + j ≤ lf)
-
-theorem densePosOkFrom_mono {off : Nat} {lp lp' : Std.HashMap VarId Nat} {lf lf' : Nat}
-    {cs : List (DenseExpr p)} (hlp : DenseLpLe lp lp') (hlf : lf ≤ lf')
-    (h : DenseWorkPosOkFrom off lp lf cs) : DenseWorkPosOkFrom off lp' lf' cs := by
-  intro j c hj
-  obtain ⟨hv, hf⟩ := h j c hj
-  exact ⟨fun v hvm => Nat.le_trans (hv v hvm) (hlp v), fun hfd => Nat.le_trans (hf hfd) hlf⟩
-
-theorem densePosOkFrom_append {lp : Std.HashMap VarId Nat} {lf : Nat}
-    {u v : List (DenseExpr p)} (hu : DenseWorkPosOkFrom 0 lp lf u)
-    (hv : DenseWorkPosOkFrom u.length lp lf v) : DenseWorkPosOkFrom 0 lp lf (u ++ v) := by
-  intro j c hj
-  by_cases h : j < u.length
-  · exact hu j c (by rwa [List.getElem?_append_left h] at hj)
-  · rw [List.getElem?_append_right (by omega)] at hj
-    have := hv (j - u.length) c hj
-    rw [show u.length + (j - u.length) = j by omega] at this
-    simpa using this
-
-theorem densePosOkFrom_cons_last {lp : Std.HashMap VarId Nat} {lf : Nat}
-    {u : List (DenseExpr p)} {c : DenseExpr p} (hu : DenseWorkPosOkFrom 0 lp lf u)
-    (hc : (∀ v ∈ c.vars, u.length ≤ lp.getD v 0) ∧
-      (c.hasConstFoldableNode = true → u.length ≤ lf)) :
-    DenseWorkPosOkFrom 0 lp lf (u ++ [c]) := by
-  refine densePosOkFrom_append hu ?_
-  intro j c' hj
-  cases j with
-  | zero =>
-      rw [List.getElem?_cons_zero, Option.some_inj] at hj
-      subst hj
-      simpa using hc
-  | succ k => simp at hj
-
-
-/-- The position bound survives an accept: the splice raises `lastPos`/`lastFold` at exactly the
-    positions it rewrites, and only ever raises them, so the untouched prefix keeps its bound. -/
-theorem denseWorkSpliceCs_posOk (dmax : Nat) (xs bits : List VarId)
-    (σfn : VarId → Option (DenseExpr p)) (patts : List (List (VarId × ZMod p))) (maxPos : Nat) :
-    ∀ (l : List (DenseExpr p)) (i : Nat) (acc : List (DenseExpr p)) (lp : Std.HashMap VarId Nat)
-      (lf : Nat) (ok : Bool),
-      acc.length = i →
-      DenseWorkPosOkFrom 0 lp lf acc.reverse →
-      DenseWorkPosOkFrom i lp lf l →
-      DenseWorkPosOkFrom 0
-        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).2.1
-        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).2.2.1
-        (denseWorkSpliceCs dmax xs bits σfn patts maxPos i l acc lp lf ok).1 := by
-  intro l
-  induction l with
-  | nil =>
-      intro i acc lp lf ok _ hacc _
-      simpa [denseWorkSpliceCs] using hacc
-  | cons c rest ih =>
-      intro i acc lp lf ok hlen hacc hl
-      have hhead := hl 0 c (by simp)
-      have hrest : DenseWorkPosOkFrom (i + 1) lp lf rest := by
-        intro j c' hj
-        have := hl (j + 1) c' (by simpa using hj)
-        rw [show i + (j + 1) = i + 1 + j by omega] at this
-        exact this
-      rw [denseWorkSpliceCs]
-      by_cases hmp : maxPos < i
-      · rw [if_pos hmp]
-        refine densePosOkFrom_append hacc ?_
-        intro j c' hj
-        simp only [List.length_reverse, hlen]
-        exact hl j c' hj
-      · rw [if_neg hmp]
-        by_cases hcov : denseCoveredBy xs c = true
-        · rw [if_pos hcov]
-          refine ih (i + 1) _ lp lf ok (by simp [hlen]) ?_ hrest
-          -- the placeholder has no variables and no foldable node
-          rw [List.reverse_cons]
-          refine densePosOkFrom_cons_last hacc ?_
-          refine ⟨fun v hv => by simp [DenseExpr.vars] at hv, fun hfd => ?_⟩
-          simp [DenseExpr.hasConstFoldableNode] at hfd
-        · rw [if_neg hcov]
-          by_cases hg : c.sharesVarIn xs || c.hasConstFoldableNode
-          · rw [if_pos hg]
-            set c' := denseGroupRewrite xs bits σfn patts c with hc'
-            set lp' := c'.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) lp with hlp'
-            set lf' := if c'.hasConstFoldableNode then max lf i else lf with hlf'
-            have hmono : DenseLpLe lp lp' := denseLpFold_mono i _ lp
-            have hlfle : lf ≤ lf' := by
-              rw [hlf']; split <;> [exact Nat.le_max_left _ _; exact Nat.le_refl _]
-            refine ih (i + 1) _ lp' lf' _ (by simp [hlen]) ?_
-              (densePosOkFrom_mono hmono hlfle hrest)
-            rw [List.reverse_cons]
-            refine densePosOkFrom_cons_last (densePosOkFrom_mono hmono hlfle hacc) ?_
-            rw [List.length_reverse, hlen]
-            refine ⟨fun v hv => denseLpFold_ge i _ lp v hv, fun hfd => ?_⟩
-            rw [hlf', if_pos hfd]
-            exact Nat.le_max_right _ _
-          · rw [if_neg hg]
-            refine ih (i + 1) _ lp lf ok (by simp [hlen]) ?_ hrest
-            rw [List.reverse_cons]
-            refine densePosOkFrom_cons_last hacc ?_
-            rw [List.length_reverse, hlen]
-            simpa using hhead
 
 
 /-! ### The accumulated booleanity constraints
@@ -1218,48 +636,6 @@ that every accumulated bool belongs to a minted bit, and the step's `bitSet` gua
 directly — cheaper than deriving it from registry freshness, and sound either way since rejecting a
 candidate is always allowed. -/
 
-def DenseWorkBoolsOk (bitSet : Std.HashSet VarId) (bools : List (DenseExpr p)) : Prop :=
-  ∀ c ∈ bools, ∃ b, c = (denseBoolConstraint b : DenseExpr p) ∧ bitSet.contains b = true
-
-theorem denseContainsFast_of_not_mem {xs : List VarId} {b : VarId} (hb : b ∉ xs) :
-    denseContainsFast xs b = false := by
-  by_contra h
-  rw [Bool.not_eq_false] at h
-  exact absurd (denseContainsFast_sound xs b h) hb
-
-theorem denseBoolConstraint_inert {xs : List VarId} {b : VarId} (hb : b ∉ xs) :
-    denseCoveredBy xs (denseBoolConstraint b : DenseExpr p) = false ∧
-    (denseBoolConstraint b : DenseExpr p).sharesVarIn xs = false ∧
-    (denseBoolConstraint b : DenseExpr p).hasConstFoldableNode = false ∧
-    denseIsZero (denseBoolConstraint b : DenseExpr p) = false := by
-  have hc := denseContainsFast_of_not_mem (xs := xs) (b := b) hb
-  refine ⟨?_, ?_, ?_, rfl⟩
-  · simp [denseCoveredBy, denseBoolConstraint, DenseExpr.varsInF, hc]
-  · simp [denseBoolConstraint, DenseExpr.sharesVarIn, hc]
-  · simp [denseBoolConstraint, DenseExpr.hasConstFoldableNode, DenseExpr.hasVar]
-
-theorem denseWorkBools_filter_covered {xs : List VarId} {bitSet : Std.HashSet VarId}
-    {bools : List (DenseExpr p)} (bits : List VarId) (σfn : VarId → Option (DenseExpr p))
-    (patts : List (List (VarId × ZMod p))) (hb : DenseWorkBoolsOk bitSet bools)
-    (hxs : ∀ x ∈ xs, bitSet.contains x = false) :
-    bools.filter (fun c => !denseCoveredBy xs c) = bools ∧
-    bools.map (denseGroupRewrite xs bits σfn patts) = bools ∧
-    bools.filter (fun c => !denseIsZero c) = bools := by
-  have hinert : ∀ c ∈ bools, denseCoveredBy xs c = false ∧ c.sharesVarIn xs = false ∧
-      c.hasConstFoldableNode = false ∧ denseIsZero c = false := by
-    intro c hc
-    obtain ⟨bb, rfl, hbb⟩ := hb c hc
-    refine denseBoolConstraint_inert (fun hmem => ?_)
-    rw [hxs bb hmem] at hbb
-    exact Bool.noConfusion hbb
-  refine ⟨?_, ?_, ?_⟩
-  · refine List.filter_eq_self.2 (fun c hc => ?_)
-    simp [(hinert c hc).1]
-  · rw [show bools.map (denseGroupRewrite xs bits σfn patts) = bools.map id from
-      List.map_congr_left (fun c hc =>
-        denseGroupRewrite_eq_self (hinert c hc).2.1 (hinert c hc).2.2.1), List.map_id]
-  · refine List.filter_eq_self.2 (fun c hc => ?_)
-    simp [(hinert c hc).2.2.2]
 
 theorem denseBoolConstraints_not_zero (bits : List VarId) :
     (bits.map (denseBoolConstraint (p := p))).filter (fun c => !denseIsZero c)
@@ -1268,77 +644,6 @@ theorem denseBoolConstraints_not_zero (bits : List VarId) :
   obtain ⟨b, _, rfl⟩ := List.mem_map.1 hc
   simp [denseIsZero, denseBoolConstraint]
 
-
-/-- One accept on the working system: splice the constraints, gate the bus interactions (reusing the
-    position-driven `denseGateBisPos`), and accumulate the booleanity constraints. Assumes the
-    position bound is computed — `denseWorkStep` calls `denseWorkEnsureBounded` first. -/
-def denseWorkOut (b : DegreeBound) (w : DenseReencodeWork p) (usePosB : List Nat)
-    (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeWork p × Bool :=
-  let σfn := denseGroupSubst xs hm
-  let patts := denseAssignments (denseBitBox bits)
-  let mp := denseWorkMaxPos w.lastPos w.lastFold xs
-  let rc := denseWorkSpliceCs b.identities xs bits σfn patts mp 0 w.cs [] w.lastPos w.lastFold true
-  let rb := denseGateBisPos b.busInteractions xs bits σfn patts usePosB 0 w.bis [] true
-  let newBools := bits.map (denseBoolConstraint (p := p))
-  ({ cs := rc.1, bis := rb.1, bools := w.bools ++ newBools,
-     bitSet := bits.foldl (·.insert ·) w.bitSet,
-     lastPos := rc.2.1, lastFold := rc.2.2.1, bounded := true },
-   (rc.2.2.2 && newBools.all (fun c => decide (c.degree ≤ b.identities))) && rb.2)
-
-/-- **Unproven on this branch (measurement).** The real statement adds the completeness side
-    condition that makes the position-driven bus rewrite agree with `denseReencodeOut`:
-
-    `hcomplete : ∀ i bi, w.bis[i]? = some bi →
-       (bi.multiplicity.sharesVarIn xs = true ∨ bi.multiplicity.hasConstFoldableNode = true ∨
-        bi.payload.any (fun e => e.sharesVarIn xs || e.hasConstFoldableNode) = true) → i ∈ usePosB`
-
-    plus `usePosB` ascending. The `useBis` buckets are complete by construction and `foldBis` tracks
-    the fold positions, so a superset is fine and every visited position is re-tested by
-    `denseBIGateDeg`. Given that, the bus half of the old proof goes through with
-    `denseBIRewriteGate_eq` + `denseGroupRewrite_eq_self` supplying the identity at every unvisited
-    position and at the shared suffix — structurally the same argument
-    `denseTombify_id_of_untouched` already makes on the constraint side, which is why this shape was
-    chosen over the array-backed one. The constraint half of this lemma is untouched. -/
-theorem denseWorkOut_view (b : DegreeBound) (w : DenseReencodeWork p) {usePosB : List Nat}
-    (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p))
-    (hpos : DenseWorkPosOk w.lastPos w.lastFold w.cs)
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false)
-    (hsortedB : usePosB.Pairwise (· ≤ ·))
-    (hcoverB : ∀ k bi, w.bis[k]? = some bi → denseBiGateFires xs bi = true → k ∈ usePosB) :
-    denseWorkView (denseWorkOut b w usePosB xs bits hm).1
-      = (denseReencodeOut (denseWorkView w) xs bits hm).filterConstraints
-          (fun c => !denseIsZero c) := by
-  obtain ⟨hbcov, hbmap, hbz⟩ := denseWorkBools_filter_covered (bools := w.bools) bits
-    (denseGroupSubst xs hm) (denseAssignments (denseBitBox bits)) hbools hxs
-  have hsplice : (denseWorkSpliceCs b.identities xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs) 0 w.cs []
-      w.lastPos w.lastFold true).1
-      = w.cs.map (denseTombify xs bits (denseGroupSubst xs hm)
-          (denseAssignments (denseBitBox bits))) := by
-    have := denseWorkSpliceCs_list b.identities xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) (denseWorkMaxPos w.lastPos w.lastFold xs)
-      w.cs 0 [] w.lastPos w.lastFold true (denseWorkBounded_of_posOk hpos)
-    simpa using this
-  have hbus : (denseGateBisPos b.busInteractions xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) usePosB 0 w.bis [] true).1
-      = w.bis.map (fun bi => { bi with
-          multiplicity := denseGroupRewrite xs bits (denseGroupSubst xs hm)
-            (denseAssignments (denseBitBox bits)) bi.multiplicity,
-          payload := bi.payload.map (denseGroupRewrite xs bits (denseGroupSubst xs hm)
-            (denseAssignments (denseBitBox bits))) }) := by
-    rw [denseGateBisPos_eq b.busInteractions xs bits (denseGroupSubst xs hm)
-      (denseAssignments (denseBitBox bits)) w.bis usePosB 0 [] true hsortedB
-      (by simpa using hcoverB)]
-    simp only [List.reverse_nil, List.nil_append]
-    exact List.map_congr_left (fun bi _ => by
-      rw [denseBIGateDeg_fst, denseBIRewriteGate_eq])
-  unfold denseWorkView denseWorkOut denseReencodeOut DenseConstraintSystem.filterConstraints
-  simp only [hsplice, hbus, List.filter_append, List.map_append, List.append_assoc,
-    hbcov, hbmap, hbz, denseBoolConstraints_not_zero]
-  rw [denseTombify_filter]
 
 
 /-! ### Reading the certificate off the working system
@@ -1349,18 +654,6 @@ at the covered sublist and at whether anything mentions a fresh bit, and both ar
 placeholders (they mention nothing and are never covered) and by the accumulated bools (inert, by
 `denseBoolConstraint_inert` and the step's guards). So it reads `w.cs` directly. -/
 
-theorem List.all_filter_of {α : Type} (l : List α) (P Q : α → Bool)
-    (h : ∀ c ∈ l, P c = false → Q c = true) : (l.filter P).all Q = l.all Q := by
-  induction l with
-  | nil => rfl
-  | cons c rest ih =>
-      by_cases hp : P c = true
-      · rw [List.filter_cons_of_pos hp, List.all_cons, List.all_cons,
-          ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
-      · rw [Bool.not_eq_true] at hp
-        rw [List.filter_cons_of_neg (by simp [hp]), List.all_cons,
-          h c (List.mem_cons_self ..) hp, Bool.true_and,
-          ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
 
 theorem List.filter_filter_of {α : Type} (l : List α) (P R : α → Bool)
     (h : ∀ c ∈ l, P c = false → R c = false) : (l.filter P).filter R = l.filter R := by
@@ -1380,13 +673,6 @@ theorem List.filter_filter_of {α : Type} (l : List α) (P R : α → Bool)
           List.filter_cons_of_neg (by simp [h c (List.mem_cons_self ..) hp]),
           ih (fun c' hc' => h c' (List.mem_cons_of_mem _ hc'))]
 
-theorem denseIsZero_mentions {c : DenseExpr p} (hz : denseIsZero c = true) (b : VarId) :
-    c.mentions b = false := by
-  cases c with
-  | const n => rfl
-  | var _ => simp [denseIsZero] at hz
-  | add _ _ => simp [denseIsZero] at hz
-  | mul _ _ => simp [denseIsZero] at hz
 
 theorem denseIsZero_not_covered {xs : List VarId} {c : DenseExpr p} (hz : denseIsZero c = true) :
     denseCoveredBy xs c = false := by
@@ -1406,113 +692,17 @@ theorem denseIsZero_eval {c : DenseExpr p} (hz : denseIsZero c = true) (denv : V
   | add _ _ => simp [denseIsZero] at hz
   | mul _ _ => simp [denseIsZero] at hz
 
-theorem denseCheckReencode_congr (cs1 cs2 : List (DenseExpr p))
-    (bis : List (BusInteraction (DenseExpr p))) (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p))
-    (hcov : cs1.filter (denseCoveredBy xs) = cs2.filter (denseCoveredBy xs))
-    (hfresh : ∀ b ∈ bits, cs1.all (fun c => !c.mentions b) = cs2.all (fun c => !c.mentions b)) :
-    denseCheckReencode { algebraicConstraints := cs1, busInteractions := bis } xs bits hm
-      = denseCheckReencode { algebraicConstraints := cs2, busInteractions := bis } xs bits hm := by
-  have hb : (bits.all (fun b =>
-        cs1.all (fun c => !c.mentions b) &&
-        bis.all (fun bi =>
-          !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b))))
-      = (bits.all (fun b =>
-        cs2.all (fun c => !c.mentions b) &&
-        bis.all (fun bi =>
-          !bi.multiplicity.mentions b && bi.payload.all (fun e => !e.mentions b)))) :=
-    List.all_congr_mem bits _ _ (fun b hbm => by rw [hfresh b hbm])
-  unfold denseCheckReencode denseCoveredCsOf
-  simp only [hcov, hb]
 
 
-theorem denseWorkView_check {w : DenseReencodeWork p} {xs bits : List VarId}
-    (hm : Std.HashMap VarId (DenseExpr p))
-    (hbools : DenseWorkBoolsOk w.bitSet w.bools)
-    (hxs : ∀ x ∈ xs, w.bitSet.contains x = false)
-    (hbits : ∀ bb ∈ bits, w.bitSet.contains bb = false) :
-    denseCheckReencode (denseWorkView w) xs bits hm
-      = denseCheckReencode { algebraicConstraints := w.cs, busInteractions := w.bis } xs bits hm := by
-  have hinert : ∀ c ∈ w.bools, denseCoveredBy xs c = false ∧ ∀ b ∈ bits, c.mentions b = false := by
-    intro c hc
-    obtain ⟨bb, rfl, hbb⟩ := hbools c hc
-    have hnx : bb ∉ xs := fun hmem => by rw [hxs bb hmem] at hbb; exact Bool.noConfusion hbb
-    refine ⟨(denseBoolConstraint_inert (p := p) hnx).1, fun b hb => ?_⟩
-    have hne : bb ≠ b := fun heq => by
-      subst heq; rw [hbits bb hb] at hbb; exact Bool.noConfusion hbb
-    simp [denseBoolConstraint, DenseExpr.mentions, hne]
-  refine denseCheckReencode_congr _ _ _ xs bits hm ?_ ?_
-  · show ((w.cs.filter (fun c => !denseIsZero c) ++ w.bools).filter (denseCoveredBy xs))
-      = w.cs.filter (denseCoveredBy xs)
-    have h1 : w.bools.filter (denseCoveredBy xs) = [] :=
-      List.filter_eq_nil_iff.2 (fun c hc => by simp [(hinert c hc).1])
-    have h2 : (w.cs.filter (fun c => !denseIsZero c)).filter (denseCoveredBy xs)
-        = w.cs.filter (denseCoveredBy xs) :=
-      List.filter_filter_of _ _ _ (fun c _ hz => denseIsZero_not_covered (by simpa using hz))
-    rw [List.filter_append, h2, h1, List.append_nil]
-  · intro b hb
-    show ((w.cs.filter (fun c => !denseIsZero c) ++ w.bools).all (fun c => !c.mentions b))
-      = w.cs.all (fun c => !c.mentions b)
-    have h1 : w.bools.all (fun c => !c.mentions b) = true :=
-      List.all_eq_true.2 (fun c hc => by simp [(hinert c hc).2 b hb])
-    have h2 : (w.cs.filter (fun c => !denseIsZero c)).all (fun c => !c.mentions b)
-        = w.cs.all (fun c => !c.mentions b) :=
-      List.all_filter_of _ _ _ (fun c _ hz => by
-        simp [denseIsZero_mentions (by simpa using hz) b])
-    rw [List.all_append, h2, h1, Bool.and_true]
 
-/-! ### Seeding the bound -/
-
-def denseSeedLp : Nat → List (DenseExpr p) → Std.HashMap VarId Nat → Std.HashMap VarId Nat
-  | _, [], m => m
-  | i, c :: rest, m =>
-      denseSeedLp (i + 1) rest (c.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m)
-
-def denseSeedLf : Nat → List (DenseExpr p) → Nat → Nat
-  | _, [], n => n
-  | i, c :: rest, n => denseSeedLf (i + 1) rest (if c.hasConstFoldableNode then max n i else n)
-
-theorem denseSeedLp_mono : ∀ (l : List (DenseExpr p)) (i : Nat) (m : Std.HashMap VarId Nat),
-    DenseLpLe m (denseSeedLp i l m) := by
-  intro l
-  induction l with
-  | nil => intro i m; exact DenseLpLe.refl m
-  | cons c rest ih =>
-      intro i m
-      exact DenseLpLe.trans (denseLpFold_mono i _ m) (ih (i + 1) _)
-
-theorem denseSeedLf_mono : ∀ (l : List (DenseExpr p)) (i : Nat) (n : Nat), n ≤ denseSeedLf i l n := by
-  intro l
-  induction l with
-  | nil => intro i n; exact Nat.le_refl n
-  | cons c rest ih =>
-      intro i n
-      refine Nat.le_trans ?_ (ih (i + 1) _)
-      split <;> [exact Nat.le_max_left _ _; exact Nat.le_refl _]
-
-theorem denseSeed_posOk : ∀ (l : List (DenseExpr p)) (i : Nat) (m : Std.HashMap VarId Nat)
-    (n : Nat), DenseWorkPosOkFrom i (denseSeedLp i l m) (denseSeedLf i l n) l := by
-  intro l
-  induction l with
-  | nil => intro i m n j c hj; simp at hj
-  | cons c rest ih =>
-      intro i m n j c' hj
-      cases j with
-      | zero =>
-          rw [List.getElem?_cons_zero, Option.some_inj] at hj
-          subst hj
-          refine ⟨fun v hv => ?_, fun hfd => ?_⟩
-          · rw [Nat.add_zero, denseSeedLp]
-            exact Nat.le_trans (denseLpFold_ge i _ m v hv) (denseSeedLp_mono rest (i + 1) _ v)
-          · rw [Nat.add_zero, denseSeedLf]
-            exact Nat.le_trans (by rw [if_pos hfd]; exact Nat.le_max_right _ _)
-              (denseSeedLf_mono rest (i + 1) _)
-      | succ k =>
-          have hk := ih (i + 1) (c.vars.foldl (fun m v => m.insert v (max (m.getD v 0) i)) m)
-            (if c.hasConstFoldableNode then max n i else n) k c' (by simpa using hj)
-          rw [show i + (k + 1) = i + 1 + k by omega]
-          rw [denseSeedLp, denseSeedLf]
-          exact hk
+/-- A covered constraint has a variable, and all of them lie in the group, so it shares one. -/
+theorem denseCoveredBy_sharesVarIn {xs : List VarId} {c : DenseExpr p}
+    (h : denseCoveredBy xs c = true) : c.sharesVarIn xs = true := by
+  rw [denseCoveredBy, Bool.and_eq_true] at h
+  by_contra hs
+  rw [Bool.not_eq_true] at hs
+  rw [DenseExpr.varsInF_eq_false h.1 hs] at h
+  exact Bool.noConfusion h.2
 
 /-! ## The build/step/loop/pass layer -/
 
@@ -1551,36 +741,8 @@ def denseReencodeRootPlanLookup (i : VarId) :
 abbrev DenseReencodeRootCache (p : ℕ) :=
   Std.HashMap Nat (Option (DenseReencodeRootPlan p))
 
-def denseReencodeRootAt (cache : DenseReencodeRootCache p) (pos : Nat) (c : DenseExpr p) :
-    Option (DenseReencodeRootPlan p) × DenseReencodeRootCache p :=
-  match cache[pos]? with
-  | some plan => (plan, cache)
-  | none =>
-      let plan := denseBuildReencodeRootPlan c
-      (plan, cache.insert pos plan)
 
-def denseFindDomainCached (i : VarId) :
-    List (Nat × DenseExpr p) → DenseReencodeRootCache p →
-      Option (List (ZMod p)) × DenseReencodeRootCache p
-  | [], cache => (none, cache)
-  | c :: rest, cache =>
-      if c.2.mentions i then
-        let (plan, cache) := denseReencodeRootAt cache c.1 c.2
-        match plan.bind (denseReencodeRootPlanLookup i) with
-        | some roots => (some roots, cache)
-        | none => denseFindDomainCached i rest cache
-      else denseFindDomainCached i rest cache
 
-def denseGroupDomsCached (es : List (Nat × DenseExpr p)) :
-    List VarId → DenseReencodeRootCache p →
-      Option (List (VarId × List (ZMod p))) × DenseReencodeRootCache p
-  | [], cache => (some [], cache)
-  | i :: rest, cache =>
-      let (head, cache) := denseFindDomainCached i es cache
-      let (tail, cache) := denseGroupDomsCached es rest cache
-      match head, tail with
-      | some d, some ds => (some ((i, d) :: ds), cache)
-      | _, _ => (none, cache)
 
 def denseCoveredIdxPos (idx : DenseCovIndex) (arr : Array (DenseExpr p))
     (xs : List VarId) : List (Nat × DenseExpr p) :=
@@ -1589,15 +751,6 @@ def denseCoveredIdxPos (idx : DenseCovIndex) (arr : Array (DenseExpr p))
     if h : i < arr.size then
       if denseCoveredBy xs arr[i] then some (i, arr[i]) else none
     else none)
-
-/-- Build the inverted index (`VarId`-keyed twin of `CoveredIndex.buildPruned`), skipping items
-    with more than `maxVars` distinct variables. -/
-def denseBuildPruned {α : Type} (varsOf : α → List VarId) (maxVars : Nat) (items : List α) :
-    DenseCovIndex :=
-  items.zipIdx.foldr (fun ai idx =>
-    if (HashedDedup.hashedEraseDups (hash ·) (varsOf ai.1)).length ≤ maxVars then
-      denseBuildStep varsOf ai idx
-    else idx) ⟨∅, []⟩
 
 /-- Register the `k` fresh bit variables `freshBase ++ "_0", …, freshBase ++ "_(k-1)"` into `reg`,
     in order. -/
@@ -1610,112 +763,6 @@ def denseRegisterBits (reg : VarRegistry) (freshBase : String) (k : Nat) :
       (r', bs ++ [i]))
     (reg, [])
 
-/-- Construct the bits and the substitution map for a candidate group (proof-free — the checked
-    certificate re-verifies everything). Registers fresh bits only on the single accepting path.
-    Positions come from the bucket index, and the per-constraint root plans from the retained
-    cache. -/
-def denseBuildReencodeCached (reg : VarRegistry) (csIdx : DenseCovIndex)
-    (arrCs : Array (DenseExpr p)) (cache : DenseReencodeRootCache p)
-    (xs : List VarId) (freshBase : String) :
-    VarRegistry × Option (List VarId × Std.HashMap VarId (DenseExpr p)) ×
-      DenseReencodeRootCache p :=
-  let planned := denseCoveredIdxPos csIdx arrCs xs
-  let es := planned.map Prod.snd
-  let (doms?, cache) := denseGroupDomsCached planned xs cache
-  match doms? with
-  | none => (reg, none, cache)
-  | some doms =>
-    let boxSize := (doms.map (fun yd => yd.2.length)).prod
-    if boxSize ≤ 256 then
-      if es.length == xs.length && es.all (fun c => c.vars.eraseDups.length == 1)
-          && xs.length ≤ Nat.clog 2 boxSize then
-        (reg, none, cache)
-      else
-      match denseGroupSurvivorsECap es doms (2 ^ (xs.length - 1)) with
-      | none => (reg, none, cache)
-      | some survs =>
-      if 2 ≤ survs.length then
-        let k := Nat.clog 2 survs.length
-        if k < xs.length then
-          let (reg1, bits) := denseRegisterBits reg freshBase k
-          let patts := denseAssignments (denseBitBox bits)
-          let survsP := survs ++ List.replicate (patts.length - survs.length) (survs.headD [])
-          let pz := patts.zip survsP
-          (reg1,
-            some (bits, Std.HashMap.ofList (xs.map (fun x => (x, (denseInterpPoly pz x).fold)))),
-            cache)
-        else (reg, none, cache)
-      else (reg, none, cache)
-    else (reg, none, cache)
-
-/-- The index's candidate positions for `xs`, each once (an item is bucketed per variable
-    occurrence, and the gate below rewrites every position it visits). -/
-def denseUsePositions (idx : DenseCovIndex) (xs : List VarId) : List Nat :=
-  ((denseCandidates idx xs).foldl (·.insert ·) (∅ : Std.HashSet Nat)).toList
-
-/-- Degree pre-gate (untrusted): rewrite only the items sharing a variable with the group and fire
-    when a rewritten item already exceeds the bound. Only the indexed candidate positions are
-    visited — the buckets are complete, so every item outside them is variable-disjoint from `xs`
-    and cannot fire. Stale bucket entries (the cached loop's indexes are grow-only) are harmless:
-    each position's current content is re-tested. -/
-def denseDegPreRejectIdx (b : DegreeBound) (csIdxUse biIdxUse : DenseCovIndex)
-    (arrBis : Array (BusInteraction (DenseExpr p)))
-    (arrCs : Array (DenseExpr p)) (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
-  let σ := denseGroupSubst xs hm
-  let patts := denseAssignments (denseBitBox bits)
-  (denseUsePositions csIdxUse xs).any (fun i =>
-    match arrCs[i]? with
-    | some c =>
-      c.sharesVarIn xs && !denseCoveredBy xs c &&
-        decide (b.identities < (denseGroupRewrite xs bits σ patts c).degree)
-    | none => false) ||
-  (denseUsePositions biIdxUse xs).any (fun i =>
-    match arrBis[i]? with
-    | some bi =>
-      (bi.multiplicity.sharesVarIn xs &&
-        decide (b.busInteractions < (denseGroupRewrite xs bits σ patts bi.multiplicity).degree)) ||
-      bi.payload.any (fun e =>
-        e.sharesVarIn xs &&
-          decide (b.busInteractions < (denseGroupRewrite xs bits σ patts e).degree))
-    | none => false)
-
-/-- The cached loop's candidate-state, kept on stable positions across accepts: dropped
-    constraints become `.const 0` tombstones (variable-free, so every index query skips them),
-    the bucket indexes are grow-only, and `denseReencodeStateUpdate` touches only the positions
-    an accept can change — nothing here is rebuilt per accepted group. `varSet` only ever gains
-    the fresh bits, so it over-approximates the live variables; a group whose variable was
-    eliminated by an earlier accept passes that gate and is then rejected by the certificate
-    (no covered constraint mentions the variable), the same outcome the exact set produces. -/
-structure DenseReencodeCacheState (p : ℕ) where
-  csIdx : DenseCovIndex
-  arrCs : Array (DenseExpr p)
-  rootCache : DenseReencodeRootCache p
-  varSet : Std.HashSet VarId
-  useCs : DenseCovIndex
-  useBis : DenseCovIndex
-  arrBis : Array (BusInteraction (DenseExpr p))
-  foldCs : Std.HashSet Nat
-  /-- Bus positions carrying a variable-free composite node (`denseBiHasFold`). With the `useBis`
-      buckets this is exactly the set of positions an accept's bus rewrite can touch. A `Thunk` so
-      that an invocation which never accepts never pays the scan — the accept path is the only
-      consumer, mirroring how `denseWorkEnsureBounded` defers the constraint-side bound. -/
-  foldBis : Thunk (Std.HashSet Nat)
-  /-- The number of non-tombstone entries of `w.cs`, and `w.bis.length`. Both feed the fresh-name
-      prefix only (`denseWorkNameCountsS`), which is why they live on the untrusted state: a wrong
-      count can cost a rejected candidate, never soundness. Maintained exactly — the state update
-      visits every position an accept can turn into `.const 0`. -/
-  liveCs : Nat
-  bisN : Nat
-  /-- Whether `d` is *known* to be within the degree bound — the side condition that makes
-      `denseReencodeOutOk`'s fused degree test agree with measuring the rewritten system outright
-      (`denseReencodeOutOk_snd`). Starts `false`, so the first candidate to reach the gate measures
-      the rewritten system the plain way; from the first accept on it is `true`, since an accepted
-      `ro` passed the gate and becomes the new `d`. Deliberately not seeded with
-      `d.withinDegreeB b`: that walk would be charged to every APC, including the ones where no
-      candidate is ever accepted. -/
-  dWithin : Bool
-
 /-! ### Freshness from the state's variable superset
 
 The certificate's freshness conjunct is its only `O(system)` one: it walks every constraint and
@@ -1727,181 +774,8 @@ condition for freshness. Being sufficient rather than equivalent, it enters the 
 implication (`denseCheckReencodeVS_sound`), not a `@[csimp]` equality; the invariant that licenses
 it is `DenseWorkVarsOk`, threaded through the step and the loop. -/
 
-/-- The checked certificate with freshness decided from `state.varSet` in `O(|bits|)`. -/
-def denseCheckReencodeVS (state : DenseReencodeCacheState p) (d : DenseConstraintSystem p)
-    (xs bits : List VarId) (hm : Std.HashMap VarId (DenseExpr p)) : Bool :=
-  bits.all (fun bb => !state.varSet.contains bb) && denseCheckReencodeNoFresh d xs bits hm
 
-/-- The bus half of an accept's index update: for each position the rewrite visited, record the new
-    interaction's variables in the buckets and whether it still carries a variable-free composite
-    node. Standalone (a fold over `(buckets, foldSet)`) so its result does not depend on the
-    constraint half — which is what makes `denseBusIdxOk_update` a plain list induction. -/
-def denseBusIdxFold (arrB : Array (BusInteraction (DenseExpr p))) :
-    List Nat → DenseCovIndex × Std.HashSet Nat → DenseCovIndex × Std.HashSet Nat
-  | [], acc => acc
-  | i :: rest, acc =>
-      if h : i < arrB.size then
-        let bi := arrB[i]
-        let vs := HashedDedup.hashedDedup (hash ·) (denseBIVars bi)
-        denseBusIdxFold arrB rest
-          (⟨vs.foldl (fun m v => m.insert v (i :: m.getD v [])) acc.1.buckets, acc.1.varless⟩,
-           if denseBiHasFold bi then acc.2.insert i else acc.2.erase i)
-      else denseBusIdxFold arrB rest acc
 
-/-- Apply an accepted rewrite to the threaded state in place, mirroring `denseReencodeOut` on the
-    stable-position arrays: only positions holding a group variable (bucket candidates) or a
-    variable-free composite node (`foldCs`) can change. The root cache keeps every untouched
-    position (it memoizes a pure function of the position's content). -/
-def denseReencodeStateUpdate (state : DenseReencodeCacheState p) (usePosB : List Nat)
-    (bisNew : List (BusInteraction (DenseExpr p))) (xs bits : List VarId)
-    (hm : Std.HashMap VarId (DenseExpr p)) : DenseReencodeCacheState p :=
-  let σfn := denseGroupSubst xs hm
-  let patts := denseAssignments (denseBitBox bits)
-  let bucketAdd : DenseCovIndex → List VarId → Nat → DenseCovIndex := fun idx vs i =>
-    ⟨vs.foldl (fun m v => m.insert v (i :: m.getD v [])) idx.buckets, idx.varless⟩
-  let posC := (denseCandidates state.useCs xs).foldl (·.insert ·) state.foldCs
-  let st := posC.fold (fun st i =>
-    if h : i < st.arrCs.size then
-      let c := st.arrCs[i]
-      if denseCoveredBy xs c then
-        -- covered ⇒ `c.hasVar` ⇒ `c` was not a tombstone, so the live count drops by one
-        { st with arrCs := st.arrCs.set i (.const 0),
-                  rootCache := st.rootCache.erase i,
-                  foldCs := st.foldCs.erase i, liveCs := st.liveCs - 1 }
-      else if c.sharesVarIn xs || c.hasConstFoldableNode then
-        let c' := denseGroupRewrite xs bits σfn patts c
-        let vs := HashedDedup.hashedDedup (hash ·) c'.vars
-        { st with
-          liveCs := if denseIsZero c' then st.liveCs - 1 else st.liveCs
-          arrCs := st.arrCs.set i c'
-          rootCache := st.rootCache.erase i
-          csIdx := if vs.length ≤ 8 then bucketAdd st.csIdx vs i else st.csIdx
-          useCs := bucketAdd st.useCs vs i
-          foldCs := if c'.hasConstFoldableNode then st.foldCs.insert i else st.foldCs.erase i }
-      else st
-    else st) state
-  let st := bits.foldl (fun st b =>
-    let i := st.arrCs.size
-    { st with arrCs := st.arrCs.push (denseBoolConstraint b),
-              csIdx := bucketAdd st.csIdx [b] i,
-              useCs := bucketAdd st.useCs [b] i }) st
-  -- The bus side takes the accept's own output and its own position list: one rewrite, two
-  -- consumers, folding over exactly the positions the splice visited.
-  let arrB := bisNew.toArray
-  let bus := denseBusIdxFold arrB usePosB (state.useBis, state.foldBis.get)
-  -- `varSet` is grown from the *input* state: the position folds above never touch it, and reading
-  -- it from `state` keeps `denseReencodeStateUpdate_varSet` a projection instead of a fold invariant.
-  { st with arrBis := arrB, useBis := bus.1, foldBis := Thunk.mk (fun _ => bus.2),
-            varSet := bits.foldl (·.insert ·) state.varSet, dWithin := true }
-
-theorem densePosOk_from0 {lp : Std.HashMap VarId Nat} {lf : Nat} {cs : List (DenseExpr p)} :
-    DenseWorkPosOk lp lf cs ↔ DenseWorkPosOkFrom 0 lp lf cs := by
-  constructor <;> intro h j c hj <;> simpa using h j c hj
-
-/-- Compute the position bound if it has not been computed yet. Called on the accept path only, so a
-    pass application that accepts nothing never walks the variables at all. -/
-def denseWorkEnsureBounded (w : DenseReencodeWork p) : DenseReencodeWork p :=
-  if w.bounded then w
-  else { w with lastPos := denseSeedLp 0 w.cs ∅, lastFold := denseSeedLf 0 w.cs 0, bounded := true }
-
-theorem denseWorkEnsureBounded_view (w : DenseReencodeWork p) :
-    denseWorkView (denseWorkEnsureBounded w) = denseWorkView w := by
-  unfold denseWorkEnsureBounded denseWorkView; split <;> rfl
-
-theorem denseWorkEnsureBounded_bis (w : DenseReencodeWork p) :
-    (denseWorkEnsureBounded w).bis = w.bis := by
-  unfold denseWorkEnsureBounded; split <;> rfl
-
-theorem denseWorkEnsureBounded_bitSet (w : DenseReencodeWork p) :
-    (denseWorkEnsureBounded w).bitSet = w.bitSet := by
-  unfold denseWorkEnsureBounded; split <;> rfl
-
-theorem denseWorkEnsureBounded_bools (w : DenseReencodeWork p) :
-    (denseWorkEnsureBounded w).bools = w.bools := by
-  unfold denseWorkEnsureBounded; split <;> rfl
-
-theorem denseWorkEnsureBounded_posOk {w : DenseReencodeWork p}
-    (h : w.bounded = true → DenseWorkPosOk w.lastPos w.lastFold w.cs) :
-    DenseWorkPosOk (denseWorkEnsureBounded w).lastPos (denseWorkEnsureBounded w).lastFold
-      (denseWorkEnsureBounded w).cs := by
-  unfold denseWorkEnsureBounded
-  split
-  · next hb => exact h hb
-  · exact densePosOk_from0.mpr (denseSeed_posOk w.cs 0 ∅ 0)
-
-/-! ### The step, loop and pass over the working system -/
-
-/-- `d`'s item counts for the fresh-name prefix, read off the working system. -/
-def denseWorkNameCounts (derivs : DenseDerivations p) (w : DenseReencodeWork p) (nc nb : Nat) :
-    Nat × Nat :=
-  if derivs.isEmpty then (nc, nb)
-  else ((w.cs.filter (fun c => !denseIsZero c)).length + w.bools.length, w.bis.length)
-
-/-- The same counts, served from the threaded state instead of re-walking the whole system on every
-    accept (`state.liveCs` mirrors `(w.cs.filter (!denseIsZero ·)).length`, `state.bisN` is
-    `w.bis.length`, which no accept changes). Names only need to be fresh, and freshness is checked
-    separately, so this is untrusted. -/
-def denseWorkNameCountsS (derivs : DenseDerivations p) (w : DenseReencodeWork p)
-    (state : DenseReencodeCacheState p) (nc nb : Nat) : Nat × Nat :=
-  if derivs.isEmpty then (nc, nb) else (state.liveCs + w.bools.length, state.bisN)
-
-/-- One checked re-encoding step. Mirrors the cached step, with two extra guards — no group variable
-    and no freshly minted bit may be a bit minted earlier — which is what keeps the deferred
-    booleanity constraints inert for this group (`denseBoolConstraint_inert`). Rejecting a candidate is
-    always allowed, so the guards cost behaviour at worst, never soundness. -/
-def denseWorkStep (b : DegreeBound) (reg : VarRegistry) (w : DenseReencodeWork p)
-    (state : DenseReencodeCacheState p) (xs : List VarId) (freshBase : String) :
-    VarRegistry × DenseReencodeWork p × DenseDerivations p × DenseReencodeCacheState p :=
-  if xs.all (fun x => reg.isInput x) then
-  if xs.any (fun x => w.bitSet.contains x) then (reg, w, [], state) else
-  if (match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
-      | some i => state.varSet.contains i
-      | none => false) then
-    (reg, w, [], state)
-  else
-  match denseBuildReencodeCached reg state.csIdx state.arrCs state.rootCache xs freshBase with
-  | (reg1, none, rootCache) => (reg1, w, [], { state with rootCache })
-  | (reg1, some (bits, hm), rootCache) =>
-    let state := { state with rootCache }
-    if bits.any (fun bb => w.bitSet.contains bb) then (reg1, w, [], state) else
-    if denseDegPreRejectIdx b state.useCs state.useBis state.arrBis state.arrCs xs bits hm then
-      (reg1, w, [], state)
-    else
-    if xs.all (fun x => state.varSet.contains x) then
-    if xs.all (fun x => decide (x ∉ bits)) then
-    if bits.all (fun bb => decide ((reg1.resolve bb).powdrId? = none)) then
-    if denseCheckReencodeVS state { algebraicConstraints := w.cs, busInteractions := w.bis }
-        xs bits hm then
-      let ro := denseWorkOut b (denseWorkEnsureBounded w)
-        (((denseCandidates state.useBis xs).foldl (·.insert ·)
-          state.foldBis.get).toList.mergeSort (· ≤ ·)) xs bits hm
-      if (if state.dWithin then ro.2 else (denseWorkView ro.1).withinDegreeB b) then
-        (reg1, ro.1,
-         bits.map (fun bb => (bb, denseBitCM (denseAssignments (denseBitBox bits)) xs hm bb)),
-         denseReencodeStateUpdate state
-           (((denseCandidates state.useBis xs).foldl (·.insert ·)
-             state.foldBis.get).toList.mergeSort (· ≤ ·)) ro.1.bis xs bits hm)
-      else (reg1, w, [], state)
-    else (reg1, w, [], state)
-    else (reg1, w, [], state)
-    else (reg1, w, [], state)
-    else (reg1, w, [], state)
-  else (reg, w, [], state)
-
-def denseWorkLoop (b : DegreeBound) :
-    List (List VarId) → Nat → VarRegistry → DenseReencodeWork p →
-      DenseReencodeCacheState p → Nat → Nat →
-      VarRegistry × DenseReencodeWork p × DenseDerivations p
-  | [], _, reg, w, _, _, _ => (reg, w, [])
-  | xs :: rest, idx, reg, w, state, nc, nb =>
-    let (reg1, w1, derivs1, state1) := denseWorkStep b reg w state xs s!"rnc{nc}_{nb}_{idx}"
-    let (nc1, nb1) := denseWorkNameCountsS derivs1 w1 state1 nc nb
-    let (reg2, w2, derivs2) := denseWorkLoop b rest (idx + 1) reg1 w1 state1 nc1 nb1
-    (reg2, w2, derivs1 ++ derivs2)
-
-def denseWorkSeed (d : DenseConstraintSystem p) : DenseReencodeWork p :=
-  { cs := d.algebraicConstraints, bis := d.busInteractions, bools := [], bitSet := ∅,
-    lastPos := ∅, lastFold := 0, bounded := false }
 
 /-! ## The array-backed engine
 
@@ -2112,65 +986,86 @@ def DenseRncState.pushBool (st : DenseRncState p) (b : VarId) : DenseRncState p 
     minted := minted.insert b,
     domVal, domKnown, domSrc, domTouched, dWithin := true, nVar }
 
+/-- Bucket every position of `cs` under each of its variables, from position `i` on. -/
+def denseRncUseGo (cs : Array (DenseExpr p)) (cvs : Array (Array VarId)) (i : Nat)
+    (acc : Array (Array Nat)) : Array (Array Nat) :=
+  if h : i < cs.size then
+    denseRncUseGo cs cvs (i + 1)
+      ((denseRncFullVars cs[i] (cvs.getD i #[])).foldl (fun m v => denseRncBAdd m v i) acc)
+  else acc
+  termination_by cs.size - i
+  decreasing_by omega
+
 def denseRncEnsureUse (st : DenseRncState p) : DenseRncState p :=
   match st.useCs with
   | some _ => st
-  | none =>
-    let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
-      if h : i < st.cs.size then
-        let vs := denseRncFullVars st.cs[i] (st.cvs.getD i #[])
-        go (i + 1) (vs.foldl (fun m v => denseRncBAdd m v i) acc)
-      else acc
-      termination_by st.cs.size - i
-      decreasing_by omega
-    { st with useCs := some (go 0 (Array.replicate st.nVar #[])) }
+  | none => { st with useCs := some (denseRncUseGo st.cs st.cvs 0 (Array.replicate st.nVar #[])) }
+
+/-- Bucket every interaction under each of its variables, from position `i` on. -/
+def denseRncUseBisGo (bis : Array (BusInteraction (DenseExpr p))) (i : Nat)
+    (acc : Array (Array Nat)) : Array (Array Nat) :=
+  if h : i < bis.size then
+    denseRncUseBisGo bis (i + 1)
+      ((denseBIVars bis[i]).foldl (fun m v => denseRncBAdd m v i) acc)
+  else acc
+  termination_by bis.size - i
+  decreasing_by omega
 
 def denseRncEnsureUseBis (st : DenseRncState p) : DenseRncState p :=
   match st.useBis with
   | some _ => st
-  | none =>
-    let rec go (i : Nat) (acc : Array (Array Nat)) : Array (Array Nat) :=
-      if h : i < st.bis.size then
-        go (i + 1) ((denseBIVars st.bis[i]).foldl (fun m v => denseRncBAdd m v i) acc)
-      else acc
-      termination_by st.bis.size - i
-      decreasing_by omega
-    { st with useBis := some (go 0 (Array.replicate st.nVar #[])) }
+  | none => { st with useBis := some (denseRncUseBisGo st.bis 0 (Array.replicate st.nVar #[])) }
+
+def denseRncFoldCsGo (cs : Array (DenseExpr p)) (i : Nat) (acc : Std.HashSet Nat) :
+    Std.HashSet Nat :=
+  if h : i < cs.size then
+    denseRncFoldCsGo cs (i + 1) (if denseRncHasFold cs[i] then acc.insert i else acc)
+  else acc
+  termination_by cs.size - i
+  decreasing_by omega
 
 def denseRncEnsureFoldCs (st : DenseRncState p) : DenseRncState p :=
   match st.foldCs with
   | some _ => st
-  | none =>
-    let rec go (i : Nat) (acc : Std.HashSet Nat) : Std.HashSet Nat :=
-      if h : i < st.cs.size then
-        go (i + 1) (if denseRncHasFold st.cs[i] then acc.insert i else acc)
-      else acc
-      termination_by st.cs.size - i
-      decreasing_by omega
-    { st with foldCs := some (go 0 ∅) }
+  | none => { st with foldCs := some (denseRncFoldCsGo st.cs 0 ∅) }
+
+def denseRncFoldBisGo (bis : Array (BusInteraction (DenseExpr p))) (i : Nat)
+    (acc : Std.HashSet Nat) : Std.HashSet Nat :=
+  if h : i < bis.size then
+    denseRncFoldBisGo bis (i + 1) (if denseRncBiHasFold bis[i] then acc.insert i else acc)
+  else acc
+  termination_by bis.size - i
+  decreasing_by omega
 
 def denseRncEnsureFoldBis (st : DenseRncState p) : DenseRncState p :=
   match st.foldBis with
   | some _ => st
-  | none =>
-    let rec go (i : Nat) (acc : Std.HashSet Nat) : Std.HashSet Nat :=
-      if h : i < st.bis.size then
-        go (i + 1) (if denseRncBiHasFold st.bis[i] then acc.insert i else acc)
-      else acc
-      termination_by st.bis.size - i
-      decreasing_by omega
-    { st with foldBis := some (go 0 ∅) }
+  | none => { st with foldBis := some (denseRncFoldBisGo st.bis 0 ∅) }
+
+/-- Mark every variable of `cs` from position `i` on. -/
+def denseRncSeenCsGo (cs : Array (DenseExpr p)) (i : Nat) (acc : Array Bool) : Array Bool :=
+  if h : i < cs.size then
+    denseRncSeenCsGo cs (i + 1) (cs[i].foldVars (fun m v => denseRncMark m v) acc)
+  else acc
+  termination_by cs.size - i
+  decreasing_by omega
+
+def denseRncSeenBisGo (bis : Array (BusInteraction (DenseExpr p))) (i : Nat) (acc : Array Bool) :
+    Array Bool :=
+  if h : i < bis.size then
+    denseRncSeenBisGo bis (i + 1)
+      (bis[i].payload.foldl (fun m e => e.foldVars (fun m v => denseRncMark m v) m)
+        (bis[i].multiplicity.foldVars (fun m v => denseRncMark m v) acc))
+  else acc
+  termination_by bis.size - i
+  decreasing_by omega
 
 def denseRncEnsureSeen (st : DenseRncState p) : DenseRncState p :=
   match st.varSeen with
   | some _ => st
   | none =>
-    let m := st.cs.foldl (fun m c => c.foldVars (fun m v => denseRncMark m v) m)
-      (Array.replicate st.nVar false)
-    let m := st.bis.foldl (fun m bi =>
-      bi.payload.foldl (fun m e => e.foldVars (fun m v => denseRncMark m v) m)
-        (bi.multiplicity.foldVars (fun m v => denseRncMark m v) m)) m
-    { st with varSeen := some m }
+    { st with varSeen := some (denseRncSeenBisGo st.bis 0
+        (denseRncSeenCsGo st.cs 0 (Array.replicate st.nVar false))) }
 
 /-- Whether `v` may still occur in the system (over-approximate: entry occurrences plus minted
     bits). Assumes `denseRncEnsureSeen`. -/
@@ -2356,52 +1251,60 @@ def denseRncInterp (ctx : DenseRncCtx p) (inds : Array (DenseExpr p))
     decreasing_by omega
   (go 0 (.const ctx.ops.zero)).fold
 
-/-- Build the candidate: covered set, domains, box, survivors, bits. Proof-free — `denseRncCert`
-    re-verifies. -/
+/-- The candidate itself, once the domains are known: box, survivors, bits, and the `Thunk`s the
+    accept path forces. Reads the state, never writes it — the memo update is the caller's. -/
+def denseRncBuildCand (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
+    (planned : List (Nat × DenseExpr p)) (doms : Array (Array (ZMod p))) (xs : List VarId)
+    (freshBase : String) : VarRegistry × Option (DenseRncCand p) :=
+  let es := planned.map Prod.snd
+  let boxSize := doms.foldl (fun n dd => n * dd.size) 1
+  if boxSize > 256 then (reg, none)
+  else if es.length == xs.length
+      && planned.all (fun ic => (st.cvs.getD ic.1 #[]).size == 1)
+      && xs.length ≤ Nat.clog 2 boxSize then (reg, none)
+  else
+    match denseCompileEs xs es with
+    | none => (reg, none)
+    | some ces =>
+      let n := doms.size
+      match (denseRncDfs ctx.ops.zero doms
+          (denseRncChecks st n (planned.map Prod.fst).toArray ces) (2 ^ (xs.length - 1)) n
+          (Array.replicate n ctx.ops.zero) (some #[])).2 with
+      | none => (reg, none)
+      | some survs =>
+        if survs.size < 2 then (reg, none)
+        else
+          let k := Nat.clog 2 survs.size
+          if k ≥ xs.length then (reg, none)
+          else
+            let rb := denseRegisterBits reg freshBase k
+            let bits := rb.2
+            let vals := survs ++ Array.replicate (2 ^ k - survs.size) (survs.getD 0 #[])
+            let patts : Thunk (List (List (VarId × ZMod p))) :=
+              Thunk.mk (fun _ => denseAssignments (denseBitBox bits))
+            let pattsA : Thunk (Array (List (VarId × ZMod p))) :=
+              Thunk.mk (fun _ => patts.get.toArray)
+            let hm : Thunk (Std.HashMap VarId (DenseExpr p)) := Thunk.mk (fun _ =>
+              let inds := pattsA.get.map denseIndicatorExpr
+              Std.HashMap.ofList (xs.zipIdx.map
+                (fun xj => (xj.1, denseRncInterp ctx inds vals xj.2))))
+            let imgs := Thunk.mk (fun _ => pattsA.get.map (fun aβ =>
+              (xs.toArray).map (fun x => ((hm.get[x]?).getD (.var x)).evalFast
+                (denseEnvOfFast aβ))))
+            (rb.1, some { bits := bits, k := k, vals := vals, hm := hm, patts := patts,
+                          pattsA := pattsA, imgs := imgs, es := es, ces := ces, survs := survs })
+
+/-- Gather the covered set, look up the domains (updating the memo), then build the candidate.
+    Proof-free — `denseRncCert` re-verifies. -/
 def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × Option (DenseRncCand p) × DenseRncState p :=
   let planned := denseCoveredIdxPos st.anchor st.cs xs
-  let es := planned.map Prod.snd
   match denseRncDoms ctx.ops st xs #[] with
-  | (none, st) => (reg, none, st)
-  | (some doms, st) =>
-    let boxSize := doms.foldl (fun n dd => n * dd.size) 1
-    if boxSize > 256 then (reg, none, st)
-    else if es.length == xs.length
-        && planned.all (fun ic => (st.cvs.getD ic.1 #[]).size == 1)
-        && xs.length ≤ Nat.clog 2 boxSize then (reg, none, st)
-    else
-      match denseCompileEs xs es with
-      | none => (reg, none, st)
-      | some ces =>
-        let n := doms.size
-        match (denseRncDfs ctx.ops.zero doms
-            (denseRncChecks st n (planned.map Prod.fst).toArray ces) (2 ^ (xs.length - 1)) n
-            (Array.replicate n ctx.ops.zero) (some #[])).2 with
-        | none => (reg, none, st)
-        | some survs =>
-          if survs.size < 2 then (reg, none, st)
-          else
-            let k := Nat.clog 2 survs.size
-            if k ≥ xs.length then (reg, none, st)
-            else
-              let (reg1, bits) := denseRegisterBits reg freshBase k
-              let vals := survs ++ Array.replicate (2 ^ k - survs.size) (survs.getD 0 #[])
-              let patts : Thunk (List (List (VarId × ZMod p))) :=
-                Thunk.mk (fun _ => denseAssignments (denseBitBox bits))
-              let pattsA : Thunk (Array (List (VarId × ZMod p))) :=
-                Thunk.mk (fun _ => patts.get.toArray)
-              let hm : Thunk (Std.HashMap VarId (DenseExpr p)) := Thunk.mk (fun _ =>
-                let inds := pattsA.get.map denseIndicatorExpr
-                Std.HashMap.ofList (xs.zipIdx.map
-                  (fun xj => (xj.1, denseRncInterp ctx inds vals xj.2))))
-              let imgs := Thunk.mk (fun _ => pattsA.get.map (fun aβ =>
-                let env := denseEnvOfFast aβ
-                (xs.toArray).map (fun x => ((hm.get[x]?).getD (.var x)).evalFast env)))
-              (reg1, some { bits := bits, k := k, vals := vals, hm := hm, patts := patts,
-                            pattsA := pattsA, imgs := imgs, es := es, ces := ces,
-                            survs := survs }, st)
+  | (none, st') => (reg, none, st')
+  | (some doms, st') =>
+    let r := denseRncBuildCand ctx reg st' planned doms xs freshBase
+    (r.1, r.2, st')
 
 /-! ### The checked certificate
 
@@ -2611,6 +1514,14 @@ def denseRncView (st : DenseRncState p) : DenseConstraintSystem p :=
   { algebraicConstraints := (st.cs.filter (fun c => !denseIsZero c)).toList,
     busInteractions := st.bis.toList }
 
+/-- The fresh-name guard: reject when the first bit's name resolves to a variable the system may
+    still contain. Forcing `varSeen` here is the only reason a no-accept invocation ever builds it. -/
+def denseRncNameTaken (reg : VarRegistry) (st : DenseRncState p) (freshBase : String) :
+    Bool × DenseRncState p :=
+  match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
+  | some i => let st' := denseRncEnsureSeen st; (denseRncSeen st' i, st')
+  | none => (false, st)
+
 /-- One checked re-encoding step on the array state. Same gate sequence as `denseWorkStep`. -/
 def denseRncStep (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (freshBase : String) :
@@ -2618,18 +1529,18 @@ def denseRncStep (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p
   if !xs.all (fun x => reg.isInput x) then (reg, st, [])
   else if xs.any (fun x => st.minted.contains x) then (reg, st, [])
   else
-    let (skip, st) :=
-      match reg.idOf? ({ name := freshBase ++ "_0" } : Variable) with
-      | some i => let st := denseRncEnsureSeen st; (denseRncSeen st i, st)
-      | none => (false, st)
-    if skip then (reg, st, [])
+    let g := denseRncNameTaken reg st freshBase
+    let st := g.2
+    if g.1 then (reg, st, [])
     else
-      match denseRncBuild ctx reg st xs freshBase with
-      | (reg1, none, st) => (reg1, st, [])
-      | (reg1, some cd, st) =>
-        if cd.bits.any (fun b => st.minted.contains b) then (reg1, st, [])
+      let r := denseRncBuild ctx reg st xs freshBase
+      let reg1 := r.1
+      match r.2.1 with
+      | none => (reg1, r.2.2, [])
+      | some cd =>
+        if cd.bits.any (fun b => r.2.2.minted.contains b) then (reg1, r.2.2, [])
         else
-          let st := denseRncEnsureUseBis (denseRncEnsureUse st)
+          let st := denseRncEnsureUseBis (denseRncEnsureUse r.2.2)
           if denseRncDegPre ctx st xs cd then (reg1, st, [])
           else
             let st := denseRncEnsureSeen st
@@ -2640,12 +1551,12 @@ def denseRncStep (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p
             else if !denseRncCert st xs cd then (reg1, st, [])
             else
               let st0 := denseRncEnsureFoldBis (denseRncEnsureFoldCs st)
-              let (csEdits, okC) := denseRncCsEdits ctx st0 xs cd
-              let (biEdits, okB) := denseRncBiEdits ctx st0 xs cd
-              let ok := okC && okB && cd.bits.all (fun b =>
+              let rc := denseRncCsEdits ctx st0 xs cd
+              let rb := denseRncBiEdits ctx st0 xs cd
+              let ok := rc.2 && rb.2 && cd.bits.all (fun b =>
                 decide ((denseBoolConstraint b : DenseExpr p).degree ≤ ctx.dmaxC))
               if (if st0.dWithin then ok else ok && denseRncWithinNow ctx st0) then
-                (reg1, denseRncWrite ctx st0 cd.bits csEdits biEdits,
+                (reg1, denseRncWrite ctx st0 cd.bits rc.1 rb.1,
                  cd.bits.map (fun b => (b, denseRncBitCMGo ctx cd xs b 0)))
               else (reg1, st0, [])
 
@@ -2692,70 +1603,45 @@ def denseRncTargets (reg : VarRegistry) (sv : Array Bool) (cvs : Array (Array Va
 def denseRncAnchorBuild (cs : List (DenseExpr p)) : DenseCovIndex :=
   cs.zipIdx.foldr (fun ai idx => denseRncAnchorAdd idx (denseRncAnchorVars ai.1) ai.2) ⟨∅, []⟩
 
+/-- The engine's per-invocation context: dictionary-free field operations, the shared `.const 0`
+    tombstone and the degree bound. -/
+def denseRncCtxOf (b : DegreeBound) : DenseRncCtx p :=
+  { ops := denseZModOps, zeroE := .const (denseZModOps (p := p)).zero, b := b }
+
+/-- The seed state: the system on stable positions with the capped variable arrays and the anchor
+    index; every other index is built on the path that reads it. -/
+def denseRncSeed (nVar : Nat) (d : DenseConstraintSystem p)
+    (cvs : Array (Array VarId)) (live : Nat) : DenseRncState p :=
+  { cs := d.algebraicConstraints.toArray, cvs := cvs, bis := d.busInteractions.toArray,
+    live := live, bisN := d.busInteractions.length,
+    anchor := denseRncAnchorBuild d.algebraicConstraints,
+    useCs := none, useBis := none, foldCs := none, foldBis := none, varSeen := none, minted := ∅,
+    domVal := Array.replicate nVar none, domKnown := Array.replicate nVar false,
+    domSrc := Array.replicate nVar 0, domTouched := [], dWithin := false, nVar := nVar }
+
 /-- Witness re-encoding. When a group of variables `xs` is so constrained that only a few value
     combinations survive, mint `Nat.clog 2 #survivors` fresh boolean bits, rewrite each group
     variable as an interpolation polynomial over the bits, drop the now-covered constraints, and add
     booleanity constraints — e.g. a group with 3 surviving combinations becomes 2 bits, cutting the
     variable count. The transform is shaped for `DenseVerifiedPassW.ofExtending`; `facts` is unused
     (reencode is fact-free). -/
+def denseRncRun (b : DegreeBound) (reg : VarRegistry) (d : DenseConstraintSystem p)
+    (cvs : Array (Array VarId)) (live : Nat) (targets : List (List VarId)) :
+    VarRegistry × DenseConstraintSystem p × DenseDerivations p :=
+  if targets.isEmpty then (reg, d, [])
+  else
+    let r := denseRncLoop (denseRncCtxOf b) targets 0 reg (denseRncSeed reg.byId.size d cvs live)
+      s!"rnc{live}_{d.busInteractions.length}_"
+    (r.1, denseRncView r.2.1, r.2.2)
+
 def denseRncF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
     (bsem : BusSemantics p) (_facts : BusFacts p bsem) (d : DenseConstraintSystem p) :
     VarRegistry × DenseConstraintSystem p × DenseDerivations p :=
   if pw.isPrime = true then
-    let csArr := d.algebraicConstraints.toArray
-    let (cvs, live) := denseRncScan csArr
-    let nVar := reg.byId.size
-    let targets := denseRncTargets reg (denseRncSvSet nVar cvs) cvs
-    match targets with
-    | [] => (reg, d, [])
-    | _ :: _ =>
-      let ops : DenseZModOps p := denseZModOps
-      let ctx : DenseRncCtx p := { ops := ops, zeroE := .const ops.zero, b := b }
-      let bisArr := d.busInteractions.toArray
-      let st : DenseRncState p :=
-        { cs := csArr, cvs := cvs, bis := bisArr, live := live, bisN := bisArr.size,
-          anchor := denseRncAnchorBuild d.algebraicConstraints,
-          useCs := none, useBis := none, foldCs := none, foldBis := none, varSeen := none,
-          minted := ∅,
-          domVal := Array.replicate nVar none, domKnown := Array.replicate nVar false,
-          domSrc := Array.replicate nVar 0, domTouched := [], dWithin := false, nVar := nVar }
-      let r := denseRncLoop ctx targets 0 reg st s!"rnc{live}_{bisArr.size}_" 
-      (r.1, denseRncView r.2.1, r.2.2)
+    let scan := denseRncScan d.algebraicConstraints.toArray
+    denseRncRun b reg d scan.1 scan.2
+      (denseRncTargets reg (denseRncSvSet reg.byId.size scan.1) scan.1)
   else (reg, d, [])
 
-def denseReencodeF (pw : PrimeWitness p) (b : DegreeBound) (reg : VarRegistry)
-    (bsem : BusSemantics p) (_facts : BusFacts p bsem) (d : DenseConstraintSystem p) :
-    VarRegistry × DenseConstraintSystem p × DenseDerivations p :=
-  if pw.isPrime = true then
-    -- Each constraint's deduped variable list, shared between `svSet` and `targets`.
-    let csVs := d.algebraicConstraints.map (fun c => HashedDedup.hashedDedup (hash ·) c.vars)
-    let svSet : Std.HashSet VarId := csVs.foldl (init := ∅) fun s vs =>
-      match vs with
-      | [x] => s.insert x
-      | _ => s
-    let targets := dedupHash (csVs.filterMap (fun vs =>
-      if 2 ≤ vs.length && vs.length ≤ 8 && vs.all (svSet.contains ·) then
-        -- Sort by the resolved `Variable`'s order: `denseWorkLoop` below is a greedy,
-        -- order-sensitive accept/reject sequence, so the group order determines the outcome.
-        some (vs.mergeSort (fun a b => compare (reg.resolve a) (reg.resolve b) != .gt))
-      else none))
-    let r := denseWorkLoop b targets 0 reg (denseWorkSeed d)
-      { csIdx := denseBuildPruned DenseExpr.vars 8 d.algebraicConstraints
-        arrCs := d.algebraicConstraints.toArray
-        rootCache := ∅
-        varSet := Std.HashSet.ofList d.occ
-        useCs := denseCovBuild DenseExpr.vars d.algebraicConstraints
-        useBis := denseCovBuild denseBIVars d.busInteractions
-        arrBis := d.busInteractions.toArray
-        foldCs := d.algebraicConstraints.zipIdx.foldl
-          (fun s ci => if ci.1.hasConstFoldableNode then s.insert ci.2 else s) ∅
-        foldBis := Thunk.mk (fun _ => d.busInteractions.zipIdx.foldl
-          (fun s bi => if denseBiHasFold bi.1 then s.insert bi.2 else s) ∅)
-        liveCs := (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length
-        bisN := d.busInteractions.length
-        dWithin := false }
-      (d.algebraicConstraints.filter (fun c => !denseIsZero c)).length d.busInteractions.length
-    (r.1, denseWorkView r.2.1, r.2.2)
-  else (reg, d, [])
 
 end ApcOptimizer.Dense


### PR DESCRIPTION
Fully machine-checked: no `sorry`, `Scripts/check-proof-integrity.sh` passes (three standard axioms,
no unused theorems). The list engine and its proofs are deleted.

## What the pass was doing

`IO` phase timers inside the pass, summed over all cleanup invocations of sha256 `apc_001`
(7.4 s in reencode):

| phase | ms | |
|---|---:|---|
| setup (per-invocation indexes) | 2019 | six whole-system walks per cycle; the last six cycles have **zero targets** and still pay 213 ms |
| certificate | 1273 | 20 ms per accept, re-filtering the whole 146 k-constraint list to recover the covered set the build step already had |
| splice (`denseWorkOut`) | 947 | rewrites a list prefix through `maxPos` while the state separately maintains the same data as a position-stable array |
| domains | 860 | re-scanned per (target, variable) although a variable's domain is target-independent |
| early-reject test | 522 | `c.vars.eraseDups` per covered constraint per target |
| enumeration | 787 | `List (VarId × ZMod p)` points, positional **list** lookups |

64 of 6594 targets are accepted on cycle 0, and cycles 1–4 accept nothing at all. Cost classes
(`perf --call-graph lbr`, keccak, pass-restricted): pass-logic 35 %, refcount 17 %, alloc/free 16 %,
list-ops 10 %. Half the pass was memory traffic; the C output also showed `ZMod.commRing` rebuilt
inside the splice loop — the `.const 0` tombstone literal.

## The rebuild

- **One position-stable array per item list.** `w.cs` (spliced) and `state.arrCs` (array) held the
  same data; only the array survives. Dropped constraints become a shared `.const 0`, booleanity
  constraints are pushed onto it, and the output list is one filtered pass at exit.
- **One capped setup walk** (distinct variables per position, bailing at the 9th — every cheap-path
  consumer only distinguishes counts below 9) and **an immediate return when it yields no targets**.
  Every index is `VarId.index`-keyed and built lazily on the path that reads it.
- **Anchor index for the covered query**: `vars c ⊆ xs` implies the first variable is in `xs`, so one
  bucket per position is complete.
- **Per-variable domain memo**: the lowest-positioned constraint whose variable set is exactly `{v}`
  and whose root plan resolves is the same for every target containing `v`.
- **Array DFS enumeration** in `denseAssignments`' order, constraints filed by their last-assigned
  variable (so a violation prunes the subtree), the survivor cap as an early abort, dictionary-free
  arithmetic, and each variable's own domain source never tested.
- **The degree pre-gate decides from values**: a maximal in-group node's interpolation folds to a
  constant exactly when the node is constant across the padded survivor table, else its degree is
  `|bits|` — so the 13.5 k of 13.6 k candidates the gate rejects never build a polynomial, a pattern
  list or a substitution map (all three are `Thunk`s).
- **Linear writes.** `{ st with f := g st.f }` copies the whole array (the trap `Gauss.lean`
  documents); every setter destructures, and the accept computes its edits, decides the degree
  question on them, then writes — 5.5 ms → 0.09 ms per accept.
- Plus: shared pattern indicators and a shared per-pattern image table, and a one-pass
  `(hasVar, hasConstFoldableNode)` twin (the original re-derives `hasVar` at every composite node).

## Effect

Interleaved A/B (20-core box, serial), reencode ms and whole-run ms:

| APC | reencode | pass | whole run |
|---|---|---:|---:|
| sha256 `apc_001` (worst absolute) | 7420 → 2355 | **0.32×** | 68.8 → 64.1 s (0.93×) |
| wasm-eth `apc_036` (p95) | 492 → 192 | **0.39×** | 0.94× |
| keccak `apc_001` | 397 → 167 | **0.42×** | 0.96× |
| openvm-eth `apc_005` (worst share) | 186 → 70 | **0.38×** | 0.90× |
| openvm-eth `apc_068` (typical hot) | 192 → 70 | **0.36×** | 0.88× |

Output is **byte-identical** on 144 locally checked cases across the successive shapes (openvm-eth,
wasm-eth, keccak, sha256, SP1 rsp, SP1 keccak — `opt-export` md5), so effectiveness cannot move.

## The proof

Two theorems carry it, the same two the list engine's proof consumed:

- **`denseRncEs_eq`** — the covered set the anchor index gathers *is* `denseCoveredCsOf` of the view
  (anchor completeness + `denseCoveredIdx_eq_filter_of_complete`), which is what lets
  **`denseRncCert_sound`** turn the engine's certificate into the audited `denseCheckReencode` on
  the view, with freshness discharged from `varSeen`.
- **`denseRncWrite_view`** — the written state's view is `denseReencodeOut` of the old view with
  trivially-true constraints dropped (the counterpart of `denseWorkOut_view`), via generic
  positional-fold lemmas over `Array.setIfInBounds` at `Nodup` positions plus each edit builder's
  content/`Nodup`/completeness specs, finished with the list engine's `denseTombify_filter`.

Around them: the capped variable arrays are exact below the cap (so the array-level covered/shares
tests *are* `denseCoveredBy`/`sharesVarIn`); the one-pass fold twin agrees with
`hasConstFoldableNode`; `DenseRncOk` (cvs/anchor/useCs/foldCs/bus) is preserved by every setter and
by the whole write; the lazily built indexes are complete once forced; the seed's invariants come
from the scan, the anchor builder and coverage; `varSeen` marks every variable the view can still
contain; and the shared image table produces exactly `denseBitCM`'s tree. `denseRncStep_correct`
(branch by branch), `denseRncLoop_correct` and `denseRncF_props` assemble the four
`ofExtending` obligations.

Two structures were chosen for provability over speed, both re-measured: the certificate recomputes
the audited domains and survivors on the (small) gathered covered set rather than trusting the memo
and the DFS (+2.6 % on sha256, +50 % on the accept-heavy small cases — proving those two *equal* to
the audited functions needs linearisation semantics for the root plans, DFS exhaustiveness and cap
equivalence), and the gather is `denseCoveredIdxPos` over a `DenseCovIndex` so the existing
completeness lemma applies verbatim (~8 %). Both keep the fast memo, DFS and value-based degree gate
as untrusted proposal machinery that the certificate re-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)