### PR TITLE
perf(disconnected): rebuild the pass as a union-find over the co-occurrence hypergraph (0.14–0.21× on the pass, sha256 total 0.93×)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DisconnectedComponent.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DisconnectedComponent.lean
@@ -5,139 +5,187 @@ set_option autoImplicit false
 /-! # Disconnected-component removal
 
 A *disconnected component* is a set of algebraic constraints and stateless bus interactions whose
-variables never touch a stateful bus interaction. The pass finds one by connectivity from the
-stateful buses, tries the all-zero witness, and drops the component only if the witness certifies
-it at run time (the same re-check `guardDegree` uses). Correctness is in
-`Proofs/DisconnectedComponent.lean`; the connectivity closure is a well-founded recursion (no fuel)
-whose decreasing lexicographic measure `(unprocessed-groups-in-range, stack.length)` is proved by
-`denseBfsMeasureDecreasing`. -/
+variables never touch a stateful bus interaction. The pass finds one by union-find over the
+co-occurrence hypergraph, tries the all-zero witness, and drops the component only if the witness
+certifies it at run time (the same re-check `guardDegree` uses). Correctness is in
+`Proofs/DisconnectedComponent.lean`, and is generic in the removable set: nothing below the
+`denseDropGuarded` line is ever reasoned about. -/
 
 namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
-/-! ## The co-occurrence graph -/
+/-! ## Union-find over variable indices
 
-/-- The co-occurrence graph: `groups` gives each item (constraint, then interaction) its list of
-    `VarId`s; `v2g` maps each `VarId` to the indices of the items it occurs in. -/
-def denseBuildGraph (d : DenseConstraintSystem p) :
-    Array (List VarId) × Std.HashMap VarId (List Nat) :=
-  let groups : Array (List VarId) :=
-    (d.algebraicConstraints.map DenseExpr.vars ++
-      d.busInteractions.map denseBIVars).toArray
-  let v2g : Std.HashMap VarId (List Nat) :=
-    (List.range groups.size).foldl
-      (fun mp i => (groups.getD i []).foldl (fun mp x => mp.insert x (i :: mp.getD x [])) mp) ∅
-  (groups, v2g)
+Each item (constraint or interaction) is a hyperedge: unioning its variables makes the connected
+component of the co-occurrence graph a single find away, so an item's whole `all disconnected` test
+collapses to one array read. `dcUnion` attaches the larger root to the smaller, which keeps
+`par[i] ≤ i` — that is what lets `dcFind` recurse on the strictly decreasing index (no fuel, no
+invariant to carry) and what makes `dcFlatten` a single increasing sweep. A violated invariant would
+cost precision, never soundness. -/
 
-/-! ## The terminating closure -/
+/-- Grow the parent array so that index `n - 1` exists, each new slot its own root. -/
+def dcEnsure (par : Array Nat) (n : Nat) : Array Nat :=
+  if _h : par.size < n then dcEnsure (par.push par.size) n else par
+termination_by n - par.size
+decreasing_by simp only [Array.size_push]; omega
 
-/-- Membership in a left-fold of `insert`s over a `Std.HashSet Nat`: an index is present iff it was
-    already present or it is one of the folded elements. -/
-private theorem denseProcMem (l : List Nat) (s : Std.HashSet Nat) (i : Nat) :
-    i ∈ l.foldl (fun s g => s.insert g) s ↔ i ∈ s ∨ i ∈ l := by
-  induction l generalizing s with
-  | nil => simp
-  | cons a rest ih =>
-    rw [List.foldl_cons, ih (s.insert a), Std.HashSet.mem_insert, List.mem_cons]
-    simp only [beq_iff_eq]
-    constructor
-    · rintro ((rfl | h) | h)
-      · exact Or.inr (Or.inl rfl)
-      · exact Or.inl h
-      · exact Or.inr (Or.inr h)
-    · rintro (h | rfl | h)
-      · exact Or.inl (Or.inr h)
-      · exact Or.inl (Or.inl rfl)
-      · exact Or.inr h
+/-- Find with path halving. -/
+def dcFind (par : Array Nat) (x : Nat) : Array Nat × Nat :=
+  let px := par.getD x x
+  if _hx : px < x then
+    let g := par.getD px px
+    if _hg : g < px then dcFind (par.set! x g) g else (par, px)
+  else (par, x)
+termination_by x
+decreasing_by exact Nat.lt_trans _hg _hx
 
-/-- Folding a list of out-of-range group indices leaves the stack unchanged: each `groups.getD g []`
-    is the default empty list. -/
-private theorem denseFoldOutOfRange (groups : Array (List VarId)) :
-    ∀ (l : List Nat), (∀ g ∈ l, groups.size ≤ g) → ∀ (acc : List VarId),
-      l.foldl (fun acc g => groups.getD g [] ++ acc) acc = acc := by
-  intro l
-  induction l with
-  | nil => intro _ acc; rfl
-  | cons a t ih =>
-    intro hl acc
-    rw [List.foldl_cons]
-    have ha : groups.getD a ([] : List VarId) = [] := by
-      rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_none (hl a (List.mem_cons_self ..)),
-        Option.getD_none]
-    rw [ha, List.nil_append]
-    exact ih (fun g hg => hl g (List.mem_cons_of_mem _ hg)) acc
+def dcUnion (par : Array Nat) (a b : Nat) : Array Nat :=
+  let (par, ra) := dcFind par a
+  let (par, rb) := dcFind par b
+  if ra == rb then par else if ra < rb then par.set! rb ra else par.set! ra rb
 
