### PR TITLE
perf(rootPairUnify): merge each factor once and tabulate the inverses (0.13-0.53x on the pass, sha256 total 0.97x)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RootPairUnify.lean
@@ -276,7 +276,7 @@ theorem denseRpCheckPair_sound [Fact p.Prime] (bs : BusSemantics p)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.accepts (denseBIEval bi denv)) :
     denv x = denv y := by
-  unfold denseRpCheckPair at h
+  unfold denseRpCheckPair denseRpCheckPairB at h
   cases hxt : denseTwoRootOf? cX x with
   | none => rw [hxt] at h; simp at h
   | some t =>
@@ -314,7 +314,7 @@ theorem denseRpCheckPair_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
     (cX cY : DenseExpr p) (x y : VarId)
     (h : denseRpCheckPair bs facts bis domCs cX cY x y = true) : x ∈ cX.vars ∧ y ∈ cY.vars := by
-  unfold denseRpCheckPair at h
+  unfold denseRpCheckPair denseRpCheckPairB at h
   cases hxt : denseTwoRootOf? cX x with
   | none => rw [hxt] at h; simp at h
   | some t =>
@@ -354,96 +354,98 @@ theorem denseRpInsertAll_seen {S : List (DenseExpr p)} :
       have hacc : ∀ hsh' e', e' ∈ (denseRpInsertAll seen rest).getD hsh' [] → e'.c ∈ S :=
         ih seen hseen (fun e' he' => hes e' (List.mem_cons_of_mem _ he'))
       have hstep : denseRpInsertAll seen (e0 :: rest)
-          = (denseRpInsertAll seen rest).insert (denseRpKeyHash e0.key)
-              (e0 :: (denseRpInsertAll seen rest).getD (denseRpKeyHash e0.key) []) := by
+          = (denseRpInsertAll seen rest).insert e0.h
+              (e0 :: (denseRpInsertAll seen rest).getD e0.h []) := by
         simp only [denseRpInsertAll, List.foldr_cons]
       rw [hstep, Std.HashMap.getD_insert] at hmem
       split_ifs at hmem with hk
       · rcases List.mem_cons.1 hmem with rfl | hmem'
         · exact hes e (List.mem_cons_self ..)
-        · exact hacc (denseRpKeyHash e0.key) e hmem'
+        · exact hacc e0.h e hmem'
       · exact hacc hsh e hmem
 
-/-- **The scan loop is sound**: the final solution map is entailed (a) and occurrence-closed (b).
+/-- **The scan is sound**: the final solution map is entailed (a) and occurrence-closed (b).
     The certificate (`denseRpCheckPair_sound`) forces each adopted `x = y` on satisfying
-    assignments; the bucketed `seen` scan is proof-free, its membership recovered by
-    `denseRpInsertAll_seen`. -/
-theorem denseRpLoop_sound [Fact p.Prime] (bs : BusSemantics p)
+    assignments; candidate preparation, the bucket hash and the key match are proof-free, the
+    entries' constraint membership recovered by `denseRpInsertAll_seen`. -/
+theorem denseRpScan_sound [Fact p.Prime] (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
-    ∀ (pending : List (DenseExpr p)) (seen : Std.HashMap UInt64 (List (DenseRPSeen p)))
-      (σ : DenseSolved p),
-      (∀ c ∈ pending, c ∈ d.algebraicConstraints) →
+    ∀ (groups : List (List (DenseRPSeen p)))
+      (seen : Std.HashMap UInt64 (List (DenseRPSeen p))) (σ : DenseSolved p),
+      (∀ g ∈ groups, ∀ e ∈ g, e.c ∈ d.algebraicConstraints) →
       (∀ hsh e, e ∈ seen.getD hsh [] → e.c ∈ d.algebraicConstraints) →
       (∀ denv, d.satisfies bs denv → ∀ i t, σ.fn i = some t → denv i = t.eval denv) →
       (∀ i t, σ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
       (∀ denv, d.satisfies bs denv → ∀ i t,
-          (denseRpLoop bs facts d.busInteractions d.algebraicConstraints pending seen σ).fn i
-            = some t → denv i = t.eval denv) ∧
-      (∀ i t, (denseRpLoop bs facts d.busInteractions d.algebraicConstraints pending seen σ).fn i
-          = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
-  intro pending
-  induction pending with
+          (denseRpScan (denseAnyVarBound bs facts d.busInteractions d.algebraicConstraints)
+              groups seen σ).fn i = some t → denv i = t.eval denv) ∧
+      (∀ i t, (denseRpScan (denseAnyVarBound bs facts d.busInteractions d.algebraicConstraints)
+          groups seen σ).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
+  intro groups
+  induction groups with
   | nil =>
       intro seen σ _ _ hσs hσv
       exact ⟨hσs, hσv⟩
-  | cons c rest ih =>
-      intro seen σ hpend hseen hσs hσv
-      have hcmem : c ∈ d.algebraicConstraints := hpend c (List.mem_cons_self ..)
-      have hrest : ∀ c' ∈ rest, c' ∈ d.algebraicConstraints :=
-        fun c' h' => hpend c' (List.mem_cons_of_mem _ h')
-      rw [denseRpLoop]
-      cases hf : (denseRpCandidates c).findSome? (fun xk =>
-          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-            if e.key == xk.2 && e.x != xk.1 &&
-                denseRpCheckPair bs facts d.busInteractions d.algebraicConstraints e.c c e.x xk.1
-            then some (e, xk.1) else none)) with
+  | cons g rest ih =>
+      intro seen σ hgroups hseen hσs hσv
+      have hgmem : ∀ e ∈ g, e.c ∈ d.algebraicConstraints :=
+        hgroups g (List.mem_cons_self ..)
+      have hrest : ∀ g' ∈ rest, ∀ e ∈ g', e.c ∈ d.algebraicConstraints :=
+        fun g' h' => hgroups g' (List.mem_cons_of_mem _ h')
+      rw [denseRpScan]
+      cases hf : g.findSome? (fun cand =>
+          (seen.getD cand.h []).findSome? (fun e =>
+            if denseRpKeyEq e cand && !(e.x.index == cand.x.index) &&
+                denseRpBoundGate (denseAnyVarBound bs facts d.busInteractions
+                  d.algebraicConstraints) e cand &&
+                denseRpCheckPairB (denseAnyVarBound bs facts d.busInteractions
+                  d.algebraicConstraints) e.c cand.c e.x cand.x
+            then some (e, cand.x) else none)) with
       | none =>
           simp only []
           refine ih _ σ hrest ?_ hσs hσv
-          refine denseRpInsertAll_seen _ seen hseen ?_
-          intro e he
-          obtain ⟨xk, _hxk, rfl⟩ := List.mem_map.1 he
-          exact hcmem
+          exact denseRpInsertAll_seen _ seen hseen hgmem
       | some ex =>
           simp only []
-          obtain ⟨xk, _hxkmem, hinner⟩ := List.exists_of_findSome?_eq_some hf
+          obtain ⟨cand, hcandmem, hinner⟩ := List.exists_of_findSome?_eq_some hf
           obtain ⟨e, hemem, hif⟩ := List.exists_of_findSome?_eq_some hinner
-          by_cases hcnd : (e.key == xk.2 && e.x != xk.1 &&
-              denseRpCheckPair bs facts d.busInteractions d.algebraicConstraints e.c c e.x xk.1)
-              = true
+          by_cases hcnd : (denseRpKeyEq e cand && !(e.x.index == cand.x.index) &&
+              denseRpBoundGate (denseAnyVarBound bs facts d.busInteractions
+                d.algebraicConstraints) e cand &&
+              denseRpCheckPairB (denseAnyVarBound bs facts d.busInteractions
+                d.algebraicConstraints) e.c cand.c e.x cand.x) = true
           · rw [if_pos hcnd] at hif
             simp only [Option.some.injEq] at hif
             subst hif
-            rw [Bool.and_eq_true, Bool.and_eq_true] at hcnd
+            rw [Bool.and_eq_true] at hcnd
             have hcert : denseRpCheckPair bs facts d.busInteractions d.algebraicConstraints
-                e.c c e.x xk.1 = true := hcnd.2
-            have hecmem : e.c ∈ d.algebraicConstraints := hseen (denseRpKeyHash xk.2) e hemem
-            obtain ⟨hexv, _hxkv⟩ := denseRpCheckPair_vars bs facts d.busInteractions
-              d.algebraicConstraints e.c c e.x xk.1 hcert
+                e.c cand.c e.x cand.x = true := hcnd.2
+            have hecmem : e.c ∈ d.algebraicConstraints := hseen cand.h e hemem
+            have hcandmem' : cand.c ∈ d.algebraicConstraints := hgmem cand hcandmem
+            obtain ⟨hexv, _hcandv⟩ := denseRpCheckPair_vars bs facts d.busInteractions
+              d.algebraicConstraints e.c cand.c e.x cand.x hcert
             have hexocc : e.x ∈ d.occ := DenseConstraintSystem.mem_occ_of_constraint hecmem hexv
