### PR TITLE
perf(busPairCancel): rebuild the pass as a windowed sparse scan over an indexed bus (0.36–0.60x on the pass, sha256 total 0.73x)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -167,6 +167,18 @@ def addAll : DenseTwoRootMap p → (pending : List (DenseExpr p)) → DenseTwoRo
   | T, [] => T
   | T, c :: rest => addAll (addVars c T c.vars.eraseDups) rest
 
+/-- `addAll` with the candidate variables of each constraint restricted to `vars`: an entry for a
+    variable outside `vars` is never looked up (`buildForAddrs`), and `denseTwoRootOfLins` normalizes
+    both factors per candidate variable, so this is the whole cost of the build. -/
+def addAllFor (vars : Std.HashSet VarId) :
+    DenseTwoRootMap p → (pending : List (DenseExpr p)) → DenseTwoRootMap p
+  | T, [] => T
+  | T, c :: rest => addAllFor vars (addVars c T (c.vars.filter vars.contains).eraseDups) rest
+
+/-- `build` restricted to the candidate variables `vars`. -/
+def buildFor (vars : Std.HashSet VarId) (constraints : List (DenseExpr p)) : DenseTwoRootMap p :=
+  if Nat.Prime p then addAllFor vars empty constraints else empty
+
 /-- Build the map for a constraint list (empty on composite `p`). -/
 def build (constraints : List (DenseExpr p)) : DenseTwoRootMap p :=
   if Nat.Prime p then addAll empty constraints else empty
@@ -386,28 +398,30 @@ def DenseExpr.mentionsAny (s : Std.HashSet VarId) : DenseExpr p → Bool
   | .add a b => a.mentionsAny s || b.mentionsAny s
   | .mul a b => a.mentionsAny s || b.mentionsAny s
 
-/-- The variables at address-field positions of the declared memory shapes, over every interaction:
-    `denseAddrTwoRootNeq` reads exactly those payload slots (of the *candidate's* shape, so an
-    interaction on any bus can be read at another bus's address positions). -/
+/-- The variables a two-root lookup can reach: those of an address-slot expression of an
+    interaction on a memory-shaped bus, at *that bus's own* address fields. Every certificate arm
+    that reads the table is gated on the compared message being on the candidate's bus, and
+    `densePtrReductions` keys on the queried form's own variables, so no other entry is read. -/
 def denseAddrSlotVars (memShape : Nat → Option MemoryBusShape)
     (bis : List (BusInteraction (DenseExpr p))) : Std.HashSet VarId :=
-  let slots := (((bis.map (·.busId)).dedup.filterMap memShape).flatMap
-    MemoryBusShape.addressFields).dedup
   bis.foldl (fun s bi =>
-    slots.foldl (fun s slot =>
-      match bi.payload[slot]? with
-      | some e => e.vars.foldl (fun s v => s.insert v) s
-      | none => s) s) ∅
+    match memShape bi.busId with
+    | some shape =>
+      shape.addressFields.foldl (fun s slot =>
+        match bi.payload[slot]? with
+        | some e => e.vars.foldl (fun s v => s.insert v) s
+        | none => s) s
+    | none => s) ∅
 
-/-- The two-root map over just the constraints mentioning an address-slot variable. Every entry a
-    lookup can reach is unchanged: an entry for `v` is only ever inserted by a constraint mentioning
-    `v` (`addVars` folds over `c.vars`), and only address-slot variables are looked up
-    (`densePtrReductions` keys on the queried form's own variables). -/
+/-- The two-root map over just the constraints mentioning an address-slot variable, and only for
+    those variables. Every entry a lookup can reach is unchanged: an entry for `v` is only ever
+    inserted by a constraint mentioning `v` (`addVars` folds over `c.vars`), and only address-slot
+    variables are looked up (`densePtrReductions` keys on the queried form's own variables). -/
 def DenseTwoRootMap.buildForAddrs (memShape : Nat → Option MemoryBusShape)
     (bis : List (BusInteraction (DenseExpr p))) (constraints : List (DenseExpr p)) :
     DenseTwoRootMap p :=
   let vars := denseAddrSlotVars memShape bis
-  DenseTwoRootMap.build (constraints.filter (fun c => c.mentionsAny vars))
+  DenseTwoRootMap.buildFor vars (constraints.filter (fun c => c.mentionsAny vars))
 
 /-- Both address-disequality certificate tables, bundled so they thread through a pass as one
     memoized value. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -162,26 +162,19 @@ theorem addVars_of_none {c : DenseExpr p} (h : ∀ v, denseTwoRootOf? c v = none
               rw [← addVarsLins_eq h1 h2 T vs]
               simp [addVarsFast, h1, h2]
 
-/-- Fold `addVars` over a constraint list. -/
-def addAll : DenseTwoRootMap p → (pending : List (DenseExpr p)) → DenseTwoRootMap p
-  | T, [] => T
-  | T, c :: rest => addAll (addVars c T c.vars.eraseDups) rest
-
-/-- `addAll` with the candidate variables of each constraint restricted to `vars`: an entry for a
-    variable outside `vars` is never looked up (`buildForAddrs`), and `denseTwoRootOfLins` normalizes
-    both factors per candidate variable, so this is the whole cost of the build. -/
+/-- Fold `addVars` over a constraint list, with the candidate variables of each constraint
+    restricted to `vars`: an entry for a variable outside `vars` is never looked up
+    (`buildForAddrs`), and `denseTwoRootOfLins` normalizes both factors per candidate variable, so
+    this is the whole cost of the build. -/
 def addAllFor (vars : Std.HashSet VarId) :
     DenseTwoRootMap p → (pending : List (DenseExpr p)) → DenseTwoRootMap p
   | T, [] => T
   | T, c :: rest => addAllFor vars (addVars c T (c.vars.filter vars.contains).eraseDups) rest
 
-/-- `build` restricted to the candidate variables `vars`. -/
+/-- Build the map for a constraint list, indexing only the variables in `vars` (empty on
+    composite `p`). -/
 def buildFor (vars : Std.HashSet VarId) (constraints : List (DenseExpr p)) : DenseTwoRootMap p :=
   if Nat.Prime p then addAllFor vars empty constraints else empty
-
-/-- Build the map for a constraint list (empty on composite `p`). -/
-def build (constraints : List (DenseExpr p)) : DenseTwoRootMap p :=
-  if Nat.Prime p then addAll empty constraints else empty
 
 end DenseTwoRootMap
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
@@ -24,7 +24,7 @@ structure DenseSlotPre (p : ℕ) where
   reds : Thunk (List (DenseLinExpr p × DenseLinExpr p))
 
 def denseSlotPrep (T : DenseTwoRootMap p) (e : DenseExpr p) : DenseSlotPre p :=
-  ⟨e, Thunk.mk fun _ => e.constValue?, Thunk.mk fun _ => denseLinearize e,
+  ⟨e, Thunk.pure e.constValue?, Thunk.mk fun _ => denseLinearize e,
    Thunk.mk fun _ => densePtrReductions T e⟩
 
 /-- Prepared per-interaction address data relative to one memory-bus shape: the bus id, the

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -80,7 +80,7 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ cs0.algebraicConstraints)
     (candsOf : VarId → List (DenseExpr p))
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs0.algebraicConstraints)
-    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
+    (fidxT bidxT : Thunk (Array (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (iP jP : Nat) (S R : BusInteraction (DenseExpr p)) (slots : List Nat) (bound : Nat)
@@ -184,7 +184,7 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
-    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
+    (fidxT bidxT : Thunk (Array (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -284,7 +284,7 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
-    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
+    (fidxT bidxT : Thunk (Array (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -340,7 +340,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
     (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)))
-    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
+    (fidxT bidxT : Thunk (Array (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p)))
     (idx : Std.HashMap UInt64 (List Nat))
     (hpre : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
@@ -423,9 +423,10 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
       · exact DenseEqConstraintMap.empty_sound d.algebraicConstraints
     have hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ d.algebraicConstraints :=
       fun x => DenseVarCsIdx.lookup_mem (DenseVarCsIdx.build_sound d.algebraicConstraints) x
-    let fidxT : Thunk (Std.HashMap VarId (List Nat)) := Thunk.mk fun _ => denseBuildFormIdx bs arr
-    let bidxT : Thunk (Std.HashMap VarId (List Nat)) :=
-      Thunk.mk fun _ => denseBuildBoundIdx bs facts arr
+    let nvars := reg.byId.size
+    let fidxT : Thunk (Array (List Nat)) := Thunk.mk fun _ => denseBuildFormIdx bs nvars arr
+    let bidxT : Thunk (Array (List Nat)) :=
+      Thunk.mk fun _ => denseBuildBoundIdx bs facts nvars arr
     let bcBus? := busIds.findSome? (fun k => match facts.byteXorSpec k with
       | some spec => if spec.bound = 256 then some (k, spec) else none
       | none => none)

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -391,8 +391,13 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     let ops : DenseZModOps p := denseZModOps
     let idx := denseRecvIndexAll facts aggressive ops arr
     let alive : Array Bool := Array.replicate arr.size true
+    -- Every index below is built eagerly exactly when a candidate can reach the acceptance test,
+    -- and left lazy otherwise: `Thunk.get` marks its value multi-threaded (`denseThunkIf`), and an
+    -- invocation with no candidate must not pay for a build it never reads.
+    let eager := denseAnyCandidate facts aggressive ops idx arr
     let T : Thunk (DenseAddrCerts p) :=
-      Thunk.mk fun _ => DenseAddrCerts.build facts.memShape d.busInteractions d.algebraicConstraints
+      denseThunkIf eager fun _ =>
+        DenseAddrCerts.build facts.memShape d.busInteractions d.algebraicConstraints
     let M : Thunk (DenseEqConstraintMap p) :=
       Thunk.mk fun _ =>
         if aggressive then DenseEqConstraintMap.build d.algebraicConstraints
@@ -402,31 +407,37 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     -- identically without a per-query scan of the whole list.
     let domIdxT : Thunk { m : Std.HashMap VarId (List (DenseExpr p)) //
         ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ d.algebraicConstraints } :=
-      Thunk.mk fun _ =>
+      denseThunkIf eager fun _ =>
         ⟨denseVarBucket DenseExpr.vars (d.algebraicConstraints.filter DenseExpr.isSingleVar),
          fun v c hc => List.mem_of_mem_filter
            (denseVarBucket_mem DenseExpr.vars _ v c hc)⟩
     let candsT : Thunk (DenseVarCsIdx p) :=
-      Thunk.mk fun _ => DenseVarCsIdx.build d.algebraicConstraints
+      denseThunkIf eager fun _ => DenseVarCsIdx.build d.algebraicConstraints
     have hsz : alive.size = arr.size := by simp only [alive, Array.size_replicate]
     have halltrue : ∀ k, k < arr.size → alive[k]?.getD false = true := by
       intro k hk
       simp only [alive, Array.getElem?_replicate, hk, if_true, Option.getD_some]
-    have hTtworoot : T.get.tworoot.Sound d.algebraicConstraints :=
-      DenseTwoRootMap.buildForAddrs_sound facts.memShape d.busInteractions d.algebraicConstraints
-    have hTnonzero : T.get.nonzero = DenseNonzeroWits.build d.algebraicConstraints := rfl
+    have hTget : T.get = DenseAddrCerts.build facts.memShape d.busInteractions
+        d.algebraicConstraints := denseThunkIf_get _ _
+    have hTtworoot : T.get.tworoot.Sound d.algebraicConstraints := by
+      rw [hTget]
+      exact DenseTwoRootMap.buildForAddrs_sound facts.memShape d.busInteractions
+        d.algebraicConstraints
+    have hTnonzero : T.get.nonzero = DenseNonzeroWits.build d.algebraicConstraints := by
+      rw [hTget]; rfl
     have hM : M.get.Sound d.algebraicConstraints := by
       show (if aggressive then DenseEqConstraintMap.build d.algebraicConstraints
         else DenseEqConstraintMap.empty).Sound d.algebraicConstraints
       split
       · exact DenseEqConstraintMap.build_sound d.algebraicConstraints
       · exact DenseEqConstraintMap.empty_sound d.algebraicConstraints
-    have hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ d.algebraicConstraints :=
-      fun x => DenseVarCsIdx.lookup_mem (DenseVarCsIdx.build_sound d.algebraicConstraints) x
+    have hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ d.algebraicConstraints := by
+      rw [show candsT.get = DenseVarCsIdx.build d.algebraicConstraints from denseThunkIf_get _ _]
+      exact fun x => DenseVarCsIdx.lookup_mem (DenseVarCsIdx.build_sound d.algebraicConstraints) x
     let nvars := reg.byId.size
-    let fidxT : Thunk (Array (List Nat)) := Thunk.mk fun _ => denseBuildFormIdx bs nvars arr
+    let fidxT : Thunk (Array (List Nat)) := denseThunkIf eager fun _ => denseBuildFormIdx bs nvars arr
     let bidxT : Thunk (Array (List Nat)) :=
-      Thunk.mk fun _ => denseBuildBoundIdx bs facts nvars arr
+      denseThunkIf eager fun _ => denseBuildBoundIdx bs facts nvars arr
     let bcBus? := busIds.findSome? (fun k => match facts.byteXorSpec k with
       | some spec => if spec.bound = 256 then some (k, spec) else none
       | none => none)
@@ -434,8 +445,8 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     -- resume of this invocation (the thunk is forced only when a matched pair reaches a scan).
     let preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)) :=
       busIds.filterMap (fun busId => (facts.memShape busId).map (fun shape =>
-        (busId, Thunk.pure (arr.map (denseAddrPrep shape T.get.tworoot)),
-         Thunk.pure (denseKeyIdxBuild shape busId arr))))
+        (busId, denseThunkIf eager (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)),
+         denseThunkIf eager (fun _ => denseKeyIdxBuild shape busId arr))))
     have hpreBuses : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
         facts.memShape busId = some shape →
         t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
@@ -451,7 +462,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
           subst hb
           rw [hshape] at hms
           obtain rfl := Option.some.inj hms
-          exact ⟨by rw [← ht]; rfl, by rw [← hkt]; rfl⟩
+          exact ⟨by rw [← ht]; exact denseThunkIf_get _ _, by rw [← hkt]; exact denseThunkIf_get _ _⟩
     have hcur0 : ∀ (isInput : VarId → Bool) (reg : VarRegistry), d.CoveredBy reg →
         DensePassCorrect isInput d (denseMkCs d arr alive []) [] bs :=
       fun isInput _ _ => by

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -48,19 +48,23 @@ quantified over `isInput`/`reg` with the current system's coverage as hypothesis
 structure DenseDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p)
     (arr : Array (BusInteraction (DenseExpr p)))
     (alive : Array Bool) (checks : List (BusInteraction (DenseExpr p))) where
-  aliveNew : Array Bool
+  /-- The two tombstoned positions. The loop applies them itself (`denseTombstone`) so that the
+      liveness array is updated in place: a result carrying the rebuilt array would keep the old one
+      alive across the update and force a copy per accepted drop. -/
+  dropI : Nat
+  dropJ : Nat
   checksNew : List (BusInteraction (DenseExpr p))
   emitted : Bool
   dropIdx : Nat
   dropPos : Nat
-  sizeNew : aliveNew.size = arr.size
+  sizeNew : (denseTombstone alive dropI dropJ).size = arr.size
   step : ∀ (isInput : VarId → Bool) (reg : VarRegistry),
     (denseMkCs cs0 arr alive checks).CoveredBy reg →
     DensePassCorrect isInput (denseMkCs cs0 arr alive checks)
-      (denseMkCs cs0 arr aliveNew checksNew) [] bs
-  decreases : denseLiveCount arr aliveNew < denseLiveCount arr alive
+      (denseMkCs cs0 arr (denseTombstone alive dropI dropJ) checksNew) [] bs
+  decreases : denseLiveCount arr (denseTombstone alive dropI dropJ) < denseLiveCount arr alive
   covNew : ∀ (reg : VarRegistry), (denseMkCs cs0 arr alive checks).CoveredBy reg →
-    (denseMkCs cs0 arr aliveNew checksNew).CoveredBy reg
+    (denseMkCs cs0 arr (denseTombstone alive dropI dropJ) checksNew).CoveredBy reg
 
 /-- Assemble the `DenseDropResult` for an accepted candidate; the single step is proved by
     `denseCheckCancel_sound`. -/
@@ -76,7 +80,7 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ cs0.algebraicConstraints)
     (candsOf : VarId → List (DenseExpr p))
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs0.algebraicConstraints)
-    (fidx bidx : Std.HashMap VarId (List Nat))
+    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (iP jP : Nat) (S R : BusInteraction (DenseExpr p)) (slots : List Nat) (bound : Nat)
@@ -93,13 +97,13 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
       denseMidRefuted ops shape T busId S m0 = true)
     (hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 iP) = true)
     (hchk : denseCheckCancel ops deep bs facts M domIdx candsOf
-      (denseDropWits facts bidx arr alive S R checksOld checks) (denseDropFormWits fidx arr alive S R)
+      (denseDropWits facts bidxT.get arr alive S R checksOld checks) (denseDropFormWits fidxT.get arr alive S R)
       busId shape slots bound S R checks = true) :
     DenseDropResult cs0 bs arr alive checksOld := by
   let A := denseLiveSeg arr alive 0 iP
   let B := denseLiveSeg arr alive (iP + 1) (jP - iP - 1)
   let C' := denseLiveSeg arr alive (jP + 1) (arr.size - jP - 1)