-/-- The lexicographic measure `(unprocessed-groups-in-range, stack.length)` strictly decreases on a
-    productive closure step: a triggered in-range group index is newly processed (first component
-    drops), else every push is empty and the stack shrinks. -/
-private theorem denseBfsMeasureDecreasing (groups : Array (List VarId))
-    (procGroups : Std.HashSet Nat) (gids : List Nat) (rest : List VarId)
-    (hg : ∀ g ∈ gids, procGroups.contains g = false) :
-    (toLex (((Finset.range groups.size).filter
-                (fun g => (gids.foldl (fun s g => s.insert g) procGroups).contains g = false)).card,
-              (gids.foldl (fun acc g => groups.getD g [] ++ acc) rest).length) : Nat ×ₗ Nat)
-      < toLex (((Finset.range groups.size).filter (fun g => procGroups.contains g = false)).card,
-               rest.length + 1) := by
-  set P' := gids.foldl (fun s g => s.insert g) procGroups with hP'
-  have hmem : ∀ g, g ∈ P' ↔ g ∈ procGroups ∨ g ∈ gids := fun g => denseProcMem gids procGroups g
-  have himpl : ∀ a, P'.contains a = false → procGroups.contains a = false := by
-    intro a ha
-    rw [Std.HashSet.contains_eq_false_iff_not_mem] at ha ⊢
-    exact fun hm => ha ((hmem a).2 (Or.inl hm))
-  rw [Prod.Lex.toLex_lt_toLex]
-  by_cases hcase : ∃ g ∈ gids, g < groups.size
-  · left
-    obtain ⟨g0, hg0, hg0lt⟩ := hcase
-    show ((Finset.range groups.size).filter (fun g => P'.contains g = false)).card
-       < ((Finset.range groups.size).filter (fun g => procGroups.contains g = false)).card
-    apply Finset.card_lt_card
-    rw [Finset.ssubset_iff_of_subset (Finset.monotone_filter_right _ (fun a _ => himpl a))]
-    refine ⟨g0, ?_, ?_⟩
-    · rw [Finset.mem_filter, Finset.mem_range]; exact ⟨hg0lt, hg g0 hg0⟩
-    · rw [Finset.mem_filter]
-      rintro ⟨-, hc⟩
-      rw [Std.HashSet.contains_eq_false_iff_not_mem] at hc
-      exact hc ((hmem g0).2 (Or.inr hg0))
-  · right
-    have hcase' : ∀ g ∈ gids, groups.size ≤ g := by
-      intro g hgin; by_contra hlt; exact hcase ⟨g, hgin, by omega⟩
-    refine ⟨?_, ?_⟩
-    · show ((Finset.range groups.size).filter (fun g => P'.contains g = false)).card
-         = ((Finset.range groups.size).filter (fun g => procGroups.contains g = false)).card
-      refine congrArg Finset.card (Finset.filter_congr fun g hg' => ?_)
-      rw [Finset.mem_range] at hg'
-      have hgni : g ∉ gids := fun hgin => absurd (hcase' g hgin) (by omega)
-      constructor
-      · exact fun h => himpl g h
-      · intro h
-        rw [Std.HashSet.contains_eq_false_iff_not_mem] at h ⊢
-        exact fun hm => h (((hmem g).1 hm).resolve_right hgni)
-    · show (gids.foldl (fun acc g => groups.getD g [] ++ acc) rest).length < rest.length + 1
-      rw [denseFoldOutOfRange groups gids hcase' rest]; omega
+/-- `par[i] ≤ i`, so scanning upward finds every entry's parent already flattened: one pass makes
+    every entry point straight at its root. -/
+def dcFlatten (par : Array Nat) (x : Nat) : Array Nat :=
+  if h : x < par.size then
+    let px := par.getD x x
+    dcFlatten (par.set! x (par.getD px px)) (x + 1)
+  else par
+termination_by par.size - x
+decreasing_by simp only [Array.set!, Array.size_setIfInBounds]; omega
 
-/-- Variables reachable from a seed via co-occurrence in a constraint or interaction. Correctness
-    never depends on this result — the pass re-checks the partition it induces. -/
-def denseBfsClosure (groups : Array (List VarId)) (v2g : Std.HashMap VarId (List Nat))
-    (visited : Std.HashSet VarId) (procGroups : Std.HashSet Nat) (stack : List VarId) :
-    Std.HashSet VarId :=
-  match stack with
-  | [] => visited
-  | x :: rest =>
-    if visited.contains x then denseBfsClosure groups v2g visited procGroups rest
-    else
-      let gids := (v2g.getD x []).filter (fun g => !procGroups.contains g)
-      let procGroups' := gids.foldl (fun s g => s.insert g) procGroups
-      let newVars := gids.foldl (fun acc g => groups.getD g [] ++ acc) rest
-      denseBfsClosure groups v2g (visited.insert x) procGroups' newVars
-  termination_by toLex (((Finset.range groups.size).filter
-      (fun g => procGroups.contains g = false)).card, stack.length)
-  decreasing_by
-    · exact Prod.Lex.toLex_lt_toLex.2 (Or.inr ⟨rfl, by simp⟩)
-    · simp only [List.length_cons]
-      exact denseBfsMeasureDecreasing groups procGroups
-        ((v2g.getD x []).filter (fun g => !procGroups.contains g)) rest
-        (fun g hg => by simpa using (List.mem_filter.1 hg).2)
+/-! ## Building the partition
+
+The second component threaded through the walks is the item's *shifted* representative variable:
+`0` for a variable-free item, `i + 1` for variable index `i`. Every argument is threaded linearly so
+the parent array stays uniquely owned. -/
+
+/-- Union every variable of `e` into the item's representative, which is maintained as the *root* of
+    the item's component so each occurrence costs one find rather than the two a bare
+    `dcUnion rep i` would. -/
+def dcUnionExpr : DenseExpr p → Array Nat × Nat → Array Nat × Nat
+  | .const _, st => st
+  | .var i, (par, rep) =>
+      let par := if i.index < par.size then par else dcEnsure par (i.index + 1)
+      let (par, ri) := dcFind par i.index
+      if rep == 0 then (par, ri + 1)
+      else
+        let r := rep - 1
+        if ri == r then (par, rep)
+        else if ri < r then (par.set! r ri, ri + 1) else (par.set! ri r, rep)
+  | .add a b, st => dcUnionExpr b (dcUnionExpr a st)
+  | .mul a b, st => dcUnionExpr b (dcUnionExpr a st)
+
+def dcUnionBI (bi : BusInteraction (DenseExpr p)) (st : Array Nat × Nat) : Array Nat × Nat :=
+  bi.payload.foldl (fun st e => dcUnionExpr e st) (dcUnionExpr bi.multiplicity st)
+
+def dcBuildCs (par : Array Nat) (reps : Array Nat) :
+    List (DenseExpr p) → Array Nat × Array Nat
+  | [] => (par, reps)
+  | c :: rest =>
+      let (par, rep) := dcUnionExpr c (par, 0)
+      dcBuildCs par (reps.push rep) rest
+
+/-- Interactions are unioned like constraints, and every stateful one additionally joins one
+    designated *stateful* component — whose members are exactly the variables the old breadth-first
+    closure reached from the stateful seeds. -/
+def dcBuildBis (bs : BusSemantics p) (par : Array Nat) (reps : Array Nat) (stRep : Nat) :
+    List (BusInteraction (DenseExpr p)) → Array Nat × Array Nat × Nat
+  | [] => (par, reps, stRep)
+  | bi :: rest =>
+      let (par, rep) := dcUnionBI bi (par, 0)
+      if bs.isStateful bi.busId && rep != 0 then
+        if stRep == 0 then dcBuildBis bs par (reps.push rep) rep rest
+        else dcBuildBis bs (dcUnion par (stRep - 1) (rep - 1)) (reps.push rep) stRep rest
+      else dcBuildBis bs par (reps.push rep) stRep rest
+
+/-! ## The all-zero witness -/
+
+/-- `e.eval (fun _ => 0)`, dictionary-free (`Encoding.lean`'s primitives), so no `CommRing (ZMod p)`
+    chain is built per item. -/
+def denseEvalZero : DenseExpr p → ZMod p
+  | .const n => n
+  | .var _ => zmodZeroP p
+  | .add a b => zmodAddP (denseEvalZero a) (denseEvalZero b)
+  | .mul a b => zmodMulP (denseEvalZero a) (denseEvalZero b)
+
+def denseBIEvalZero (bi : BusInteraction (DenseExpr p)) : BusInteraction (ZMod p) :=
+  { busId := bi.busId, multiplicity := denseEvalZero bi.multiplicity,
+    payload := bi.payload.map denseEvalZero }
+
+/-! ## Bad components
+
+A disconnected item the all-zero witness fails on poisons its whole component; marking its root is
+the mark-side of what used to be a second breadth-first closure. -/
+
+def dcMarkBadCs (par : Array Nat) (connRoot : Nat) (reps : Array Nat) (i : Nat) (bad : Array Bool) :
+    List (DenseExpr p) → Array Bool
+  | [] => bad
+  | c :: rest =>
+      let rep := reps.getD i 0
+      if rep == 0 then dcMarkBadCs par connRoot reps (i + 1) bad rest
+      else
+        let r := par.getD (rep - 1) connRoot
+        if r == connRoot || zmodIsZero (denseEvalZero c) then
+          dcMarkBadCs par connRoot reps (i + 1) bad rest
+        else dcMarkBadCs par connRoot reps (i + 1) (bad.set! r true) rest
+
+def dcMarkBadBis (bs : BusSemantics p) (facts : BusFacts p bs) (par : Array Nat) (connRoot : Nat)
+    (reps : Array Nat) (i : Nat) (bad : Array Bool) :
+    List (BusInteraction (DenseExpr p)) → Array Bool
+  | [] => bad
+  | bi :: rest =>
+      let rep := reps.getD i 0
+      if rep == 0 || bs.isStateful bi.busId then
+        dcMarkBadBis bs facts par connRoot reps (i + 1) bad rest
+      else
+        let r := par.getD (rep - 1) connRoot
+        if r == connRoot || facts.acceptsDec (denseBIEvalZero bi) then
+          dcMarkBadBis bs facts par connRoot reps (i + 1) bad rest
+        else dcMarkBadBis bs facts par connRoot reps (i + 1) (bad.set! r true) rest
+
+/-- Is any item's component removable? A pure array scan over the item representatives, run before
+    the per-variable table is built so a system with nothing to drop costs no further work. -/
+def dcAnyRemovable (par : Array Nat) (connRoot : Nat) (bad : Array Bool) (reps : Array Nat)
+    (i : Nat) : Bool :=
+  if h : i < reps.size then
+    let rep := reps.getD i 0
+    if rep != 0 then
+      let r := par.getD (rep - 1) connRoot
+      if r != connRoot && !bad.getD r false then true
+      else dcAnyRemovable par connRoot bad reps (i + 1)
+    else dcAnyRemovable par connRoot bad reps (i + 1)
+  else false
+termination_by reps.size - i
+
+/-- The per-variable removable flags: neither in the stateful component nor in a poisoned one. -/
+def dcRemVars (par : Array Nat) (connRoot : Nat) (bad : Array Bool) (x : Nat) (out : Array Bool) :
+    Array Bool :=
+  if h : x < par.size then
+    let r := par.getD x x
+    dcRemVars par connRoot bad (x + 1) (out.set! x (r != connRoot && !bad.getD r false))
+  else out
+termination_by par.size - x
+decreasing_by omega
+
+/-- The removable variables, indexed by `VarId.index`; `#[]` when nothing is removable. Returned as
+    data, not as a `VarId → Bool` predicate: a function-valued def is eta-expanded to maximal arity,
+    which would rerun the whole search on every application (arity-expansion trap). The predicate is
+    built once at the use site in `denseDisconnectedF`. Treated opaquely by the correctness proof. -/
+def denseRemovableVars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : Array Bool :=
+  let (par, reps) := dcBuildCs #[] #[] d.algebraicConstraints
+  let (par, reps, stRep) := dcBuildBis bs par reps 0 d.busInteractions
+  let par := dcFlatten par 0
+  let n := par.size
+  let connRoot := if stRep == 0 then n else par.getD (stRep - 1) n
+  let bad := dcMarkBadCs par connRoot reps 0 (Array.replicate n false) d.algebraicConstraints
+  let bad := dcMarkBadBis bs facts par connRoot reps d.algebraicConstraints.length bad
+    d.busInteractions
+  if dcAnyRemovable par connRoot bad reps 0 then
+    dcRemVars par connRoot bad 0 (Array.replicate n false)
+  else #[]
 
 /-! ## Keep predicates -/
 
@@ -149,37 +197,6 @@ def denseKeepConWith (remV : VarId → Bool) (c : DenseExpr p) : Bool :=
 def denseKeepBiWith (bs : BusSemantics p) (remV : VarId → Bool)
     (bi : BusInteraction (DenseExpr p)) : Bool :=
   bs.isStateful bi.busId || (denseBIVars bi).isEmpty || !((denseBIVars bi).all remV)
-
-/-! ## Computing the removable set
-
-`denseConnBad` returns the two reachable sets as data (a pair), not a `VarId → Bool` predicate: a
-function-valued def is eta-expanded to maximal arity, which would rebuild the graph and rerun both
-closures on every `remV x` application (arity-expansion trap). The `remV` predicate is built once at
-the use site in `denseDisconnectedF`. -/
-
-/-- The two reachable sets: `conn` (variables connected to a stateful bus interaction) and `bad`
-    (the co-occurrence closure of any disconnected item the all-zero witness fails on). Treated
-    opaquely by the correctness proof. -/
-def denseConnBad (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
-    Std.HashSet VarId × Std.HashSet VarId :=
-  let (groups, v2g) := denseBuildGraph d
-  -- variables connected to a stateful bus interaction
-  let connSeed : List VarId :=
-    d.busInteractions.foldl (fun acc bi =>
-      if bs.isStateful bi.busId then denseBIVars bi ++ acc else acc) []
-  let conn := denseBfsClosure groups v2g ∅ ∅ connSeed
-  let disc : VarId → Bool := fun x => !conn.contains x
-  -- variables of a disconnected item the all-zero witness fails on: keep its whole component
-  let badSeeds : List VarId :=
-    d.algebraicConstraints.foldl (fun acc c =>
-        if !c.vars.isEmpty && c.vars.all disc && !decide (c.eval (fun _ => 0) = 0)
-        then c.vars ++ acc else acc)
-      (d.busInteractions.foldl (fun acc bi =>
-        if !bs.isStateful bi.busId && !(denseBIVars bi).isEmpty && (denseBIVars bi).all disc
-            && !facts.acceptsDec (denseBIEval bi (fun _ => 0))
-        then denseBIVars bi ++ acc else acc) [])
-  let bad := denseBfsClosure groups v2g ∅ ∅ badSeeds
-  (conn, bad)
 
 /-! ## The guarded drop -/
 
@@ -199,6 +216,79 @@ def denseDropCheck (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConst
   d.busInteractions.all (fun bi =>
     !denseKeepBiWith bs remV bi || (denseBIVars bi).all (fun x => !remV x))
 
+/-! ### The fused re-check
+
+`denseDropCheck` and the filter below it read `DenseExpr.vars` five times per item, each read
+allocating a cons per occurrence. Two allocation-free walks answer everything they ask, and
+`dcAnyVar` alone settles the common case: an item with no removable variable is kept *and* its
+kept-side obligation (`vars.all (!remV)`) is exactly the same walk's negation. -/
+
+/-- `e.vars.any f`, without materialising `e.vars`. -/
+def dcAnyVar (f : VarId → Bool) : DenseExpr p → Bool
+  | .const _ => false
+  | .var i => f i
+  | .add a b => dcAnyVar f a || dcAnyVar f b
+  | .mul a b => dcAnyVar f a || dcAnyVar f b
+
+/-- `e.vars.all f`, without materialising `e.vars`. -/
+def dcAllVar (f : VarId → Bool) : DenseExpr p → Bool
+  | .const _ => true
+  | .var i => f i
+  | .add a b => dcAllVar f a && dcAllVar f b
+  | .mul a b => dcAllVar f a && dcAllVar f b
+
+def dcAnyVarBI (f : VarId → Bool) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  dcAnyVar f bi.multiplicity || bi.payload.any (dcAnyVar f)
+
+def dcAllVarBI (f : VarId → Bool) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  dcAllVar f bi.multiplicity && bi.payload.all (dcAllVar f)
+
+/-- The keep flags of the constraint list, or `none` if an obligation of `denseDropCheck` fails; the
+    `Bool` reports whether anything is dropped. -/
+def dcCheckCs (remV : VarId → Bool) (keep : Array Bool) (dropped : Bool) :
+    List (DenseExpr p) → Option (Array Bool × Bool)
+  | [] => some (keep, dropped)
+  | c :: rest =>
+      if dcAnyVar remV c then
+        if dcAllVar remV c && zmodIsZero (denseEvalZero c) then
+          dcCheckCs remV (keep.push false) true rest
+        else none
+      else dcCheckCs remV (keep.push true) dropped rest
+
+def dcCheckBis (bs : BusSemantics p) (facts : BusFacts p bs) (remV : VarId → Bool)
+    (keep : Array Bool) (dropped : Bool) :
+    List (BusInteraction (DenseExpr p)) → Option (Array Bool × Bool)
+  | [] => some (keep, dropped)
+  | bi :: rest =>
+      if dcAnyVarBI remV bi then
+        if !bs.isStateful bi.busId && dcAllVarBI remV bi &&
+            facts.acceptsDec (denseBIEvalZero bi) then
+          dcCheckBis bs facts remV (keep.push false) true rest
+        else none
+      else dcCheckBis bs facts remV (keep.push true) dropped rest
+
+def dcFilterIdx {α : Type} (keep : Array Bool) (i : Nat) : List α → List α
+  | [] => []
+  | a :: rest =>
+      if keep.getD i true then a :: dcFilterIdx keep (i + 1) rest else dcFilterIdx keep (i + 1) rest
+
+/-- `denseDropGuarded`'s runtime twin: the two sweeps decide the whole re-check and the keep flags
+    they produce drive the filter. When an obligation fails this still walks the rest of the list
+    where `denseDropCheck`'s `&&` short-circuits — the *value* is the same (`d` either way), which
+    is what the equality below has to say. -/
+def denseDropGuardedFast (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) (remV : VarId → Bool) : DenseConstraintSystem p :=
+  match dcCheckCs remV #[] false d.algebraicConstraints with
+  | none => d
+  | some (keepC, dropC) =>
+    match dcCheckBis bs facts remV #[] false d.busInteractions with
+    | none => d
+    | some (keepB, dropB) =>
+      if dropC || dropB then
+        { algebraicConstraints := dcFilterIdx keepC 0 d.algebraicConstraints,
+          busInteractions := dcFilterIdx keepB 0 d.busInteractions }
+      else d
+
 /-- Drop the removable component if the re-check passes; otherwise the identity. Stated for an
     arbitrary `remV` so the correctness proof is generic in the connectivity search. -/
 def denseDropGuarded (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
@@ -208,12 +298,218 @@ def denseDropGuarded (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseCon
       busInteractions := d.busInteractions.filter (denseKeepBiWith bs remV) }
   else d
 
+/-! ### The twin computes the same value
+
+The walks and the all-zero witness are pointwise equalities; the sweeps are characterised against
+`denseDropCheck`'s own conjuncts. The one gap the equality has to bridge is short-circuiting: a
+failed obligation stops `denseDropCheck`'s `&&` early where `dcCheckCs` keeps walking. Both yield
+`d`, which is all the equality claims. -/
+
+theorem dcAnyVar_eq (f : VarId → Bool) (e : DenseExpr p) : dcAnyVar f e = e.vars.any f := by
+  induction e with
+  | const n => rfl
+  | var i => simp [dcAnyVar, DenseExpr.vars]
+  | add a b iha ihb => simp [dcAnyVar, DenseExpr.vars, iha, ihb]
+  | mul a b iha ihb => simp [dcAnyVar, DenseExpr.vars, iha, ihb]
+
+theorem dcAllVar_eq (f : VarId → Bool) (e : DenseExpr p) : dcAllVar f e = e.vars.all f := by
+  induction e with
+  | const n => rfl
+  | var i => simp [dcAllVar, DenseExpr.vars]
+  | add a b iha ihb => simp [dcAllVar, DenseExpr.vars, iha, ihb]
+  | mul a b iha ihb => simp [dcAllVar, DenseExpr.vars, iha, ihb]
+
+theorem dcAnyVarBI_eq (f : VarId → Bool) (bi : BusInteraction (DenseExpr p)) :
+    dcAnyVarBI f bi = (denseBIVars bi).any f := by
+  have hv : (dcAnyVar f : DenseExpr p → Bool) = fun e => e.vars.any f :=
+    funext (dcAnyVar_eq f)
+  simp [dcAnyVarBI, denseBIVars, hv]
+
+theorem dcAllVarBI_eq (f : VarId → Bool) (bi : BusInteraction (DenseExpr p)) :
+    dcAllVarBI f bi = (denseBIVars bi).all f := by
+  have hv : (dcAllVar f : DenseExpr p → Bool) = fun e => e.vars.all f :=
+    funext (dcAllVar_eq f)
+  simp [dcAllVarBI, denseBIVars, hv]
+
+theorem denseEvalZero_eq (e : DenseExpr p) : denseEvalZero e = e.eval (fun _ => 0) := by
+  induction e with
+  | const n => rfl
+  | var i => simp [denseEvalZero, DenseExpr.eval]
+  | add a b iha ihb => simp [denseEvalZero, DenseExpr.eval, iha, ihb]
+  | mul a b iha ihb => simp [denseEvalZero, DenseExpr.eval, iha, ihb]
+
+theorem denseBIEvalZero_eq (bi : BusInteraction (DenseExpr p)) :
+    denseBIEvalZero bi = denseBIEval bi (fun _ => 0) := by
+  have hv : (denseEvalZero : DenseExpr p → ZMod p) = fun e => e.eval (fun _ => 0) :=
+    funext denseEvalZero_eq
+  simp [denseBIEvalZero, denseBIEval, hv]
+
+/-! The two walks decide the keep predicate and both of `denseDropCheck`'s per-item obligations: no
+removable variable keeps the item *and* discharges its kept-side obligation, and a removable
+variable leaves the item removable only when every variable is. -/
+
+theorem dcAllNot (f : VarId → Bool) (l : List VarId) : l.all (fun x => !f x) = !l.any f := by
+  induction l with
+  | nil => rfl
+  | cons a t ih => simp [ih]
+
+theorem dcKeepOfNotAny (f : VarId → Bool) (l : List VarId) (h : l.any f = false) :
+    (l.isEmpty || !(l.all f)) = true := by
+  cases l with
+  | nil => rfl
+  | cons a t =>
+    rw [List.any_cons, Bool.or_eq_false_iff] at h
+    simp [h.1]
+
+/-- The one array fact the sweeps need: a push is an append of a singleton. -/
+theorem dcPushAppend (a : Array Bool) (b : Bool) (l : List Bool) :
+    a.push b ++ l.toArray = a ++ (b :: l).toArray := by
+  apply Array.ext'; simp
+
+theorem dcCheckCs_spec (remV : VarId → Bool) (L : List (DenseExpr p)) :
+    ∀ (keep : Array Bool) (dropped : Bool),
+    dcCheckCs remV keep dropped L =
+      if L.all (fun c => denseKeepConWith remV c || decide (c.eval (fun _ => 0) = 0)) &&
+         L.all (fun c => !denseKeepConWith remV c || c.vars.all (fun x => !remV x))
+      then some (keep ++ (L.map (denseKeepConWith remV)).toArray,
+                 dropped || L.any (fun c => !denseKeepConWith remV c))
+      else none := by
+  induction L with
+  | nil => intro keep dropped; simp [dcCheckCs]
+  | cons c rest ih =>
+    intro keep dropped
+    have hzc : zmodIsZero (denseEvalZero c) = decide (c.eval (fun _ => 0) = 0) := by
+      rw [zmodIsZero_eq, denseEvalZero_eq]
+    rw [dcCheckCs, dcAnyVar_eq, dcAllVar_eq, hzc]
+    cases hany : c.vars.any remV with
+    | false =>
+      have hkeep : denseKeepConWith remV c = true := dcKeepOfNotAny remV c.vars hany
+      have hobl : c.vars.all (fun x => !remV x) = true := by rw [dcAllNot, hany]; rfl
+      rw [if_neg (by simp), ih]
+      simp [hkeep, hobl]
+    | true =>
+      have hne : c.vars.isEmpty = false := by
+        cases hc : c.vars with
+        | nil => rw [hc] at hany; simp at hany
+        | cons _ _ => rfl
+      cases hall : c.vars.all remV with
+      | false =>
+        have hkeep : denseKeepConWith remV c = true := by simp [denseKeepConWith, hall]
+        have hobl : c.vars.all (fun x => !remV x) = false := by rw [dcAllNot, hany]; rfl
+        simp [hkeep, hobl]
+      | true =>
+        have hkeep : denseKeepConWith remV c = false := by
+          simp [denseKeepConWith, hall, hne]
+        cases hz : decide (c.eval (fun _ => 0) = 0) with
+        | false => simp [hkeep, hz]
+        | true =>
+          rw [if_pos rfl, ih]
+          simp [hkeep, hz]
+
+theorem dcCheckBis_spec (bs : BusSemantics p) (facts : BusFacts p bs) (remV : VarId → Bool)
+    (L : List (BusInteraction (DenseExpr p))) :
+    ∀ (keep : Array Bool) (dropped : Bool),
+    dcCheckBis bs facts remV keep dropped L =
+      if L.all (fun bi => denseKeepBiWith bs remV bi ||
+            facts.acceptsDec (denseBIEval bi (fun _ => 0))) &&
+         L.all (fun bi => !denseKeepBiWith bs remV bi ||
+            (denseBIVars bi).all (fun x => !remV x))
+      then some (keep ++ (L.map (denseKeepBiWith bs remV)).toArray,
+                 dropped || L.any (fun bi => !denseKeepBiWith bs remV bi))
+      else none := by
+  induction L with
+  | nil => intro keep dropped; simp [dcCheckBis]
+  | cons bi rest ih =>
+    intro keep dropped
+    rw [dcCheckBis, dcAnyVarBI_eq, dcAllVarBI_eq, denseBIEvalZero_eq]
+    cases hany : (denseBIVars bi).any remV with
+    | false =>
+      have hkeep : denseKeepBiWith bs remV bi = true := by
+        rw [denseKeepBiWith, Bool.or_assoc]
+        exact Bool.or_eq_true_iff.2 (Or.inr (dcKeepOfNotAny remV (denseBIVars bi) hany))
+      have hobl : (denseBIVars bi).all (fun x => !remV x) = true := by rw [dcAllNot, hany]; rfl
+      rw [if_neg (by simp), ih]
+      simp [hkeep, hobl]
+    | true =>
+      have hobl : (denseBIVars bi).all (fun x => !remV x) = false := by rw [dcAllNot, hany]; rfl
+      have hne : (denseBIVars bi).isEmpty = false := by
+        cases hc : denseBIVars bi with
+        | nil => rw [hc] at hany; simp at hany
+        | cons _ _ => rfl
+      cases hst : bs.isStateful bi.busId with
+      | true =>
+        have hkeep : denseKeepBiWith bs remV bi = true := by simp [denseKeepBiWith, hst]
+        simp [hkeep, hobl]
+      | false =>
+        cases hall : (denseBIVars bi).all remV with
+        | false =>
+          have hkeep : denseKeepBiWith bs remV bi = true := by simp [denseKeepBiWith, hall]
+          simp [hkeep, hobl]
+        | true =>
+          have hkeep : denseKeepBiWith bs remV bi = false := by
+            simp [denseKeepBiWith, hall, hne, hst]
+          cases hz : facts.acceptsDec (denseBIEval bi (fun _ => 0)) with
+          | false => simp [hkeep, hz]
+          | true =>
+            rw [if_pos rfl, ih]
+            simp [hkeep, hz]
+
+theorem dcFilterIdx_prefix {α : Type} (f : α → Bool) (L : List α) :
+    ∀ (pre : Array Bool), dcFilterIdx (pre ++ (L.map f).toArray) pre.size L = L.filter f := by
+  induction L with
+  | nil => intro pre; rfl
+  | cons a rest ih =>
+    intro pre
+    have hhd : (pre ++ ((a :: rest).map f).toArray).getD pre.size true = f a := by
+      simp [Array.getD]
+    rw [dcFilterIdx, hhd]
+    have hsz : (pre.push (f a)).size = pre.size + 1 := by simp
+    have hkeep : pre ++ ((a :: rest).map f).toArray
+        = pre.push (f a) ++ (rest.map f).toArray := by
+      rw [dcPushAppend]; rfl
+    rw [hkeep, ← hsz, ih (pre.push (f a))]
+    cases hfa : f a <;> simp [hfa]
+
+theorem dcFilterIdx_eq {α : Type} (f : α → Bool) (L : List α) :
+    dcFilterIdx (L.map f).toArray 0 L = L.filter f := by
+  have h := dcFilterIdx_prefix f L #[]
+  simpa using h
+
+@[csimp] theorem denseDropGuarded_eq_fast : @denseDropGuarded = @denseDropGuardedFast := by
+  funext q bs facts d remV
+  rw [denseDropGuardedFast, dcCheckCs_spec, dcCheckBis_spec, denseDropGuarded, denseDropCheck]
+  cases hB : d.algebraicConstraints.all
+      (fun c => denseKeepConWith remV c || decide (c.eval (fun _ => 0) = 0)) with
+  | false => simp
+  | true =>
+    cases hD : d.algebraicConstraints.all
+        (fun c => !denseKeepConWith remV c || c.vars.all (fun x => !remV x)) with
+    | false => simp
+    | true =>
+      cases hC : d.busInteractions.all (fun bi => denseKeepBiWith bs remV bi ||
+          facts.acceptsDec (denseBIEval bi (fun _ => 0))) with
+      | false => simp
+      | true =>
+        cases hE : d.busInteractions.all (fun bi => !denseKeepBiWith bs remV bi ||
+            (denseBIVars bi).all (fun x => !remV x)) with
+        | false => simp
+        | true =>
+          simp only [Bool.and_true, if_true, Bool.false_or]
+          split_ifs with h
+          · simp [dcFilterIdx_eq]
+          · rfl
+
+/-- `#[]` means nothing is removable, so the re-check is skipped entirely. -/
+def denseDropWithTable (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
+    (rem : Array Bool) : DenseConstraintSystem p :=
+  if rem.isEmpty then d else denseDropGuarded bs facts d (fun x => rem.getD x.index false)
+
 /-- Finds a set of constraints and stateless interactions whose variables never reach a stateful
     bus, and — if the all-zero witness satisfies them (re-checked at run time by `denseDropCheck`) —
-    drops the whole component. -/
+    drops the whole component. For a system whose only link to a memory interaction is through `y`,
+    a constraint `x * x = x` on an otherwise unused `x` is dropped with `x := 0`. -/
 def denseDisconnectedF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseConstraintSystem p :=
-  let cb := denseConnBad bs facts d
-  denseDropGuarded bs facts d (fun x => !cb.1.contains x && !cb.2.contains x)
+  denseDropWithTable bs facts d (denseRemovableVars bs facts d)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DisconnectedComponent.lean
@@ -274,14 +274,18 @@ theorem denseDropGuarded_correct (bs : BusSemantics p) (facts : BusFacts p bs)
 theorem denseDisconnectedF_covered {reg : VarRegistry} (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (hc : d.CoveredBy reg) :
     (denseDisconnectedF bs facts d).CoveredBy reg := by
-  unfold denseDisconnectedF
-  exact denseDropGuarded_covered bs facts d _ hc
+  unfold denseDisconnectedF denseDropWithTable
+  split_ifs with h
+  · exact hc
+  · exact denseDropGuarded_covered bs facts d _ hc
 
 theorem denseDisconnectedF_correct (bs : BusSemantics p) (facts : BusFacts p bs)
     (isInput : VarId → Bool) (d : DenseConstraintSystem p) :
     DensePassCorrect isInput d (denseDisconnectedF bs facts d) [] bs := by
-  unfold denseDisconnectedF
-  exact denseDropGuarded_correct bs facts isInput d _
+  unfold denseDisconnectedF denseDropWithTable
+  split_ifs with h
+  · exact DensePassCorrect.refl isInput d bs
+  · exact denseDropGuarded_correct bs facts isInput d _
 
 /-- The dense disconnected-component pass (see `denseDisconnectedF`). -/
 def denseDisconnectedPass : DenseVerifiedPassW p :=

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -612,6 +612,23 @@ the allocation traffic of their results. The `.fallback` row is **done (entry 15
      Preflight's `T.doms xs` is 6.8 % on sha256, all `Std.HashMap VarId` probes: the R12 array-indexed
      prototype belongs here first.
 
+### disconnected residual after entry 166 (the union-find)  ·  *runtime, sha256*
+
+The pass is 479 ms of sha256 `apc_001` and 37 ms of keccak. ~60 % of what is left is the union-find
+build — one path-halving find per variable occurrence, which is the floor for computing connectivity
+from scratch. Two things were looked at and left:
+
+- **An allocation-free `dcFind`.** It returns `Array Nat × Nat`, so it allocates one tuple per
+  variable occurrence. Splitting it into a pure `dcRoot` plus a path-rewriting `dcLink` trades that
+  for four short array walks instead of two — a wash at these path lengths (1–2 after compression),
+  and it makes the link-to-min invariant load-bearing rather than merely useful.
+- **Sharing the zero-evaluations.** Removed items are evaluated twice (once to decide whether their
+  component is poisoned, once by the re-check). Threading a cache into the guarded drop is exactly
+  the argument the re-check exists *not* to trust, and the evaluation is dictionary-free now.
+
+Reusing the partition across cleanup cycles (the pass runs 6–11 times per case) needs incrementality
+the stateless pass framework does not have.
+
 ### gauss residual after entries 160–161 (the sparse engine)  ·  *runtime, sha256*
 
 Entry 160 replaced the pass with a watch-driven sparse engine and entry 161 removed a pointer-sharing
@@ -683,6 +700,13 @@ and in `run` alike. Consequences, all measured on busPairCancel:
      and `Thunk.mk` have the same `.get`, so the choice is invisible to every proof.
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **A three-bit `UInt8` summary walk for disconnected's fused re-check** (entry 166): one walk
+  computing has-a-variable / some-removable / some-not measures the *same* as two separate
+  `dcAnyVar` / `dcAllVar` walks (keccak 35 vs 37 ms, identical output) and costs ~3x the proof
+  (bitmask reasoning against `vars` instead of two `List.any`/`List.all` inductions). Two walks win
+  on their own terms: `dcAnyVar` exits on the first variable of a removed item, and is the only walk
+  a kept item pays.
 
 - **Dropping gauss's second source-order sweep** (entry 160): looks provably fruitless over a prime
   field, and measures openvm-eth `apc_037` gauss **170 → 317 ms** with changed output — 35 % of that

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6093,3 +6093,64 @@ everywhere but `apc_067` while needing its own soundness proof over a mutable lo
 byte-identical output.
 
 **Worked: yes.**
+
+### 166. Runtime: disconnected rebuilt as a union-find over the co-occurrence hypergraph (0.14–0.21x on the pass, sha256 total 0.93x)
+
+**Idea.** The pass built a `Std.HashMap VarId (List Nat)` co-occurrence graph and ran *two*
+breadth-first closures over it (variables reachable from a stateful bus; variables of any
+disconnected item the all-zero witness fails on), then re-checked the induced partition and filtered.
+An `IO` phase probe put the cost at graph 21 %, `conn` BFS 25 %, bad seeds 15 %, `bad` BFS 11 %,
+re-check + filter 26 % on sha256 `apc_001` — no villain, so a rewrite rather than a hoist.
+
+Two mechanical findings behind that spread: `DenseExpr.vars` was materialised **~12 times per
+constraint per invocation** (once for the graph, twice in the bad-seed fold, twice per
+`denseKeepConWith` across four `denseDropCheck` call sites, twice in the filter), and the C sweep
+flagged `List_foldl___at___00denseConnBad_spec__1/2` rebuilding `ZMod.commRing p → … → toZero`
+*inside* the bad-seed loop for `decide (c.eval (fun _ => 0) = 0)` — with `denseDropCheck` doing it
+again.
+
+**What it is now.** Each item is a hyperedge, so unioning its variables makes an item's whole
+"are all my variables disconnected" test one array read. Stateful interactions join one designated
+component, which *is* the old `conn` closure; a failing disconnected item marks its root, which
+replaces the whole `bad` closure with an O(1) mark. `dcUnion` links the larger root to the smaller,
+so `par[i] ≤ i` — that is what lets `dcFind` recurse on the strictly decreasing index (no fuel, no
+invariant carried) and what makes flattening a single increasing sweep, after which every root query
+is one array read. The parent array grows on demand, so there is no separate maximum-index pass.
+`denseDropCheck` and the filter are fused into `denseDropGuardedFast` behind a `@[csimp]`: two
+allocation-free scalar walks (`dcAnyVar`, `dcAllVar`) replace all five `vars` reads, and
+`dcAnyVar` alone settles the common case, because an item with no removable variable is kept *and*
+its kept-side obligation `vars.all (!remV)` is the same walk negated. Zero-evaluation is
+`denseEvalZero` over `Encoding.lean`'s primitives, so no `CommRing` chain is built anywhere.
+
+MEASURED (this box, serial, interleaved, 3 reps best-of; sha256 and SP1 keccak single-shot),
+pass / total, against `origin/main`'s binary:
+
+| case | pass | ratio | total | ratio |
+|---|---:|---:|---:|---:|
+| sha256 `apc_001` | 2 331 → **479** | **0.21x** | 37 240 → 34 781 | **0.93x** |
+| wasm-eth `apc_012` | 253 → **40** | 0.16x | 4 655 → 4 397 | 0.94x |
+| wasm-eth `apc_036` | 180 → **34** | 0.19x | 3 889 → 3 699 | 0.95x |
+| keccak `apc_001` | 175 → **37** | 0.21x | 3 413 → 3 258 | 0.96x |
+| SP1 keccak `apc_001` | 53 → **10** | 0.19x | 1 577 → 1 524 | 0.97x |
+| openvm-eth `apc_006` | 21 → **3** | 0.14x | 484 → 466 | 0.96x |
+
+No other pass regressed outside noise. `opt-export` is **byte-identical to `origin/main`** on five
+OpenVM cases and SP1 keccak.
+
+**The proof story is the reusable part: the search cost nothing to replace.** `denseDisconnectedF`
+is `denseDropGuarded_correct bs facts isInput d _`, universally quantified over `remV` — the pass
+*proposes* a removable set and `denseDropCheck` re-checks the partition it induces, so the entire
+connectivity rewrite (72 % of the win, on its own 0.30x) needed **zero** new proof, and deleted
+`denseBuildGraph`/`denseBfsClosure`/`denseConnBad` plus the three termination lemmas
+(`denseProcMem`, `denseFoldOutOfRange`, `denseBfsMeasureDecreasing`, ~85 lines) with them. The only
+new obligation is the `@[csimp]` for the fused re-check (~150 lines), which changes no theorem
+statement; the one gap it bridges is short-circuiting — a failed obligation stops `denseDropCheck`'s
+`&&` early where `dcCheckCs` keeps walking, and both yield `d`.
+
+**Measured dead end:** a first fused re-check used one walk returning a three-bit `UInt8` summary
+(has-a-variable / some-removable / some-not). Same speed (35 vs 37 ms on keccak, identical output),
+~3x the proof — bitmask reasoning against `vars` instead of two `List.any`/`List.all` inductions.
+Two walks win because `dcAnyVar` exits on the first variable of a removed item and is the *only*
+walk on a kept one.
+
+**Worked: yes.**


### PR DESCRIPTION
## What

`disconnected` built a `Std.HashMap VarId (List Nat)` co-occurrence graph and ran **two** breadth-first closures over it — variables reachable from a stateful bus, then variables of any disconnected item the all-zero witness fails on — before re-checking the induced partition and filtering. An `IO` phase probe put the cost at graph 21 %, `conn` BFS 25 %, bad seeds 15 %, `bad` BFS 11 %, re-check + filter 26 % on sha256 `apc_001`: no villain, so a rewrite rather than a hoist.

Two mechanical findings behind that spread:

- `DenseExpr.vars` was materialised **~12 times per constraint per invocation** — once for the graph, twice in the bad-seed fold, twice per `denseKeepConWith` across four `denseDropCheck` call sites, twice in the filter. Each read allocates a cons per occurrence.
- The C sweep flagged `List_foldl___at___00denseConnBad_spec__1/2` rebuilding `ZMod.commRing p → … → toZero` **inside** the bad-seed loop for `decide (c.eval (fun _ => 0) = 0)`, with `denseDropCheck` doing it again.

## How

**Union-find over the hypergraph.** Each item is a hyperedge, so unioning its variables makes an item's whole "are all my variables disconnected" test *one array read*. Stateful interactions join one designated component, which *is* the old `conn` closure; a failing disconnected item marks its root, which replaces the entire `bad` closure with an O(1) mark. `dcUnion` links the larger root to the smaller, so `par[i] ≤ i` — that is what lets `dcFind` recurse on the strictly decreasing index (no fuel, no invariant carried) and what makes flattening a single increasing sweep, after which every root query is one array read. The parent array grows on demand, so there is no separate maximum-index pass.

**A fused, allocation-free re-check** (`denseDropGuardedFast`, behind a `@[csimp]`). Two scalar walks replace all five `vars` reads, and `dcAnyVar` alone settles the common case:

| `vars.any remV` | `vars.all remV` | keep? | obligation |
|---|---|---|---|
| false | — | **kept** | `vars.all (!remV)` = `!any remV` — **the same walk** |
| true | false | kept | obligation is false → the check fails |
| true | true | **removed** | the all-zero witness must zero it |

Zero-evaluation goes through `Encoding.lean`'s primitives (`denseEvalZero`, `zmodIsZero`), so no `CommRing` chain is built anywhere in the pass.

## Proof

**The connectivity search cost nothing to replace.** `denseDisconnectedF_correct` is `denseDropGuarded_correct bs facts isInput d _`, universally quantified over `remV` — the pass *proposes* a removable set and `denseDropCheck` re-checks the partition it induces. So the whole rewrite of the search (72 % of the win; on its own 0.30×) needed **zero** new proof, and deleted `denseBuildGraph`, `denseBfsClosure`, `denseConnBad` and the three termination lemmas (`denseProcMem`, `denseFoldOutOfRange`, `denseBfsMeasureDecreasing`, ~85 lines) with them. The proof file changes by 12 lines, all of them `split_ifs` for the new early-out.

The only new obligation is the `@[csimp]` `denseDropGuarded = denseDropGuardedFast` (~150 lines), which changes no theorem statement. The one gap it bridges is short-circuiting: a failed obligation stops `denseDropCheck`'s `&&` early where `dcCheckCs` keeps walking — both yield `d`, which is all the equality claims. No `sorry`/`implemented_by`; `Scripts/check-proof-integrity.sh` passes and the twin is verified live in the generated C.

## Measured

This box, serial, interleaved, 3 reps best-of; sha256 and SP1 keccak single-shot; against `origin/main`'s binary.

| case | pass | ratio | total | ratio |
|---|---:|---:|---:|---:|
| sha256 `apc_001` | 2 331 → **479** | **0.21×** | 37 240 → 34 781 | **0.93×** |
| wasm-eth `apc_012` | 253 → **40** | 0.16× | 4 655 → 4 397 | 0.94× |
| wasm-eth `apc_036` | 180 → **34** | 0.19× | 3 889 → 3 699 | 0.95× |
| keccak `apc_001` | 175 → **37** | 0.21× | 3 413 → 3 258 | 0.96× |
| SP1 keccak `apc_001` | 53 → **10** | 0.19× | 1 577 → 1 524 | 0.97× |
| openvm-eth `apc_006` | 21 → **3** | 0.14× | 484 → 466 | 0.96× |

No other pass regressed outside noise. **Effectiveness is unchanged by construction** — `opt-export` is byte-identical to `origin/main` on OpenVM keccak, wasm-eth `apc_012` / `apc_036`, openvm-eth `apc_006` / `apc_100` and SP1 keccak. CI arbitrates.

## Dead end recorded

A first fused re-check used one walk returning a three-bit `UInt8` summary (has-a-variable / some-removable / some-not). Same speed (35 vs 37 ms on keccak, identical output), ~3× the proof — bitmask reasoning against `vars` instead of two `List.any`/`List.all` inductions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)