### PR TITLE
measure(profile): drop the per-pass whole-system `varCount` the profiler was timing itself for

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -262,9 +262,14 @@ def cmdOptExport (vm inFile outFile : String) : IO Unit :=
 The whole pipeline runs over the dense `VarId` representation (`ApcOptimizer/Implementation/`
 `OptimizerPasses/`), so the profiler steps the dense `preludePasses` / `cleanupPasses` / `codaPasses`
 lists the optimizer actually runs: it encodes once at the pipeline entry, threads a `⟨reg, dense
-system, coverage⟩` bundle from pass to pass and iteration to iteration, forces per-pass output with
-the **dense** count helpers (no decode), and decodes once at the pipeline output. Encode/decode are
-reported on their own lines and never charged to any pass. -/
+system, coverage⟩` bundle from pass to pass and iteration to iteration, and decodes once at the
+pipeline output. Encode/decode are reported on their own lines and never charged to any pass.
+
+A pass's reported time is the pass and nothing else: `denseApplyTimed` adds no work of its own
+(see its note on why the output needs no forcing), so the only shared cost inside it is the
+`guardDegree` wrapper `cleanupPasses` puts on every entry. What the profiler does *not* see is the
+derivation list — it threads `reg`/`out`/`coverage` and drops `derivs`, while `pipeline` appends
+them at every `andThen` and decodes them at the exit. -/
 
 /-- The threaded dense cleanup state: the registry, the dense system, and its coverage proof (erased
     at runtime — it just lets `DenseVerifiedPassW` application typecheck). -/

--- a/Main.lean
+++ b/Main.lean
@@ -271,16 +271,18 @@ reported on their own lines and never charged to any pass. -/
 abbrev DenseProfState (p : ℕ) :=
   Σ' (reg : VarRegistry) (d : DenseConstraintSystem p), d.CoveredBy reg
 
-/-- Apply one dense pass, forcing its output with the dense count helpers (no decode), and return the
-    threaded state plus elapsed milliseconds. -/
+/-- Apply one dense pass and return the threaded state plus elapsed milliseconds.
+
+    `IO.lazyPure fn` is `pure (fn ())`, so the application — and with it the whole pass — runs
+    between the two clock reads; that is all it is here for (a plain `let` the compiler may float
+    across an IO action would not be timed at all). Nothing further needs forcing: Lean is strict,
+    so the returned `DensePassResult`'s `out` is already a fully built `DenseConstraintSystem`
+    (two `List`s of `DenseExpr`, no `Thunk` anywhere in the type), and its remaining fields are
+    `Prop`s, erased at runtime. -/
 def denseApplyTimed {p : ℕ} (pass : DenseVerifiedPassW p) (st : DenseProfState p)
     (bs : BusSemantics p) (facts : BusFacts p bs) : IO (DenseProfState p × Nat) := do
   let t0 ← IO.monoMsNow
   let r ← IO.lazyPure (fun _ => pass st.1 st.2.1 st.2.2 bs facts)
-  -- Force the whole dense output (dense varCount traverses every expression node), on the dense
-  -- system, without ever decoding.
-  let _ ← IO.lazyPure (fun _ =>
-    r.out.varCount + r.out.algebraicConstraints.length + r.out.busInteractions.length)
   let t1 ← IO.monoMsNow
   pure (⟨r.reg', r.out, r.covered⟩, t1 - t0)
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -5974,3 +5974,43 @@ the scan is already cheap. Also sized but not implemented: **busPairCancel build
 over-scoped, cubic table and pays 31 % of its runtime for it on wasm-eth `apc_012`** (R10b).
 
 **Worked: yes.**
+
+### 164. Measurement: `profile` was charging every pass a whole-system `varCount` of its own (numbers drop ~23 %)
+
+**This entry changes no optimizer code and no output — only what `profile` reports.** Per-pass
+numbers in entries before this one are ~23 % higher than the same code measures now, unevenly, so
+**do not compare a pre-164 per-pass number with a post-164 one.** Ratios inside a single entry
+(A/B on one binary pair) are unaffected.
+
+`denseApplyTimed` timed each pass as `IO.lazyPure (pass …)` followed by a second `IO.lazyPure`
+forcing `r.out.varCount + lengths`, on the theory that the pass output had to be forced to be
+measured. It does not: `IO.lazyPure fn` is `pure (fn ())` — plain Lean in the toolchain, no extern,
+no thunk — so applying it runs the pass to completion, and Lean is strict, so the returned
+`out` is an already-built `DenseConstraintSystem` (two `List`s of `DenseExpr`; no `Thunk` occurs
+anywhere in the type, and the result's other fields are `Prop`s, erased). The forcing was a
+whole-system hash-set build over every variable occurrence, discarded, inside the stopwatch, once
+per pass per cycle — 283 times on keccak, 310 on sha256.
+
+**The distortion was in the ranking, not just the scale**, because the walk costs the same whatever
+the pass did. keccak (main, 5508 → 4223 ms total): `zeroMultBus` 55 → 10, `tautoBus` 58 → 14,
+`trivialConstr` 60 → 16, `oneHotAnnihilate` 55 → 15, `xorEqExtract` 118 → 53, `degenRange` 145 → 83
+— i.e. the cheap passes were reported at up to **5.5x** their real cost, while `flagFold` 475 → 425
+moved 11 %. sha256 `apc_001` total 54.9 → 40.8 s (26 %); wasm-eth `apc_012` 6.8 → 5.1 s (25 %).
+
+**Falsification test.** If the work were merely deferred rather than eliminated, it would resurface
+in whichever pass touched the value next: some column would grow and the total would hold. All 30
+keccak columns fell, none grew, and the total fell by the amount a separate timer had attributed to
+the `varCount` call (1124 ms direct; 1285 observed — the excess is the allocator pressure the
+hash-set builds were adding). `run` wall time and `run`/`profile` output are unchanged.
+
+**Consequences.** `ranked_passes.md` (untracked) must be regenerated before it is used to pick a
+target again; on the old numbers the trivial passes ranked near real ones. A `Runtime Bench` A/B is
+only meaningful with this on *both* sides, so it lands alone.
+
+**Still unattributed, and now the bigger measurement gap:** `run` on keccak is a reproducible
+4470-4880 ms against a 3790-4220 ms profile total. The profiler threads `reg`/`out`/`covered` and
+**discards `derivs`**, while `pipeline` does `r1.derivs ++ r2.derivs` in every `andThen` (a
+left-nested append over ~283 invocations, on a list that reaches ~25 k entries as keccak eliminates
+variables) and then `decodeDerivs` over the whole thing at the exit. Neither is timed anywhere.
+
+**Worked: yes.**


### PR DESCRIPTION
**No optimizer code changes and no output changes — only what `profile` reports.** Per-pass numbers
drop ~23 %, and because the removed work was independent of what the pass did, the *ranking* changes
too.

## What was happening

`denseApplyTimed` ran the pass under `IO.lazyPure` and then forced
`r.out.varCount + lengths`, on the theory that the output had to be forced to be measured. It does
not need forcing:

- `IO.lazyPure fn` is `pure (fn ())` — plain Lean in the toolchain, no extern and no thunk — so
  applying it already runs the pass to completion between the clock reads. That sequencing is the
  only thing it is needed for (a plain `let` may be floated across an IO action and would not be
  timed at all).
- Lean is strict, so the returned `out` is an already-built `DenseConstraintSystem` — two `List`s of
  `DenseExpr`, with no `Thunk` anywhere in the type — and the result record's other fields are
  `Prop`s, erased at runtime.

So the forcing was a whole-system hash-set build over every variable occurrence, discarded, inside
the stopwatch, once per pass per cycle: 283 times on keccak, 310 on sha256.

## Falsification test

If the work were merely *deferred* rather than eliminated it would resurface in whichever pass
touched the value next — some column would grow and the total would hold. On keccak **all 30 columns
fell and none grew**, and the total fell by what a separate timer had directly attributed to the
`varCount` call (1124 ms direct, 1285 ms observed; the excess is the allocator pressure those
hash-set builds were adding).

`run` wall time (4882 → 4823 ms), `run` output and the per-cycle sizes are all unchanged.
`lake build` is clean and `Scripts/check-proof-integrity.sh` passes.

## The distortion was in the ranking, not just the scale

The removed walk costs the same whatever the pass did, so the cheap passes were hit hardest
(keccak, total 5508 → 4223 ms):

| pass | before | after | over-reported by |
|---|---:|---:|---:|
| `zeroMultBus` | 55 | 10 | 5.5× |
| `tautoBus` | 58 | 14 | 4.1× |
| `trivialConstr` | 60 | 16 | 3.8× |
| `oneHotAnnihilate` | 55 | 15 | 3.7× |
| `xorEqExtract` | 118 | 53 | 2.2× |
| `degenRange` | 145 | 83 | 1.7× |
| `flagFold` | 475 | 425 | 1.1× |

Totals elsewhere: sha256 `apc_001` 54.9 → 40.8 s (26 %), wasm-eth `apc_012` 6.8 → 5.1 s (25 %).

## Consequences worth knowing

- **Per-pass numbers in log entries before #164 are ~23 % high, unevenly, and are no longer
  comparable to post-#164 ones.** Ratios *within* an entry (an A/B on one binary pair) are
  unaffected.
- A `Runtime Bench` A/B is only meaningful with this on **both** sides, which is why it lands alone
  rather than bundled with a pass change.

## Still unattributed, and now the larger measurement gap

`run` on keccak is a reproducible 4470–4880 ms against a 3790–4220 ms profile total. The profiler
threads `reg`/`out`/`covered` and **discards `derivs`**, while `pipeline` does
`r1.derivs ++ r2.derivs` in every `andThen` — a left-nested append over ~283 invocations, on a list
that reaches ~25 k entries as keccak eliminates variables — and then `decodeDerivs` over the whole
thing at the exit. Neither is timed anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)