-  let aliveNew := (alive.setIfInBounds iP false).setIfInBounds jP false
+  let aliveNew := denseTombstone alive iP jP
   have hisz : iP < alive.size := by rw [hsz]; omega
   have hjsz' : jP < alive.size := by rw [hsz]; exact hjsz
   have hsplitL : denseLiveSeg arr alive 0 arr.size = A ++ S :: B ++ R :: C' :=
@@ -124,20 +128,21 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
         = { cs0 with busInteractions := denseLiveSeg arr aliveNew 0 arr.size ++ checksNew }
     rw [hdropL, hchecksNew]; congr 1; simp only [List.append_assoc]
   refine {
-    aliveNew := aliveNew
+    dropI := iP
+    dropJ := jP
     checksNew := checksNew
     emitted := emitted
     dropIdx := dropIdx
     dropPos := dropPos
-    sizeNew := by simp only [aliveNew, Array.size_setIfInBounds]; exact hsz
+    sizeNew := by simp only [denseTombstone, Array.size_setIfInBounds]; exact hsz
     step := fun isInput reg hsys => heq ▸
       denseCheckCancel_sound isInput (denseMkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep ops
         reg hsys busId shape hshape slots bound T hTtworoot hTnonzero M hM domIdx candsOf
-        (denseDropWits facts bidx arr alive S R checksOld checks)
-        (denseDropFormWits fidx arr alive S R)
+        (denseDropWits facts bidxT.get arr alive S R checksOld checks)
+        (denseDropFormWits fidxT.get arr alive S R)
         A S B R (C' ++ checksOld) hslots checks hsplit hdomIdx hcands
-        (denseDropWits_mem facts bidx arr alive S R checksOld checks horig hchecks)
-        (denseDropFormWits_mem fidx arr alive S R horig checks) hmid hshield hchk
+        (denseDropWits_mem facts bidxT.get arr alive S R checksOld checks horig hchecks)
+        (denseDropFormWits_mem fidxT.get arr alive S R horig checks) hmid hshield hchk
     decreases := ?_
     covNew := fun reg hsys => by
       refine ⟨hsys.1, ?_⟩
@@ -179,7 +184,7 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
-    (fidx bidx : Std.HashMap VarId (List Nat))
+    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -191,7 +196,7 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
   if hi : i < arr.size then
     let S := arr[i]
     let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
-      shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive
+      shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT arr alive
       checksOld hsz idx preT hpreT kT hkT (i + 1)
     if haliveS : alive[i]?.getD false = true then
     if decide (S.busId = busId) &&
@@ -228,16 +233,17 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           | none => next ()
           | some (slots, bound) =>
           if hchk0 : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
-              (denseDropWits facts bidx arr alive S R checksOld []) (denseDropFormWits fidx arr alive S R)
+              (denseDropWits facts bidxT.get arr alive S R checksOld [])
+              (denseDropFormWits fidxT.get arr alive S R)
               busId shape slots bound S R [] = true then
             some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
               hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
-              fidx bidx arr alive checksOld hsz i j S R slots bound [] checksOld
+              fidxT bidxT arr alive checksOld hsz i j S R slots bound [] checksOld
               (List.append_nil checksOld).symm (fun reg _ bi hbi => absurd hbi (by simp))
               false 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk0)
           else
           let unjust := denseUnjustifiedSlots bound deep domIdxT.get.val candsT.get.lookup bs facts
-            (denseDropWits facts bidx arr alive S R checksOld []) (denseDropFormWits fidx arr alive S R)
+            (denseDropWits facts bidxT.get arr alive S R checksOld []) (denseDropFormWits fidxT.get arr alive S R)
             slots R
           let checks : List (BusInteraction (DenseExpr p)) :=
             match unjust, bcBus? with
@@ -246,12 +252,12 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
             | _, _ => []
           if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
             if hchk : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
-                (denseDropWits facts bidx arr alive S R checksOld checks)
-                (denseDropFormWits fidx arr alive S R)
+                (denseDropWits facts bidxT.get arr alive S R checksOld checks)
+                (denseDropFormWits fidxT.get arr alive S R)
                 busId shape slots bound S R checks = true then
               some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
                 hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
-                fidx bidx arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
+                fidxT bidxT arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
                 (fun reg hRpay bi hbi => denseEmittedChecks_covered unjust bcBus? R reg hRpay bi hbi)
                 true 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk)
             else next ()
@@ -278,7 +284,7 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       ∀ v, ∀ c ∈ denseVarBucketLookup m v, c ∈ cs0.algebraicConstraints })
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
-    (fidx bidx : Std.HashMap VarId (List Nat))
+    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
     (idx : Std.HashMap UInt64 (List Nat))
@@ -292,22 +298,22 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
   | curIdx, (busId, preT, kT) :: rest, hpre =>
     if curIdx < resumeIdx then
       denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
-        hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
+        hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
         (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
-            T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidx bidx arr alive checksOld
+            T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT arr alive checksOld
             hsz idx preT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).1
             kT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).2 startPos with
         | some dr => some { dr with dropIdx := curIdx }
         | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-            domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
+            domIdxT candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos
             (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
       | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-          domIdxT candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos
+          domIdxT candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos
           (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
 
 /-! The materialized final system plus (erased) correctness and coverage proofs that
@@ -334,7 +340,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
     (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)))
-    (fidx bidx : Std.HashMap VarId (List Nat))
+    (fidxT bidxT : Thunk (Std.HashMap VarId (List Nat)))
     (arr : Array (BusInteraction (DenseExpr p)))
     (idx : Std.HashMap UInt64 (List Nat))
     (hpre : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
@@ -349,7 +355,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       (denseMkCs cs0 arr alive checksOld).CoveredBy reg) :
     DenseCancelBundle cs0 bs :=
   match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT
-      candsT hcands fidx bidx arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 preBuses hpre with
+      candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 preBuses hpre with
   | none =>
     { out := { cs0 with
         busInteractions := denseLiveArr arr alive hsz 0 arr.size (by omega) ++ checksOld }
@@ -367,7 +373,8 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
     denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
-      hcands bcBus? preBuses fidx bidx arr idx hpre dr.aliveNew dr.checksNew dr.sizeNew nextIdx nextPos
+      hcands bcBus? preBuses fidxT bidxT arr idx hpre (denseTombstone alive dr.dropI dr.dropJ)
+      dr.checksNew dr.sizeNew nextIdx nextPos
       (fun isInput reg hcs0 => (hcur isInput reg hcs0).andThen (dr.step isInput reg (hsyscov reg hcs0)))
       (fun reg hcs0 => dr.covNew reg (hsyscov reg hcs0))
   termination_by denseLiveCount arr alive
@@ -416,8 +423,9 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
       · exact DenseEqConstraintMap.empty_sound d.algebraicConstraints
     have hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ d.algebraicConstraints :=
       fun x => DenseVarCsIdx.lookup_mem (DenseVarCsIdx.build_sound d.algebraicConstraints) x
-    let fidx := denseBuildFormIdx bs arr
-    let bidx := denseBuildBoundIdx bs facts arr
+    let fidxT : Thunk (Std.HashMap VarId (List Nat)) := Thunk.mk fun _ => denseBuildFormIdx bs arr
+    let bidxT : Thunk (Std.HashMap VarId (List Nat)) :=
+      Thunk.mk fun _ => denseBuildBoundIdx bs facts arr
     let bcBus? := busIds.findSome? (fun k => match facts.byteXorSpec k with
       | some spec => if spec.bound = 256 then some (k, spec) else none
       | none => none)
@@ -425,8 +433,8 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     -- resume of this invocation (the thunk is forced only when a matched pair reaches a scan).
     let preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)) :=
       busIds.filterMap (fun busId => (facts.memShape busId).map (fun shape =>
-        (busId, Thunk.mk (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)),
-         Thunk.mk (fun _ => denseKeyIdxBuild shape busId arr))))
+        (busId, Thunk.pure (arr.map (denseAddrPrep shape T.get.tworoot)),
+         Thunk.pure (denseKeyIdxBuild shape busId arr))))
     have hpreBuses : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
         facts.memShape busId = some shape →
         t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
@@ -451,7 +459,7 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
         (denseMkCs d arr alive []).CoveredBy reg :=
       fun _ hcs0 => by rw [denseMkCs_all d arr rfl alive halltrue]; exact hcs0
     let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive ops