-            have hfn : ∀ i, (σ.insertAll [((e, xk.1).2, DenseExpr.var (e, xk.1).1.x)]).fn i
-                = (σ.map.insert xk.1 (DenseExpr.var e.x))[i]? := by
+            have hfn : ∀ i, (σ.insertAll [((e, cand.x).2, DenseExpr.var (e, cand.x).1.x)]).fn i
+                = (σ.map.insert cand.x (DenseExpr.var e.x))[i]? := by
               intro i
-              show (σ.insertAll [(xk.1, DenseExpr.var e.x)]).map[i]? = _
+              show (σ.insertAll [(cand.x, DenseExpr.var e.x)]).map[i]? = _
               rw [DenseSolved.insertAll_map]; rfl
             refine ih _ _ hrest ?_ ?_ ?_
-            · -- `seen` invariant preservation
-              refine denseRpInsertAll_seen _ seen hseen ?_
+            · refine denseRpInsertAll_seen _ seen hseen ?_
               intro e' he'
-              obtain ⟨xk', _hxk', rfl⟩ := List.mem_map.1 he'
-              exact hcmem
+              exact hgmem e' (List.mem_of_mem_filter he')
             · -- (a) entailment of the updated map
               intro denv hsat i t hti
               rw [hfn, Std.HashMap.getElem?_insert] at hti
               split_ifs at hti with hik
-              · have hi : xk.1 = i := by simpa using hik
+              · have hi : cand.x = i := by simpa using hik
                 simp only [Option.some.injEq] at hti
                 subst hti
                 subst hi
                 have heq := denseRpCheckPair_sound bs facts d.busInteractions