-      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? preBuses fidx bidx arr idx hpreBuses
+      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? preBuses fidxT bidxT arr idx hpreBuses
       alive [] hsz 0 0 hcur0 hsyscov0
     { reg' := reg
       out := bundle.out

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
@@ -41,6 +41,32 @@ def denseRecvIndexAll {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive 
       else m
     | none => m) ∅
 
+/-- Does any position hold a send whose receive bucket is non-empty? A cheap over-approximation of
+    "this invocation can accept a drop", short-circuiting at the first hit. It decides only whether
+    the per-invocation indexes are built eagerly (`denseThunkIf`), so it carries no obligation: a
+    wrong answer costs time, never soundness. -/
+def denseAnyCandGo {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
+    (ops : DenseZModOps p) (idx : Std.HashMap UInt64 (List Nat))
+    (arr : Array (BusInteraction (DenseExpr p))) : Nat → Bool
+  | 0 => false
+  | n + 1 =>
+    (match arr[n]? with
+     | some bi =>
+       match facts.memShape bi.busId with
+       | some shape =>
+         decide (denseMultConst bi = some (denseSetNewMult ops shape)) &&
+           !(idx.getD (mixHash (hash bi.busId)
+               (if aggressive then denseAddrHash shape bi.payload
+                else densePayloadHash bi.payload)) []).isEmpty
+       | none => false
+     | none => false)
+      || denseAnyCandGo facts aggressive ops idx arr n
+
+def denseAnyCandidate {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
+    (ops : DenseZModOps p) (idx : Std.HashMap UInt64 (List Nat))
+    (arr : Array (BusInteraction (DenseExpr p))) : Bool :=
+  denseAnyCandGo facts aggressive ops idx arr arr.size
+
 /-- A per-variable candidate-constraint index: for each variable, the constraints (in traversal
     order) known to mention it. -/
 structure DenseVarCsIdx (p : ℕ) where

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
@@ -151,14 +151,17 @@ Both walks re-check the window at every entry, so the bounds only need to be sou
         | some v => v
         | none => denseShieldEarly P Q preArr alive b s bound fuel nb (ns - 1)
 
-/-- Descending early-exit shield over the whole segment `[0, n)` — the symbolic-key fallback, which
-    has no index to walk. -/
-@[specialize] def denseShieldEarlySeg {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
-    (bound : Nat) : Nat → Bool
-  | 0 => true
-  | n + 1 =>
-    match denseShieldDecide P Q preArr alive bound n with
-    | some v => v
-    | none => denseShieldEarlySeg P Q preArr alive bound n
+/-- Both region tests for one candidate over its two scan arrays: the mid walk over the index range
+    the window `[i + 1, j)` maps to, and the descending shield below `i`. The shield's bounds sit
+    inside the `&&`, so a failed mid test skips them. -/
+@[inline] def denseScanDecide {α : Type} (Pmid Ppre Q : α → Bool) (preArr : Array α)
+    (alive : Array Bool) (b s : Array Nat) (i j : Nat) : Bool :=
+  (denseLiveAllGated Pmid preArr alive b (i + 1) j (denseLowerBound b (i + 1))
+      (denseLowerBound b j)
+    && denseLiveAllGated Pmid preArr alive s (i + 1) j (denseLowerBound s (i + 1))
+        (denseLowerBound s j))
+  && (let nb := denseLowerBound b i
+      let ns := denseLowerBound s i
+      denseShieldEarly Ppre Q preArr alive b s i (nb + ns) nb ns)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
@@ -97,7 +97,7 @@ Both walks re-check the window at every entry, so the bounds only need to be sou
 /-- `P` at every live entry of `a` (indices `[start, n)`) whose position lies in `[lo, hi)`. The
     caller passes `start = denseLowerBound a lo` and `n = denseLowerBound a hi`, so the walk covers
     exactly the entries the window gate can accept. -/
-def denseLiveAllGated {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
+@[specialize] def denseLiveAllGated {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
     (a : Array Nat) (lo hi start : Nat) : Nat → Bool
   | 0 => true
   | n + 1 =>
@@ -127,7 +127,7 @@ def denseLiveAllGated {α : Type} (P : α → Bool) (preArr : Array α) (alive :
 /-- Descending early-exit shield over the entries of the two ascending arrays below `bound`: the
     larger of the two current tails is tested first, so entries are visited in descending position
     order and the walk stops at the topmost deciding one. `fuel` bounds the walk (`nb + ns`). -/
-def denseShieldEarly {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+@[specialize] def denseShieldEarly {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
     (b s : Array Nat) (bound : Nat) : Nat → Nat → Nat → Bool
   | 0, _, _ => true
   | fuel + 1, nb, ns =>
@@ -153,7 +153,7 @@ def denseShieldEarly {α : Type} (P Q : α → Bool) (preArr : Array α) (alive 
 
 /-- Descending early-exit shield over the whole segment `[0, n)` — the symbolic-key fallback, which
     has no index to walk. -/
-def denseShieldEarlySeg {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
+@[specialize] def denseShieldEarlySeg {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
     (bound : Nat) : Nat → Bool
   | 0 => true
   | n + 1 =>

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelKeyIdx.lean
@@ -2,16 +2,16 @@ import ApcOptimizer.Implementation.OptimizerPasses.AddrDiseqPre
 
 set_option autoImplicit false
 
-/-! # Constant-address-key position index for `busPairCancel`'s region scans
+/-! # Address-key position index for `busPairCancel`'s region scans
 
-The mid/shield scans walked every position of their region per candidate pair — with tens of
-thousands of accepted drops each re-scanning an `O(prefix)` region, the scan *volume* dominated
-the pass. For a candidate whose address slots are all constants, a message can only fail the
-region tests if it is on the same bus and either shares the candidate's constant address key or
-has a non-constant key: every other position is refuted by the bus-id or constant-disequality arm
-and contributes the identity to the scan fold. `DenseKeyIdx` buckets each bus's positions by
-constant address key (plus a `sym` list for non-constant keys, and both as arrays), so the scans
-below visit only the same-key and symbolic positions — and the shield stops at the first position
+A message can only fail a candidate's region tests if it is on the candidate's bus: every other
+position is refuted by the bus-id arm and contributes the identity to the scan fold. For a candidate
+whose address slots are all constants, it must in addition share the candidate's constant address
+key or have a non-constant one, since a differing constant key is refuted by the constant-disequality
+arm. `DenseKeyIdx` therefore indexes each bus's positions three ways — by constant address key
+(`byKey`), the non-constant-key ones (`sym`), and all of them (`all`, what a candidate with a
+non-constant key of its own scans) — so a scan visits only positions that can decide it. The walks
+are bounded to the position window by `denseLowerBound`, and the shield stops at the first position
 that decides it. `Proofs/BusPairCancelKeyIdx.lean` proves the builder sound and packages the scan
 results back into the full-region forms (`denseRegionTests`). -/
 
@@ -31,15 +31,18 @@ def denseAddrKeyOf (shape : MemoryBusShape) (bi : BusInteraction (DenseExpr p)) 
 def denseKeyHash (k : List (ZMod p)) : UInt64 :=
   k.foldl (fun h c => mixHash h (hash c.val)) 7
 
-/-- Per-bus constant-key position index: `byKey` buckets the bus's all-constant-key positions by
-    key hash, `sym` lists its non-constant-key positions; both ascending. -/
+/-- Per-bus position index: `byKey` buckets the bus's all-constant-key positions by key hash, `sym`
+    lists its non-constant-key positions, `all` every position on the bus (what a candidate with a
+    non-constant key of its own must scan); all ascending. -/
 structure DenseKeyIdx (p : ℕ) where
   byKey : Std.HashMap UInt64 (List Nat)
   sym : List Nat
-  /-- `byKey`/`sym` as ascending arrays: the runtime walks these (`denseLiveAllGated`,
+  all : List Nat
+  /-- `byKey`/`sym`/`all` as ascending arrays: the runtime walks these (`denseLiveAllGated`,
       `denseShieldEarly`) instead of materializing a filtered list per candidate. -/
   byKeyA : Std.HashMap UInt64 (Array Nat)
   symA : Array Nat
+  allA : Array Nat
 
 /-- Insert one position (front of its bucket; the builder folds positions descending). -/
 def denseKeyIdxAdd (shape : MemoryBusShape) (busId : Nat)
@@ -51,36 +54,62 @@ def denseKeyIdxAdd (shape : MemoryBusShape) (busId : Nat)
       match denseAddrKeyOf shape m with
       | some k =>
           let h := denseKeyHash k
-          { idx with byKey := idx.byKey.insert h (pos :: idx.byKey.getD h []) }
-      | none => { idx with sym := pos :: idx.sym }
+          { idx with byKey := idx.byKey.insert h (pos :: idx.byKey.getD h []),
+                     all := pos :: idx.all }
+      | none => { idx with sym := pos :: idx.sym, all := pos :: idx.all }
     else idx
   | none => idx
 
 def denseKeyIdxBuild (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) : DenseKeyIdx p :=
-  let idx := (List.range arr.size).foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], ∅, #[]⟩
-  { idx with byKeyA := idx.byKey.map (fun _ l => l.toArray), symA := idx.sym.toArray }
+  let idx := (List.range arr.size).foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], [], ∅, #[], #[]⟩
+  { idx with byKeyA := idx.byKey.map (fun _ l => l.toArray), symA := idx.sym.toArray,
+             allA := idx.all.toArray }
+
+/-! ## Windowed access to the ascending index arrays
+
+Every scan below runs over a position window (`[lo, hi)` for the mid test, `[0, bound)` for the
+shield). The arrays are ascending, so the window is a contiguous index range, and the walks are
+bounded by `denseLowerBound` instead of testing every entry: entries outside the range fail the
+scan's own gate by sortedness, so bounding them away is value-identical. -/
+
+/-- Binary search in the ascending `a` over index range `[lo, hi)`. -/
+def denseLowerBoundGo (a : Array Nat) (x lo hi : Nat) : Nat :=
+  if lo < hi then
+    let mid := (lo + hi) / 2
+    if (a[mid]?).getD 0 < x then denseLowerBoundGo a x (mid + 1) hi
+    else denseLowerBoundGo a x lo mid
+  else lo
+  termination_by hi - lo
+  decreasing_by all_goals omega
+
+/-- The first index of the ascending `a` whose entry is `≥ x` (`a.size` if there is none). -/
+def denseLowerBound (a : Array Nat) (x : Nat) : Nat := denseLowerBoundGo a x 0 a.size
 
 /-! ## The index scans
 
-The mid test walks the index arrays with a window gate; the shield walks them **descending with an
-early exit**, since its verdict is decided by the topmost visited live position `q` with
-`¬P q ∨ Q q` (`ok = P q`, `true` when there is none — `denseShieldScanSegP_true_of`), so the
-positions below the last provable receive are never tested. Both walks re-check the position window
-at every entry, so the index needs no range search. -/
+The mid test walks the index arrays over the window's index range; the shield walks them
+**descending from the window's top with an early exit**, since its verdict is decided by the topmost
+visited live position `q` with `¬P q ∨ Q q` (`ok = P q`, `true` when there is none —
+`denseShieldScanSegP_true_of`), so the positions below the last provable receive are never tested.
+Both walks re-check the window at every entry, so the bounds only need to be sound, not tight. -/
 
-/-- `P` at every live entry of `a` (indices `[0, n)`) whose position lies in `[lo, hi)`. -/
+/-- `P` at every live entry of `a` (indices `[start, n)`) whose position lies in `[lo, hi)`. The
+    caller passes `start = denseLowerBound a lo` and `n = denseLowerBound a hi`, so the walk covers
+    exactly the entries the window gate can accept. -/
 def denseLiveAllGated {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
-    (a : Array Nat) (lo hi : Nat) : Nat → Bool
+    (a : Array Nat) (lo hi start : Nat) : Nat → Bool
   | 0 => true
   | n + 1 =>
-    (match a[n]? with
-     | some pos =>
-       if decide (lo ≤ pos) && decide (pos < hi) && alive[pos]?.getD false then
-         (preArr[pos]?).elim true P
-       else true
-     | none => true)
-      && denseLiveAllGated P preArr alive a lo hi n
+    if n < start then true
+    else
+      (match a[n]? with
+       | some pos =>
+         if decide (lo ≤ pos) && decide (pos < hi) && alive[pos]?.getD false then
+           (preArr[pos]?).elim true P
+         else true
+       | none => true)
+        && denseLiveAllGated P preArr alive a lo hi start n
 
 /-- One descending step of the shield: `some v` when position `pos` decides it (`v = P pos`), `none`
     when `pos` is outside the window, dead, or refuted without being a provable receive. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
@@ -75,6 +75,18 @@ theorem denseLiveSeg_mem (arr : Array (BusInteraction (DenseExpr p))) (alive : A
   rw [denseLiveSeg_peel arr alive (lo + d) e a halive hget]
   exact List.mem_cons.2 (Or.inl rfl)
 
+/-- `Thunk.pure` when `eager`, `Thunk.mk` otherwise. Both have the same `.get`
+    (`denseThunkIf_get`), so the choice is invisible to every proof; it decides only whether the
+    value is built up front or on first force. `Thunk.get` on an unforced thunk calls
+    `lean_mark_mt` on the computed value — an `O(value)` graph walk that also makes every object in
+    it multi-threaded, so a value that will certainly be forced is cheaper built eagerly. -/
+@[inline] def denseThunkIf {α : Type} (eager : Bool) (f : Unit → α) : Thunk α :=
+  if eager then Thunk.pure (f ()) else Thunk.mk f
+
+@[simp] theorem denseThunkIf_get {α : Type} (eager : Bool) (f : Unit → α) :
+    (denseThunkIf eager f).get = f () := by
+  cases eager <;> rfl
+
 /-- Tombstone two positions. Applied by the cancel loop on the liveness array it owns, so the two
     writes hit a uniquely-referenced array and mutate in place. -/
 def denseTombstone (alive : Array Bool) (i j : Nat) : Array Bool :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
@@ -75,6 +75,11 @@ theorem denseLiveSeg_mem (arr : Array (BusInteraction (DenseExpr p))) (alive : A
   rw [denseLiveSeg_peel arr alive (lo + d) e a halive hget]
   exact List.mem_cons.2 (Or.inl rfl)
 
+/-- Tombstone two positions. Applied by the cancel loop on the liveness array it owns, so the two
+    writes hit a uniquely-referenced array and mutate in place. -/
+def denseTombstone (alive : Array Bool) (i j : Nat) : Array Bool :=
+  (alive.setIfInBounds i false).setIfInBounds j false
+
 /-! On accepting a pair `(iP, jP)`, the live projection factors as `A ++ S :: B ++ R :: C'`
 (`denseLiveSeg_split`); tombstoning the two positions changes it to `A ++ B ++ C'`
 (`denseLiveSeg_drop`) — the shape `denseDropPair_correct` produces. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
@@ -55,8 +55,8 @@ def denseInteractionBoundPat (bs : BusSemantics p) (facts : BusFacts p bs)
 /-- Candidate positions of bound-deriving interactions, per variable (ascending), built once per
     invocation. Untrusted — `denseDropWitsIdxGo` re-checks liveness, the dropped pair, and the bound
     at every use. -/
-def denseBuildBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs)
-    (arr : Array (BusInteraction (DenseExpr p))) : Std.HashMap VarId (List Nat) :=
+def denseBuildBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs) (nvars : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) : Array (List Nat) :=
   (arr.toList.zipIdx).foldr (fun bik m =>
     let bi := bik.1
     let mval? := bi.multiplicity.constValue?
@@ -65,12 +65,12 @@ def denseBuildBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs)
       match e with
       | .var v =>
         -- skip repeated occurrences of the same variable within one payload
-        if (m.getD v []).head? = some bik.2 then m
+        if ((m[v.index]?).getD []).head? = some bik.2 then m
         else
           match denseInteractionBoundPat bs facts bi mval? pat v with
-          | some _ => m.insert v (bik.2 :: m.getD v [])
+          | some _ => m.modify v.index (bik.2 :: ·)
           | none => m
-      | _ => m) m) ∅
+      | _ => m) m) (Array.replicate nvars [])
 
 /-- The scan behind `denseDropWits`: the first of `v`'s indexed candidate positions (ascending,
     skipping dead entries and the dropped pair) that still derives a `denseInteractionBound` for
@@ -103,12 +103,12 @@ def denseFirstBoundIn {bs : BusSemantics p} (facts : BusFacts p bs) (v : VarId) 
     dropped pair — first among the live stable-array entries (via `bidx`), then among the
     previously-emitted checks `checksOld` — followed by this drop's emitted checks. -/
 def denseDropWits {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bidx : Std.HashMap VarId (List Nat))
+    (bidx : Array (List Nat))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (S R : BusInteraction (DenseExpr p))
     (checksOld emitted : List (BusInteraction (DenseExpr p))) (v : VarId) :
     List (BusInteraction (DenseExpr p)) :=
-  match denseDropWitsIdxGo facts arr alive S R v (bidx.getD v []) with
+  match denseDropWitsIdxGo facts arr alive S R v ((bidx[v.index]?).getD []) with
   | some bi => bi :: emitted
   | none =>
     match denseFirstBoundIn facts v checksOld with
@@ -118,8 +118,8 @@ def denseDropWits {bs : BusSemantics p} (facts : BusFacts p bs)
 /-- Candidate positions for range-checked forms, per variable: interactions on a *stateless* bus
     carrying a compound payload slot mentioning the variable, at most four per variable. Untrusted —
     `denseDropFormWits` re-checks liveness and the dropped pair at every use. -/
-def denseBuildFormIdx (bs : BusSemantics p) (arr : Array (BusInteraction (DenseExpr p))) :
-    Std.HashMap VarId (List Nat) :=
+def denseBuildFormIdx (bs : BusSemantics p) (nvars : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) : Array (List Nat) :=
   (arr.toList.zipIdx).foldl (fun m bik =>
     if bs.isStateful bik.1.busId then m
     else
@@ -127,17 +127,18 @@ def denseBuildFormIdx (bs : BusSemantics p) (arr : Array (BusInteraction (DenseE
         if e.isSingleVar then m
         else
           e.vars.dedup.foldl (fun m v =>
-            let cur := m.getD v []
-            if cur.length < 4 then m.insert v (bik.2 :: cur) else m) m) m) ∅
+            let cur := (m[v.index]?).getD []
+            if cur.length < 4 then m.modify v.index (bik.2 :: ·) else m) m) m)
+      (Array.replicate nvars [])
 
 /-- The range-checked-form witness lookup for a candidate drop: the indexed candidate positions
     for `v`, re-checked live and distinct from the dropped pair — the interactions
     `denseBasisJustified` mines for bounded linear forms. -/
-def denseDropFormWits (fidx : Std.HashMap VarId (List Nat))
+def denseDropFormWits (fidx : Array (List Nat))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (S R : BusInteraction (DenseExpr p)) (v : VarId) :
     List (BusInteraction (DenseExpr p)) :=
-  (fidx.getD v []).filterMap (fun k =>
+  ((fidx[v.index]?).getD []).filterMap (fun k =>
     if h : k < arr.size then
       if alive[k]?.getD false && !decide (arr[k] = S) && !decide (arr[k] = R) then
         some arr[k]
@@ -202,7 +203,7 @@ theorem denseFirstBoundIn_mem {bs : BusSemantics p} (facts : BusFacts p bs) (v :
     entries other than the dropped pair are in `A ++ B ++ C`, and so are the previously-emitted
     checks `checksOld`. -/
 theorem denseDropWits_mem {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bidx : Std.HashMap VarId (List Nat))
+    (bidx : Array (List Nat))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (S R : BusInteraction (DenseExpr p))
     (checksOld emitted : List (BusInteraction (DenseExpr p)))
@@ -213,7 +214,7 @@ theorem denseDropWits_mem {bs : BusSemantics p} (facts : BusFacts p bs)
       bi ∈ A ++ B ++ C ++ emitted := by
   intro v bi hbi
   unfold denseDropWits at hbi
-  cases hgo : denseDropWitsIdxGo facts arr alive S R v (bidx.getD v []) with
+  cases hgo : denseDropWitsIdxGo facts arr alive S R v ((bidx[v.index]?).getD []) with
   | some bi' =>
     rw [hgo] at hbi
     rcases List.mem_cons.1 hbi with rfl | hbi
@@ -233,7 +234,7 @@ theorem denseDropWits_mem {bs : BusSemantics p} (facts : BusFacts p bs)
       exact List.mem_append_right _ hbi
 
 /-- Every form witness is in the remaining region (the index entry is re-checked at use). -/
-theorem denseDropFormWits_mem (fidx : Std.HashMap VarId (List Nat))
+theorem denseDropFormWits_mem (fidx : Array (List Nat))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (S R : BusInteraction (DenseExpr p))
     {A B C : List (BusInteraction (DenseExpr p))}

--- a/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
@@ -11,8 +11,33 @@ variable {p : ℕ}
 
 /-! ## Tautology-lookup removal (dense) -/
 
+/-- PROBE (unproven): `constValue?` without materializing `e.fold`. -/
+def DenseExpr.constValueImpl : DenseExpr p → Option (ZMod p)
+  | .const n => some n
+  | .var _ => none
+  | .add a b =>
+    match a.constValueImpl with
+    | none => none
+    | some x =>
+      match b.constValueImpl with
+      | none => none
+      | some y => some (zmodAdd x y)
+  | .mul a b =>
+    match a.constValueImpl with
+    | some x =>
+      if zmodIsZero x then some x
+      else
+        match b.constValueImpl with
+        | none => none
+        | some y => some (zmodMul x y)
+    | none =>
+      match b.constValueImpl with
+      | some y => if zmodIsZero y then some y else none
+      | none => none
+
 /-- Constant value of a dense expression (fold then require a literal). -/
-def DenseExpr.constValue? (e : DenseExpr p) : Option (ZMod p) :=
+@[implemented_by DenseExpr.constValueImpl] def DenseExpr.constValue? (e : DenseExpr p) :
+    Option (ZMod p) :=
   match e.fold with
   | .const c => some c
   | _ => none

--- a/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DropPasses.lean
@@ -11,7 +11,9 @@ variable {p : ℕ}
 
 /-! ## Tautology-lookup removal (dense) -/
 
-/-- PROBE (unproven): `constValue?` without materializing `e.fold`. -/
+/-- `constValue?` deciding the fold's shape instead of building it: a non-constant subterm
+    short-circuits, so no folded copy of the expression is allocated. The multiplication arms return
+    the annihilating factor itself rather than a zero literal, which is the same value there. -/
 def DenseExpr.constValueImpl : DenseExpr p → Option (ZMod p)
   | .const n => some n
   | .var _ => none
@@ -36,11 +38,26 @@ def DenseExpr.constValueImpl : DenseExpr p → Option (ZMod p)
       | none => none
 
 /-- Constant value of a dense expression (fold then require a literal). -/
-@[implemented_by DenseExpr.constValueImpl] def DenseExpr.constValue? (e : DenseExpr p) :
-    Option (ZMod p) :=
+def DenseExpr.constValue? (e : DenseExpr p) : Option (ZMod p) :=
   match e.fold with
   | .const c => some c
   | _ => none
+
+@[csimp] theorem DenseExpr_constValue?_eq_impl :
+    @DenseExpr.constValue? = @DenseExpr.constValueImpl := by
+  funext q e
+  induction e with
+  | const n => rfl
+  | var i => rfl
+  | add a b iha ihb =>
+      simp only [DenseExpr.constValue?, DenseExpr.fold] at *
+      rw [DenseExpr.constValueImpl, ← iha, ← ihb]
+      cases a.fold <;> cases b.fold <;> simp [DenseExpr.foldAdd] <;> split_ifs <;> simp
+  | mul a b iha ihb =>
+      simp only [DenseExpr.constValue?, DenseExpr.fold] at *
+      rw [DenseExpr.constValueImpl, ← iha, ← ihb]
+      cases a.fold <;> cases b.fold <;>
+        simp [DenseExpr.foldMul] <;> (try split_ifs) <;> simp_all
 
 /-- Constant values of a dense payload list. -/
 def denseConstValues? : List (DenseExpr p) → Option (List (ZMod p))

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -162,6 +162,19 @@ theorem DenseTwoRootMap.Sound.addAll {dcs : List (DenseExpr p)} (hp : Nat.Prime 
       exact ih _ (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
         (DenseTwoRootMap.Sound.addVars hp (hmem c (List.mem_cons_self ..)) T _ hT)
 
+theorem DenseTwoRootMap.Sound.addAllFor {dcs : List (DenseExpr p)} (hp : Nat.Prime p)
+    (vars : Std.HashSet VarId) :
+    ∀ (T : DenseTwoRootMap p) (pending : List (DenseExpr p)), (∀ c ∈ pending, c ∈ dcs) →
+      T.Sound dcs → (DenseTwoRootMap.addAllFor vars T pending).Sound dcs := by
+  intro T pending
+  induction pending generalizing T with
+  | nil => intro _ hT; exact hT
+  | cons c rest ih =>
+      intro hmem hT
+      rw [DenseTwoRootMap.addAllFor]
+      exact ih _ (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
+        (DenseTwoRootMap.Sound.addVars hp (hmem c (List.mem_cons_self ..)) T _ hT)
+
 /-- `Sound` only asserts the existence of a witnessing constraint, so it survives passing to a
     superset of the indexed list. -/
 theorem DenseTwoRootMap.Sound.mono {l1 l2 : List (DenseExpr p)} {T : DenseTwoRootMap p}
@@ -179,11 +192,20 @@ theorem DenseTwoRootMap.build_sound (dcs : List (DenseExpr p)) :
       (DenseTwoRootMap.empty_sound dcs)
   · rw [if_neg hp]; exact DenseTwoRootMap.empty_sound dcs
 
+theorem DenseTwoRootMap.buildFor_sound (vars : Std.HashSet VarId) (dcs : List (DenseExpr p)) :
+    (DenseTwoRootMap.buildFor vars dcs).Sound dcs := by
+  rw [DenseTwoRootMap.buildFor]
+  by_cases hp : Nat.Prime p
+  · rw [if_pos hp]
+    exact DenseTwoRootMap.Sound.addAllFor hp vars DenseTwoRootMap.empty dcs (fun _ h => h)
+      (DenseTwoRootMap.empty_sound dcs)
+  · rw [if_neg hp]; exact DenseTwoRootMap.empty_sound dcs
+
 /-- The address-restricted build is sound for the whole constraint list. -/
 theorem DenseTwoRootMap.buildForAddrs_sound (memShape : Nat → Option MemoryBusShape)
     (bis : List (BusInteraction (DenseExpr p))) (dcs : List (DenseExpr p)) :
     (DenseTwoRootMap.buildForAddrs memShape bis dcs).Sound dcs :=
-  (DenseTwoRootMap.build_sound _).mono (fun _ hc => List.mem_of_mem_filter hc)
+  (DenseTwoRootMap.buildFor_sound _ _).mono (fun _ hc => List.mem_of_mem_filter hc)
 
 /-! ## Two-root decomposition soundness (value-level)
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -150,18 +150,6 @@ theorem DenseTwoRootMap.Sound.addVars {dcs : List (DenseExpr p)} (hp : Nat.Prime
           · rw [if_pos hu]; exact ih _ (hT.insertEntry ⟨hp, hu, c, hc, htr⟩)
           · rw [if_neg hu]; exact ih T hT
 
-theorem DenseTwoRootMap.Sound.addAll {dcs : List (DenseExpr p)} (hp : Nat.Prime p) :
-    ∀ (T : DenseTwoRootMap p) (pending : List (DenseExpr p)), (∀ c ∈ pending, c ∈ dcs) →
-      T.Sound dcs → (DenseTwoRootMap.addAll T pending).Sound dcs := by
-  intro T pending
-  induction pending generalizing T with
-  | nil => intro _ hT; exact hT
-  | cons c rest ih =>
-      intro hmem hT
-      rw [DenseTwoRootMap.addAll]
-      exact ih _ (fun c' h => hmem c' (List.mem_cons_of_mem _ h))
-        (DenseTwoRootMap.Sound.addVars hp (hmem c (List.mem_cons_self ..)) T _ hT)
-
 theorem DenseTwoRootMap.Sound.addAllFor {dcs : List (DenseExpr p)} (hp : Nat.Prime p)
     (vars : Std.HashSet VarId) :
     ∀ (T : DenseTwoRootMap p) (pending : List (DenseExpr p)), (∀ c ∈ pending, c ∈ dcs) →
@@ -182,15 +170,6 @@ theorem DenseTwoRootMap.Sound.mono {l1 l2 : List (DenseExpr p)} {T : DenseTwoRoo
   intro v k A δ h
   obtain ⟨hp, hu, c, hc, hwit⟩ := hT v k A δ h
   exact ⟨hp, hu, c, hsub c hc, hwit⟩
-
-theorem DenseTwoRootMap.build_sound (dcs : List (DenseExpr p)) :
-    (DenseTwoRootMap.build dcs).Sound dcs := by
-  rw [DenseTwoRootMap.build]
-  by_cases hp : Nat.Prime p
-  · rw [if_pos hp]
-    exact DenseTwoRootMap.Sound.addAll hp DenseTwoRootMap.empty dcs (fun _ h => h)
-      (DenseTwoRootMap.empty_sound dcs)
-  · rw [if_neg hp]; exact DenseTwoRootMap.empty_sound dcs
 
 theorem DenseTwoRootMap.buildFor_sound (vars : Std.HashSet VarId) (dcs : List (DenseExpr p)) :
     (DenseTwoRootMap.buildFor vars dcs).Sound dcs := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
@@ -143,7 +143,7 @@ structure DenseKeyIdx.Sound (shape : MemoryBusShape) (busId : Nat)
 theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) :
     ∀ (ps : List Nat), ps.Pairwise (· < ·) →
-      (let idx := ps.foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], ∅, #[]⟩
+      (let idx := ps.foldr (denseKeyIdxAdd shape busId arr) ⟨∅, [], [], ∅, #[], #[]⟩
        (∀ pos m k, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
           denseAddrKeyOf shape m = some k → pos ∈ idx.byKey.getD (denseKeyHash k) []) ∧
        (∀ pos m, pos ∈ ps → arr[pos]? = some m → m.busId = busId →
@@ -163,7 +163,7 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
       have hqlt : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hps).1 r hr
       obtain ⟨ck, cs, sk, ss, mk, ms⟩ := ih (List.pairwise_cons.mp hps).2
       simp only [List.foldr_cons]
-      set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, [], ∅, #[]⟩ : DenseKeyIdx p) with hidx
+      set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, [], [], ∅, #[], #[]⟩ : DenseKeyIdx p) with hidx
       unfold denseKeyIdxAdd
       cases hq : arr[q]? with
       | none =>
@@ -634,25 +634,29 @@ theorem denseShieldEarly_sound {α : Type} (P Q : α → Bool) (preArr : Array �
 
 /-- The gated window walk: every live entry of the array inside the window is refuted. -/
 theorem denseLiveAllGated_sound {α : Type} (P : α → Bool) (preArr : Array α) (alive : Array Bool)
-    (a : Array Nat) (lo hi : Nat) :
-    ∀ (n : Nat), denseLiveAllGated P preArr alive a lo hi n = true →
-      ∀ k q, k < n → a[k]? = some q → lo ≤ q → q < hi → alive[q]?.getD false = true →
+    (a : Array Nat) (lo hi start : Nat) :
+    ∀ (n : Nat), denseLiveAllGated P preArr alive a lo hi start n = true →
+      ∀ k q, start ≤ k → k < n → a[k]? = some q → lo ≤ q → q < hi →
+        alive[q]?.getD false = true →
         ∀ m, preArr[q]? = some m → P m = true := by
   intro n
   induction n with
-  | zero => intro _ k q hk; exact absurd hk (by omega)
+  | zero => intro _ k q _ hk; exact absurd hk (by omega)
   | succ n ih =>
-    intro hw k q hk hkq hlo hhi hal m hme
-    rw [denseLiveAllGated, Bool.and_eq_true] at hw
-    rcases Nat.lt_or_ge k n with h | h
-    · exact ih hw.2 k q h hkq hlo hhi hal m hme
-    · obtain rfl : k = n := by omega
-      have h1 := hw.1
-      rw [hkq] at h1
-      dsimp only at h1
-      rw [if_pos (by rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq,
-        decide_eq_true_eq]; exact ⟨⟨hlo, hhi⟩, hal⟩), hme] at h1
-      exact h1
+    intro hw k q hst hk hkq hlo hhi hal m hme
+    rw [denseLiveAllGated] at hw
+    split at hw
+    · exact sorry
+    · rw [Bool.and_eq_true] at hw
+      rcases Nat.lt_or_ge k n with h | h
+      · exact ih hw.2 k q hst h hkq hlo hhi hal m hme
+      · obtain rfl : k = n := by omega
+        have h1 := hw.1
+        rw [hkq] at h1
+        dsimp only at h1
+        rw [if_pos (by rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq,
+          decide_eq_true_eq]; exact ⟨⟨hlo, hhi⟩, hal⟩), hme] at h1
+        exact h1
 
 /-- The index's arrays are the list buckets, entry for entry. -/
 theorem denseKeyIdxBuild_byKeyA_getD (shape : MemoryBusShape) (busId : Nat)
@@ -677,9 +681,11 @@ One decision for a candidate pair's mid and shield regions, sparse when the cand
 key is constant, with the scan results already converted to the forms `denseMkDropResult`
 consumes. -/
 
-/-- Decide both region tests for the candidate `S` at `i` with matched receive at `j`. With a
-    constant candidate key the scans visit only the same-key bucket and the symbolic-key list;
-    every skipped position is refuted by the bus-id or constant-key arm. -/
+/-- Decide both region tests for the candidate `S` at `i` with matched receive at `j`. Both scans
+    walk only the bus's own index arrays, over the index range the position window maps to
+    (`denseLowerBound`): the candidate's own key bucket plus the symbolic-key positions when its
+    address key is constant, every position of the bus when it is not. Every skipped position is
+    refuted by the bus-id or constant-key arm, or falls outside the window. -/
 def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
@@ -693,154 +699,20 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
       (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
         denseMidRefuted ops shape T busId S m0 = true) ∧
       denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true } :=
-  -- the mid `all` and the shield fold, converted to the forms `denseMkDropResult` consumes
-  have hmidOf : denseLiveAllSegP preArr alive
-      (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true →
-      ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
-        denseMidRefuted ops shape T busId S m0 = true := by
-    intro hmidB
-    rw [hpre, denseLiveAllSegP_eq] at hmidB
-    intro m0 hm0
-    have h := List.all_eq_true.mp hmidB m0 hm0
-    rw [hpreS] at h
-    rwa [denseMidRefutedP_eq] at h
-  have hshieldOf : (denseShieldScanSegP
-      (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-      (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-      preArr alive 0 i).2 = true →
-      denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
-    intro hshieldA
-    rw [hpre, denseShieldScanSegP_eq] at hshieldA
-    have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
-          (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
-        = densePreRefuted ops shape T busId S :=
-      funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
-    have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
-          (denseAddrPrep shape T.get.tworoot m))
-        = denseProvRecv ops shape busId S :=
-      funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
-    rw [hP, hQ, denseShieldScanW_eq] at hshieldA
-    exact hshieldA
-  -- the prepared record at a position is the prepared record of the interaction there
-  have hentry : ∀ q m0, arr[q]? = some m0 →
-      preArr[q]? = some (denseAddrPrep shape T.get.tworoot m0) := by
-    intro q m0 hq
-    rw [hpre, Array.getElem?_map, hq]
-    rfl
-  have hentry' : ∀ q m, preArr[q]? = some m →
-      ∃ m0, arr[q]? = some m0 ∧ m = denseAddrPrep shape T.get.tworoot m0 := by
-    intro q m hm
-    rw [hpre, Array.getElem?_map] at hm
-    cases hq : arr[q]? with
-    | none => rw [hq] at hm; exact absurd hm (by simp)
-    | some m0 => rw [hq] at hm; exact ⟨m0, hq, (Option.some.inj hm).symm⟩
-  match hkS : denseAddrKeyOf shape S with
-  | none =>
-      ⟨denseLiveAllSegP preArr alive
-            (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1)
-          && denseShieldEarlySeg
-            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive i i, by
-        intro hb
-        rw [Bool.and_eq_true] at hb
-        obtain ⟨q0, hq0, habove⟩ := denseShieldEarlySeg_sound
-          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS) preArr alive i i hb.2
-        refine ⟨hmidOf hb.1, hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
-          (fun q hq => (hq0 q hq).2)
-          (fun q hqi hgt hal m hme => habove q hqi hgt hqi hal m hme)
-          (fun r hr => (hq0 r hr).1))⟩⟩
-  | some kS =>
-      ⟨(denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
-              (kIdx.byKeyA.getD (denseKeyHash kS) #[]) (i + 1) j
-              (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size
-            && denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
-              kIdx.symA (i + 1) j kIdx.symA.size)
-          && denseShieldEarly
-            (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-            (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-            preArr alive (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i
-            ((kIdx.byKeyA.getD (denseKeyHash kS) #[]).size + kIdx.symA.size)
-            (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size kIdx.symA.size, by
-        intro hb
-        rw [Bool.and_eq_true, Bool.and_eq_true] at hb
-        obtain ⟨⟨hmidB, hmidS⟩, hshieldB⟩ := hb
-        have hsound := hkIdx ▸ denseKeyIdxBuild_sound shape busId arr
-        -- the arrays are the buckets
-        have hbA : kIdx.byKeyA.getD (denseKeyHash kS) #[]
-            = (kIdx.byKey.getD (denseKeyHash kS) []).toArray := by
-          rw [hkIdx]; exact denseKeyIdxBuild_byKeyA_getD shape busId arr _
-        have hsA : kIdx.symA = kIdx.sym.toArray := by
-          rw [hkIdx]; exact denseKeyIdxBuild_symA shape busId arr
-        -- a list membership is an in-bounds array entry
-        have hidxB : ∀ q, q ∈ kIdx.byKey.getD (denseKeyHash kS) [] →
-            ∃ k, k < (kIdx.byKeyA.getD (denseKeyHash kS) #[]).size ∧
-              (kIdx.byKeyA.getD (denseKeyHash kS) #[])[k]? = some q := by
-          intro q hq
-          obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp hq
-          have hkA : (kIdx.byKeyA.getD (denseKeyHash kS) #[])[k]? = some q := by
-            rw [hbA, List.getElem?_toArray]; exact hk
-          refine ⟨k, ?_, hkA⟩
-          by_contra hc
-          rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hkA
-          exact absurd hkA (by simp)
-        have hidxS : ∀ q, q ∈ kIdx.sym →
-            ∃ k, k < kIdx.symA.size ∧ kIdx.symA[k]? = some q := by
-          intro q hq
-          obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp hq
-          have hkA : kIdx.symA[k]? = some q := by
-            rw [hsA, List.getElem?_toArray]; exact hk
-          refine ⟨k, ?_, hkA⟩
-          by_contra hc
-          rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hkA
-          exact absurd hkA (by simp)
-        -- every position is a bucket entry, a symbolic entry, or refuted by its key
-        have hclass : ∀ q m0, arr[q]? = some m0 →
-            q ∈ kIdx.byKey.getD (denseKeyHash kS) [] ∨ q ∈ kIdx.sym ∨
-              denseMidRefuted ops shape T busId S m0 = true := by
-          intro q m0 hq
-          by_cases hbus : m0.busId = busId
-          · cases hkm : denseAddrKeyOf shape m0 with
-            | none => exact Or.inr (Or.inl (hsound.complete_sym q m0 hq hbus hkm))
-            | some km =>
-                by_cases hkeq : km = kS
-                · exact Or.inl (hkeq ▸ hsound.complete_key q m0 km hq hbus hkm)
-                · exact Or.inr (Or.inr (denseMidRefuted_of_keyNe ops shape T busId S m0 kS km hkS
-                    hkm (fun h => hkeq h.symm)))
-          · exact Or.inr (Or.inr (denseMidRefuted_of_crossBus ops shape T busId S m0 hbus))
-        -- the mid region
-        have hmidPos : ∀ q, i + 1 ≤ q → q < j → alive[q]?.getD false = true →
-            ∀ m, preArr[q]? = some m →
-              denseMidRefutedP ops T.get.nonzero busId preS m = true := by
-          intro q hq1 hq2 hal m hme
-          obtain ⟨m0, hq, rfl⟩ := hentry' q m hme
-          rcases hclass q m0 hq with hin | hin | href
-          · obtain ⟨k, hklt, hkq⟩ := hidxB q hin
-            exact denseLiveAllGated_sound _ preArr alive _ (i + 1) j _ hmidB k q hklt hkq hq1 hq2
-              hal _ hme
-          · obtain ⟨k, hklt, hkq⟩ := hidxS q hin
-            exact denseLiveAllGated_sound _ preArr alive _ (i + 1) j _ hmidS k q hklt hkq hq1 hq2
-              hal _ hme
-          · rw [hpreS, denseMidRefutedP_eq]; exact href
-        -- the shield region
-        obtain ⟨q0, hq0, habB, habS⟩ := denseShieldEarly_sound
-          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS) preArr alive
-          (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i
-          (by rw [hbA, List.toList_toArray]; exact hsound.sorted_key _)
-          (by rw [hsA, List.toList_toArray]; exact hsound.sorted_sym)
-          _ _ _ (by omega) (le_refl _) (le_refl _) hshieldB
-        refine ⟨hmidOf (denseLiveAllSegP_true_of _ preArr alive (i + 1) j hmidPos (j - i - 1)
-            (i + 1) (le_refl _) (by omega)), ?_⟩
-        refine hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
-          (fun q hq => (hq0 q hq).2) (fun q hqi hgt hal m hme => ?_) (fun r hr => (hq0 r hr).1))
-        obtain ⟨m0, hq, rfl⟩ := hentry' q m hme
-        rcases hclass q m0 hq with hin | hin | href
-        · obtain ⟨k, hklt, hkq⟩ := hidxB q hin
-          exact habB k q hklt hkq hgt hqi hal _ hme
-        · obtain ⟨k, hklt, hkq⟩ := hidxS q hin
-          exact habS k q hklt hkq hgt hqi hal _ hme
-        · rw [hpreS, densePreRefutedP_eq]
-          exact densePreRefuted_of_midRefuted ops shape T busId S m0 href⟩
+  let scan : Array Nat × Array Nat :=
+    match denseAddrKeyOf shape S with
+    | some kS => (kIdx.byKeyA.getD (denseKeyHash kS) #[], kIdx.symA)
+    | none => (kIdx.allA, #[])
+  let nb := denseLowerBound scan.1 i
+  let ns := denseLowerBound scan.2 i
+  ⟨(denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
+        scan.1 (i + 1) j (denseLowerBound scan.1 (i + 1)) (denseLowerBound scan.1 j)
+      && denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
+        scan.2 (i + 1) j (denseLowerBound scan.2 (i + 1)) (denseLowerBound scan.2 j))
+    && denseShieldEarly
+        (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+        (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+        preArr alive scan.1 scan.2 i (nb + ns) nb ns,
+   by intro _; exact sorry⟩
+
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
@@ -123,16 +123,18 @@ theorem densePreRefuted_of_midRefuted (ops : DenseZModOps p) (shape : MemoryBusS
 /-! ## The builder is sound -/
 
 /-- What the builder guarantees, all in one bundle: completeness (every same-bus position is in
-    its key's bucket, or in `sym` when its key is not constant), and strict ascending order of
-    every bucket and of `sym`. -/
+    its key's bucket, or in `sym` when its key is not constant, and in `all` either way), and strict
+    ascending order of every bucket, of `sym` and of `all`. -/
 structure DenseKeyIdx.Sound (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) (idx : DenseKeyIdx p) : Prop where
   complete_key : ∀ pos m k, arr[pos]? = some m → m.busId = busId →
     denseAddrKeyOf shape m = some k → pos ∈ idx.byKey.getD (denseKeyHash k) []
   complete_sym : ∀ pos m, arr[pos]? = some m → m.busId = busId →
     denseAddrKeyOf shape m = none → pos ∈ idx.sym
+  complete_all : ∀ pos m, arr[pos]? = some m → m.busId = busId → pos ∈ idx.all
   sorted_key : ∀ h, (idx.byKey.getD h []).Pairwise (· < ·)
   sorted_sym : idx.sym.Pairwise (· < ·)
+  sorted_all : idx.all.Pairwise (· < ·)
   mem_key : ∀ h pos, pos ∈ idx.byKey.getD h [] → ∃ m k, arr[pos]? = some m ∧
     m.busId = busId ∧ denseAddrKeyOf shape m = some k ∧ denseKeyHash k = h
   mem_sym : ∀ pos, pos ∈ idx.sym → ∃ m, arr[pos]? = some m ∧ m.busId = busId ∧
@@ -153,15 +155,18 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
        (∀ h pos, pos ∈ idx.byKey.getD h [] → pos ∈ ps ∧ ∃ m k, arr[pos]? = some m ∧
           m.busId = busId ∧ denseAddrKeyOf shape m = some k ∧ denseKeyHash k = h) ∧
        (∀ pos, pos ∈ idx.sym → pos ∈ ps ∧ ∃ m, arr[pos]? = some m ∧ m.busId = busId ∧
-          denseAddrKeyOf shape m = none)) := by
+          denseAddrKeyOf shape m = none) ∧
+       (∀ pos m, pos ∈ ps → arr[pos]? = some m → m.busId = busId → pos ∈ idx.all) ∧
+       idx.all.Pairwise (· < ·) ∧
+       (∀ pos, pos ∈ idx.all → pos ∈ ps)) := by
   intro ps hps
   induction ps with
   | nil =>
-      refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+      refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
         simp [Std.HashMap.getD_empty]
   | cons q rest ih =>
       have hqlt : ∀ r ∈ rest, q < r := fun r hr => (List.pairwise_cons.mp hps).1 r hr
-      obtain ⟨ck, cs, sk, ss, mk, ms⟩ := ih (List.pairwise_cons.mp hps).2
+      obtain ⟨ck, cs, sk, ss, mk, ms, ca, sa, ma⟩ := ih (List.pairwise_cons.mp hps).2
       simp only [List.foldr_cons]
       set idx := rest.foldr (denseKeyIdxAdd shape busId arr) (⟨∅, [], [], ∅, #[], #[]⟩ : DenseKeyIdx p) with hidx
       unfold denseKeyIdxAdd
@@ -169,7 +174,8 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
       | none =>
           dsimp only
           refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_, sk, ss,
-            fun h pos hpos => ?_, fun pos hpos => ?_⟩
+            fun h pos hpos => ?_, fun pos hpos => ?_, fun pos m hpos hm hb => ?_, sa,
+            fun pos hpos => List.mem_cons_of_mem _ (ma pos hpos)⟩
           · rcases List.mem_cons.mp hpos with rfl | hpos
             · rw [hq] at hm; exact absurd hm (by simp)
             · exact ck pos m k hpos hm hb hk
@@ -180,6 +186,9 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
             exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
           · obtain ⟨hin, rest'⟩ := ms pos hpos
             exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+          · rcases List.mem_cons.mp hpos with rfl | hpos
+            · rw [hq] at hm; exact absurd hm (by simp)
+            · exact ca pos m hpos hm hb
       | some mq =>
           dsimp only
           by_cases hbq : mq.busId = busId
@@ -188,7 +197,9 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
             | some kq =>
                 dsimp only
                 refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_,
-                  fun h => ?_, ss, fun h pos hpos => ?_, fun pos hpos => ?_⟩
+                  fun h => ?_, ss, fun h pos hpos => ?_, fun pos hpos => ?_,
+                  fun pos m hpos hm hb => ?_,
+                  List.pairwise_cons.mpr ⟨fun r hr => hqlt r (ma r hr), sa⟩, fun pos hpos => ?_⟩
                 · rcases List.mem_cons.mp hpos with rfl | hpos
                   · rw [hq] at hm
                     obtain rfl := Option.some.inj hm
@@ -231,10 +242,18 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
                     exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
                 · obtain ⟨hin, rest'⟩ := ms pos hpos
                   exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact List.mem_cons_self ..
+                  · exact List.mem_cons_of_mem _ (ca pos m hpos hm hb)
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact List.mem_cons_self ..
+                  · exact List.mem_cons_of_mem _ (ma pos hpos)
             | none =>
                 dsimp only
                 refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_,
-                  sk, ?_, fun h pos hpos => ?_, fun pos hpos => ?_⟩
+                  sk, ?_, fun h pos hpos => ?_, fun pos hpos => ?_,
+                  fun pos m hpos hm hb => ?_,
+                  List.pairwise_cons.mpr ⟨fun r hr => hqlt r (ma r hr), sa⟩, fun pos hpos => ?_⟩
                 · rcases List.mem_cons.mp hpos with rfl | hpos
                   · rw [hq] at hm
                     obtain rfl := Option.some.inj hm
@@ -252,9 +271,16 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
                   · exact ⟨List.mem_cons_self .., mq, hq, hbq, hkq⟩
                   · obtain ⟨hin, rest'⟩ := ms pos hpos
                     exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact List.mem_cons_self ..
+                  · exact List.mem_cons_of_mem _ (ca pos m hpos hm hb)
+                · rcases List.mem_cons.mp hpos with rfl | hpos
+                  · exact List.mem_cons_self ..
+                  · exact List.mem_cons_of_mem _ (ma pos hpos)
           · rw [if_neg hbq]
             refine ⟨fun pos m k hpos hm hb hk => ?_, fun pos m hpos hm hb hk => ?_, sk, ss,
-              fun h pos hpos => ?_, fun pos hpos => ?_⟩
+              fun h pos hpos => ?_, fun pos hpos => ?_, fun pos m hpos hm hb => ?_, sa,
+              fun pos hpos => List.mem_cons_of_mem _ (ma pos hpos)⟩
             · rcases List.mem_cons.mp hpos with rfl | hpos
               · rw [hq] at hm
                 obtain rfl := Option.some.inj hm
@@ -269,12 +295,17 @@ theorem denseKeyIdxBuild_sound_aux (shape : MemoryBusShape) (busId : Nat)
               exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
             · obtain ⟨hin, rest'⟩ := ms pos hpos
               exact ⟨List.mem_cons_of_mem _ hin, rest'⟩
+            · rcases List.mem_cons.mp hpos with rfl | hpos
+              · rw [hq] at hm
+                obtain rfl := Option.some.inj hm
+                exact absurd hb hbq
+              · exact ca pos m hpos hm hb
 
 theorem denseKeyIdxBuild_sound (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) :
     (denseKeyIdxBuild shape busId arr).Sound shape busId arr := by
   have hrange : (List.range arr.size).Pairwise (· < ·) := List.pairwise_lt_range
-  obtain ⟨ck, cs, sk, ss, mk, ms⟩ :=
+  obtain ⟨ck, cs, sk, ss, mk, ms, ca, sa, _⟩ :=
     denseKeyIdxBuild_sound_aux shape busId arr (List.range arr.size) hrange
   have hin : ∀ pos m, arr[pos]? = some m → pos ∈ List.range arr.size := by
     intro pos m hm
@@ -284,7 +315,8 @@ theorem denseKeyIdxBuild_sound (shape : MemoryBusShape) (busId : Nat)
     exact absurd hm (by simp)
   exact ⟨fun pos m k hm hb hk => ck pos m k (hin pos m hm) hm hb hk,
     fun pos m hm hb hk => cs pos m (hin pos m hm) hm hb hk,
-    sk, ss,
+    fun pos m hm hb => ca pos m (hin pos m hm) hm hb,
+    sk, ss, sa,
     fun h pos hpos => (mk h pos hpos).2,
     fun pos hpos => (ms pos hpos).2⟩
 
@@ -436,6 +468,87 @@ theorem denseArrEntry_le {a : Array Nat} (ha : a.toList.Pairwise (· < ·)) {k t
     rw [hkv, htv] at hpw
     exact Nat.le_of_lt hpw
 
+/-! #### The window bounds
+
+`denseLowerBound a x` splits an ascending `a` into the entries below `x` and those at or above it,
+so an entry inside a position window is inside the index range the two bounds delimit — which is
+what lets the walks skip the rest of the array. -/
+
+/-- The search stays inside its range. -/
+theorem denseLowerBoundGo_le_hi (a : Array Nat) (x : Nat) :
+    ∀ (d lo hi : Nat), hi - lo ≤ d → lo ≤ hi → denseLowerBoundGo a x lo hi ≤ hi := by
+  intro d
+  induction d with
+  | zero =>
+    intro lo hi hd hle
+    rw [denseLowerBoundGo, if_neg (by omega)]
+    omega
+  | succ d ih =>
+    intro lo hi hd hle
+    rw [denseLowerBoundGo]
+    by_cases hc : lo < hi
+    · rw [if_pos hc]
+      dsimp only
+      by_cases hv : (a[(lo + hi) / 2]?).getD 0 < x
+      · rw [if_pos hv]; exact ih _ _ (by omega) (by omega)
+      · rw [if_neg hv]; exact Nat.le_trans (ih _ _ (by omega) (by omega)) (by omega)
+    · rw [if_neg hc]; omega
+
+theorem denseLowerBound_le_size (a : Array Nat) (x : Nat) : denseLowerBound a x ≤ a.size :=
+  denseLowerBoundGo_le_hi a x a.size 0 a.size (by omega) (by omega)
+
+/-- The split invariant: entries left of the result are below `x`, entries from it on are not. Both
+    halves are carried in as hypotheses about what lies outside `[lo, hi)`. -/
+theorem denseLowerBoundGo_spec (a : Array Nat) (ha : a.toList.Pairwise (· < ·)) (x : Nat) :
+    ∀ (d lo hi : Nat), hi - lo ≤ d → lo ≤ hi → hi ≤ a.size →
+      (∀ t y, t < lo → a[t]? = some y → y < x) →
+      (∀ t y, hi ≤ t → a[t]? = some y → x ≤ y) →
+      (∀ t y, t < denseLowerBoundGo a x lo hi → a[t]? = some y → y < x) ∧
+        (∀ t y, denseLowerBoundGo a x lo hi ≤ t → a[t]? = some y → x ≤ y) := by
+  intro d
+  induction d with
+  | zero =>
+    intro lo hi hd hle _ h1 h2
+    rw [denseLowerBoundGo, if_neg (by omega)]
+    exact ⟨h1, fun t y ht => h2 t y (by omega)⟩
+  | succ d ih =>
+    intro lo hi hd hle hsz h1 h2
+    rw [denseLowerBoundGo]
+    by_cases hc : lo < hi
+    · rw [if_pos hc]
+      dsimp only
+      obtain ⟨v, hv⟩ : ∃ v, a[(lo + hi) / 2]? = some v :=
+        ⟨a[(lo + hi) / 2]'(by omega), Array.getElem?_eq_getElem (by omega)⟩
+      rw [show (a[(lo + hi) / 2]?).getD 0 = v by rw [hv]; rfl]
+      by_cases hlt : v < x
+      · rw [if_pos hlt]
+        refine ih _ hi (by omega) (by omega) hsz (fun t y ht hty => ?_) h2
+        exact Nat.lt_of_le_of_lt (denseArrEntry_le ha (by omega) hty hv) hlt
+      · rw [if_neg hlt]
+        refine ih lo _ (by omega) (by omega) (by omega) h1 (fun t y ht hty => ?_)
+        exact Nat.le_trans (by omega) (denseArrEntry_le ha ht hv hty)
+    · rw [if_neg hc]
+      exact ⟨h1, fun t y ht => h2 t y (by omega)⟩
+
+theorem denseLowerBound_spec (a : Array Nat) (ha : a.toList.Pairwise (· < ·)) (x : Nat) :
+    (∀ t y, t < denseLowerBound a x → a[t]? = some y → y < x) ∧
+      (∀ t y, denseLowerBound a x ≤ t → a[t]? = some y → x ≤ y) :=
+  denseLowerBoundGo_spec a ha x a.size 0 a.size (by omega) (by omega) (le_refl _)
+    (fun t y ht => absurd ht (by omega))
+    (fun t y ht hty => by rw [Array.getElem?_eq_none ht] at hty; exact absurd hty (by simp))
+
+/-- An entry at or above the bound is not skipped by the walk's start. -/
+theorem denseLowerBound_le_of_le {a : Array Nat} (ha : a.toList.Pairwise (· < ·)) {x k q : Nat}
+    (hk : a[k]? = some q) (h : x ≤ q) : denseLowerBound a x ≤ k := by
+  by_contra hc
+  exact absurd ((denseLowerBound_spec a ha x).1 k q (by omega) hk) (by omega)
+
+/-- An entry below the bound is inside the walk's length. -/
+theorem denseLowerBound_lt_of_lt {a : Array Nat} (ha : a.toList.Pairwise (· < ·)) {x k q : Nat}
+    (hk : a[k]? = some q) (h : q < x) : k < denseLowerBound a x := by
+  by_contra hc
+  exact absurd ((denseLowerBound_spec a ha x).2 k q (by omega) hk) (by omega)
+
 /-- A decided descending step: the position is in the window, live, and a provable receive whose
     `P` value is the verdict. -/
 theorem denseShieldDecide_some {α : Type} (P Q : α → Bool) (preArr : Array α) (alive : Array Bool)
@@ -469,43 +582,6 @@ theorem denseShieldDecide_none {α : Type} (P Q : α → Bool) (preArr : Array �
   by_contra hP
   have hPf : P m = false := by simpa using hP
   simp [denseShieldDecide, hme, hal, hlt, hPf] at h
-
-/-- The descending early-exit shield over one segment: the position it stopped at is a live in-window
-    provable receive, and every live in-window position above it is refuted. -/
-theorem denseShieldEarlySeg_sound {α : Type} (P Q : α → Bool) (preArr : Array α)
-    (alive : Array Bool) (bound : Nat) :
-    ∀ (n : Nat), denseShieldEarlySeg P Q preArr alive bound n = true →
-      ∃ q0 : Option Nat,
-        (∀ q ∈ q0, q < bound ∧ ∃ m, alive[q]?.getD false = true ∧ preArr[q]? = some m ∧
-          P m = true ∧ Q m = true) ∧
-        (∀ q, q < n → (∀ r ∈ q0, r < q) → q < bound → alive[q]?.getD false = true →
-          ∀ m, preArr[q]? = some m → P m = true) := by
-  intro n
-  induction n with
-  | zero => exact fun _ => ⟨none, by simp, fun q hq => absurd hq (by omega)⟩
-  | succ n ih =>
-    intro hw
-    rw [denseShieldEarlySeg] at hw
-    cases hd : denseShieldDecide P Q preArr alive bound n with
-    | some v =>
-      rw [hd] at hw
-      obtain rfl : v = true := hw
-      obtain ⟨hlt, m, hal, hme, hPm, hQm⟩ := denseShieldDecide_some P Q preArr alive hd
-      refine ⟨some n, ?_, ?_⟩
-      · intro q hq
-        obtain rfl : n = q := by simpa using hq
-        exact ⟨hlt, m, hal, hme, hPm, hQm rfl⟩
-      · intro q hq hgt _ _ _ _
-        have := hgt n (by simp)
-        omega
-    | none =>
-      rw [hd] at hw
-      obtain ⟨q0, hq0, habove⟩ := ih hw
-      refine ⟨q0, hq0, fun q hq hgt hqb hal m hme => ?_⟩
-      rcases Nat.lt_or_ge q n with h | h
-      · exact habove q h hgt hqb hal m hme
-      · obtain rfl : q = n := by omega
-        exact denseShieldDecide_none P Q preArr alive hd hqb hal m hme
 
 /-- The descending early-exit shield over the two index arrays: same conclusion, with the "above the
     witness" facts restricted to the arrays' entries (every other position is refuted by the
@@ -646,7 +722,9 @@ theorem denseLiveAllGated_sound {α : Type} (P : α → Bool) (preArr : Array α
     intro hw k q hst hk hkq hlo hhi hal m hme
     rw [denseLiveAllGated] at hw
     split at hw
-    · exact sorry
+    · -- the walk stopped below `start`, which no `start ≤ k < n + 1` can reach
+      rename_i hstart
+      exact absurd hst (by omega)
     · rw [Bool.and_eq_true] at hw
       rcases Nat.lt_or_ge k n with h | h
       · exact ih hw.2 k q hst h hkq hlo hhi hal m hme
@@ -675,6 +753,105 @@ theorem denseKeyIdxBuild_symA (shape : MemoryBusShape) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) :
     (denseKeyIdxBuild shape busId arr).symA = (denseKeyIdxBuild shape busId arr).sym.toArray := rfl
 
+theorem denseKeyIdxBuild_allA (shape : MemoryBusShape) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    (denseKeyIdxBuild shape busId arr).allA = (denseKeyIdxBuild shape busId arr).all.toArray := rfl
+
+/-- A list member is an entry of the list's array. -/
+theorem denseArrEntry_of_mem {q : Nat} {l : List Nat} (h : q ∈ l) :
+    ∃ k : Nat, l.toArray[k]? = some q := by
+  obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp h
+  exact ⟨k, by rw [List.getElem?_toArray]; exact hk⟩
+
+/-- What one candidate's scan pair establishes. The two arrays need only be ascending and jointly
+    cover every position that is not already mid-refuted; which arrays those are — the candidate's
+    key bucket plus the symbolic positions, or all of the bus's positions — is the caller's choice. -/
+theorem denseScanDecide_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
+    (preArr : Array (DenseAddrPre p))
+    (hpre : preArr = arr.map (denseAddrPrep shape T.get.tworoot))
+    (S : BusInteraction (DenseExpr p)) (preS : DenseAddrPre p)
+    (hpreS : preS = denseAddrPrep shape T.get.tworoot S)
+    (i j : Nat) (hij : i < j) (b s : Array Nat)
+    (hbs : b.toList.Pairwise (· < ·)) (hss : s.toList.Pairwise (· < ·))
+    (hclass : ∀ (q : Nat) m0, arr[q]? = some m0 →
+      (∃ k : Nat, b[k]? = some q) ∨ (∃ k : Nat, s[k]? = some q) ∨
+        denseMidRefuted ops shape T busId S m0 = true)
+    (hw : denseScanDecide (denseMidRefutedP ops T.get.nonzero busId preS)
+        (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+        (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+        preArr alive b s i j = true) :
+    (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
+        denseMidRefuted ops shape T busId S m0 = true) ∧
+      denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
+  rw [denseScanDecide, Bool.and_eq_true, Bool.and_eq_true] at hw
+  obtain ⟨⟨hmidB, hmidS⟩, hshieldB⟩ := hw
+  -- the prepared record at a position is the prepared record of the interaction there
+  have hentry : ∀ (q : Nat) m, preArr[q]? = some m →
+      ∃ m0, arr[q]? = some m0 ∧ m = denseAddrPrep shape T.get.tworoot m0 := by
+    intro q m hm
+    rw [hpre, Array.getElem?_map] at hm
+    cases hq : arr[q]? with
+    | none => rw [hq] at hm; exact absurd hm (by simp)
+    | some m0 => rw [hq] at hm; exact ⟨m0, rfl, (Option.some.inj hm).symm⟩
+  -- the mid `all` and the shield fold, converted to the forms `denseMkDropResult` consumes
+  have hmidOf : denseLiveAllSegP preArr alive
+      (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true →
+      ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
+        denseMidRefuted ops shape T busId S m0 = true := by
+    intro hmidA
+    rw [hpre, denseLiveAllSegP_eq] at hmidA
+    intro m0 hm0
+    have h := List.all_eq_true.mp hmidA m0 hm0
+    rw [hpreS] at h
+    rwa [denseMidRefutedP_eq] at h
+  have hshieldOf : (denseShieldScanSegP
+      (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+      (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+      preArr alive 0 i).2 = true →
+      denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
+    intro hshieldA
+    rw [hpre, denseShieldScanSegP_eq] at hshieldA
+    have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
+          (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
+        = densePreRefuted ops shape T busId S :=
+      funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
+    have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
+          (denseAddrPrep shape T.get.tworoot m))
+        = denseProvRecv ops shape busId S :=
+      funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
+    rw [hP, hQ, denseShieldScanW_eq] at hshieldA
+    exact hshieldA
+  -- the mid region
+  have hmidPos : ∀ q, i + 1 ≤ q → q < j → alive[q]?.getD false = true →
+      ∀ m, preArr[q]? = some m → denseMidRefutedP ops T.get.nonzero busId preS m = true := by
+    intro q hq1 hq2 hal m hme
+    obtain ⟨m0, hq, rfl⟩ := hentry q m hme
+    rcases hclass q m0 hq with ⟨k, hkq⟩ | ⟨k, hkq⟩ | href
+    · exact denseLiveAllGated_sound _ preArr alive b (i + 1) j _ _ hmidB k q
+        (denseLowerBound_le_of_le hbs hkq hq1) (denseLowerBound_lt_of_lt hbs hkq hq2) hkq hq1 hq2
+        hal _ hme
+    · exact denseLiveAllGated_sound _ preArr alive s (i + 1) j _ _ hmidS k q
+        (denseLowerBound_le_of_le hss hkq hq1) (denseLowerBound_lt_of_lt hss hkq hq2) hkq hq1 hq2
+        hal _ hme
+    · rw [hpreS, denseMidRefutedP_eq]; exact href
+  -- the shield region
+  obtain ⟨q0, hq0, habB, habS⟩ := denseShieldEarly_sound
+    (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+    (denseProvRecvP busId (denseGetPreviousMult ops shape) preS) preArr alive b s i hbs hss
+    _ _ _ (le_refl _) (denseLowerBound_le_size b i) (denseLowerBound_le_size s i) hshieldB
+  refine ⟨hmidOf (denseLiveAllSegP_true_of _ preArr alive (i + 1) j hmidPos (j - i - 1)
+      (i + 1) (le_refl _) (by omega)), ?_⟩
+  refine hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
+    (fun q hq => (hq0 q hq).2) (fun q hqi hgt hal m hme => ?_) (fun r hr => (hq0 r hr).1))
+  obtain ⟨m0, hq, rfl⟩ := hentry q m hme
+  rcases hclass q m0 hq with ⟨k, hkq⟩ | ⟨k, hkq⟩ | href
+  · exact habB k q (denseLowerBound_lt_of_lt hbs hkq hqi) hkq hgt hqi hal _ hme
+  · exact habS k q (denseLowerBound_lt_of_lt hss hkq hqi) hkq hgt hqi hal _ hme
+  · rw [hpreS, densePreRefutedP_eq]
+    exact densePreRefuted_of_midRefuted ops shape T busId S m0 href
+
 /-! ## The combined region test
 
 One decision for a candidate pair's mid and shield regions, sparse when the candidate's address
@@ -699,20 +876,51 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
       (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
         denseMidRefuted ops shape T busId S m0 = true) ∧
       denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true } :=
-  let scan : Array Nat × Array Nat :=
-    match denseAddrKeyOf shape S with
-    | some kS => (kIdx.byKeyA.getD (denseKeyHash kS) #[], kIdx.symA)
-    | none => (kIdx.allA, #[])
-  let nb := denseLowerBound scan.1 i
-  let ns := denseLowerBound scan.2 i
-  ⟨(denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
-        scan.1 (i + 1) j (denseLowerBound scan.1 (i + 1)) (denseLowerBound scan.1 j)
-      && denseLiveAllGated (denseMidRefutedP ops T.get.nonzero busId preS) preArr alive
-        scan.2 (i + 1) j (denseLowerBound scan.2 (i + 1)) (denseLowerBound scan.2 j))
-    && denseShieldEarly
-        (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
-        (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
-        preArr alive scan.1 scan.2 i (nb + ns) nb ns,
-   by intro _; exact sorry⟩
+  have hsound := hkIdx ▸ denseKeyIdxBuild_sound shape busId arr
+  match hkS : denseAddrKeyOf shape S with
+  | some kS =>
+      have hbA : kIdx.byKeyA.getD (denseKeyHash kS) #[]
+          = (kIdx.byKey.getD (denseKeyHash kS) []).toArray := by
+        rw [hkIdx]; exact denseKeyIdxBuild_byKeyA_getD shape busId arr _
+      have hsA : kIdx.symA = kIdx.sym.toArray := by
+        rw [hkIdx]; exact denseKeyIdxBuild_symA shape busId arr
+      ⟨denseScanDecide (denseMidRefutedP ops T.get.nonzero busId preS)
+          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+          preArr alive (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i j, by
+        intro hw
+        refine denseScanDecide_sound ops shape T busId arr alive preArr hpre S preS hpreS i j hij
+          _ _ (by rw [hbA, List.toList_toArray]; exact hsound.sorted_key _)
+          (by rw [hsA, List.toList_toArray]; exact hsound.sorted_sym) (fun q m0 hq => ?_) hw
+        by_cases hbus : m0.busId = busId
+        · cases hkm : denseAddrKeyOf shape m0 with
+          | none =>
+              refine Or.inr (Or.inl ?_)
+              rw [hsA]
+              exact denseArrEntry_of_mem (hsound.complete_sym q m0 hq hbus hkm)
+          | some km =>
+              by_cases hkeq : km = kS
+              · refine Or.inl ?_
+                rw [hbA]
+                exact denseArrEntry_of_mem (hkeq ▸ hsound.complete_key q m0 km hq hbus hkm)
+              · exact Or.inr (Or.inr (denseMidRefuted_of_keyNe ops shape T busId S m0 kS km hkS
+                  hkm (fun h => hkeq h.symm)))
+        · exact Or.inr (Or.inr (denseMidRefuted_of_crossBus ops shape T busId S m0 hbus))⟩
+  | none =>
+      have haA : kIdx.allA = kIdx.all.toArray := by
+        rw [hkIdx]; exact denseKeyIdxBuild_allA shape busId arr
+      ⟨denseScanDecide (denseMidRefutedP ops T.get.nonzero busId preS)
+          (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
+          (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
+          preArr alive kIdx.allA #[] i j, by
+        intro hw
+        refine denseScanDecide_sound ops shape T busId arr alive preArr hpre S preS hpreS i j hij
+          _ _ (by rw [haA, List.toList_toArray]; exact hsound.sorted_all) (by simp)
+          (fun q m0 hq => ?_) hw
+        by_cases hbus : m0.busId = busId
+        · refine Or.inl ?_
+          rw [haA]
+          exact denseArrEntry_of_mem (hsound.complete_all q m0 hq hbus)
+        · exact Or.inr (Or.inr (denseMidRefuted_of_crossBus ops shape T busId S m0 hbus))⟩
 
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -639,6 +639,50 @@ eager back-substitution's exponent). What is left, LBR shares of the *new* pass 
   active-degree index back. The scheduler is 3.8 % of the pass, so it is affordable — but measure the
   bus trade before doing it.
 
+**R14. The per-invocation index lifecycle is now the dominant cost of the index-heavy passes**  ·
+*measured 2026-08-02 on the rebuilt busPairCancel; cross-pass, framework-level effort*. After that
+pass was rebuilt (windowed region scans, scoped two-root table, in-place tombstones, non-allocating
+`constValue?`, per-invocation eagerness decision — 0.36–0.60x), its remaining profile is **~45 %
+building, marking and freeing `O(system)` indexes**, not scanning: on sha256 `apc_001` it constructs
+seven of them (receive index, per-bus key index, per-bus prepared address records, bound-witness
+index, form-witness index, candidate-constraint index, single-variable domain buckets) on **each of
+11 invocations**, while the last five invocations produce **nine drops between them**. `entry` alone
+is 14 % of the pass and 57 % of that is `lean_dec_ref_cold` freeing exactly those structures.
+
+Every index-heavy pass has the same shape — the indexes are a pure function of the system, the
+system barely changes across the terminal cycles, and the pass framework's type
+(`DenseVerifiedPassW`, morally `cs → cs`) gives a pass no way to carry anything from one invocation
+to the next. The fix is a **state channel**: let a pass return an opaque per-pass cache alongside
+its output, keyed by a cheap system fingerprint, and hand it back on the next invocation. Notes:
+
+- It is *not* R6. R6 is about skipping recomputed **work** (per-target memoization, dirty
+  worklists) and was measured to be a poor fit at target granularity. R14 is about not rebuilding
+  **derived read-only structures** whose inputs are unchanged — a strictly simpler contract.
+- Soundness is cheap if the cache is *untrusted*: every index in busPairCancel is already re-checked
+  at use, so a stale entry costs time, never soundness. The trusted ones (`domIdx`, `cands`) carry
+  a `∀ c ∈ lookup v, c ∈ cs.algebraicConstraints` obligation, which a fingerprint on
+  `cs.algebraicConstraints` does not discharge — those either stay per-invocation or need the
+  membership proof carried in the cache.
+- Sizing before building: on sha256 `apc_001` busPairCancel would save on the order of 1 s of its
+  3.2 s; the same lever exists in reencode, domainBatch, gauss and flagFold, whose per-invocation
+  index builds were never separately attributed.
+- The cheap slice that is already **done** and should be done first everywhere else: decide
+  *eagerness* per invocation instead of caching across them (`denseThunkIf` + a cheap
+  "will any candidate exist?" predicate, 0.84–0.92x on busPairCancel). See also the `Thunk` note
+  below.
+
+**`Thunk.get` marks its value multi-threaded — always** (verified in the 4.32.2 runtime
+disassembly: `lean_thunk_get_core` calls `lean_apply_1` then `lean_mark_mt` unconditionally). So
+forcing a thunk walks the whole freshly-built value graph and permanently flips every object in it
+to atomic refcounting — `lean_dec_ref_cold` is 18–20 % of the *whole run's* samples, in `profile`
+and in `run` alike. Consequences, all measured on busPairCancel:
+   - a `Thunk` holding a large value that will certainly be forced is **slower** than building it
+     eagerly (prepared records: 0.91x by switching to `Thunk.pure`);
+   - but unconditional eagerness is worse still when some invocations never force it
+     (3672 → 3966 ms);
+   - so the decision belongs at the call site, per invocation (`denseThunkIf`, above). `Thunk.pure`
+     and `Thunk.mk` have the same `.get`, so the choice is invisible to every proof.
+
 ### Runtime dead ends (measured; do not re-propose without new evidence)
 
 - **Dropping gauss's second source-order sweep** (entry 160): looks provably fruitless over a prime


### PR DESCRIPTION
Fully machine-checked: no `sorry`, no `@[implemented_by]`, `Scripts/check-proof-integrity.sh` passes
(three standard axioms, no unused theorems). The pass's decisions are unchanged — see *Effectiveness*.

## What the pass does

`busPairCancel` drops a matched send/receive pair on a memory bus when every live interaction
**between** them is refuted (it cannot be the same address) and the region **before** the send
satisfies the earliest-send condition. Both regions are decided per candidate pair, so the pass is
quadratic in the interaction count by construction; sha256 `apc_001` runs it over ~2.6 k
interactions per cleanup invocation.

## Where the time went

`IO` phase timers inside the pass, summed over all cleanup invocations of sha256 `apc_001`
(6.6 s in busPairCancel):

| phase | ms | |
|---|---:|---|
| region tests | 2870 | every candidate re-scans **all** positions, though only the ones on its own bus can decide it |
| two-root table | 1180 | indexed every variable of every constraint; only address-slot variables are ever queried |
| drop application | 780 | each accepted drop rebuilds the whole interaction list |
| prepared records | 640 | rebuilt per invocation, including invocations with no candidate at all |
| witness lookups | 410 | `HashMap VarId (List Nat)` on a key that is already a dense index |

Cost classes (`perf record --call-graph lbr`, pass-restricted): the single largest leaf across the
whole binary was `lean_dec_ref_cold` at 18–20 % of the run — atomic refcount decrements on objects
that are not shared between threads.

## The rebuild

- **Scoped two-root table.** `DenseTwoRootMap.buildForAddrs` indexes only variables that occur in a
  memory-bus address slot, over the constraints that mention one. The table's queries all come from
  the address-disequality arms, so nothing else was ever read back.
- **In-place tombstones.** A drop is `alive.setIfInBounds i false` on a uniquely-referenced array
  (`denseTombstone`), not a rebuilt list; `denseLiveSeg` stays the logical projection the proofs
  talk about. That removes ~7 GB of `memcpy` on sha256.
- **Windowed sparse region scans.** `DenseKeyIdx` indexes each bus's positions three ways — by
  constant address key, the non-constant-key ones, and all of them — so a candidate scans only
  positions that can decide it (every other one is refuted by the bus-id or constant-key arm,
  proved). `denseLowerBound` then bounds each walk to the index range the position window maps to,
  and the shield walks descending with an early exit at the topmost deciding position.
- **Per-invocation index eagerness decided by a probe.** `denseAnyCandidate` asks whether any send
  has a non-empty receive bucket; when it does not, the indexes stay unforced `Thunk`s. This is
  worth more than the work it saves: `Thunk.get` calls `lean_mark_mt`, which walks the entire fresh
  value graph and permanently marks every object in it multi-threaded, so **all** later refcount
  operations on that data take the atomic path. It carries no proof obligation — a wrong answer
  costs time, never soundness.
- **`constValue?` without materializing the fold.** `DenseExpr.constValueImpl` decides the shape of
  `e.fold` instead of building it, wired in by a proved `@[csimp]`. Shared infrastructure:
  `degenRange` and `domainBatch` improve from it too.
- **Array-indexed witness maps** keyed by `VarId.index`, and `@[specialize]` on the region walks.

## Results

Interleaved A/B against `main`, `apc-optimizer profile`, median of 2–3 reps:

| case | busPairCancel | | optimizer total | |
|---|---:|---:|---:|---:|
| OpenVM sha256 `apc_001` | 6594 → 3247 ms | **0.50x** | 82.0 → 59.7 s | 0.73x |
| OpenVM wasm-eth `apc_012` | 1007 → 359 ms | **0.36x** | 10.9 → 8.1 s | 0.74x |
| OpenVM keccak `apc_001` | 414 → 240 ms | **0.58x** | 8.3 → 5.7 s | 0.68x |
| OpenVM openvm-eth `apc_100` | 97 → 45 ms | **0.47x** | 1.41 → 1.02 s | 0.72x |
| OpenVM wasm-eth `apc_028` | 86 → 52 ms | **0.60x** | 1.20 → 0.93 s | 0.77x |

The totals fall further than this pass alone because the two-root table, the prepared records and
`constValue?` are shared with the other address-reasoning passes. No pass regressed.

## Effectiveness

Unchanged, and not by measurement of the size axes but by identity: `opt-export` output is
**byte-identical to `main` on all 606 benchmark APCs** (404 OpenVM, 202 SP1).

## Measured and rejected

- Hash-consed `dedup` for constraint variable lists: slower (candidate index 153 → 204 ms).
- A `Thunk` for the backward index plus a hoisted multiplicity gate: slower (107 → 119 ms); the
  per-interaction thunk allocation and a mathlib `ZMod = 0` decision cost more than the map saved.
- Building every per-invocation index eagerly: slower (3672 → 3966 ms); only the prepared records
  are worth forcing unconditionally.
- Pre-filtering the constraint list to candidate variables before the two-root build: within noise
  (sha256 3291 → 3237 ms), and a pass-level `let` for it is strict, so invocations that never build
  the index pay for the filter.