-                  d.algebraicConstraints e.c c e.x xk.1 hcert denv
-                  hsat.1 (hsat.1 e.c hecmem) (hsat.1 c hcmem) hsat.2
-                show denv xk.1 = denv e.x
+                  d.algebraicConstraints e.c cand.c e.x cand.x hcert denv
+                  hsat.1 (hsat.1 e.c hecmem) (hsat.1 cand.c hcandmem') hsat.2
+                show denv cand.x = denv e.x
                 exact heq.symm
               · exact hσs denv hsat i t hti
             · -- (b) occurrence closure of the updated map
@@ -459,31 +461,108 @@ theorem denseRpLoop_sound [Fact p.Prime] (bs : BusSemantics p)
           · rw [if_neg hcnd] at hif
             exact absurd hif (by simp)
 
+/-! ## Prepared candidates come from the system's constraints
+
+The only thing the scan's soundness needs from candidate preparation (`denseRpPres` and the
+root-gap filter): every bucketed entry's constraint is one of `d`'s. Everything else about a
+candidate — its key, its bucket hash, its gap — is re-derived by `denseRpCheckPair` for the pair it
+proposes, so it carries no obligation. -/
+
+/-- The root-gap filter keeps a candidate's constraint data. -/
+private theorem denseRpGroupOf_src (ops : DenseZModOps p) (inv : Std.HashMap Nat (ZMod p))
+    (src : DenseRpSrc p) :
+    ∀ (cands : List (VarId × ZMod p)) (e : DenseRPSeen p),
+      e ∈ denseRpGroupOf ops inv src cands → e.src = src := by
+  intro cands
+  induction cands with
+  | nil => intro e he; simp [denseRpGroupOf] at he
+  | cons t rest ih =>
+      intro e he
+      obtain ⟨v, k⟩ := t
+      rw [denseRpGroupOf] at he
+      cases hat : denseRpCandAt ops inv src v k with
+      | none => rw [hat] at he; exact ih e he
+      | some e0 =>
+          rw [hat] at he
+          have he0 : e0.src = src := by
+            simp only [denseRpCandAt, Option.ite_none_right_eq_some, Option.some.injEq] at hat
+            rw [← hat.2]
+          rcases List.mem_cons.1 he with rfl | he'
+          · exact he0
+          · exact ih e he'
+
+/-- Every group's entries come from one prepared constraint. -/
+private theorem denseRpGroupsOf_mem (ops : DenseZModOps p) (inv : Std.HashMap Nat (ZMod p)) :
+    ∀ (pres : List (DenseRpPre p)) (g : List (DenseRPSeen p)),
+      g ∈ denseRpGroupsOf ops inv pres →
+      ∃ pre ∈ pres, ∀ e ∈ g, e.src = pre.src := by
+  intro pres
+  induction pres with
+  | nil => intro g hg; simp [denseRpGroupsOf] at hg
+  | cons pre rest ih =>
+      intro g hg
+      rw [denseRpGroupsOf] at hg
+      cases hgo : denseRpGroupOf ops inv pre.src pre.cands with
+      | nil => rw [hgo] at hg
+               obtain ⟨pre', hpre', hall⟩ := ih g hg
+               exact ⟨pre', List.mem_cons_of_mem _ hpre', hall⟩
+      | cons e0 es =>
+          rw [hgo] at hg
+          rcases List.mem_cons.1 hg with rfl | hg'
+          · refine ⟨pre, List.mem_cons_self .., fun e he => ?_⟩
+            exact denseRpGroupOf_src ops inv pre.src pre.cands e (hgo ▸ he)
+          · obtain ⟨pre', hpre', hall⟩ := ih g hg'
+            exact ⟨pre', List.mem_cons_of_mem _ hpre', hall⟩
+
+/-- Every prepared constraint is one of the input constraints. -/
+private theorem denseRpPres_mem (ops : DenseZModOps p) :
+    ∀ (all : List (DenseExpr p)) (pre : DenseRpPre p),
+      pre ∈ denseRpPres ops all → pre.src.c ∈ all := by
+  intro all
+  induction all with
+  | nil => intro pre hpre; simp [denseRpPres] at hpre
+  | cons c rest ih =>
+      intro pre hpre
+      rw [denseRpPres] at hpre
+      cases hdata : denseRpDataOf ops c with
+      | none => rw [hdata] at hpre; exact List.mem_cons_of_mem _ (ih pre hpre)
+      | some data =>
+          obtain ⟨terms, cands, aconst, δ⟩ := data
+          rw [hdata] at hpre
+          rcases List.mem_cons.1 hpre with rfl | hpre'
+          · exact List.mem_cons_self ..
+          · exact List.mem_cons_of_mem _ (ih pre hpre')
+
+/-- Every prepared candidate's constraint is one of the system's. -/
+theorem denseRpLiveGroups_mem (all : List (DenseExpr p)) :
+    ∀ g ∈ denseRpLiveGroups (denseRpGroups denseZModOps all), ∀ e ∈ g, e.c ∈ all := by
+  intro g hg e he
+  have hgs : g ∈ denseRpGroups denseZModOps all := List.mem_of_mem_filter hg
+  obtain ⟨pre, hpre, hall⟩ := denseRpGroupsOf_mem denseZModOps _ _ g hgs
+  have : e.c = pre.src.c := by rw [DenseRPSeen.c, hall e he]
+  rw [this]
+  exact denseRpPres_mem denseZModOps all pre hpre
+
 /-! ## The dense `rootPairUnify` pass -/
 
-/-- The dense `rootPairUnify` transform re-expressed with the loop's solution map named, for the
+/-- The dense `rootPairUnify` transform re-expressed with the scan's solution map named, for the
     correctness/coverage proofs. -/
 theorem denseRootPairUnifyF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     denseRootPairUnifyF pw bs facts d
       = (if pw.isPrime = true then
-          (if (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
-                d.algebraicConstraints ∅ DenseSolved.empty).map.isEmpty then d
-           else d.substF (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
-                d.algebraicConstraints ∅ DenseSolved.empty).fn)
+          (if (denseRpSigma bs facts d).map.isEmpty then d
+           else d.substF (denseRpSigma bs facts d).fn)
          else d) := rfl
 
-/-- The final loop solution map is entailed and occurrence-closed (specializing `denseRpLoop_sound`
-    to the pass's initial `∅`/`empty` accumulators). -/
+/-- The final scan solution map is entailed and occurrence-closed. -/
 theorem denseRootPairUnify_loop_invariant [Fact p.Prime] (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     (∀ denv, d.satisfies bs denv → ∀ i t,
-        (denseRpLoop bs facts d.busInteractions d.algebraicConstraints d.algebraicConstraints ∅
-          DenseSolved.empty).fn i = some t → denv i = t.eval denv) ∧
-    (∀ i t, (denseRpLoop bs facts d.busInteractions d.algebraicConstraints d.algebraicConstraints ∅
-        DenseSolved.empty).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
-  refine denseRpLoop_sound bs facts d d.algebraicConstraints ∅ DenseSolved.empty
-    (fun _ h => h) ?_ ?_ ?_
+        (denseRpSigma bs facts d).fn i = some t → denv i = t.eval denv) ∧
+    (∀ i t, (denseRpSigma bs facts d).fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
+  refine denseRpScan_sound bs facts d _ ∅ DenseSolved.empty
+    (denseRpLiveGroups_mem d.algebraicConstraints) ?_ ?_ ?_
   · intro hsh e hmem
     rw [Std.HashMap.getD_empty] at hmem
     exact absurd hmem (by simp)
@@ -943,86 +1022,40 @@ private theorem denseAnyVarBoundIdx_eq (bs : BusSemantics p) (facts : BusFacts p
               (fun v => denseFindDomainAlg domCs v) bi x hp1 B ?_)
             rw [denseScaledSlotBoundD_eq bs facts domCs _ (fun _ => rfl) bi x, hb])
 
-/-- The indexed pair certificate answers exactly the scanning one. -/
-private theorem denseRpCheckPairIdx_eq (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
-    (dom : VarId → Option (List (ZMod p)))
-    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v)
-    (hp1 : (1 : ZMod p) ≠ 0) (cX cY : DenseExpr p) (x y : VarId) :
-    denseRpCheckPairIdx bs facts (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom
-        cX cY x y
-      = denseRpCheckPair bs facts bis domCs cX cY x y := by
-  unfold denseRpCheckPairIdx denseRpCheckPair
-  rw [denseAnyVarBoundIdx_eq bs facts bis domCs dom hdom hp1 x,
-    denseAnyVarBoundIdx_eq bs facts bis domCs dom hdom hp1 y]
-
-/-- The indexed scan loop computes the same solution map. -/
-private theorem denseRpLoopIdx_eq (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
-    (dom : VarId → Option (List (ZMod p)))
-    (hdom : ∀ v, dom v = denseFindDomainAlg domCs v)
-    (hp1 : (1 : ZMod p) ≠ 0) :
-    ∀ (cs : List (DenseExpr p)) (seen : Std.HashMap UInt64 (List (DenseRPSeen p)))
-      (σ : DenseSolved p),
-      denseRpLoopIdx bs facts (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom
-          cs seen σ
-        = denseRpLoop bs facts bis domCs cs seen σ := by
-  intro cs
-  induction cs with
-  | nil => intro seen σ; rfl
-  | cons c rest ih =>
-      intro seen σ
-      have hfind : (denseRpCandidates c).findSome? (fun xk =>
-          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-            if e.key == xk.2 && e.x != xk.1 &&
-                denseRpCheckPairIdx bs facts
-                  (denseVarBucketLookup (denseVarBucket denseBIVars bis)) dom e.c c e.x xk.1
-            then some (e, xk.1) else none))
-          = (denseRpCandidates c).findSome? (fun xk =>
-          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-            if e.key == xk.2 && e.x != xk.1 &&
-                denseRpCheckPair bs facts bis domCs e.c c e.x xk.1
-            then some (e, xk.1) else none)) := by
-        refine findSome?_congr' _ (fun xk _ => findSome?_congr' _ (fun e _ => ?_))
-        rw [denseRpCheckPairIdx_eq bs facts bis domCs dom hdom hp1]
-      simp only [denseRpLoopIdx, denseRpLoop]
-      rw [hfind]
-      cases (denseRpCandidates c).findSome? (fun xk =>
-          (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-            if e.key == xk.2 && e.x != xk.1 &&
-                denseRpCheckPair bs facts bis domCs e.c c e.x xk.1
-            then some (e, xk.1) else none)) with
-      | some ex => exact ih _ _
-      | none => exact ih _ _
-
-/-- The pass with indexed lookups, installed as `denseRootPairUnifyF`'s compiled body. -/
+/-- The pass with indexed lookups, installed as `denseRootPairUnifyF`'s compiled body. The scan
+    takes its bound lookup as a function, so the indexed answers being pointwise equal
+    (`denseAnyVarBoundIdx_eq`) makes the two bodies the same term. -/
 @[csimp] theorem denseRootPairUnifyF_eq_fast :
     @denseRootPairUnifyF = @denseRootPairUnifyFFast := by
   funext p pw bs facts d
   by_cases hp : pw.isPrime = true
   · haveI : Fact p.Prime := ⟨pw.correct hp⟩
-    have hp1 : (1 : ZMod p) ≠ 0 := one_ne_zero
-    have hloop := denseRpLoopIdx_eq bs facts d.busInteractions d.algebraicConstraints
-      (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
-      (fun v => denseFindDomainMap_getElem? d.algebraicConstraints v) hp1
-      d.algebraicConstraints ∅ DenseSolved.empty
+    have hbnd : (fun x => denseAnyVarBoundIdx bs facts
+          (fun v => denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions) v)
+          (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?) x)
+        = denseAnyVarBound bs facts d.busInteractions d.algebraicConstraints := by
+      funext x
+      exact denseAnyVarBoundIdx_eq bs facts d.busInteractions d.algebraicConstraints
+        (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
+        (fun v => denseFindDomainMap_getElem? d.algebraicConstraints v) one_ne_zero x
     show (if pw.isPrime = true then
-        if (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
-            d.algebraicConstraints ∅ DenseSolved.empty).map.isEmpty then d
-        else d.substF (denseRpLoop bs facts d.busInteractions d.algebraicConstraints
-            d.algebraicConstraints ∅ DenseSolved.empty).fn
+        (if (denseRpSigma bs facts d).map.isEmpty then d
+         else d.substF (denseRpSigma bs facts d).fn)
       else d)
       = (if pw.isPrime = true then
-        if (denseRpLoopIdx bs facts
-            (denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions))
-            (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
-            d.algebraicConstraints ∅ DenseSolved.empty).map.isEmpty then d
-        else d.substF (denseRpLoopIdx bs facts
-            (denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions))
-            (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?)
-            d.algebraicConstraints ∅ DenseSolved.empty).fn
+        (if (denseRpScan (fun x => denseAnyVarBoundIdx bs facts
+              (fun v => denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions) v)
+              (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?) x)
+            (denseRpLiveGroups (denseRpGroups denseZModOps d.algebraicConstraints)) ∅
+            DenseSolved.empty).map.isEmpty then d
+         else d.substF (denseRpScan (fun x => denseAnyVarBoundIdx bs facts
+              (fun v => denseVarBucketLookup (denseVarBucket denseBIVars d.busInteractions) v)
+              (fun v => (denseFindDomainMap d.algebraicConstraints)[v]?) x)
+            (denseRpLiveGroups (denseRpGroups denseZModOps d.algebraicConstraints)) ∅
+            DenseSolved.empty).fn)
       else d)
-    rw [hloop]
+    rw [hbnd]
+    rfl
   · show (if pw.isPrime = true then _ else d) = (if pw.isPrime = true then _ else d)
     rw [if_neg hp, if_neg hp]
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/RootPairUnify.lean
@@ -143,130 +143,283 @@ def denseAnyVarBound (bs : BusSemantics p) (facts : BusFacts p bs)
 /-! ## The pair certificate (dense) -/
 
 /-- Decidable certificate that constraints `cX` (in `x`) and `cY` (in `y`) are two-root twins and
-    both variables are range-bounded below the root gap. -/
-def denseRpCheckPair (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
-    (cX cY : DenseExpr p) (x y : VarId) : Bool :=
+    both variables are range-bounded below the root gap, with the two value bounds served by
+    `bnd` (`denseRpCheckPair` instantiates it with the scanning lookup). -/
+def denseRpCheckPairB (bnd : VarId → Option Nat) (cX cY : DenseExpr p) (x y : VarId) : Bool :=
   match denseTwoRootOf? cX x, denseTwoRootOf? cY y with
   | some (k, A, δ), some (k', A', δ') =>
     decide (k' = k) && decide (A'.terms = A.terms) && decide (A'.const = A.const) &&
     decide (δ' = δ) && decide (k * k⁻¹ = 1) &&
     decide (x ∈ cX.vars) && decide (y ∈ cY.vars) &&
-    (match denseAnyVarBound bs facts bis domCs x, denseAnyVarBound bs facts bis domCs y with
+    (match bnd x, bnd y with
      | some Bx, some By =>
        decide (max Bx By ≤ (k⁻¹ * δ).val) && decide (max Bx By ≤ p - (k⁻¹ * δ).val)
      | _, _ => false)
   | _, _ => false
 
-/-! ## The scan loop and the pass (dense) -/
+/-- The pair certificate with both bounds derived by scanning the full interaction list. -/
+def denseRpCheckPair (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p))
+    (cX cY : DenseExpr p) (x y : VarId) : Bool :=
+  denseRpCheckPairB (denseAnyVarBound bs facts bis domCs) cX cY x y
 
-/-- A previously seen two-root constraint: the constraint, its variable, and the matching key
-    `(k, A.terms, A.const, δ)`. Keys are compared before the expensive certificate is attempted. -/
-structure DenseRPSeen (p : ℕ) where
+/-! ## Candidate preparation (dense)
+
+A two-root candidate is a `(constraint, variable)` pair whose key `(k, A.terms, A.const, δ)` is
+matched against earlier candidates' keys. Both factors are merged **once** per constraint and each
+candidate reads its data off the merged pair: for a linearized factor `l`,
+`(l.others x).norm.terms` is exactly `(merge l.terms) \ x` — `denseMergeTerms` keeps
+first-occurrence order, so filtering before or after the merge gives the same list. Nothing here is
+trusted; `denseRpCheckPairB` re-derives every proposed pair's two-root data. -/
+
+/-- No entry of `ts` carries `v`. -/
+def denseRpNoVar (v : VarId) : List (VarId × ZMod p) → Bool
+  | [] => true
+  | (w, _) :: rest => !(w.index == v.index) && denseRpNoVar v rest
+
+/-- Whether a term list is already a normal form: distinct variables, no zero coefficient. Checking
+    this costs index compares only, where the general merge allocates a list per term. -/
+def denseRpTermsClean : List (VarId × ZMod p) → Bool
+  | [] => true
+  | (v, c) :: rest => !(c.val == 0) && denseRpNoVar v rest && denseRpTermsClean rest
+
+/-- The normal form of a linearized factor's terms, sharing the input when it is already normal. -/
+def denseRpMerged (ops : DenseZModOps p) (ts : List (VarId × ZMod p)) : List (VarId × ZMod p) :=
+  if denseRpTermsClean ts then ts else denseDropZeroWith ops (denseMergeTermsWith ops ts)
+
+/-- The coefficient `x` carries in a normal form. -/
+def denseRpCoeffIn : List (VarId × ZMod p) → VarId → Option (ZMod p)
+  | [], _ => none
+  | (v, c) :: rest, x => if v.index == x.index then some c else denseRpCoeffIn rest x
+
+/-- Whether `l1 \ x` and `l2 \ y` are equal, by one simultaneous walk skipping each side's own
+    candidate entry (the offset-form comparison behind a key match). -/
+def denseRpSkipEq : List (VarId × ZMod p) → VarId → List (VarId × ZMod p) → VarId → Bool
+  | [], _, [], _ => true
+  | (v, c) :: r1, x, l2, y =>
+      if v.index == x.index then denseRpSkipEq r1 x l2 y
+      else match l2 with
+        | [] => false
+        | (w, dd) :: r2 =>
+            if w.index == y.index then denseRpSkipEq ((v, c) :: r1) x r2 y
+            else v.index == w.index && c.val == dd.val && denseRpSkipEq r1 x r2 y
+  | [], x, (w, _) :: r2, y => if w.index == y.index then denseRpSkipEq [] x r2 y else false
+  termination_by l1 _ l2 _ => l1.length + l2.length
+
+/-- `none` when the two normal forms are identical — every variable is a candidate; otherwise the
+    at most two variables a candidate can still be. Entries before the first difference are equal,
+    so removing a variable occurring there removes the same position from both lists and leaves the
+    difference in place: only the differing position's own variables can qualify. -/
+def denseRpDiffVars : List (VarId × ZMod p) → List (VarId × ZMod p) → Option (List VarId)
+  | [], [] => none
+  | (v, c) :: r1, (w, dd) :: r2 =>
+      if v.index == w.index then
+        (if c.val == dd.val then denseRpDiffVars r1 r2 else some [v])
+      else some [v, w]
+  | (v, _) :: _, [] => some [v]
+  | [], (w, _) :: _ => some [w]
+
+/-- A candidate's shared per-constraint data: the constraint, the first factor's normal form (the
+    key's offset terms with `x` still in), the key's constant and root offset, and a multiset hash
+    of the terms, from which each candidate's bucket hash is one subtraction. -/
+structure DenseRpSrc (p : ℕ) where
   c : DenseExpr p
+  terms : List (VarId × ZMod p)
+  aconst : ZMod p
+  δ : ZMod p
+  tsum : UInt64
+
+/-- A candidate, and once bucketed a previously seen one: its constraint's shared data, its
+    variable and coefficient, its bucket hash, and the root gap `g = k⁻¹·δ` as the two `Nat` bounds
+    the certificate compares against. -/
+structure DenseRPSeen (p : ℕ) where
+  src : DenseRpSrc p
   x : VarId
-  key : ZMod p × List (VarId × ZMod p) × ZMod p × ZMod p
+  k : ZMod p
+  h : UInt64
+  gval : Nat
+  gco : Nat
 
-/-- The two-root candidates of one constraint, with their matching keys. Candidates whose root gap
-    `g = k⁻¹·δ` is tiny are dropped up front: the pair condition `B ≤ min(g.val, p − g.val)` can
-    never hold for a useful bound `B`, and booleanity constraints `b(b−1) = 0` would otherwise make
-    every boolean variable a (never-unifiable, expensive-to-reject) candidate. -/
-def denseRpCandidates (c : DenseExpr p) :
-    List (VarId × (ZMod p × List (VarId × ZMod p) × ZMod p × ZMod p)) :=
-  -- Both factors are linearized once (not per candidate variable); each `x` reads its coefficient
-  -- and x-free part off the shared linear forms — exactly `denseTwoRootOf?`'s values.
-  match c with
-  | .mul f1 f2 =>
-    (match denseLinearize f1, denseLinearize f2 with
-     | some l1, some l2 =>
-       (HashedDedup.hashedEraseDups (hash ·) c.vars).filterMap (fun x =>
-         let k := l1.coeff x
-         let A := (l1.others x).norm
-         let A2 := (l2.others x).norm
-         if k ≠ 0 ∧ l2.coeff x = k ∧ A2.terms = A.terms then
-           let δ := A2.const - A.const
-           if 256 ≤ min (k⁻¹ * δ).val (p - (k⁻¹ * δ).val) then
-             some (x, (k, A.terms, A.const, δ))
-           else none
-         else none)
-     | _, _ => [])
-  | _ => []
+/-- The constraint a candidate came from. -/
+def DenseRPSeen.c (e : DenseRPSeen p) : DenseExpr p := e.src.c
 
-/-- One `DenseZModOps p` above the candidate scan: each variable otherwise derives six instance
-    chains (two coefficients, two normal forms, the zero test and the `k⁻¹ · δ` product). -/
-def denseRpCandidatesWith (ops : DenseZModOps p) (c : DenseExpr p) :
-    List (VarId × (ZMod p × List (VarId × ZMod p) × ZMod p × ZMod p)) :=
+/-- Hash of one term of a key's offset form. -/
+def denseRpTermHash (v : VarId) (c : ZMod p) : UInt64 := mixHash (hash v.index) (hash c.val)
+
+/-- Multiset hash of a term list: a sum, so dropping the candidate's own term is a subtraction. -/
+def denseRpTermsSum : List (VarId × ZMod p) → UInt64
+  | [] => 0
+  | (v, c) :: rest => denseRpTermHash v c + denseRpTermsSum rest
+
+/-- Bucket hash of the key `(k, A.terms, A.const, δ)`, `asum` being `A.terms`' multiset hash.
+    Bucketing never hides a twin — equal keys hash equal — and the scan's exact test separates
+    collisions. -/
+def denseRpBucketHash (k aconst δ : ZMod p) (asum : UInt64) : UInt64 :=
+  mixHash (hash k.val) (mixHash (hash aconst.val) (mixHash (hash δ.val) asum))
+
+/-- The candidate variables of one constraint, with their coefficients: `cands` is the first
+    factor's own normal form when the two forms agreed (shared, not rebuilt). -/
+structure DenseRpPre (p : ℕ) where
+  src : DenseRpSrc p
+  cands : List (VarId × ZMod p)
+
+/-- The candidate variable and coefficient for one explicitly proposed variable: it must carry the
+    same coefficient in both normal forms, which must agree away from it. -/
+def denseRpCandOne (terms n2 : List (VarId × ZMod p)) (x : VarId) : Option (VarId × ZMod p) :=
+  match denseRpCoeffIn terms x, denseRpCoeffIn n2 x with
+  | some k, some k2 =>
+      if k.val == k2.val && denseRpSkipEq terms x n2 x then some (x, k) else none
+  | _, _ => none
+
+/-- One constraint's two-root data: the first factor's normal form, the candidate variables with
+    their coefficients, the key's constant and the root offset. A product of two affine factors
+    whose normal forms differ only in their constant contributes one candidate per variable; a
+    nonzero constant gap `δ` is necessary (the root gap `k⁻¹·δ` would otherwise be `0`), and is
+    checked before merging. -/
+def denseRpDataOf (ops : DenseZModOps p) (c : DenseExpr p) :
+    Option (List (VarId × ZMod p) × List (VarId × ZMod p) × ZMod p × ZMod p) :=
   match c with
   | .mul f1 f2 =>
     (match denseLinearizeWith ops f1, denseLinearizeWith ops f2 with
      | some l1, some l2 =>
-       (HashedDedup.hashedEraseDups (hash ·) c.vars).filterMap (fun x =>
-         let k := denseCoeffSumWith ops x l1.terms
-         let A := (l1.others x).normWith ops
-         let A2 := (l2.others x).normWith ops
-         if k ≠ ops.zero ∧ denseCoeffSumWith ops x l2.terms = k ∧ A2.terms = A.terms then
-           let δ := A2.const - A.const
-           if 256 ≤ min (ops.mul k⁻¹ δ).val (p - (ops.mul k⁻¹ δ).val) then
-             some (x, (k, A.terms, A.const, δ))
-           else none
-         else none)
-     | _, _ => [])
-  | _ => []
+       let δ := ops.add l2.const (ops.mul ops.negOne l1.const)
+       if δ.val == 0 then none else
+       let n1 := denseRpMerged ops l1.terms
+       let n2 := denseRpMerged ops l2.terms
+       match denseRpDiffVars n1 n2 with
+       | none => if n1.isEmpty then none else some (n1, n1, l1.const, δ)
+       | some vs =>
+         match vs.filterMap (denseRpCandOne n1 n2) with
+         | [] => none
+         | cands => some (n1, cands, l1.const, δ)
+     | _, _ => none)
+  | _ => none
 
-def denseRpCandidatesFast (c : DenseExpr p) :
-    List (VarId × (ZMod p × List (VarId × ZMod p) × ZMod p × ZMod p)) :=
-  denseRpCandidatesWith denseZModOps c
+/-- Every constraint's candidate variables, in source order. -/
+def denseRpPres (ops : DenseZModOps p) : List (DenseExpr p) → List (DenseRpPre p)
+  | [] => []
+  | c :: rest =>
+    match denseRpDataOf ops c with
+    | some (terms, cands, aconst, δ) =>
+        (⟨⟨c, terms, aconst, δ, denseRpTermsSum terms⟩, cands⟩ : DenseRpPre p) ::
+          denseRpPres ops rest
+    | none => denseRpPres ops rest
 
-theorem denseRpCandidatesWith_eq (ops : DenseZModOps p) (c : DenseExpr p) :
-    denseRpCandidatesWith ops c = denseRpCandidates c := by
-  simp only [denseRpCandidatesWith, denseRpCandidates, denseLinearizeWith_eq,
-    DenseLinExpr.coeff, denseCoeffSumWith_eq, DenseLinExpr.normWith_eq, ops.zero_eq, ops.mul_eq]
+/-! ### Root gaps
 
-@[csimp] theorem denseRpCandidates_eq_fast :
-    @denseRpCandidates = @denseRpCandidatesFast := by
-  funext p c
-  exact (denseRpCandidatesWith_eq denseZModOps c).symm
+A candidate's root gap `g = k⁻¹·δ` decides whether it can ever be unified: the pair condition
+`B ≤ min(g.val, p − g.val)` cannot hold for a useful bound `B` when the gap is tiny, and booleanity
+constraints `b(b−1) = 0` would otherwise make every boolean variable a (never-unifiable,
+expensive-to-reject) candidate. `ZMod`'s `Inv` is an extended gcd — the single most expensive
+operation in the pass — and a coefficient repeats across every constraint of the same instruction
+shape, so the inverses are tabulated once per invocation by value. -/
 
-/-- Content hash of a two-root key's offset form. Hashing the terms rather than their count keeps
-    key-unequal candidates out of each other's buckets, so the scan's exact `key == key'` test is
-    reached once per genuine twin instead of once per same-arity candidate. -/
-def denseRpTermsHash : List (VarId × ZMod p) → UInt64
-  | [] => 0x9e3779b97f4a7c15
-  | (v, c) :: rest => mixHash (mixHash (hash v.index) (hash c.val)) (denseRpTermsHash rest)
+/-- One inverse per distinct candidate coefficient. -/
+def denseRpInvTable (pres : List (DenseRpPre p)) : Std.HashMap Nat (ZMod p) :=
+  pres.foldl (fun m pre =>
+    pre.cands.foldl (fun m t =>
+      if m.contains t.2.val then m else m.insert t.2.val t.2⁻¹) m) ∅
 
-/-- Hash of a candidate key, used to bucket the `seen` accumulator (bucketing never hides a twin;
-    the exact `key == key'` check inside the scan separates any hash collision). -/
-def denseRpKeyHash (key : ZMod p × List (VarId × ZMod p) × ZMod p × ZMod p) : UInt64 :=
-  mixHash (hash key.1.val)
-    (mixHash (hash key.2.2.1.val) (mixHash (hash key.2.2.2.val) (denseRpTermsHash key.2.1)))
+/-- The candidate record for `x` with coefficient `k`, unless its root gap is tiny. -/
+def denseRpCandAt (ops : DenseZModOps p) (inv : Std.HashMap Nat (ZMod p)) (src : DenseRpSrc p)
+    (x : VarId) (k : ZMod p) : Option (DenseRPSeen p) :=
+  let g := ops.mul ((inv[k.val]?).getD k⁻¹) src.δ
+  let gv := g.val
+  let gc := p - gv
+  if 256 ≤ gv && 256 ≤ gc then
+    some ⟨src, x, k, denseRpBucketHash k src.aconst src.δ (src.tsum - denseRpTermHash x k), gv, gc⟩
+  else none
 
-/-- Prepend seen-entries into their key-hash buckets, preserving per-bucket insertion order. -/
+/-- The candidate records of one constraint that survive the root-gap test. -/
+def denseRpGroupOf (ops : DenseZModOps p) (inv : Std.HashMap Nat (ZMod p)) (src : DenseRpSrc p) :
+    List (VarId × ZMod p) → List (DenseRPSeen p)
+  | [] => []
+  | (v, k) :: rest =>
+    match denseRpCandAt ops inv src v k with
+    | some e => e :: denseRpGroupOf ops inv src rest
+    | none => denseRpGroupOf ops inv src rest
+
+/-- The nonempty candidate groups, in source order. -/
+def denseRpGroupsOf (ops : DenseZModOps p) (inv : Std.HashMap Nat (ZMod p)) :
+    List (DenseRpPre p) → List (List (DenseRPSeen p))
+  | [] => []
+  | pre :: rest =>
+    match denseRpGroupOf ops inv pre.src pre.cands with
+    | [] => denseRpGroupsOf ops inv rest
+    | g => g :: denseRpGroupsOf ops inv rest
+
+/-- Every constraint's two-root candidates, grouped by constraint, in source order. -/
+def denseRpGroups (ops : DenseZModOps p) (cs : List (DenseExpr p)) :
+    List (List (DenseRPSeen p)) :=
+  let pres := denseRpPres ops cs
+  denseRpGroupsOf ops (denseRpInvTable pres) pres
+
+/-- Hash of the part of a key shared by a whole group: a pair match needs equal `A.const` and equal
+    `δ`, i.e. equal factor constants. -/
+def denseRpSigHash (e : DenseRPSeen p) : UInt64 :=
+  mixHash (hash e.src.aconst.val) (hash e.src.δ.val)
+
+/-- How many groups carry each signature. -/
+def denseRpSigCounts (gs : List (List (DenseRPSeen p))) : Std.HashMap UInt64 Nat :=
+  gs.foldl (fun m g =>
+    match g with
+    | [] => m
+    | e :: _ => let s := denseRpSigHash e; m.insert s (m.getD s 0 + 1)) ∅
+
+/-- Drop the groups whose signature no other group shares: they can match nothing, so bucketing and
+    scanning them is pure cost (two candidates of the same group never pair — the scan only looks at
+    earlier constraints). -/
+def denseRpLiveGroups (gs : List (List (DenseRPSeen p))) : List (List (DenseRPSeen p)) :=
+  let counts := denseRpSigCounts gs
+  gs.filter (fun g =>
+    match g with
+    | [] => false
+    | e :: _ => 2 ≤ counts.getD (denseRpSigHash e) 0)
+
+/-! ## The scan and the pass (dense) -/
+
+/-- Prepend seen-entries into their bucket, preserving per-bucket insertion order. -/
 def denseRpInsertAll (m : Std.HashMap UInt64 (List (DenseRPSeen p)))
     (es : List (DenseRPSeen p)) : Std.HashMap UInt64 (List (DenseRPSeen p)) :=
-  es.foldr (fun e acc => acc.insert (denseRpKeyHash e.key) (e :: acc.getD (denseRpKeyHash e.key) []))
-    m
+  es.foldr (fun e acc => acc.insert e.h (e :: acc.getD e.h [])) m
 
-/-- Scan the constraints: for each two-root candidate, look for an earlier twin with the same key
-    whose pair certificate passes, and adopt the entailed equality into the solution map. -/
-def denseRpLoop (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (domCs : List (DenseExpr p)) :
-    List (DenseExpr p) → Std.HashMap UInt64 (List (DenseRPSeen p)) → DenseSolved p → DenseSolved p
+/-- Whether two candidates carry the same key `(k, A.terms, A.const, δ)`. -/
+def denseRpKeyEq (e cand : DenseRPSeen p) : Bool :=
+  e.k.val == cand.k.val && e.src.aconst.val == cand.src.aconst.val &&
+    e.src.δ.val == cand.src.δ.val && denseRpSkipEq e.src.terms e.x cand.src.terms cand.x
+
+/-- The certificate's bound clause, on the candidates' own gap. It is a necessary condition of
+    `denseRpCheckPairB`, so gating on it cannot accept a pair the certificate rejects — and it
+    rejects a same-key non-twin for two bound lookups instead of two two-root re-derivations. -/
+def denseRpBoundGate (bnd : VarId → Option Nat) (e cand : DenseRPSeen p) : Bool :=
+  match bnd e.x, bnd cand.x with
+  | some Bx, some By => decide (max Bx By ≤ cand.gval) && decide (max Bx By ≤ cand.gco)
+  | _, _ => false
+
+/-- Scan the candidate groups in source order: for each candidate, look for an earlier twin with the
+    same key whose pair certificate passes, and adopt the entailed equality into the solution map. -/
+def denseRpScan (bnd : VarId → Option Nat) :
+    List (List (DenseRPSeen p)) → Std.HashMap UInt64 (List (DenseRPSeen p)) → DenseSolved p →
+      DenseSolved p
   | [], _, σ => σ
-  | c :: rest, seen, σ =>
-    let cands := denseRpCandidates c
-    match cands.findSome? (fun xk =>
-        (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-          if e.key == xk.2 && e.x != xk.1 &&
-              denseRpCheckPair bs facts bis domCs e.c c e.x xk.1
-          then some (e, xk.1) else none)) with
+  | g :: rest, seen, σ =>
+    match g.findSome? (fun cand =>
+        (seen.getD cand.h []).findSome? (fun e =>
+          if denseRpKeyEq e cand && !(e.x.index == cand.x.index) &&
+              denseRpBoundGate bnd e cand &&
+              denseRpCheckPairB bnd e.c cand.c e.x cand.x
+          then some (e, cand.x) else none)) with
     | some ex =>
-        denseRpLoop bs facts bis domCs rest
-          (denseRpInsertAll seen ((cands.filter (fun xk => xk.1 != ex.2)).map
-            (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p))))
+        denseRpScan bnd rest
+          (denseRpInsertAll seen (g.filter (fun cand => !(cand.x.index == ex.2.index))))
           (σ.insertAll [(ex.2, DenseExpr.var ex.1.x)])
-    | none =>
-        denseRpLoop bs facts bis domCs rest
-          (denseRpInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p)))) σ
+    | none => denseRpScan bnd rest (denseRpInsertAll seen g) σ
+
+/-- The solution map the scan adopts over a whole system. -/
+def denseRpSigma (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
+    DenseSolved p :=
+  denseRpScan (denseAnyVarBound bs facts d.busInteractions d.algebraicConstraints)
+    (denseRpLiveGroups (denseRpGroups denseZModOps d.algebraicConstraints)) ∅ DenseSolved.empty
 
 /-- For twin constraints `(a+k·x)(a+δ+k·x)=0` and `(a+k·y)(a+δ+k·y)=0` — each pinning its variable
     to one of two roots a fixed gap `g = k⁻¹·δ` apart — when both variables are range-bounded below
@@ -275,8 +428,7 @@ def denseRpLoop (bs : BusSemantics p) (facts : BusFacts p bs)
 def denseRootPairUnifyF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let σ := denseRpLoop bs facts d.busInteractions d.algebraicConstraints
-      d.algebraicConstraints ∅ DenseSolved.empty
+    let σ := denseRpSigma bs facts d
     if σ.map.isEmpty then d else d.substF σ.fn
   else d
 
@@ -343,44 +495,6 @@ def denseAnyVarBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs)
   | some B => some B
   | none => (witsOf x).findSome? (fun bi => denseScaledSlotBoundD bs facts dom bi x)
 
-/-- `denseRpCheckPair` with indexed bound lookups. -/
-def denseRpCheckPairIdx (bs : BusSemantics p) (facts : BusFacts p bs)
-    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
-    (dom : VarId → Option (List (ZMod p)))
-    (cX cY : DenseExpr p) (x y : VarId) : Bool :=
-  match denseTwoRootOf? cX x, denseTwoRootOf? cY y with
-  | some (k, A, δ), some (k', A', δ') =>
-    decide (k' = k) && decide (A'.terms = A.terms) && decide (A'.const = A.const) &&
-    decide (δ' = δ) && decide (k * k⁻¹ = 1) &&
-    decide (x ∈ cX.vars) && decide (y ∈ cY.vars) &&
-    (match denseAnyVarBoundIdx bs facts witsOf dom x, denseAnyVarBoundIdx bs facts witsOf dom y with
-     | some Bx, some By =>
-       decide (max Bx By ≤ (k⁻¹ * δ).val) && decide (max Bx By ≤ p - (k⁻¹ * δ).val)
-     | _, _ => false)
-  | _, _ => false
-
-/-- `denseRpLoop` with indexed bound lookups. -/
-def denseRpLoopIdx (bs : BusSemantics p) (facts : BusFacts p bs)
-    (witsOf : VarId → List (BusInteraction (DenseExpr p)))
-    (dom : VarId → Option (List (ZMod p))) :
-    List (DenseExpr p) → Std.HashMap UInt64 (List (DenseRPSeen p)) → DenseSolved p → DenseSolved p
-  | [], _, σ => σ
-  | c :: rest, seen, σ =>
-    let cands := denseRpCandidates c
-    match cands.findSome? (fun xk =>
-        (seen.getD (denseRpKeyHash xk.2) []).findSome? (fun e =>
-          if e.key == xk.2 && e.x != xk.1 &&
-              denseRpCheckPairIdx bs facts witsOf dom e.c c e.x xk.1
-          then some (e, xk.1) else none)) with
-    | some ex =>
-        denseRpLoopIdx bs facts witsOf dom rest
-          (denseRpInsertAll seen ((cands.filter (fun xk => xk.1 != ex.2)).map
-            (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p))))
-          (σ.insertAll [(ex.2, DenseExpr.var ex.1.x)])
-    | none =>
-        denseRpLoopIdx bs facts witsOf dom rest
-          (denseRpInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseRPSeen p)))) σ
-
 /-- `denseRootPairUnifyF` with the per-variable interaction index and the tabulated domain map. -/
 def denseRootPairUnifyFFast (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
@@ -391,8 +505,11 @@ def denseRootPairUnifyFFast (pw : PrimeWitness p) (bs : BusSemantics p) (facts :
       Thunk.mk fun _ => denseVarBucket denseBIVars d.busInteractions
     let domMap : Thunk (Std.HashMap VarId (List (ZMod p))) :=
       Thunk.mk fun _ => denseFindDomainMap d.algebraicConstraints
-    let σ := denseRpLoopIdx bs facts (fun x => denseVarBucketLookup witsIdx.get x)
-      (fun v => (domMap.get)[v]?) d.algebraicConstraints ∅ DenseSolved.empty
+    let bndIdx : VarId → Option Nat := fun x =>
+      denseAnyVarBoundIdx bs facts (fun v => denseVarBucketLookup witsIdx.get v)
+        (fun v => (domMap.get)[v]?) x
+    let gs := denseRpLiveGroups (denseRpGroups denseZModOps d.algebraicConstraints)
+    let σ := denseRpScan bndIdx gs ∅ DenseSolved.empty
     if σ.map.isEmpty then d else d.substF σ.fn
   else d
 

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -198,9 +198,10 @@ these need no new proof.
      certificate re-derived the domains from the unbucketed single-variable list per candidate —
      9.2 s of a 13.7 s pass on sha256 `apc_001` — while the bucket built in the same function served
      only the prefilter in front of it. ~~`boxRewrite`, `fxSubst`~~ **done (entry 165)**: all of
-     `flagFold` now reads one `VarId.index`-keyed table built once per invocation. `flagUnify` and
-     `rootPairUnify` still call `denseFindDomainAlg` on whole lists; same fix applies if they show
-     up in a profile (rootPairUnify 9 s is the candidate).
+     `flagFold` now reads one `VarId.index`-keyed table built once per invocation. `flagUnify` still
+     calls `denseFindDomainAlg` on whole lists; same fix applies if it shows up in a profile.
+     `rootPairUnify` keeps a `denseFindDomainMap` table already, and after entry 170 its domain path
+     (the scaled slot bound) is never reached on the measured cases.
    - `busPairCancel`: ~~`liveArr` materialization per candidate~~ **done (#210)** — see R8.
      The O(B²) *certificate* scans remain (R8 design (b)); in coda mode the `addrHash`
      bucket is O(B) per hot address — add a position cursor. ~~`dropWits` from-0 array scan per
@@ -449,13 +450,24 @@ per corpus**. Three things worth carrying forward:
 - **Where a twin already exists, edit only the twin**; the in-place edit costs proof work and buys
   no runtime.
 
-**R9b. What is left, and why it is expensive.** `rootPairUnify` (8.9 s on sha256) barely moved
-(0.99×): its live chain-builders are `denseRpCheckPair`/`denseRpCheckPairIdx`/`denseScaledSlotBound`,
-all reverted above for the definitional-equality reason. Same for `HintCollapse`, `SeqzCollapse`,
-`ByteCheckPack` and `BoxRewrite`. Landing these means restating the affected `…With_eq` bridges to
-rewrite through `zmodZeroP_eq`/`zmodOneP_eq` rather than `rfl` — mechanical, but ~25 proof sites for
-a few percent. Note also `Affine.trySolve`/`trySolveUnit` and `denseScaledSlotBound` need the ring
-for `⁻¹`/`scale` regardless, so converting only their guards would not empty their entries.
+**R9b. What is left, and why it is expensive.** Its `rootPairUnify` half is **superseded by entry
+170**, which rebuilt the pass (0.13–0.53×): the per-candidate chain builders are gone with the
+per-candidate work itself, and the surviving `⁻¹` is one call per distinct coefficient value.
+Still open for `HintCollapse`, `SeqzCollapse`, `ByteCheckPack` and `BoxRewrite`: landing these means
+restating the affected `…With_eq` bridges to rewrite through `zmodZeroP_eq`/`zmodOneP_eq` rather than
+`rfl` — mechanical, but ~25 proof sites for a few percent. Note also `Affine.trySolve`/`trySolveUnit`
+and `denseScaledSlotBound` need the ring for `⁻¹`/`scale` regardless, so converting only their guards
+would not empty their entries.
+
+**R9d (partly done, entry 170). The bound path is what is left of `rootPairUnify`** (sha256 918 ms:
+preparation 274, `denseVarBucket` build 125, ~900 bound queries 122, `substF` 259). A
+**candidate-restricted raw bound sweep** — one pass over the interactions recording, *for the
+candidate variables only*, the first fact-bounded literal `.var x` payload slot, behind a `Thunk` so
+the 8 of 11 sha256 cycles that never query a bound never build it — replaces both the bucket build
+and the per-query walks with ~50–60 ms of sweeping in the three cycles that adopt (**~190 ms of
+918**). It needs a first-yield sweep-equality lemma against `denseFindVarBound`, the shape of the
+existing `denseFindDomainMap_getElem?`. Do **not** widen it to all variables: that is entry 170's
+measured dead end (~1 M index entries to serve ~900 queries, worse on every case).
 
 **R9c (done, entry 159).** `denseRpKeyHash` bucketed rootPairUnify's `seen` accumulator on
 `(k, A.const, δ, A.terms.length)` while the scan re-verified with the exact whole-key test, so on a
@@ -707,6 +719,24 @@ instead of 256 (~30× on those scans). It needs a per-item degree analysis and a
 are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`).
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **An eager raw-slot bound index over every variable** (entry 170, rootPairUnify): a sweep building
+  `VarId → List (busId, mult, Thunk pattern, slot)` so a raw bound query costs one `BusFacts` call
+  with no payload walk and no re-derived slot pattern. Worse on **every** case — sha256 `apc_001`
+  1220 → 1324 ms, keccak 93 → 100, wasm-eth `apc_012` flat — because it inserts ~1 M
+  (variable, interaction) entries per invocation to serve **~900 queries in the whole run**. Eager
+  indexing loses whenever the query set is orders of magnitude smaller than the index; restrict the
+  sweep to the variables that will be queried (R9d) or leave it lazy.
+- **A memoizing bound table for rootPairUnify** (entry 170): `Std.HashMap VarId (Thunk (Option Nat))`
+  over the candidate variables, forced on first use, to stop a `seen` entry re-deriving its bound
+  once per compared pair. **Exactly 0** on sha256 (886 vs 887 ms) and noise on keccak: the queries
+  are already almost all for distinct variables, because the bound gate keeps same-key non-twins out
+  of the certificate. A memo needs repeated *keys*, not repeated call sites.
+- **A constant-only pre-walk to skip linearizing** (entry 170, `denseRpConstOf`): computing a
+  factor's linearized constant and term-emptiness without allocating, to decide `δ = 0` before the
+  merge. On sha256 cycle 0 it filters 104 264 products to 40 958 and costs **59 ms against the 68 ms
+  of linearizing all of them** — the tree walk is the expensive half of `denseLinearize`, the
+  allocation is not.
 
 - **An unchanged-node-preserving `DenseExpr.substF` twin** (entry 169): returning the input node
   when no descendant changed cut domainBatch by 144 ms and cost **+2.5 s across every other pass**

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6401,3 +6401,98 @@ would take roughly 40 % of the node visits out of the inner loop (est. −150 to
 irreducible without the cross-cutting change the dead end above rules out.
 
 **Worked: yes.**
+### 170. Runtime: rootPairUnify rebuilt — merge once per constraint, one inverse per coefficient (0.13–0.53x on the pass, sha256 total 0.97x)
+
+Full redesign of the two-root unification pass (`rootPairUnifyRedesign.md` has the design, the
+attribution and the rejected alternatives). Rank 4 by score in `ranked_passes.md` and the **top pass
+on wasm-eth `apc_012`** (697 ms of 3.9 s, 17.9 %); worst absolute sha256 `apc_001` 1825 ms.
+
+WHAT WAS WRONG. A candidate is a `(constraint, variable)` pair keyed by
+`(k, A.terms, A.const, δ)`, matched against earlier candidates. The old `denseRpCandidates`
+re-derived that key **per variable of the constraint**: `l1.coeff x`, `(l1.others x).norm`,
+`(l2.others x).norm` — the `norm` being an `O(T²)` like-term merge — and then compared the two
+offset forms as lists. Θ(V·T²) per constraint for data that is *the same merged list minus one
+entry* every time (R10b's "cubic build", fixed inside busUnify's copy in 2026-08-01, never here).
+LBR, pass-only, wasm-eth `apc_012`: the merge 30.6 % of the candidate phase, the list compare
+17.6 %, the `others` filter 8.8 %, `hashedEraseDups c.vars` 4.0 %, `l.coeff x` 2.6 % — and
+**48 % of the pass in allocator + refcount**, which is what a fresh term list per candidate
+variable costs.
+
+THE REBUILD (`RootPairUnify.lean`; soundness in `Proofs/RootPairUnify.lean`):
+1. **Merge each factor once, read the candidates off the merged pair.** `denseMergeTerms` keeps
+   first-occurrence order, so `(l.others x).norm.terms = (merge l.terms) \ x` — filtering before or
+   after the merge gives the same list. `denseRpDiffVars` then decides the candidate set with one
+   simultaneous walk: identical normal forms ⟹ every variable qualifies (the shape a real two-root
+   constraint has, its factors differing only in their constant); otherwise **at most the two
+   variables at the first difference**, since deleting a variable that occurs earlier deletes the
+   same position from both lists and leaves the difference in place. Each of those two is checked
+   by one allocation-free `denseRpSkipEq` walk.
+2. **No merge when the terms are already normal** (`denseRpTermsClean`: distinct variables, no zero
+   coefficient — index compares only): the normal form then *is* the linearized term list, shared.
+3. **The key is never materialized.** A candidate is its constraint's shared `DenseRpSrc` plus
+   `(x, k)`; `A.terms = terms \ x` stays implicit. The bucket hash is a multiset sum over the terms
+   (computed once per constraint) minus the candidate's own term — O(1) per candidate — and the
+   exact test is `denseRpSkipEq` on the two candidates' term lists, skipping each side's own entry.
+4. **One modular inverse per distinct coefficient.** `IO` phase timers on wasm-eth `apc_012`: of
+   19 ms per invocation preparing candidates, **11 ms was `ZMod`'s `Inv`** — an extended gcd, once
+   per candidate, for the root gap `g = k⁻¹·δ` behind the ≥ 256 filter, 13 500 times per
+   invocation. Preparation is now `denseRpPres` (candidate variables, no gap) → `denseRpInvTable`
+   (one inverse per distinct coefficient *value* — a coefficient recurs in every constraint of the
+   same instruction shape) → `denseRpGroupsOf` (the gap filter off the table).
+5. **A bound gate before the certificate** (`denseRpBoundGate`): the certificate's bound clause on
+   the candidate's own stored gap, a necessary condition of `denseRpCheckPair`, so a same-key
+   non-twin is rejected by two bound lookups instead of two `denseTwoRootOf?` re-derivations.
+6. **Groups whose `(A.const, δ)` signature no other group shares are dropped whole** — they can
+   match nothing (openvm-eth `apc_006`: 110 groups → 34).
+
+PROOF SURFACE: the scan-loop invariant re-run over `List (List DenseRPSeen)` instead of
+`List DenseExpr` (`denseRpScan_sound`, same argument), plus `denseRpLiveGroups_mem` — the one
+obligation preparation owes: every bucketed entry's constraint is one of `d`'s. Everything else
+about a candidate is untrusted: `denseRpCheckPair` re-derives the pair's two-root data from the two
+constraint expressions, so the merge walk, the multiset hash, the key test, the gap filter and the
+signature filter carry no obligation at all. `denseRpCheckPair_sound`/`_vars` and the certificate
+chain (`denseTwoRootOf?_sound` + `rootPair_eq`) are untouched; the certificate gained a
+`bnd`-parameterized twin (`denseRpCheckPairB`) so the indexed layer is one `funext` away
+(`denseRootPairUnifyF_eq_fast`).
+
+THE FUNNEL, and why the spread is what it is (`dbg_trace` probe, per invocation): wasm-eth
+`apc_012` prepares **13 500 candidates in 1 080 groups and adopts nothing, in every cycle** — its
+whole cost was preparation, which is what got 6× cheaper. keccak (11–187 adoptions per cycle) and
+sha256 (19–365) do adopt, so they keep paying bound queries and `substF`, which preparation had
+been hiding. sha256 has only **~900 bound queries in the whole run**.
+
+NUMBERS (this 20-core box, serial, interleaved, 2–3 reps; `profile` per-pass ms):
+wasm-eth `apc_012` **697 → 92 (0.13x)**, run total 3876 → 3347 (0.86x); wasm-eth `apc_036`
+455 → 70 (0.15x), 3216 → 2878 (0.90x); sha256 `apc_001` **1825 → 918 (0.50x)**, 29559 → 28791
+(0.97x); openvm-eth `apc_037` 50 → 10 (0.20x), 592 → 566 (0.96x); openvm-eth `apc_006` 17 → 5
+(0.30x); keccak `apc_001` 128 → 70 (0.53x), 2936 → 2829 (0.96x).
+VERIFIED: `opt-export` **byte-identical** on 18 cases — sha256 `apc_001`, OpenVM keccak `apc_001`,
+openvm-eth `apc_006` / `apc_032` / `apc_037` / `apc_058` / `apc_063` / `apc_071` / `apc_088` /
+`apc_100`, wasm-eth `apc_001` / `apc_002` / `apc_012` / `apc_036` / `apc_063`, SP1 keccak `apc_001`,
+SP1 rsp `apc_001` / `apc_002`; `lake build` clean, no warnings; `check-proof-integrity` passes.
+
+DEAD ENDS, measured (all three implemented and reverted):
+* **An eager raw-slot bound index over every variable** — `VarId → List (busId, mult, Thunk
+  pattern, slot)` built in one sweep, so a raw bound query is a `BusFacts` call with no payload walk
+  and no re-derived slot pattern. **Worse on every case**: sha256 1220 → 1324 ms, keccak 93 → 100,
+  wasm `apc_012` flat. The sweep inserts ~1 M (variable, interaction) entries per invocation to
+  serve ~900 queries in the whole run. *Eager indexing loses when the query set is three orders of
+  magnitude smaller than the index.*
+* **A memoizing bound table** (`Std.HashMap VarId (Thunk (Option Nat))` over the candidate
+  variables, forced on first use): **exactly 0** on sha256 (886 vs 887 ms), noise on keccak. The
+  queries are already almost all for distinct variables — the per-*pair* re-derivation it was built
+  to remove is already prevented by the bound gate.
+* **A constant-only pre-walk to skip linearizing** (`denseRpConstOf`: a factor's linearized constant
+  and term-emptiness without allocating, deciding `δ = 0` before the merge). On sha256 cycle 0 it
+  drops 104 264 products to 40 958 — and costs **59 ms against the 68 ms of linearizing all of
+  them**. The walk is the expensive half of `denseLinearize`; the allocation is not.
+
+RESIDUAL (sha256 918 ms, `IO` phase timers summed over 11 invocations): preparation 274 ms (of which
+`denseLinearize` 68 — near its floor), the `denseVarBucket` build 125, bound queries 122, `substF`
+259, rest ~40. The reducible item is the bound path: a **candidate-restricted raw bound sweep**
+behind a `Thunk` (record, for candidate variables only, the first fact-bounded literal `.var x`
+payload slot) replaces both the bucket build and the query walks with ~50–60 ms of sweeping in the
+three cycles that adopt — ~190 ms — and needs a first-yield sweep-equality lemma against
+`denseFindVarBound`. `substF` is the pass's own output and is ruled out by entry 169's dead end.
+
+**Worked: yes.**


### PR DESCRIPTION
Full redesign of the two-root unification pass for runtime. Rank 4 by score in the profile ranking and the **top pass on wasm-eth `apc_012`** (697 ms of 3.9 s, 17.9 %); worst absolute sha256 `apc_001` 1825 ms.

## What was wrong

A candidate is a `(constraint, variable)` pair keyed by `(k, A.terms, A.const, δ)`, matched against earlier candidates. `denseRpCandidates` re-derived that key **per variable of the constraint** — `l1.coeff x`, `(l1.others x).norm`, `(l2.others x).norm` (each `norm` an `O(T²)` like-term merge), then a list compare of the two offset forms. Θ(V·T²) per constraint, for data that is *the same merged list minus one entry* every time. LBR, pass-only, wasm-eth `apc_012`: the merge is 30.6 % of the candidate phase, the list compare 17.6 %, the `others` filter 8.8 % — and **48 % of the pass is allocator + refcount**, which is what a fresh term list per candidate variable costs.

## The rebuild

1. **Merge each factor once, read the candidates off the merged pair.** `denseMergeTerms` keeps first-occurrence order, so `(l.others x).norm.terms = (merge l.terms) \ x`. `denseRpDiffVars` decides the candidate set in one simultaneous walk: identical normal forms ⟹ every variable qualifies (the shape a real two-root constraint has); otherwise at most the two variables at the first difference, since deleting a variable occurring earlier deletes the same position from both lists and leaves the difference in place.
2. **No merge when the terms are already normal** (distinct variables, no zero coefficient — index compares only): the normal form then *is* the linearized term list, shared.
3. **The key is never materialized.** A candidate is its constraint's shared `DenseRpSrc` plus `(x, k)`; the bucket hash is a multiset sum over the terms minus the candidate's own term (O(1)), and the exact test is an allocation-free skip-walk.
4. **One modular inverse per distinct coefficient.** `IO` phase timers on wasm-eth `apc_012`: of 19 ms per invocation preparing candidates, **11 ms was `ZMod`'s `Inv`** — an extended gcd, once per candidate, 13 500 times per invocation. Preparation is now candidate variables → one inverse per distinct coefficient value → the root-gap filter off that table.
5. **A bound gate before the certificate**: the certificate's own bound clause on the candidate's stored gap, so a same-key non-twin is rejected by two bound lookups instead of two `denseTwoRootOf?` re-derivations.
6. **Groups whose `(A.const, δ)` signature no other group shares are dropped whole** (openvm-eth `apc_006`: 110 groups → 34).

## Proof surface

The scan-loop invariant re-run over `List (List DenseRPSeen)` instead of `List DenseExpr` (`denseRpScan_sound`, same argument), plus `denseRpLiveGroups_mem` — the one obligation preparation owes: every bucketed entry's constraint is one of the system's. Everything else about a candidate is untrusted, because `denseRpCheckPair` re-derives the pair's two-root data from the two constraint expressions: the merge walk, the multiset hash, the key test, the gap filter and the signature filter carry no obligation. `denseRpCheckPair_sound`/`_vars` and the certificate chain (`denseTwoRootOf?_sound` + `rootPair_eq`) are untouched.

## Numbers

Interleaved A/B, this box, serial, 2–3 reps (`profile` per-pass ms):

| case | pass before → after | ratio | run total |
|---|---:|---:|---:|
| wasm-eth `apc_012` | 697 → 92 | **0.13×** | 3876 → 3347 (0.86×) |
| wasm-eth `apc_036` | 455 → 70 | **0.15×** | 3216 → 2878 (0.90×) |
| sha256 `apc_001` | 1825 → 918 | **0.50×** | 29559 → 28791 (0.97×) |
| openvm-eth `apc_037` | 50 → 10 | **0.20×** | 592 → 566 (0.96×) |
| openvm-eth `apc_006` | 17 → 5 | **0.30×** | ~flat |
| keccak `apc_001` | 128 → 70 | **0.53×** | 2936 → 2829 (0.96×) |

The spread has a cause: wasm-eth `apc_012` prepares 13 500 candidates in 1 080 groups and **adopts nothing, in every cycle** — its whole cost was preparation. keccak and sha256 do adopt, so they keep paying bound queries and `substF` that preparation had been hiding.

**Output is byte-identical** on 18 cases (sha256 `apc_001`, OpenVM keccak, openvm-eth `apc_006`/`032`/`037`/`058`/`063`/`071`/`088`/`100`, wasm-eth `apc_001`/`002`/`012`/`036`/`063`, SP1 keccak `apc_001`, SP1 rsp `apc_001`/`002`). `lake build` clean with no warnings; `Scripts/check-proof-integrity.sh` passes (propext / Classical.choice / Quot.sound, no unused theorems). Effectiveness is expected unchanged — the CI matrix on this PR is the check.

## Measured dead ends (all implemented and reverted; recorded in `ideas.md`)

- **An eager raw-slot bound index over every variable**: worse on every case (sha256 1220 → 1324 ms) — ~1 M index entries per invocation to serve **~900 bound queries in the whole run**.
- **A memoizing bound table over the candidate variables**: exactly 0 on sha256 (886 vs 887 ms); the queries are already almost all for distinct variables.
- **A constant-only pre-walk to skip linearizing**: 59 ms of walk against the 68 ms of linearizing everything — the tree walk is the expensive half of `denseLinearize`, the allocation is not.

## Residual

sha256's remaining 918 ms: preparation 274 ms (of which `denseLinearize` 68 — near its floor), the `denseVarBucket` build 125, bound queries 122, `substF` 259. The reducible item is a **candidate-restricted** raw bound sweep behind a `Thunk` (~190 ms), which needs a first-yield sweep-equality lemma against `denseFindVarBound` — logged as R9d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)