### PR TITLE
perf(intervalForce): key-shaped seeds, one prepared interaction sweep, an O(t) window walk

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/IntervalForce.lean
@@ -71,7 +71,7 @@ theorem int_window [NeZero p] (S : Int) (B : Nat) (x : ZMod p)
     generalize hX : (p : Int) * k = X at hk h2
     omega
 
-/-- Cap on the number of affine terms analyzed per slot (the walk is quadratic). -/
+/-- Cap on the number of affine terms analyzed per slot. -/
 def maxTerms : Nat := 32
 
 end IntervalForce
@@ -82,173 +82,320 @@ open IntervalForce
 
 variable {p : ℕ}
 
-/-! ## Signed representatives and processed terms -/
+/-! ## Seed keys
 
-/-- A processed affine term: signed integer coefficient `sc`, strict value bound `bnd`, `VarId` `v`. -/
-structure DensePTerm where
+A forced seed is only ever `x = 0` or `x − y = 0`, so it is carried as a key and turned into a
+`DenseExpr` once, at the end, for the survivors only. `b = 0` is the zero arm on `⟨a⟩`;
+`b = w + 1` is the pair arm `⟨a⟩ − ⟨w⟩`. -/
+
+structure DenseIFKey where
+  a : Nat
+  b : Nat
+deriving BEq, Hashable, DecidableEq, Inhabited
+
+/-- The emitted keys in reverse emission order, with the same set mirrored for dedup. -/
+structure DenseIFAcc where
+  keys : List DenseIFKey
+  seen : Std.HashSet DenseIFKey
+
+def denseIFPush (st : DenseIFAcc) (k : DenseIFKey) : DenseIFAcc :=
+  if st.seen.contains k then st else ⟨k :: st.keys, st.seen.insert k⟩
+
+/-! ## Linearization with an early-aborting product
+
+`denseIFLin` is `denseLinearizeAcc` (`Affine.lean`) with one change: when the left factor of a
+product has terms, the right one only has to be *variable-free*, which `denseIFConst` decides by
+aborting at the first `.var` instead of linearizing it. A product of two variables now fails after
+one variable rather than after linearizing both factors. Proven equal in
+`Proofs/IntervalForce.lean`. -/
+
+/-- The constant value of a variable-free expression; `none` at the first `.var`. A `.var` leaf of a
+    linearizable expression always contributes a raw term, even under a zero coefficient, so this is
+    exactly `denseLinearize`'s "the other factor's term list is empty" test. -/
+def denseIFConst : DenseExpr p → Option (ZMod p)
+  | .const n => some n
+  | .var _ => none
+  | .add a b =>
+    match denseIFConst a with
+    | none => none
+    | some x =>
+      match denseIFConst b with
+      | none => none
+      | some y => some (zmodAdd x y)
+  | .mul a b =>
+    match denseIFConst a with
+    | none => none
+    | some x =>
+      match denseIFConst b with
+      | none => none
+      | some y => some (zmodMul x y)
+
+def denseIFLin : DenseExpr p → List (VarId × ZMod p) →
+    Option (ZMod p × List (VarId × ZMod p))
+  | .const n, acc => some (n, acc)
+  | .var i, acc => some (zmodZeroP p, (i, zmodOneP p) :: acc)
+  | .add a b, acc =>
+    match denseIFLin b acc with
+    | none => none
+    | some (cb, acc') =>
+      match denseIFLin a acc' with
+      | none => none
+      | some (ca, acc'') => some (zmodAdd ca cb, acc'')
+  | .mul a b, acc =>
+    match denseIFLin a [] with
+    | none => none
+    | some (ca, ta) =>
+      if ta.isEmpty then
+        match denseIFLin b [] with
+        | none => none
+        | some (cb, tb) => some (zmodMul ca cb, denseScaleAppend ca tb acc)
+      else
+        match denseIFConst b with
+        | none => none
+        | some cb => some (zmodMul cb ca, denseScaleAppend cb ta acc)
+
+/-! ## Processed terms -/
+
+/-- One merged term with its window contributions `mn = min (sc·(B−1)) 0`,
+    `mx = max (sc·(B−1)) 0`, where `B` is the term variable's own bound. -/
+structure DenseIFTerm where
   sc : Int
-  bnd : Nat
+  mn : Int
+  mx : Int
   v : VarId
+deriving Inhabited, DecidableEq
 
-/-- Pair every term of a dense linear form with its variable's bound; `none` if any is unbounded. -/
-def denseProcTerms (bnd : VarId → Option Nat) :
-    List (VarId × ZMod p) → Option (List DensePTerm)
+/-- `srep` with `(p−1)/2` supplied by the caller. -/
+def denseIFSrep (half : Nat) (c : ZMod p) : Int :=
+  let v := c.val
+  if v ≤ half then (v : Int) else (v : Int) - (p : Int)
+
+def denseIFTermOf (half : Nat) (c : ZMod p) (Bv : Nat) (v : VarId) : DenseIFTerm :=
+  let sc := denseIFSrep half c
+  let w := sc * ((Bv : Int) - 1)
+  ⟨sc, if w < 0 then w else 0, if 0 < w then w else 0, v⟩
+
+/-- Pair every merged nonzero term with its variable's bound. `none` when more than `maxTerms`
+    terms survive or a variable is unbounded — aborting at the first one, rather than processing
+    the tail first. -/
+def denseIFProc (half : Nat) (idx : Std.HashMap VarId Nat) (n : Nat) :
+    List (VarId × ZMod p) → Option (List DenseIFTerm)
   | [] => some []
   | (v, c) :: rest =>
-    match bnd v, denseProcTerms bnd rest with
-    | some B, some pts => some (⟨srep c, B, v⟩ :: pts)
-    | _, _ => none
-
-/-- Upper window bound: each term contributes `max (sc·(B−1)) 0`. -/
-def denseMaxSum (pts : List DensePTerm) : Int :=
-  (pts.map (fun t => max (t.sc * ((t.bnd : Int) - 1)) 0)).sum
-
-/-- Lower window bound: each term contributes `min (sc·(B−1)) 0`. -/
-def denseMinSum (pts : List DensePTerm) : Int :=
-  (pts.map (fun t => min (t.sc * ((t.bnd : Int) - 1)) 0)).sum
-
-/-! ## Seed extraction -/
-
-/-- `v − w` as a dense expression. -/
-def densePairDiff (v w : VarId) : DenseExpr p := denseEqExpr (.var v) (.var w)
-
-/-- First term with signed coefficient `g`, and the list without it. -/
-def denseFindPartner (g : Int) : List DensePTerm → Option (DensePTerm × List DensePTerm)
-  | [] => none
-  | t :: rest =>
-    if t.sc = g then some (t, rest)
+    if zmodIsZero c then denseIFProc half idx n rest
+    else if maxTerms ≤ n then none
     else
-      match denseFindPartner g rest with
-      | some (t', rest') => some (t', t :: rest')
+      match idx[v]? with
       | none => none
+      | some Bv =>
+        match denseIFProc half idx (n + 1) rest with
+        | none => none
+        | some ts => some (denseIFTermOf half c Bv v :: ts)
 
-/-- The walk over the term list: at each term, try the zero arm (against all other terms) and,
-    for a positive coefficient, the pair arm against the first `−g` partner among the other terms. -/
-def denseWalk (B : Nat) (c0 : Int) : List DensePTerm → List DensePTerm → List (DenseExpr p)
-  | _, [] => []
-  | seen, t :: rest =>
-    (if (0 < t.sc ∧ (B : Int) ≤ t.sc + (c0 + denseMinSum (seen ++ rest))) ∨
-        (t.sc < 0 ∧ c0 + denseMaxSum (seen ++ rest) + t.sc < 0) then
-      [DenseExpr.var t.v]
-    else []) ++
-    (if 0 < t.sc then
-      match denseFindPartner (-t.sc) (seen ++ rest) with
-      | some (t', others') =>
-        if (B : Int) ≤ t.sc + (c0 + denseMinSum others') ∧
-           c0 + denseMaxSum others' - t.sc < 0 ∧ t.v ≠ t'.v then
-          [densePairDiff t.v t'.v]
-        else []
-      | none => []
-    else []) ++
-    denseWalk B c0 (t :: seen) rest
+/-! ## The window walk
 
-/-! ## Per-slot seeds -/
+`denseMinSum (seen ++ rest)` and its `max` twin are the *totals* minus the excluded terms, so with
+`m = Σ mn` and `M = Σ mx` taken once every arm is O(1) arithmetic and the walk never rebuilds a
+term list. The partner search keeps the first-match order of `seen ++ rest` by scanning `seen`
+before `rest`. -/
 
-/-- All seeds forced by one bounded slot: linearize, merge like terms, pair each variable with its
-    bound, check the integer window, and extract the pair/zero arms. -/
-def denseSlotSeeds (bnd : VarId → Option Nat) (B : Nat) (e : DenseExpr p) : List (DenseExpr p) :=
-  if p = 0 then []
-  else
-    match denseLinearize e with
-    | none => []
-    | some l =>
-      if l.norm.terms.length ≤ maxTerms then
-        match denseProcTerms bnd l.norm.terms with
-        | none => []
-        | some pts =>
-          if srep l.norm.const + denseMaxSum pts ≤ (p : Int) - 1 ∧
-             (B : Int) - (p : Int) ≤ srep l.norm.const + denseMinSum pts then
-            denseWalk B (srep l.norm.const) [] pts
-          else []
-      else []
+def denseIFSumMn : List DenseIFTerm → Int
+  | [] => 0
+  | t :: rest => t.mn + denseIFSumMn rest
 
-/-! ## The per-invocation bounds index (data-only `Std.HashMap VarId Nat`) -/
+def denseIFSumMx : List DenseIFTerm → Int
+  | [] => 0
+  | t :: rest => t.mx + denseIFSumMx rest
 
-/-- Record the bound `denseInteractionBound bi x` (if any), keeping the smaller of duplicates. -/
-def denseBoundIdxInsertVar (bs : BusSemantics p) (facts : BusFacts p bs)
-    (I : Std.HashMap VarId Nat) (bi : BusInteraction (DenseExpr p)) (x : VarId) :
+def denseIFPartner (g : Int) : List DenseIFTerm → Option DenseIFTerm
+  | [] => none
+  | t :: rest => if t.sc == g then some t else denseIFPartner g rest
+
+/-- `t` alone cannot be nonzero without pushing the sum out of `[0, B)`. -/
+def denseIFZeroArm (B : Nat) (c0 m M : Int) (t : DenseIFTerm) (st : DenseIFAcc) : DenseIFAcc :=
+  if (0 < t.sc ∧ (B : Int) ≤ t.sc + (c0 + (m - t.mn))) ∨
+     (t.sc < 0 ∧ c0 + (M - t.mx) + t.sc < 0) then
+    denseIFPush st ⟨t.v.index, 0⟩
+  else st
+
+/-- `t` and the first other term with coefficient `−t.sc` cannot differ without the same
+    overflow. -/
+def denseIFPairArm (B : Nat) (c0 m M : Int) (t : DenseIFTerm) (seen rest : List DenseIFTerm)
+    (st : DenseIFAcc) : DenseIFAcc :=
+  if 0 < t.sc then
+    match (denseIFPartner (-t.sc) seen).or (denseIFPartner (-t.sc) rest) with
+    | some u =>
+      if (B : Int) ≤ t.sc + (c0 + (m - t.mn - u.mn)) ∧
+         c0 + (M - t.mx - u.mx) - t.sc < 0 ∧ t.v ≠ u.v then
+        denseIFPush st ⟨t.v.index, u.v.index + 1⟩
+      else st
+    | none => st
+  else st
+
+def denseIFStep (B : Nat) (c0 m M : Int) (t : DenseIFTerm) (seen rest : List DenseIFTerm)
+    (st : DenseIFAcc) : DenseIFAcc :=
+  denseIFPairArm B c0 m M t seen rest (denseIFZeroArm B c0 m M t st)
+
+def denseIFWalk (B : Nat) (c0 m M : Int) :
+    List DenseIFTerm → List DenseIFTerm → DenseIFAcc → DenseIFAcc
+  | _, [], st => st
+  | seen, t :: rest, st =>
+    denseIFWalk B c0 m M (t :: seen) rest (denseIFStep B c0 m M t seen rest st)
+
+/-- The integer-window gate plus the walk, shared by the general and the bare-variable slot arms. -/
+def denseIFRun (pI : Int) (B : Nat) (c0 : Int) (ts : List DenseIFTerm) (st : DenseIFAcc) :
+    DenseIFAcc :=
+  if c0 + denseIFSumMx ts ≤ pI - 1 ∧ (B : Int) - pI ≤ c0 + denseIFSumMn ts then
+    denseIFWalk B c0 (denseIFSumMn ts) (denseIFSumMx ts) [] ts st
+  else st
+
+/-- All seeds forced by one slot bounded by `B`: linearize, merge like terms, pair each variable
+    with its own bound, check the integer window, and extract the zero/pair arms. For a slot that
+    is a bare variable the term list is a singleton and is built directly. -/
+def denseIFSlot (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) (B : Nat) (e : DenseExpr p)
+    (st : DenseIFAcc) : DenseIFAcc :=
+  match e with
+  | .const _ => st
+  | .var x =>
+    match idx[x]? with
+    | none => st
+    | some Bv => denseIFRun pI B 0 [denseIFTermOf half (zmodOneP p) Bv x] st
+  | _ =>
+    match denseIFLin e [] with
+    | none => st
+    | some (c, raw) =>
+      match denseIFProc half idx 0 (denseMergeTerms raw) with
+      | none => st
+      | some ts => denseIFRun pI B (denseIFSrep half c) ts st
+
+/-! ## The prepared interaction sweep
+
+One walk over the interactions computes the constant multiplicity and the constant-payload pattern
+once per interaction and calls `slotBound` once per slot — the union of what the bounds index (bare
+variable slots) and the seed sweep (every slot) each used to recompute for themselves. The bounded
+slots are collected for the seed pass, which cannot start before the *whole* index is known. -/
+
+structure DenseIFPrep (p : ℕ) where
+  /-- Bounded slots as `(slot expression, bound)`, in reverse collection order. -/
+  slots : List (DenseExpr p × Nat)
+  idx : Std.HashMap VarId Nat
+
+/-- A one-term walk has no partner, so only its zero arm can fire, and on coefficient
+    `sc1 = srep 1` that arm's test does not mention the variable's own bound. A bare-variable slot
+    failing this emits nothing and need not be collected — which is every `256`-bounded memory
+    limb. -/
+def denseIFVarLive (sc1 : Int) (B : Nat) : Bool :=
+  (0 < sc1 ∧ (B : Int) ≤ sc1) ∨ sc1 < 0
+
+/-- `true` when no slot before index `i` is literally `.var x` — `denseVarSlot`'s first-match
+    semantics, which is the slot whose bound the index records for `x`. -/
+def denseIFFirstAt (x : VarId) : List (DenseExpr p) → Nat → Bool
+  | _, 0 => true
+  | [], _ => true
+  | e :: rest, n + 1 => if denseIsVarOf x e then false else denseIFFirstAt x rest n
+
+/-- Record the bound for `x`, keeping the smaller of duplicates. -/
+def denseIFIdxInsert (idx : Std.HashMap VarId Nat) (x : VarId) (B : Nat) :
     Std.HashMap VarId Nat :=
-  match denseInteractionBound bs facts bi x with
-  | none => I
-  | some B =>
-    if (match I[x]? with
-        | some old => decide (B < old)
-        | none => true) then
-      I.insert x B
-    else I
+  match idx[x]? with
+  | some old => if B < old then idx.insert x B else idx
+  | none => idx.insert x B
 
-/-- Record every bare-variable slot bound of one interaction. -/
-def denseBoundIdxAddBi (bs : BusSemantics p) (facts : BusFacts p bs)
-    (I : Std.HashMap VarId Nat) (bi : BusInteraction (DenseExpr p)) : Std.HashMap VarId Nat :=
-  (bi.payload.filterMap (fun e =>
-    match e with
-    | .var x => some x
-    | _ => none)).foldl (fun I x => denseBoundIdxInsertVar bs facts I bi x) I
+/-- One payload slot. A literal constant slot linearizes to a term-free form: it is no seed and no
+    index entry, so its bound is never asked for. -/
+def denseIFPrepSlot (bs : BusSemantics p) (facts : BusFacts p bs) (sc1 : Int) (busId : Nat)
+    (mval : ZMod p) (pat : List (Option (ZMod p))) (payload : List (DenseExpr p))
+    (e : DenseExpr p) (i : Nat) (st : DenseIFPrep p) : DenseIFPrep p :=
+  match e with
+  | .const _ => st
+  | _ =>
+    match facts.slotBound busId mval pat i with
+    | none => st
+    | some B =>
+      match e with
+      | .var x =>
+        let sl := if denseIFVarLive sc1 B then (e, B) :: st.slots else st.slots
+        if denseIFFirstAt x payload i then ⟨sl, denseIFIdxInsert st.idx x B⟩
+        else ⟨sl, st.idx⟩
+      | _ => ⟨(e, B) :: st.slots, st.idx⟩
 
-/-- Fold `denseBoundIdxAddBi` over every interaction. -/
-def denseBoundIdxAddAll (bs : BusSemantics p) (facts : BusFacts p bs) :
-    Std.HashMap VarId Nat → List (BusInteraction (DenseExpr p)) → Std.HashMap VarId Nat
-  | I, [] => I
-  | I, bi :: rest => denseBoundIdxAddAll bs facts (denseBoundIdxAddBi bs facts I bi) rest
+def denseIFPrepGo (bs : BusSemantics p) (facts : BusFacts p bs) (sc1 : Int) (busId : Nat)
+    (mval : ZMod p) (pat : List (Option (ZMod p))) (payload : List (DenseExpr p)) :
+    List (DenseExpr p) → Nat → DenseIFPrep p → DenseIFPrep p
+  | [], _, st => st
+  | e :: rest, i, st =>
+    denseIFPrepGo bs facts sc1 busId mval pat payload rest (i + 1)
+      (denseIFPrepSlot bs facts sc1 busId mval pat payload e i st)
 
-/-- Build the bounds index from scratch. -/
-def denseBoundIdxBuild (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) : Std.HashMap VarId Nat :=
-  denseBoundIdxAddAll bs facts ∅ bis
+def denseIFPrepBi (bs : BusSemantics p) (facts : BusFacts p bs) (sc1 : Int) (st : DenseIFPrep p)
+    (bi : BusInteraction (DenseExpr p)) : DenseIFPrep p :=
+  match bi.multiplicity.constValue? with
+  | none => st
+  | some mval =>
+    if zmodIsZero mval then st
+    else
+      denseIFPrepGo bs facts sc1 bi.busId mval (bi.payload.map DenseExpr.constValue?) bi.payload
+        bi.payload 0 st
+
+def denseIFPrep (bs : BusSemantics p) (facts : BusFacts p bs) (sc1 : Int)
+    (bis : List (BusInteraction (DenseExpr p))) : DenseIFPrep p :=
+  bis.foldl (denseIFPrepBi bs facts sc1) ⟨[], ∅⟩
 
 /-! ## The pass -/
 
-/-- The per-slot seed walk of `denseInteractionSeeds`, with the constant-payload pattern `pat`
-    computed once by the caller instead of once per slot. -/
-def denseInteractionSeedsGo (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) (mval : ZMod p)
-    (pat : List (Option (ZMod p))) : List (DenseExpr p) :=
-  (List.range bi.payload.length).flatMap (fun i =>
-    match bi.payload[i]?, facts.slotBound bi.busId mval pat i with
-    | some e, some B => denseSlotSeeds bnd B e
-    | _, _ => [])
+def denseIFSlots (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) :
+    List (DenseExpr p × Nat) → DenseIFAcc → DenseIFAcc
+  | [], st => st
+  | (e, B) :: rest, st => denseIFSlots half pI idx rest (denseIFSlot half pI idx B e st)
 
-def denseInteractionSeedsImpl (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
-  match bi.multiplicity.constValue? with
-  | none => []
-  | some mval =>
-    if zmodIsZero mval then []
-    else denseInteractionSeedsGo bs facts bnd bi mval (bi.payload.map DenseExpr.constValue?)
+def denseIFConstraintSeeds (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) :
+    List (DenseExpr p) → DenseIFAcc → DenseIFAcc
+  | [], st => st
+  | c :: rest, st => denseIFConstraintSeeds half pI idx rest (denseIFSlot half pI idx 1 c st)
 
-/-- All seeds of one interaction: every payload slot with a `slotBound`. -/
-def denseInteractionSeeds (bs : BusSemantics p) (facts : BusFacts p bs)
-    (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
-  match bi.multiplicity.constValue? with
-  | none => []
-  | some mval =>
-    if mval = 0 then []
-    else denseInteractionSeedsGo bs facts bnd bi mval (bi.payload.map DenseExpr.constValue?)
+/-- The key of an algebraic constraint that already *is* a seed shape (`x` or `x − y`); `none`
+    otherwise, decided at the top node. -/
+def denseIFCsKey (negOneVal : Nat) : DenseExpr p → Option DenseIFKey
+  | .var v => some ⟨v.index, 0⟩
+  | .add (.var v) (.mul (.const c) (.var w)) =>
+    if c.val == negOneVal then some ⟨v.index, w.index + 1⟩ else none
+  | _ => none
 
-@[csimp] theorem denseInteractionSeeds_eq_impl :
-    @denseInteractionSeeds = @denseInteractionSeedsImpl := by
-  funext q bs facts bnd bi
-  simp [denseInteractionSeeds, denseInteractionSeedsImpl]
+def denseIFCsKeys (negOneVal : Nat) :
+    List (DenseExpr p) → Std.HashSet DenseIFKey → Std.HashSet DenseIFKey
+  | [], s => s
+  | c :: rest, s =>
+    match denseIFCsKey negOneVal c with
+    | none => denseIFCsKeys negOneVal rest s
+    | some k => denseIFCsKeys negOneVal rest (s.insert k)
 
-/-- All seeds over the system: every bounded interaction slot, plus every algebraic constraint
-    consumed as a bound-`1` slot. -/
-def denseAllSeeds (bs : BusSemantics p) (facts : BusFacts p bs) (bnd : VarId → Option Nat)
-    (d : DenseConstraintSystem p) : List (DenseExpr p) :=
-  HashedDedup.hashedEraseDups DenseExpr.bHash
-    (d.busInteractions.flatMap (denseInteractionSeeds bs facts bnd) ++
-      d.algebraicConstraints.flatMap (fun c => denseSlotSeeds bnd 1 c))
+/-- The dense expression a key stands for (`densePairDiff`'s shape for the pair arm). -/
+def denseIFExprOf (negOne : ZMod p) (k : DenseIFKey) : DenseExpr p :=
+  if k.b = 0 then .var ⟨k.a⟩
+  else .add (.var ⟨k.a⟩) (.mul (.const negOne) (.var ⟨k.b - 1⟩))
 
-/-- The entailed interval-forcing seeds: every seed whose variables all occur in `d` and that is
-    not already a constraint (hash-bucket dedup). Appended by the pass (`Proofs/IntervalForce.lean`). -/
+/-- Every forced key of the system, in emission order: the bounded bus slots, then the algebraic
+    constraints (each bounded by `1`). -/
+def denseIFKeys (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
+    List DenseIFKey :=
+  let half := (p - 1) / 2
+  let prep := denseIFPrep bs facts (denseIFSrep half (zmodOneP p)) d.busInteractions
+  (denseIFConstraintSeeds half (p : Int) prep.idx d.algebraicConstraints
+    (denseIFSlots half (p : Int) prep.idx prep.slots.reverse ⟨[], ∅⟩)).keys.reverse
+
+/-- The entailed interval-forcing seeds: every slot bounded by a `BusFacts` fact — and every
+    algebraic constraint, which is bounded by `1` — analyzed over the integers, deduplicated, and
+    filtered against the constraints already present. Appended by the pass
+    (`Proofs/IntervalForce.lean`). Every seed variable comes from a term of an item of `d`, so the
+    occurrence test the obligation asks for needs no index. -/
 def denseIntervalForceNew (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : List (DenseExpr p) :=
-  let idx := denseBoundIdxBuild bs facts d.busInteractions
-  let seeds := denseAllSeeds bs facts (fun v => idx[v]?) d
-  -- Hash set / hash-bucket lookups replace per-seed linear scans of `d.occ` and the constraints.
-  let varSet : Std.HashSet VarId := Std.HashSet.ofList d.occ
-  let csBuckets : Std.HashMap UInt64 (List (DenseExpr p)) :=
-    d.algebraicConstraints.foldl (fun m c => m.insert c.bHash (c :: m.getD c.bHash [])) ∅
-  (seeds.filter (fun e => e.vars.all (fun z => varSet.contains z))).filter
-    (fun e => !(csBuckets.getD e.bHash []).contains e)
+  if p = 0 then []
+  else
+    let ks := denseIFKeys bs facts d
+    if ks.isEmpty then []
+    else
+      let cs := denseIFCsKeys (p - 1) d.algebraicConstraints ∅
+      (ks.filter (fun k => !cs.contains k)).map (denseIFExprOf (zmodNegOneP p))
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IntervalForce.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/IntervalForce.lean
@@ -5,8 +5,16 @@ import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DomainTable
 set_option autoImplicit false
 
 /-! # Dense interval forcing: proof and wiring for `denseIntervalForceNew` (`IntervalForce.lean`).
+
 The pass appends entailed constraints, so correctness rides on
-`DensePassCorrect.denseAddConstraints` once each seed is shown to evaluate to `0`. -/
+`DensePassCorrect.denseAddConstraints` once each emitted key is shown to state a truth about the
+assignment (`DenseIFKeyHolds`) and to mention only variables of `d` (`DenseIFFrom`).
+
+The chain is: `denseIFLin` is `denseLinearizeAcc`, so the whole `Affine`/`Normalize` layer
+(`denseLinearize_eval`, `denseLinearize_vars`, `denseMergeTerms_eval`, `denseMergeTerms_fst`)
+applies to the merged term list; `denseIFProc` turns that into terms carrying their integer window;
+`int_window` pins the signed integer value of a bounded slot to `[0, B)`; and the walk's two arms
+are then `omega` over that window. -/
 
 namespace ApcOptimizer.Dense
 
@@ -14,434 +22,1043 @@ open IntervalForce
 
 variable {p : ℕ}
 
-/-! ## The integer value of a dense processed-term list (proof-side only) -/
+/-! ## `denseIFLin` is `denseLinearizeAcc` -/
 
-/-- The integer value of a processed-term list under an assignment (proof-side only; states the
-    window lemmas). -/
-def denseIntEval (denv : VarId → ZMod p) (pts : List DensePTerm) : Int :=
-  (pts.map (fun t => t.sc * ((denv t.v).val : Int))).sum
+theorem denseIFConst_eq (e : DenseExpr p) :
+    denseIFConst e = (denseLinearize e).bind
+      (fun l => if l.terms.isEmpty then some l.const else none) := by
+  induction e with
+  | const n => simp [denseIFConst, denseLinearize]
+  | var i => simp [denseIFConst, denseLinearize]
+  | add a b iha ihb =>
+    cases ha : denseLinearize a with
+    | none => simp [denseIFConst, denseLinearize, ha, iha]
+    | some la =>
+      cases hb : denseLinearize b with
+      | none =>
+        cases hta : la.terms <;>
+          simp [denseIFConst, denseLinearize, ha, hb, iha, ihb, hta]
+      | some lb =>
+        simp only [denseIFConst, iha, ihb, ha, hb, Option.bind_some]
+        cases hta : la.terms <;> cases htb : lb.terms <;>
+          simp [denseLinearize, ha, hb, DenseLinExpr.add, hta, htb, zmodAdd_eq]
+  | mul a b iha ihb =>
+    cases ha : denseLinearize a with
+    | none => simp [denseIFConst, denseLinearize, ha, iha]
+    | some la =>
+      cases hb : denseLinearize b with
+      | none =>
+        cases hta : la.terms <;>
+          simp [denseIFConst, denseLinearize, ha, hb, iha, ihb, hta]
+      | some lb =>
+        simp only [denseIFConst, iha, ihb, ha, hb, Option.bind_some]
+        cases hta : la.terms <;> cases htb : lb.terms <;>
+          simp [denseLinearize, ha, hb, DenseLinExpr.scale, hta, htb, zmodMul_eq]
 
-theorem denseProcTerms_cast [NeZero p] (bnd : VarId → Option Nat)
-    (terms : List (VarId × ZMod p)) (pts : List DensePTerm)
-    (h : denseProcTerms bnd terms = some pts) (denv : VarId → ZMod p) :
-    ((denseIntEval denv pts : Int) : ZMod p) = (terms.map (fun t => t.2 * denv t.1)).sum := by
-  induction terms generalizing pts with
-  | nil =>
-    simp only [denseProcTerms, Option.some.injEq] at h
-    subst h
-    simp [denseIntEval]
+/-- `denseIFLin` is `denseLinearize` with the terms threaded onto an accumulator: the only change
+    is that a product whose left factor has terms decides its right factor with `denseIFConst`
+    (variable-free), which is the same test as "the right factor's term list is empty". -/
+theorem denseIFLin_eq (e : DenseExpr p) (acc : List (VarId × ZMod p)) :
+    denseIFLin e acc = (denseLinearize e).map (fun l => (l.const, l.terms ++ acc)) := by
+  induction e generalizing acc with
+  | const n => simp [denseIFLin, denseLinearize]
+  | var i => simp [denseIFLin, denseLinearize]
+  | add a b iha ihb =>
+    rw [denseIFLin, ihb acc]
+    cases hb : denseLinearize b with
+    | none => simp [denseLinearize, hb]
+    | some lb =>
+      simp only [Option.map_some, iha (lb.terms ++ acc)]
+      cases ha : denseLinearize a with
+      | none => simp [denseLinearize, ha, hb]
+      | some la =>
+        simp [denseLinearize, ha, hb, DenseLinExpr.add, zmodAdd_eq, List.append_assoc]
+  | mul a b iha ihb =>
+    rw [denseIFLin, iha []]
+    cases ha : denseLinearize a with
+    | none => simp [denseLinearize, ha]
+    | some la =>
+      simp only [Option.map_some, List.append_nil]
+      by_cases h1 : la.terms.isEmpty
+      · rw [if_pos h1, ihb []]
+        cases hb : denseLinearize b with
+        | none => simp [denseLinearize, ha, hb]
+        | some lb =>
+          simp only [Option.map_some, List.append_nil]
+          simp [denseLinearize, ha, hb, h1, DenseLinExpr.scale, denseScaleAppend_eq, zmodMul_eq]
+      · rw [if_neg h1, denseIFConst_eq]
+        cases hb : denseLinearize b with
+        | none => simp [denseLinearize, ha, hb]
+        | some lb =>
+          simp only [Option.bind_some]
+          by_cases h2 : lb.terms.isEmpty
+          · rw [if_pos h2]
+            simp [denseLinearize, ha, hb, h1, h2, DenseLinExpr.scale, denseScaleAppend_eq,
+              zmodMul_eq]
+          · rw [if_neg h2]
+            simp [denseLinearize, ha, hb, h1, h2]
+
+theorem denseIFLin_spec (e : DenseExpr p) (c : ZMod p) (raw : List (VarId × ZMod p))
+    (h : denseIFLin e [] = some (c, raw)) :
+    ∃ l : DenseLinExpr p, denseLinearize e = some l ∧ l.const = c ∧ l.terms = raw := by
+  rw [denseIFLin_eq] at h
+  cases hl : denseLinearize e with
+  | none => rw [hl] at h; exact absurd h (by simp)
+  | some l =>
+    rw [hl] at h
+    simp only [Option.map_some, Option.some.injEq, Prod.mk.injEq, List.append_nil] at h
+    exact ⟨l, rfl, h.1, h.2⟩
+
+/-! ## Processed terms
+
+`denseIFVal` is the integer value the term list stands for. The two facts `denseIFProc` establishes
+are that this value casts back to the slot's field value, and that each term's `(mn, mx)` bracket
+its own contribution. -/
+
+def denseIFVal (denv : VarId → ZMod p) : List DenseIFTerm → Int
+  | [] => 0
+  | t :: rest => t.sc * ((denv t.v).val : Int) + denseIFVal denv rest
+
+theorem denseIFVal_eq (denv : VarId → ZMod p) (l : List DenseIFTerm) :
+    denseIFVal denv l = (l.map (fun t => t.sc * ((denv t.v).val : Int))).sum := by
+  induction l with
+  | nil => rfl
+  | cons t rest ih => simp [denseIFVal, ih]
+
+theorem denseIFSumMn_eq (l : List DenseIFTerm) :
+    denseIFSumMn l = (l.map (fun t => t.mn)).sum := by
+  induction l with
+  | nil => rfl
+  | cons t rest ih => simp [denseIFSumMn, ih]
+
+theorem denseIFSumMx_eq (l : List DenseIFTerm) :
+    denseIFSumMx l = (l.map (fun t => t.mx)).sum := by
+  induction l with
+  | nil => rfl
+  | cons t rest ih => simp [denseIFSumMx, ih]
+
+theorem denseIFVal_perm (denv : VarId → ZMod p) {l1 l2 : List DenseIFTerm} (h : l1.Perm l2) :
+    denseIFVal denv l1 = denseIFVal denv l2 := by
+  rw [denseIFVal_eq, denseIFVal_eq]; exact List.Perm.sum_eq (List.Perm.map _ h)
+
+theorem denseIFSumMn_perm {l1 l2 : List DenseIFTerm} (h : l1.Perm l2) :
+    denseIFSumMn l1 = denseIFSumMn l2 := by
+  rw [denseIFSumMn_eq, denseIFSumMn_eq]; exact List.Perm.sum_eq (List.Perm.map _ h)
+
+theorem denseIFSumMx_perm {l1 l2 : List DenseIFTerm} (h : l1.Perm l2) :
+    denseIFSumMx l1 = denseIFSumMx l2 := by
+  rw [denseIFSumMx_eq, denseIFSumMx_eq]; exact List.Perm.sum_eq (List.Perm.map _ h)
+
+/-- Every term's contribution sits inside its own window, so the whole value sits inside the sum
+    of the windows. -/
+theorem denseIFVal_window (denv : VarId → ZMod p) (l : List DenseIFTerm)
+    (hw : ∀ t ∈ l, t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+      t.sc * ((denv t.v).val : Int) ≤ t.mx) :
+    denseIFSumMn l ≤ denseIFVal denv l ∧ denseIFVal denv l ≤ denseIFSumMx l := by
+  induction l with
+  | nil => simp [denseIFVal, denseIFSumMn, denseIFSumMx]
   | cons t rest ih =>
-    obtain ⟨v, c⟩ := t
-    simp only [denseProcTerms] at h
-    cases hb : bnd v with
-    | none => simp only [hb] at h; exact absurd h (by simp)
-    | some B =>
-      cases hr : denseProcTerms bnd rest with
-      | none => simp only [hb, hr] at h; exact absurd h (by simp)
-      | some pts' =>
-        simp only [hb, hr, Option.some.injEq] at h
-        subst h
-        have hstep : denseIntEval denv (⟨srep c, B, v⟩ :: pts')
-            = srep c * ((denv v).val : Int) + denseIntEval denv pts' := by
-          simp [denseIntEval]
-        rw [hstep, Int.cast_add, Int.cast_mul, Int.cast_natCast, srep_cast,
-          ZMod.natCast_val, ZMod.cast_id, ih pts' hr, List.map_cons, List.sum_cons]
-
-theorem denseProcTerms_bounds (bnd : VarId → Option Nat)
-    (terms : List (VarId × ZMod p)) (pts : List DensePTerm)
-    (h : denseProcTerms bnd terms = some pts) (denv : VarId → ZMod p)
-    (hbnd : ∀ v b, bnd v = some b → (denv v).val < b) :
-    ∀ t ∈ pts, ((denv t.v).val : Int) < (t.bnd : Int) := by
-  induction terms generalizing pts with
-  | nil =>
-    simp only [denseProcTerms, Option.some.injEq] at h
-    subst h
-    intro t ht
-    exact absurd ht (by simp)
-  | cons t0 rest ih =>
-    obtain ⟨v, c⟩ := t0
-    simp only [denseProcTerms] at h
-    cases hb : bnd v with
-    | none => simp only [hb] at h; exact absurd h (by simp)
-    | some B =>
-      cases hr : denseProcTerms bnd rest with
-      | none => simp only [hb, hr] at h; exact absurd h (by simp)
-      | some pts' =>
-        simp only [hb, hr, Option.some.injEq] at h
-        subst h
-        intro t ht
-        rcases List.mem_cons.mp ht with rfl | ht'
-        · exact_mod_cast hbnd v B hb
-        · exact ih pts' hr t ht'
-
-theorem denseIntEval_window (denv : VarId → ZMod p) (pts : List DensePTerm)
-    (hb : ∀ t ∈ pts, ((denv t.v).val : Int) < (t.bnd : Int)) :
-    denseMinSum pts ≤ denseIntEval denv pts ∧ denseIntEval denv pts ≤ denseMaxSum pts := by
-  induction pts with
-  | nil => simp [denseIntEval, denseMinSum, denseMaxSum]
-  | cons t rest ih =>
-    have hrest := ih (fun t' ht' => hb t' (List.mem_cons_of_mem _ ht'))
-    have ht := term_window t.sc ((denv t.v).val : Int) (t.bnd : Int)
-      (Int.natCast_nonneg _) (hb t (List.mem_cons_self ..))
-    simp only [denseIntEval, denseMinSum, denseMaxSum, List.map_cons, List.sum_cons] at *
+    have hr := ih (fun t' ht' => hw t' (List.mem_cons_of_mem _ ht'))
+    have ht := hw t (List.mem_cons_self ..)
+    simp only [denseIFVal, denseIFSumMn, denseIFSumMx]
     omega
 
-/-! ## The seed walk -/
+theorem denseIFTermOf_v (half : Nat) (c : ZMod p) (Bv : Nat) (v : VarId) :
+    (denseIFTermOf half c Bv v).v = v := rfl
 
-theorem densePairDiff_eval (v w : VarId) (denv : VarId → ZMod p) :
-    (densePairDiff v w : DenseExpr p).eval denv = denv v - denv w := by
-  unfold densePairDiff
-  rw [denseEqExpr_eval]; rfl
+theorem denseIFSrep_eq (c : ZMod p) : denseIFSrep ((p - 1) / 2) c = srep c := rfl
 
-theorem denseFindPartner_spec (g : Int) :
-    ∀ (pts : List DensePTerm) (t : DensePTerm) (rest : List DensePTerm),
-      denseFindPartner g pts = some (t, rest) → t.sc = g ∧ pts.Perm (t :: rest) := by
-  intro pts
-  induction pts with
-  | nil => intro t rest h; exact absurd h (by simp [denseFindPartner])
-  | cons t0 rest0 ih =>
-    intro t rest h
-    unfold denseFindPartner at h
-    split_ifs at h with hsc
-    · simp only [Option.some.injEq, Prod.mk.injEq] at h
-      obtain ⟨rfl, rfl⟩ := h
-      exact ⟨hsc, List.Perm.refl _⟩
-    · cases hr : denseFindPartner g rest0 with
-      | none => rw [hr] at h; exact absurd h (by simp)
-      | some tr =>
-        obtain ⟨t', rest'⟩ := tr
-        rw [hr] at h
-        simp only [Option.some.injEq, Prod.mk.injEq] at h
-        obtain ⟨rfl, rfl⟩ := h
-        obtain ⟨hg, hperm⟩ := ih t' rest' hr
-        exact ⟨hg, (hperm.cons t0).trans (List.Perm.swap t' t0 rest')⟩
+/-- The window of a term built by `denseIFTermOf`, from its variable's own bound. -/
+theorem denseIFTermOf_window (c : ZMod p) (Bv : Nat) (v : VarId) (denv : VarId → ZMod p)
+    (hb : (denv v).val < Bv) :
+    (denseIFTermOf ((p - 1) / 2) c Bv v).mn ≤
+        (denseIFTermOf ((p - 1) / 2) c Bv v).sc * ((denv v).val : Int) ∧
+      (denseIFTermOf ((p - 1) / 2) c Bv v).sc * ((denv v).val : Int) ≤
+        (denseIFTermOf ((p - 1) / 2) c Bv v).mx := by
+  have hd : ((denv v).val : Int) < (Bv : Int) := by exact_mod_cast hb
+  obtain ⟨h1, h2⟩ := term_window (srep c) ((denv v).val : Int) (Bv : Int)
+    (Int.natCast_nonneg _) hd
+  simp only [denseIFTermOf, denseIFSrep_eq]
+  refine ⟨?_, ?_⟩
+  · split_ifs with h <;> omega
+  · split_ifs with h <;> omega
 
-theorem denseIntEval_perm (denv : VarId → ZMod p) {l1 l2 : List DensePTerm} (h : l1.Perm l2) :
-    denseIntEval denv l1 = denseIntEval denv l2 :=
-  List.Perm.sum_eq (List.Perm.map _ h)
+/-- Each processed term mentions a variable of the input term list. -/
+theorem denseIFProc_vars (half : Nat) (idx : Std.HashMap VarId Nat) :
+    ∀ (n : Nat) (l : List (VarId × ZMod p)) (ts : List DenseIFTerm),
+      denseIFProc half idx n l = some ts → ∀ t ∈ ts, t.v ∈ l.map Prod.fst := by
+  intro n l
+  induction l generalizing n with
+  | nil =>
+    intro ts h t ht
+    simp only [denseIFProc, Option.some.injEq] at h
+    exact absurd (h ▸ ht) (by simp)
+  | cons vc rest ih =>
+    obtain ⟨v, c⟩ := vc
+    intro ts h t ht
+    simp only [denseIFProc] at h
+    by_cases hz : zmodIsZero c = true
+    · rw [if_pos hz] at h
+      exact List.mem_cons_of_mem _ (ih n ts h t ht)
+    rw [if_neg hz] at h
+    by_cases hcap : maxTerms ≤ n
+    · rw [if_pos hcap] at h; exact absurd h (by simp)
+    rw [if_neg hcap] at h
+    · cases hb : idx[v]? with
+      | none => rw [hb] at h; exact absurd h (by simp)
+      | some Bv =>
+        rw [hb] at h
+        cases hp : denseIFProc half idx (n + 1) rest with
+        | none => rw [hp] at h; exact absurd h (by simp)
+        | some ts' =>
+          rw [hp] at h
+          simp only [Option.some.injEq] at h
+          subst h
+          rcases List.mem_cons.1 ht with rfl | ht'
+          · simp [denseIFTermOf_v]
+          · exact List.mem_cons_of_mem _ (ih (n + 1) ts' hp t ht')
 
-theorem denseWalk_sound [NeZero p] (B : Nat) (c0 : Int) (denv : VarId → ZMod p)
-    (pts0 : List DensePTerm)
-    (hbnds : ∀ t ∈ pts0, ((denv t.v).val : Int) < (t.bnd : Int))
-    (hS0 : 0 ≤ c0 + denseIntEval denv pts0) (hSB : c0 + denseIntEval denv pts0 < (B : Int)) :
-    ∀ (seen cur : List DensePTerm), (seen ++ cur).Perm pts0 →
-      ∀ e ∈ denseWalk B c0 seen cur, e.eval denv = 0 := by
-  intro seen cur
-  induction cur generalizing seen with
-  | nil => intro _ e he; exact absurd he (by simp [denseWalk])
+/-- The processed terms' integer value casts to the term list's field value, and each term's
+    window brackets its contribution. -/
+theorem denseIFProc_val [NeZero p] (idx : Std.HashMap VarId Nat) (denv : VarId → ZMod p)
+    (hidx : ∀ v b, idx[v]? = some b → (denv v).val < b) :
+    ∀ (n : Nat) (l : List (VarId × ZMod p)) (ts : List DenseIFTerm),
+      denseIFProc ((p - 1) / 2) idx n l = some ts →
+        ((denseIFVal denv ts : Int) : ZMod p) = (l.map (fun t => t.2 * denv t.1)).sum ∧
+        ∀ t ∈ ts, t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+          t.sc * ((denv t.v).val : Int) ≤ t.mx := by
+  intro n l
+  induction l generalizing n with
+  | nil =>
+    intro ts h
+    simp only [denseIFProc, Option.some.injEq] at h
+    subst h
+    exact ⟨by simp [denseIFVal], by simp⟩
+  | cons vc rest ih =>
+    obtain ⟨v, c⟩ := vc
+    intro ts h
+    simp only [denseIFProc] at h
+    by_cases hz : zmodIsZero c = true
+    · rw [if_pos hz] at h
+      obtain ⟨h1, h2⟩ := ih n ts h
+      refine ⟨?_, h2⟩
+      have hc : c = 0 := by simpa using hz
+      simp [h1, hc]
+    rw [if_neg hz] at h
+    by_cases hcap : maxTerms ≤ n
+    · rw [if_pos hcap] at h; exact absurd h (by simp)
+    rw [if_neg hcap] at h
+    · cases hb : idx[v]? with
+      | none => rw [hb] at h; exact absurd h (by simp)
+      | some Bv =>
+        rw [hb] at h
+        cases hp : denseIFProc ((p - 1) / 2) idx (n + 1) rest with
+        | none => rw [hp] at h; exact absurd h (by simp)
+        | some ts' =>
+          rw [hp] at h
+          simp only [Option.some.injEq] at h
+          subst h
+          obtain ⟨h1, h2⟩ := ih (n + 1) ts' hp
+          have hvb : (denv v).val < Bv := hidx v Bv hb
+          refine ⟨?_, ?_⟩
+          · have hsc : (denseIFTermOf ((p - 1) / 2) c Bv v).sc = srep c := rfl
+            simp only [denseIFVal, denseIFTermOf_v, hsc, List.map_cons, List.sum_cons]
+            push_cast
+            rw [h1, srep_cast, ZMod.natCast_val, ZMod.cast_id]
+          · intro t ht
+            rcases List.mem_cons.1 ht with rfl | ht'
+            · exact denseIFTermOf_window c Bv v denv hvb
+            · exact h2 t ht'
+
+/-! ## The walk -/
+
+/-- What an emitted key says about the assignment. -/
+def DenseIFKeyHolds (denv : VarId → ZMod p) (k : DenseIFKey) : Prop :=
+  (k.b = 0 → denv ⟨k.a⟩ = 0) ∧ (k.b ≠ 0 → denv ⟨k.a⟩ = denv ⟨k.b - 1⟩)
+
+/-- Which terms an emitted key can have come from. -/
+def DenseIFFrom (ts : List DenseIFTerm) (k : DenseIFKey) : Prop :=
+  (∃ t ∈ ts, t.v.index = k.a) ∧ (k.b = 0 ∨ ∃ u ∈ ts, u.v.index + 1 = k.b)
+
+theorem denseIFPush_keys (st : DenseIFAcc) (k : DenseIFKey) :
+    ∀ k' ∈ (denseIFPush st k).keys, k' ∈ st.keys ∨ k' = k := by
+  intro k' hk'
+  unfold denseIFPush at hk'
+  split_ifs at hk' with h
+  · exact Or.inl hk'
+  · rcases List.mem_cons.1 hk' with rfl | h'
+    · exact Or.inr rfl
+    · exact Or.inl h'
+
+theorem denseIFPartner_spec (g : Int) :
+    ∀ (l : List DenseIFTerm) (u : DenseIFTerm), denseIFPartner g l = some u →
+      u ∈ l ∧ u.sc = g := by
+  intro l
+  induction l with
+  | nil => intro u h; exact absurd h (by simp [denseIFPartner])
   | cons t rest ih =>
-    intro hperm e he
-    have hperm' : (t :: (seen ++ rest)).Perm pts0 :=
+    intro u h
+    simp only [denseIFPartner] at h
+    split_ifs at h with hsc
+    · simp only [Option.some.injEq] at h
+      subst h
+      exact ⟨List.mem_cons_self .., by simpa using hsc⟩
+    · obtain ⟨hm, hg⟩ := ih u h
+      exact ⟨List.mem_cons_of_mem _ hm, hg⟩
+
+theorem denseIFPartner_or_spec (g : Int) (seen rest : List DenseIFTerm) (u : DenseIFTerm)
+    (h : ((denseIFPartner g seen).or (denseIFPartner g rest)) = some u) :
+    u ∈ seen ++ rest ∧ u.sc = g := by
+  cases hs : denseIFPartner g seen with
+  | some u' =>
+    rw [hs] at h
+    simp only [Option.some_or, Option.some.injEq] at h
+    subst h
+    obtain ⟨hm, hg⟩ := denseIFPartner_spec g seen u' hs
+    exact ⟨List.mem_append_left _ hm, hg⟩
+  | none =>
+    rw [hs] at h
+    simp only [Option.none_or] at h
+    obtain ⟨hm, hg⟩ := denseIFPartner_spec g rest u h
+    exact ⟨List.mem_append_right _ hm, hg⟩
+
+/-- Structural half of one step: every key it adds names `t` and, for a pair arm, some term of
+    `seen ++ rest`. -/
+theorem denseIFStep_keys (B : Nat) (c0 m M : Int) (t : DenseIFTerm)
+    (seen rest : List DenseIFTerm) (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFStep B c0 m M t seen rest st).keys,
+      k ∈ st.keys ∨ k = ⟨t.v.index, 0⟩ ∨ ∃ u ∈ seen ++ rest, k = ⟨t.v.index, u.v.index + 1⟩ := by
+  have h1 : ∀ k ∈ (denseIFZeroArm B c0 m M t st).keys,
+      k ∈ st.keys ∨ k = ⟨t.v.index, 0⟩ ∨
+        ∃ u ∈ seen ++ rest, k = ⟨t.v.index, u.v.index + 1⟩ := by
+    intro k hk
+    unfold denseIFZeroArm at hk
+    split_ifs at hk with hc
+    · rcases denseIFPush_keys st ⟨t.v.index, 0⟩ k hk with h | rfl
+      · exact Or.inl h
+      · exact Or.inr (Or.inl rfl)
+    · exact Or.inl hk
+  intro k hk
+  unfold denseIFStep denseIFPairArm at hk
+  split_ifs at hk with hpos
+  · cases hpt : ((denseIFPartner (-t.sc) seen).or (denseIFPartner (-t.sc) rest)) with
+    | none => simp only [hpt] at hk; exact h1 k hk
+    | some u =>
+      simp only [hpt] at hk
+      obtain ⟨hum, _⟩ := denseIFPartner_or_spec (-t.sc) seen rest u hpt
+      split_ifs at hk with hc
+      · rcases denseIFPush_keys _ ⟨t.v.index, u.v.index + 1⟩ k hk with h | rfl
+        · exact h1 k h
+        · exact Or.inr (Or.inr ⟨u, hum, rfl⟩)
+      · exact h1 k hk
+  · exact h1 k hk
+
+/-- Structural half of the walk: every key it adds mentions terms of `seen ++ rest`. -/
+theorem denseIFWalk_from (B : Nat) (c0 m M : Int) :
+    ∀ (seen rest : List DenseIFTerm) (st : DenseIFAcc),
+      ∀ k ∈ (denseIFWalk B c0 m M seen rest st).keys,
+        k ∈ st.keys ∨ DenseIFFrom (seen ++ rest) k := by
+  intro seen rest
+  induction rest generalizing seen with
+  | nil => intro st k hk; exact Or.inl hk
+  | cons t rest ih =>
+    intro st k hk
+    rw [denseIFWalk] at hk
+    have hperm : (t :: seen ++ rest).Perm (seen ++ t :: rest) :=
+      (List.perm_middle (a := t) (l₁ := seen) (l₂ := rest)).symm
+    have htk : t ∈ seen ++ t :: rest := List.mem_append_right _ (List.mem_cons_self ..)
+    rcases ih (t :: seen) _ k hk with h | h
+    · rcases denseIFStep_keys B c0 m M t seen rest st k h with h' | rfl | ⟨u, hum, rfl⟩
+      · exact Or.inl h'
+      · exact Or.inr ⟨⟨t, htk, rfl⟩, Or.inl rfl⟩
+      · have huk : u ∈ seen ++ t :: rest := by
+          rcases List.mem_append.1 hum with h' | h'
+          · exact List.mem_append_left _ h'
+          · exact List.mem_append_right _ (List.mem_cons_of_mem _ h')
+        exact Or.inr ⟨⟨t, htk, rfl⟩, Or.inr ⟨u, huk, rfl⟩⟩
+    · exact Or.inr ⟨h.1.imp (fun _ h' => ⟨hperm.subset h'.1, h'.2⟩),
+        h.2.imp id (fun h' => h'.imp (fun _ h'' => ⟨hperm.subset h''.1, h''.2⟩))⟩
+
+/-- Soundness of one step, given the slot's signed value pinned to `[0, B)`. -/
+theorem denseIFStep_sound [NeZero p] (B : Nat) (c0 : Int) (denv : VarId → ZMod p) (ts0 : List DenseIFTerm)
+    (hw : ∀ t ∈ ts0, t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+      t.sc * ((denv t.v).val : Int) ≤ t.mx)
+    (hS0 : 0 ≤ c0 + denseIFVal denv ts0) (hSB : c0 + denseIFVal denv ts0 < (B : Int))
+    (t : DenseIFTerm) (seen rest : List DenseIFTerm) (hperm : (t :: (seen ++ rest)).Perm ts0)
+    (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFStep B c0 (denseIFSumMn ts0) (denseIFSumMx ts0) t seen rest st).keys,
+      k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  have hbnds' : ∀ t' ∈ seen ++ rest, t'.mn ≤ t'.sc * ((denv t'.v).val : Int) ∧
+      t'.sc * ((denv t'.v).val : Int) ≤ t'.mx := fun t' ht' =>
+    hw t' (hperm.subset (List.mem_cons_of_mem _ ht'))
+  have hsplit : denseIFVal denv ts0
+      = t.sc * ((denv t.v).val : Int) + denseIFVal denv (seen ++ rest) := by
+    rw [← denseIFVal_perm denv hperm]; rfl
+  have hmn : denseIFSumMn ts0 = t.mn + denseIFSumMn (seen ++ rest) := by
+    rw [← denseIFSumMn_perm hperm]; rfl
+  have hmx : denseIFSumMx ts0 = t.mx + denseIFSumMx (seen ++ rest) := by
+    rw [← denseIFSumMx_perm hperm]; rfl
+  have hwother := denseIFVal_window denv (seen ++ rest) hbnds'
+  have h1 : ∀ k ∈ (denseIFZeroArm B c0 (denseIFSumMn ts0) (denseIFSumMx ts0) t st).keys,
+      k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+    intro k hk
+    unfold denseIFZeroArm at hk
+    split_ifs at hk with hc
+    · rcases denseIFPush_keys st ⟨t.v.index, 0⟩ k hk with h | rfl
+      · exact Or.inl h
+      · refine Or.inr ⟨fun _ => ?_, fun h => absurd rfl h⟩
+        show denv t.v = 0
+        rw [← ZMod.val_eq_zero]
+        by_contra hne
+        have hd1 : (1 : Int) ≤ ((denv t.v).val : Int) := by
+          have h1 : 1 ≤ (denv t.v).val := Nat.one_le_iff_ne_zero.mpr hne
+          exact_mod_cast h1
+        rcases hc with ⟨hsc, hcnd⟩ | ⟨hsc, hcnd⟩
+        · have hscd : t.sc ≤ t.sc * ((denv t.v).val : Int) :=
+            le_mul_of_one_le_right (le_of_lt hsc) hd1
+          generalize hX : t.sc * ((denv t.v).val : Int) = X at hsplit hscd
+          omega
+        · have hscd : t.sc * ((denv t.v).val : Int) ≤ t.sc := by
+            have h1 : t.sc * ((denv t.v).val : Int) ≤ t.sc * 1 :=
+              mul_le_mul_of_nonpos_left hd1 (le_of_lt hsc)
+            rwa [mul_one] at h1
+          generalize hX : t.sc * ((denv t.v).val : Int) = X at hsplit hscd
+          omega
+    · exact Or.inl hk
+  intro k hk
+  unfold denseIFStep denseIFPairArm at hk
+  split_ifs at hk with hpos
+  · cases hpt : ((denseIFPartner (-t.sc) seen).or (denseIFPartner (-t.sc) rest)) with
+    | none => simp only [hpt] at hk; exact h1 k hk
+    | some u =>
+      simp only [hpt] at hk
+      obtain ⟨hum, hug⟩ := denseIFPartner_or_spec (-t.sc) seen rest u hpt
+      obtain ⟨s1, s2, hsplitl⟩ := List.append_of_mem hum
+      have hpermu : (seen ++ rest).Perm (u :: (s1 ++ s2)) := by
+        rw [hsplitl]; exact List.perm_middle
+      have hvalu : denseIFVal denv (seen ++ rest)
+          = u.sc * ((denv u.v).val : Int) + denseIFVal denv (s1 ++ s2) := by
+        rw [denseIFVal_perm denv hpermu]; rfl
+      have hmnu : denseIFSumMn (seen ++ rest) = u.mn + denseIFSumMn (s1 ++ s2) := by
+        rw [denseIFSumMn_perm hpermu]; rfl
+      have hmxu : denseIFSumMx (seen ++ rest) = u.mx + denseIFSumMx (s1 ++ s2) := by
+        rw [denseIFSumMx_perm hpermu]; rfl
+      have hbnds'' : ∀ w ∈ s1 ++ s2, w.mn ≤ w.sc * ((denv w.v).val : Int) ∧
+          w.sc * ((denv w.v).val : Int) ≤ w.mx := fun w hwm =>
+        hbnds' w (hpermu.symm.subset (List.mem_cons_of_mem _ hwm))
+      have hwother' := denseIFVal_window denv (s1 ++ s2) hbnds''
+      split_ifs at hk with hc
+      · rcases denseIFPush_keys _ ⟨t.v.index, u.v.index + 1⟩ k hk with h | rfl
+        · exact h1 k h
+        · obtain ⟨hc1, hc2, _⟩ := hc
+          refine Or.inr ⟨fun h => absurd h (by simp), fun _ => ?_⟩
+          show denv t.v = denv u.v
+          have hcomb : denseIFVal denv ts0
+              = t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int))
+                + denseIFVal denv (s1 ++ s2) := by
+            rw [hsplit, hvalu, hug]; ring
+          have hveq : (denv t.v).val = (denv u.v).val := by
+            by_contra hnev
+            rcases Nat.lt_or_ge (denv t.v).val (denv u.v).val with hlt | hge
+            · have hdlt : ((denv t.v).val : Int) - ((denv u.v).val : Int) ≤ -1 := by
+                have h2 : ((denv t.v).val : Int) + 1 ≤ ((denv u.v).val : Int) := by
+                  exact_mod_cast hlt
+                omega
+              have hXle : t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int)) ≤ -t.sc := by
+                have h2 : t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int))
+                    ≤ t.sc * (-1) := mul_le_mul_of_nonneg_left hdlt (le_of_lt hpos)
+                rwa [mul_neg_one] at h2
+              generalize hX : t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int)) = X
+                at hcomb hXle
+              omega
+            · have hdgt : (1 : Int) ≤ ((denv t.v).val : Int) - ((denv u.v).val : Int) := by
+                have h2 : ((denv u.v).val : Int) + 1 ≤ ((denv t.v).val : Int) := by
+                  have h3 : (denv u.v).val + 1 ≤ (denv t.v).val := by omega
+                  exact_mod_cast h3
+                omega
+              have hXge : t.sc ≤ t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int)) :=
+                le_mul_of_one_le_right (le_of_lt hpos) hdgt
+              generalize hX : t.sc * (((denv t.v).val : Int) - ((denv u.v).val : Int)) = X
+                at hcomb hXge
+              omega
+          exact ZMod.val_injective p hveq
+      · exact h1 k hk
+  · exact h1 k hk
+
+/-- Soundness of the walk: with the slot's signed value pinned to `[0, B)`, every key it emits
+    states a truth about the assignment. -/
+theorem denseIFWalk_sound [NeZero p] (B : Nat) (c0 : Int) (denv : VarId → ZMod p) (ts0 : List DenseIFTerm)
+    (hw : ∀ t ∈ ts0, t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+      t.sc * ((denv t.v).val : Int) ≤ t.mx)
+    (hS0 : 0 ≤ c0 + denseIFVal denv ts0) (hSB : c0 + denseIFVal denv ts0 < (B : Int)) :
+    ∀ (seen rest : List DenseIFTerm), (seen ++ rest).Perm ts0 → ∀ st : DenseIFAcc,
+      ∀ k ∈ (denseIFWalk B c0 (denseIFSumMn ts0) (denseIFSumMx ts0) seen rest st).keys,
+        k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  intro seen rest
+  induction rest generalizing seen with
+  | nil => intro _ st k hk; exact Or.inl hk
+  | cons t rest ih =>
+    intro hperm st k hk
+    have hperm' : (t :: (seen ++ rest)).Perm ts0 :=
       (List.perm_middle (a := t) (l₁ := seen) (l₂ := rest)).symm.trans hperm
-    have hsplit : denseIntEval denv pts0
-        = t.sc * ((denv t.v).val : Int) + denseIntEval denv (seen ++ rest) := by
-      rw [← denseIntEval_perm denv hperm']
-      simp [denseIntEval]
-    have hbnds' : ∀ t' ∈ seen ++ rest, ((denv t'.v).val : Int) < (t'.bnd : Int) := fun t' ht' =>
-      hbnds t' (hperm'.subset (List.mem_cons_of_mem _ ht'))
-    have hbt : ((denv t.v).val : Int) < (t.bnd : Int) :=
-      hbnds t (hperm'.subset (List.mem_cons_self ..))
-    have hwother := denseIntEval_window denv (seen ++ rest) hbnds'
-    unfold denseWalk at he
-    simp only [List.mem_append] at he
-    rcases he with (hz | hp) | hrec
-    · -- zero arm
-      split_ifs at hz with hcond
-      swap
-      · exact absurd hz (by simp)
-      rw [List.mem_singleton] at hz
-      subst hz
-      show denv t.v = 0
-      rw [← ZMod.val_eq_zero]
-      by_contra hne
-      have hd1 : (1 : Int) ≤ ((denv t.v).val : Int) := by
-        have h1 : 1 ≤ (denv t.v).val := Nat.one_le_iff_ne_zero.mpr hne
-        exact_mod_cast h1
-      rcases hcond with ⟨hsc, hcnd⟩ | ⟨hsc, hcnd⟩
-      · have hscd : t.sc ≤ t.sc * ((denv t.v).val : Int) :=
-          le_mul_of_one_le_right (le_of_lt hsc) hd1
-        generalize hX : t.sc * ((denv t.v).val : Int) = X at hsplit hscd
-        omega
-      · have hscd : t.sc * ((denv t.v).val : Int) ≤ t.sc := by
-          have h1 : t.sc * ((denv t.v).val : Int) ≤ t.sc * 1 :=
-            mul_le_mul_of_nonpos_left hd1 (le_of_lt hsc)
-          rwa [mul_one] at h1
-        generalize hX : t.sc * ((denv t.v).val : Int) = X at hsplit hscd
-        omega
-    · -- pair arm
-      split_ifs at hp with hsc
-      swap
-      · exact absurd hp (by simp)
-      cases hfp : denseFindPartner (-t.sc) (seen ++ rest) with
-      | none => simp only [hfp] at hp; exact absurd hp (by simp)
-      | some tr =>
-        obtain ⟨t', others'⟩ := tr
-        simp only [hfp] at hp
-        split_ifs at hp with hcond
-        swap
-        · exact absurd hp (by simp)
-        rw [List.mem_singleton] at hp
-        subst hp
-        obtain ⟨hc1, hc2, _hne⟩ := hcond
-        obtain ⟨hg, hpp⟩ := denseFindPartner_spec (-t.sc) (seen ++ rest) t' others' hfp
-        have hsplit2 : denseIntEval denv (seen ++ rest)
-            = t'.sc * ((denv t'.v).val : Int) + denseIntEval denv others' := by
-          rw [denseIntEval_perm denv hpp]
-          simp [denseIntEval]
-        have hbnds'' : ∀ u ∈ others', ((denv u.v).val : Int) < (u.bnd : Int) := fun u hu =>
-          hbnds' u (hpp.symm.subset (List.mem_cons_of_mem _ hu))
-        have hwother' := denseIntEval_window denv others' hbnds''
-        have hcomb : denseIntEval denv pts0
-            = t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) + denseIntEval denv others' := by
-          rw [hsplit, hsplit2, hg]
-          ring
-        show (densePairDiff t.v t'.v).eval denv = 0
-        rw [densePairDiff_eval]
-        have hveq : (denv t.v).val = (denv t'.v).val := by
-          by_contra hnev
-          rcases Nat.lt_or_ge (denv t.v).val (denv t'.v).val with hlt | hge
-          · have hdlt : ((denv t.v).val : Int) - ((denv t'.v).val : Int) ≤ -1 := by
-              have h1 : (denv t.v).val + 1 ≤ (denv t'.v).val := hlt
-              have h2 : ((denv t.v).val : Int) + 1 ≤ ((denv t'.v).val : Int) := by exact_mod_cast h1
-              omega
-            have hXle : t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) ≤ -t.sc := by
-              have h1 : t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) ≤ t.sc * (-1) :=
-                mul_le_mul_of_nonneg_left hdlt (le_of_lt hsc)
-              rwa [mul_neg_one] at h1
-            generalize hX : t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) = X
-              at hcomb hXle
-            omega
-          · have hdgt : (1 : Int) ≤ ((denv t.v).val : Int) - ((denv t'.v).val : Int) := by
-              have h1 : (denv t'.v).val + 1 ≤ (denv t.v).val := by omega
-              have h2 : ((denv t'.v).val : Int) + 1 ≤ ((denv t.v).val : Int) := by exact_mod_cast h1
-              omega
-            have hXge : t.sc ≤ t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) :=
-              le_mul_of_one_le_right (le_of_lt hsc) hdgt
-            generalize hX : t.sc * (((denv t.v).val : Int) - ((denv t'.v).val : Int)) = X
-              at hcomb hXge
-            omega
-        rw [show denv t.v = denv t'.v from ZMod.val_injective p hveq, sub_self]
-    · -- recursive call
-      exact ih (t :: seen) (by simpa using hperm') e hrec
+    rw [denseIFWalk] at hk
+    rcases ih (t :: seen) (by simpa using hperm') _ k hk with h | h
+    · exact denseIFStep_sound B c0 denv ts0 hw hS0 hSB t seen rest hperm' st k h
+    · exact Or.inr h
 
-/-! ## Per-slot seeds -/
+/-! ## One slot -/
 
-theorem denseSlotSeeds_sound (bnd : VarId → Option Nat) (B : Nat) (e : DenseExpr p)
-    (denv : VarId → ZMod p)
-    (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
-    (hB : (e.eval denv).val < B) :
-    ∀ s ∈ denseSlotSeeds bnd B e, s.eval denv = 0 := by
-  intro s hs
-  unfold denseSlotSeeds at hs
-  split_ifs at hs with hp0
-  · exact absurd hs (by simp)
-  haveI : NeZero p := ⟨hp0⟩
-  cases hl : denseLinearize e with
-  | none => simp only [hl] at hs; exact absurd hs (by simp)
-  | some l =>
-    simp only [hl] at hs
-    split_ifs at hs with hlen
-    swap
-    · exact absurd hs (by simp)
-    cases hpt : denseProcTerms bnd l.norm.terms with
-    | none => simp only [hpt] at hs; exact absurd hs (by simp)
-    | some pts =>
-      simp only [hpt] at hs
-      split_ifs at hs with hwin
-      swap
-      · exact absurd hs (by simp)
-      obtain ⟨hhi, hlo⟩ := hwin
-      have hbnds : ∀ t ∈ pts, ((denv t.v).val : Int) < (t.bnd : Int) :=
-        denseProcTerms_bounds bnd l.norm.terms pts hpt denv hbnd
-      have hcast : (((srep l.norm.const + denseIntEval denv pts : Int)) : ZMod p) = e.eval denv := by
+theorem denseIFRun_from (pI : Int) (B : Nat) (c0 : Int) (ts : List DenseIFTerm)
+    (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFRun pI B c0 ts st).keys, k ∈ st.keys ∨ DenseIFFrom ts k := by
+  intro k hk
+  unfold denseIFRun at hk
+  split_ifs at hk with hg
+  · simpa using denseIFWalk_from B c0 (denseIFSumMn ts) (denseIFSumMx ts) [] ts st k hk
+  · exact Or.inl hk
+
+theorem denseIFRun_sound [NeZero p] (B : Nat) (c0 : Int) (ts : List DenseIFTerm)
+    (denv : VarId → ZMod p) (x : ZMod p)
+    (hw : ∀ t ∈ ts, t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+      t.sc * ((denv t.v).val : Int) ≤ t.mx)
+    (hcast : ((c0 + denseIFVal denv ts : Int) : ZMod p) = x) (hx : x.val < B) (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFRun (p : Int) B c0 ts st).keys, k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  intro k hk
+  unfold denseIFRun at hk
+  split_ifs at hk with hg
+  · obtain ⟨hhi, hlo⟩ := hg
+    obtain ⟨hwm, hwM⟩ := denseIFVal_window denv ts hw
+    have hS := int_window (c0 + denseIFVal denv ts) B x hcast hx (by omega) (by omega)
+    have hS0 : 0 ≤ c0 + denseIFVal denv ts := by rw [hS]; exact Int.natCast_nonneg _
+    have hSB : c0 + denseIFVal denv ts < (B : Int) := by rw [hS]; exact_mod_cast hx
+    exact denseIFWalk_sound B c0 denv ts hw hS0 hSB [] ts (by simp) st k hk
+  · exact Or.inl hk
+
+/-- Every key one slot emits mentions variables of the slot expression. -/
+theorem denseIFSlot_vars (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) (B : Nat)
+    (e : DenseExpr p) (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFSlot half pI idx B e st).keys,
+      k ∈ st.keys ∨ ((⟨k.a⟩ : VarId) ∈ e.vars ∧ (k.b = 0 ∨ (⟨k.b - 1⟩ : VarId) ∈ e.vars)) := by
+  have general : ∀ (e' : DenseExpr p) (c : ZMod p) (raw : List (VarId × ZMod p))
+      (ts : List DenseIFTerm), denseIFLin e' [] = some (c, raw) →
+      denseIFProc half idx 0 (denseMergeTerms raw) = some ts →
+      ∀ k ∈ (denseIFRun pI B (denseIFSrep half c) ts st).keys,
+        k ∈ st.keys ∨ ((⟨k.a⟩ : VarId) ∈ e'.vars ∧ (k.b = 0 ∨ (⟨k.b - 1⟩ : VarId) ∈ e'.vars)) := by
+    intro e' c raw ts hlin hproc k hk
+    obtain ⟨l, hl, hlc, hlt⟩ := denseIFLin_spec e' c raw hlin
+    have hterm : ∀ t ∈ ts, t.v ∈ e'.vars := by
+      intro t ht
+      have h1 := denseIFProc_vars half idx 0 (denseMergeTerms raw) ts hproc t ht
+      exact denseLinearize_vars e' l hl t.v (hlt ▸ denseMergeTerms_fst raw t.v h1)
+    rcases denseIFRun_from pI B (denseIFSrep half c) ts st k hk with h | ⟨⟨t, htm, hta⟩, hb⟩
+    · exact Or.inl h
+    · refine Or.inr ⟨?_, ?_⟩
+      · rw [← hta]; exact hterm t htm
+      · rcases hb with h | ⟨u, hum, hub⟩
+        · exact Or.inl h
+        · exact Or.inr (by rw [← hub]; simpa using hterm u hum)
+  intro k hk
+  unfold denseIFSlot at hk
+  match e with
+  | .const _ => exact Or.inl hk
+  | .var x =>
+    simp only at hk
+    cases hb : idx[x]? with
+    | none => simp only [hb] at hk; exact Or.inl hk
+    | some Bv =>
+      simp only [hb] at hk
+      rcases denseIFRun_from pI B 0 [denseIFTermOf half (zmodOneP p) Bv x] st k hk with
+        h | ⟨⟨t, htm, hta⟩, hbb⟩
+      · exact Or.inl h
+      · rw [List.mem_singleton] at htm
+        subst htm
+        rw [denseIFTermOf_v] at hta
+        refine Or.inr ⟨by rw [← hta]; simp [DenseExpr.vars], ?_⟩
+        rcases hbb with h | ⟨u, hum, hub⟩
+        · exact Or.inl h
+        · rw [List.mem_singleton] at hum
+          subst hum
+          rw [denseIFTermOf_v] at hub
+          exact Or.inr (by rw [← hub]; simp [DenseExpr.vars])
+  | .add a b =>
+    simp only at hk
+    cases hlin : denseIFLin (.add a b : DenseExpr p) [] with
+    | none => simp only [hlin] at hk; exact Or.inl hk
+    | some cr =>
+      obtain ⟨c, raw⟩ := cr
+      simp only [hlin] at hk
+      cases hproc : denseIFProc half idx 0 (denseMergeTerms raw) with
+      | none => simp only [hproc] at hk; exact Or.inl hk
+      | some ts => simp only [hproc] at hk; exact general _ c raw ts hlin hproc k hk
+  | .mul a b =>
+    simp only at hk
+    cases hlin : denseIFLin (.mul a b : DenseExpr p) [] with
+    | none => simp only [hlin] at hk; exact Or.inl hk
+    | some cr =>
+      obtain ⟨c, raw⟩ := cr
+      simp only [hlin] at hk
+      cases hproc : denseIFProc half idx 0 (denseMergeTerms raw) with
+      | none => simp only [hproc] at hk; exact Or.inl hk
+      | some ts => simp only [hproc] at hk; exact general _ c raw ts hlin hproc k hk
+
+/-- Every key one bounded slot emits states a truth about the assignment. -/
+theorem denseIFSlot_sound [NeZero p] (idx : Std.HashMap VarId Nat) (B : Nat) (e : DenseExpr p)
+    (denv : VarId → ZMod p) (hidx : ∀ v b, idx[v]? = some b → (denv v).val < b)
+    (hB : (e.eval denv).val < B) (st : DenseIFAcc) :
+    ∀ k ∈ (denseIFSlot ((p - 1) / 2) (p : Int) idx B e st).keys,
+      k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  have general : ∀ (e' : DenseExpr p) (c : ZMod p) (raw : List (VarId × ZMod p))
+      (ts : List DenseIFTerm), (e'.eval denv).val < B → denseIFLin e' [] = some (c, raw) →
+      denseIFProc ((p - 1) / 2) idx 0 (denseMergeTerms raw) = some ts →
+      ∀ k ∈ (denseIFRun (p : Int) B (denseIFSrep ((p - 1) / 2) c) ts st).keys,
+        k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+    intro e' c raw ts hB' hlin hproc k hk
+    obtain ⟨l, hl, hlc, hlt⟩ := denseIFLin_spec e' c raw hlin
+    obtain ⟨hval, hw⟩ := denseIFProc_val idx denv hidx 0 (denseMergeTerms raw) ts hproc
+    have hcast : ((denseIFSrep ((p - 1) / 2) c + denseIFVal denv ts : Int) : ZMod p)
+        = e'.eval denv := by
+      push_cast
+      rw [denseIFSrep_eq, srep_cast, hval, denseMergeTerms_eval, denseLinearize_eval e' l hl denv]
+      rw [← hlc, ← hlt]
+      rfl
+    exact denseIFRun_sound B _ ts denv (e'.eval denv) hw hcast hB' st k hk
+  intro k hk
+  unfold denseIFSlot at hk
+  match e with
+  | .const _ => exact Or.inl hk
+  | .var x =>
+    simp only at hk
+    cases hb : idx[x]? with
+    | none => simp only [hb] at hk; exact Or.inl hk
+    | some Bv =>
+      simp only [hb] at hk
+      have hvb : (denv x).val < Bv := hidx x Bv hb
+      have hw : ∀ t ∈ [denseIFTermOf ((p - 1) / 2) (zmodOneP p) Bv x],
+          t.mn ≤ t.sc * ((denv t.v).val : Int) ∧
+          t.sc * ((denv t.v).val : Int) ≤ t.mx := by
+        intro t ht
+        rw [List.mem_singleton] at ht
+        subst ht
+        rw [denseIFTermOf_v]
+        exact denseIFTermOf_window (zmodOneP p) Bv x denv hvb
+      have hcast : ((0 + denseIFVal denv [denseIFTermOf ((p - 1) / 2) (zmodOneP p) Bv x] : Int)
+          : ZMod p) = (DenseExpr.var x : DenseExpr p).eval denv := by
+        have hsc : (denseIFTermOf ((p - 1) / 2) (zmodOneP p) Bv x).sc = srep (zmodOneP p) := rfl
+        simp only [denseIFVal, denseIFTermOf_v, hsc, zero_add]
         push_cast
-        rw [srep_cast, denseProcTerms_cast bnd l.norm.terms pts hpt denv,
-          denseLinearize_eval e l hl denv, ← DenseLinExpr.norm_eval]
-        rfl
-      have hwindow := denseIntEval_window denv pts hbnds
-      have hS := int_window (srep l.norm.const + denseIntEval denv pts) B (e.eval denv) hcast hB
-        (by omega) (by omega)
-      have hSB : srep l.norm.const + denseIntEval denv pts < (B : Int) := by
-        rw [hS]; exact_mod_cast hB
-      have hS0 : 0 ≤ srep l.norm.const + denseIntEval denv pts := by
-        rw [hS]; exact Int.natCast_nonneg _
-      exact denseWalk_sound B (srep l.norm.const) denv pts hbnds hS0 hSB [] pts (by simp) s hs
+        rw [srep_cast, zmodOneP_eq, ZMod.natCast_val, ZMod.cast_id, one_mul]
+        simp [DenseExpr.eval]
+      exact denseIFRun_sound B 0 _ denv _ hw hcast hB st k hk
+  | .add a b =>
+    simp only at hk
+    cases hlin : denseIFLin (.add a b : DenseExpr p) [] with
+    | none => simp only [hlin] at hk; exact Or.inl hk
+    | some cr =>
+      obtain ⟨c, raw⟩ := cr
+      simp only [hlin] at hk
+      cases hproc : denseIFProc ((p - 1) / 2) idx 0 (denseMergeTerms raw) with
+      | none => simp only [hproc] at hk; exact Or.inl hk
+      | some ts => simp only [hproc] at hk; exact general _ c raw ts hB hlin hproc k hk
+  | .mul a b =>
+    simp only at hk
+    cases hlin : denseIFLin (.mul a b : DenseExpr p) [] with
+    | none => simp only [hlin] at hk; exact Or.inl hk
+    | some cr =>
+      obtain ⟨c, raw⟩ := cr
+      simp only [hlin] at hk
+      cases hproc : denseIFProc ((p - 1) / 2) idx 0 (denseMergeTerms raw) with
+      | none => simp only [hproc] at hk; exact Or.inl hk
+      | some ts => simp only [hproc] at hk; exact general _ c raw ts hB hlin hproc k hk
 
-/-! ## The per-invocation bounds index soundness (external fold invariant) -/
 
-/-- Bounds-map invariant: every entry is produced by some member interaction's
-    `denseInteractionBound`. -/
-def DenseBoundIdxWitnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (I : Std.HashMap VarId Nat) : Prop :=
-  ∀ (x : VarId) (B : Nat), I[x]? = some B →
-    ∃ bi ∈ bis, denseInteractionBound bs facts bi x = some B
+/-! ## The prepared interaction sweep
 
-theorem denseBoundIdxInsertVar_witnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (I : Std.HashMap VarId Nat)
-    (bi : BusInteraction (DenseExpr p)) (hbi : bi ∈ bis) (x : VarId)
-    (hI : DenseBoundIdxWitnessed facts bis I) :
-    DenseBoundIdxWitnessed facts bis (denseBoundIdxInsertVar bs facts I bi x) := by
+Both consumers of the sweep — the collected slots and the bounds index — are justified by the same
+witness: the entry came from a payload slot of a member interaction whose multiplicity is a nonzero
+constant and whose slot the facts bound. `denseIFSlotWit_bound` turns that into the value bound via
+`BusFacts.slotBound_sound`. -/
+
+def DenseIFSlotWit (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (e : DenseExpr p) (B : Nat) : Prop :=
+  ∃ bi ∈ bis, ∃ mval, bi.multiplicity.constValue? = some mval ∧ mval ≠ 0 ∧
+    ∃ j, bi.payload[j]? = some e ∧
+      facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) j = some B
+
+theorem denseIFSlotWit_bound {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (denv : VarId → ZMod p)
+    (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.accepts (denseBIEval bi denv))
+    (e : DenseExpr p) (B : Nat) (h : DenseIFSlotWit bs facts bis e B) :
+    (e.eval denv).val < B := by
+  obtain ⟨bi, hbi, mval, hmc, hmz, j, hpe, hsb⟩ := h
+  have hmeval : (denseBIEval bi denv).multiplicity = mval :=
+    bi.multiplicity.constValue?_sound mval hmc denv
+  have hv : bs.accepts (denseBIEval bi denv) := hbus bi hbi (by rw [hmeval]; exact hmz)
+  have hget : (denseBIEval bi denv).payload[j]? = some (e.eval denv) := by
+    show (bi.payload.map (fun t => t.eval denv))[j]? = some (e.eval denv)
+    rw [List.getElem?_map, hpe]
+    rfl
+  have hsb' : facts.slotBound (denseBIEval bi denv).busId (denseBIEval bi denv).multiplicity
+      (bi.payload.map DenseExpr.constValue?) j = some B := by
+    show facts.slotBound bi.busId (denseBIEval bi denv).multiplicity _ j = some B
+    rw [hmeval]
+    exact hsb
+  exact facts.slotBound_sound (denseBIEval bi denv) (bi.payload.map DenseExpr.constValue?) j B
+    (e.eval denv) hsb' (denseMatches_evalPattern bi.payload denv) hv hget
+
+theorem denseIFSlotWit_mem {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (e : DenseExpr p) (B : Nat)
+    (h : DenseIFSlotWit bs facts bis e B) : ∃ bi ∈ bis, e ∈ bi.payload := by
+  obtain ⟨bi, hbi, _, _, _, j, hpe, _⟩ := h
+  exact ⟨bi, hbi, List.mem_of_getElem? hpe⟩
+
+theorem denseIFIdxInsert_spec (idx : Std.HashMap VarId Nat) (x : VarId) (B : Nat) :
+    ∀ y B', (denseIFIdxInsert idx x B)[y]? = some B' → idx[y]? = some B' ∨ (y = x ∧ B' = B) := by
   intro y B' h
-  unfold denseBoundIdxInsertVar at h
+  unfold denseIFIdxInsert at h
+  have hins : ∀ m : Std.HashMap VarId Nat, (m.insert x B)[y]? = some B' →
+      m[y]? = some B' ∨ (y = x ∧ B' = B) := by
+    intro m hm
+    rw [Std.HashMap.getElem?_insert] at hm
+    by_cases hxy : (x == y) = true
+    · rw [if_pos hxy] at hm
+      simp only [Option.some.injEq] at hm
+      have hxy' : x = y := by simpa using hxy
+      exact Or.inr ⟨hxy'.symm, hm.symm⟩
+    · rw [if_neg hxy] at hm
+      exact Or.inl hm
   split at h
-  · exact hI y B' h
-  · rename_i B hb
-    split_ifs at h with hg
-    · rw [Std.HashMap.getElem?_insert] at h
-      by_cases hxy : (x == y) = true
-      · rw [if_pos hxy] at h
-        simp only [Option.some.injEq] at h
-        have hxy' : x = y := by simpa using hxy
-        subst hxy'
-        exact ⟨bi, hbi, h ▸ hb⟩
-      · rw [if_neg hxy] at h
-        exact hI y B' h
-    · exact hI y B' h
+  · split_ifs at h with hlt
+    · exact hins idx h
+    · exact Or.inl h
+  · exact hins idx h
 
-theorem denseBoundIdxInsertVar_foldl_witnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p)) (hbi : bi ∈ bis)
-    (xs : List VarId) :
-    ∀ (I : Std.HashMap VarId Nat), DenseBoundIdxWitnessed facts bis I →
-      DenseBoundIdxWitnessed facts bis
-        (xs.foldl (fun I x => denseBoundIdxInsertVar bs facts I bi x) I) := by
-  induction xs with
-  | nil => intro I hI; exact hI
-  | cons x rest ih =>
-    intro I hI
-    exact ih _ (denseBoundIdxInsertVar_witnessed facts bis I bi hbi x hI)
+/-- One interaction's payload walk: every slot it collects and every index entry it writes is
+    witnessed by that interaction. -/
+theorem denseIFPrepGo_spec {bs : BusSemantics p} (facts : BusFacts p bs) (sc1 : Int)
+    (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p))
+    (hbi : bi ∈ bis) (mval : ZMod p) (hmc : bi.multiplicity.constValue? = some mval)
+    (hmz : mval ≠ 0) :
+    ∀ (l : List (DenseExpr p)) (i : Nat), (∀ j, l[j]? = bi.payload[i + j]?) →
+      ∀ st : DenseIFPrep p,
+        (∀ eB ∈ (denseIFPrepGo bs facts sc1 bi.busId mval
+            (bi.payload.map DenseExpr.constValue?) bi.payload l i st).slots,
+          eB ∈ st.slots ∨ DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+        (∀ x B, (denseIFPrepGo bs facts sc1 bi.busId mval
+            (bi.payload.map DenseExpr.constValue?) bi.payload l i st).idx[x]? = some B →
+          st.idx[x]? = some B ∨ DenseIFSlotWit bs facts bis (DenseExpr.var x) B) := by
+  intro l
+  induction l with
+  | nil => intro i _ st; exact ⟨fun eB h => Or.inl h, fun x B h => Or.inl h⟩
+  | cons e rest ih =>
+    intro i hsuf st
+    have hpe : bi.payload[i]? = some e := by
+      have := hsuf 0
+      simpa using this.symm
+    have hsuf' : ∀ j, rest[j]? = bi.payload[(i + 1) + j]? := by
+      intro j
+      have := hsuf (j + 1)
+      simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using this
+    have hstep : (∀ eB ∈ (denseIFPrepSlot bs facts sc1 bi.busId mval
+          (bi.payload.map DenseExpr.constValue?) bi.payload e i st).slots,
+          eB ∈ st.slots ∨ DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+        (∀ x B, (denseIFPrepSlot bs facts sc1 bi.busId mval
+          (bi.payload.map DenseExpr.constValue?) bi.payload e i st).idx[x]? = some B →
+          st.idx[x]? = some B ∨ DenseIFSlotWit bs facts bis (DenseExpr.var x) B) := by
+      have hwit : ∀ B, facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i
+          = some B → DenseIFSlotWit bs facts bis e B := fun B hB =>
+        ⟨bi, hbi, mval, hmc, hmz, i, hpe, hB⟩
+      unfold denseIFPrepSlot
+      match e with
+      | .const _ => exact ⟨fun eB h => Or.inl h, fun x B h => Or.inl h⟩
+      | .var x =>
+        simp only
+        cases hB : facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i with
+        | none => exact ⟨fun eB h => Or.inl h, fun y B h => Or.inl h⟩
+        | some B =>
+          simp only
+          have hgen : ∀ (sl : List (DenseExpr p × Nat)) (ix : Std.HashMap VarId Nat),
+              (sl = ((DenseExpr.var x : DenseExpr p), B) :: st.slots ∨ sl = st.slots) →
+              (ix = denseIFIdxInsert st.idx x B ∨ ix = st.idx) →
+              (∀ eB ∈ sl, eB ∈ st.slots ∨ DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+              (∀ y B', ix[y]? = some B' →
+                st.idx[y]? = some B' ∨ DenseIFSlotWit bs facts bis (DenseExpr.var y) B') := by
+            intro sl ix hsl hix
+            constructor
+            · intro eB h
+              rcases hsl with rfl | rfl
+              · rcases List.mem_cons.1 h with rfl | h'
+                · exact Or.inr (hwit B hB)
+                · exact Or.inl h'
+              · exact Or.inl h
+            · intro y B' h
+              rcases hix with rfl | rfl
+              · rcases denseIFIdxInsert_spec st.idx x B y B' h with h' | ⟨rfl, rfl⟩
+                · exact Or.inl h'
+                · exact Or.inr (hwit B' hB)
+              · exact Or.inl h
+          split_ifs <;>
+            first
+              | exact hgen _ _ (Or.inl rfl) (Or.inl rfl)
+              | exact hgen _ _ (Or.inl rfl) (Or.inr rfl)
+              | exact hgen _ _ (Or.inr rfl) (Or.inl rfl)
+              | exact hgen _ _ (Or.inr rfl) (Or.inr rfl)
+      | .add a b =>
+        simp only
+        cases hB : facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i with
+        | none => exact ⟨fun eB h => Or.inl h, fun y B h => Or.inl h⟩
+        | some B =>
+          refine ⟨fun eB h => ?_, fun y B' h => Or.inl h⟩
+          rcases List.mem_cons.1 h with rfl | h'
+          · exact Or.inr (hwit B hB)
+          · exact Or.inl h'
+      | .mul a b =>
+        simp only
+        cases hB : facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i with
+        | none => exact ⟨fun eB h => Or.inl h, fun y B h => Or.inl h⟩
+        | some B =>
+          refine ⟨fun eB h => ?_, fun y B' h => Or.inl h⟩
+          rcases List.mem_cons.1 h with rfl | h'
+          · exact Or.inr (hwit B hB)
+          · exact Or.inl h'
+    obtain ⟨hrec1, hrec2⟩ := ih (i + 1) hsuf'
+      (denseIFPrepSlot bs facts sc1 bi.busId mval (bi.payload.map DenseExpr.constValue?)
+        bi.payload e i st)
+    refine ⟨fun eB h => ?_, fun x B h => ?_⟩
+    · rcases hrec1 eB (by rw [denseIFPrepGo] at h; exact h) with h' | h'
+      · exact hstep.1 eB h'
+      · exact Or.inr h'
+    · rcases hrec2 x B (by rw [denseIFPrepGo] at h; exact h) with h' | h'
+      · exact hstep.2 x B h'
+      · exact Or.inr h'
 
-theorem denseBoundIdxAddBi_witnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (I : Std.HashMap VarId Nat)
-    (bi : BusInteraction (DenseExpr p)) (hbi : bi ∈ bis)
-    (hI : DenseBoundIdxWitnessed facts bis I) :
-    DenseBoundIdxWitnessed facts bis (denseBoundIdxAddBi bs facts I bi) := by
-  unfold denseBoundIdxAddBi
-  exact denseBoundIdxInsertVar_foldl_witnessed facts bis bi hbi _ I hI
-
-theorem denseBoundIdxAddAll_witnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) (rest : List (BusInteraction (DenseExpr p))) :
-    ∀ (I : Std.HashMap VarId Nat), (∀ bi ∈ rest, bi ∈ bis) →
-      DenseBoundIdxWitnessed facts bis I →
-      DenseBoundIdxWitnessed facts bis (denseBoundIdxAddAll bs facts I rest) := by
-  induction rest with
-  | nil => intro I _ hI; exact hI
-  | cons bi rest' ih =>
-    intro I hmem hI
-    show DenseBoundIdxWitnessed facts bis (denseBoundIdxAddAll bs facts (denseBoundIdxAddBi bs facts I bi) rest')
-    exact ih (denseBoundIdxAddBi bs facts I bi) (fun b hb => hmem b (List.mem_cons_of_mem _ hb))
-      (denseBoundIdxAddBi_witnessed facts bis I bi (hmem bi (List.mem_cons_self ..)) hI)
-
-theorem denseBoundIdxBuild_witnessed {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bis : List (BusInteraction (DenseExpr p))) :
-    DenseBoundIdxWitnessed facts bis (denseBoundIdxBuild bs facts bis) := by
-  unfold denseBoundIdxBuild
-  refine denseBoundIdxAddAll_witnessed facts bis bis ∅ (fun _ h => h) ?_
-  intro x B h
-  rw [Std.HashMap.getElem?_empty] at h
-  exact absurd h (by simp)
-
-theorem denseBoundIdxBuild_lookup_sound {bs : BusSemantics p} (facts : BusFacts p bs)
-    (d : DenseConstraintSystem p) (denv : VarId → ZMod p)
-    (hbus : ∀ bi ∈ d.busInteractions, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.accepts (denseBIEval bi denv)) :
-    ∀ v B, (denseBoundIdxBuild bs facts d.busInteractions)[v]? = some B → (denv v).val < B := by
-  intro v B h
-  obtain ⟨bi, hbi, hib⟩ := denseBoundIdxBuild_witnessed facts d.busInteractions v B h
-  exact denseInteractionBound_sound bs facts bi v B hib denv (hbus bi hbi)
-
-/-! ## Per-interaction and whole-system seed soundness -/
-
-theorem denseInteractionSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bnd : VarId → Option Nat) (bi : BusInteraction (DenseExpr p)) (denv : VarId → ZMod p)
-    (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
-    (hviol : (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.accepts (denseBIEval bi denv)) :
-    ∀ s ∈ denseInteractionSeeds bs facts bnd bi, s.eval denv = 0 := by
-  intro s hs
-  unfold denseInteractionSeeds at hs
+theorem denseIFPrepBi_spec {bs : BusSemantics p} (facts : BusFacts p bs) (sc1 : Int)
+    (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p))
+    (hbi : bi ∈ bis) (st : DenseIFPrep p) :
+    (∀ eB ∈ (denseIFPrepBi bs facts sc1 st bi).slots,
+      eB ∈ st.slots ∨ DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+    (∀ x B, (denseIFPrepBi bs facts sc1 st bi).idx[x]? = some B →
+      st.idx[x]? = some B ∨ DenseIFSlotWit bs facts bis (DenseExpr.var x) B) := by
+  unfold denseIFPrepBi
   cases hmc : bi.multiplicity.constValue? with
-  | none => simp only [hmc] at hs; exact absurd hs (by simp)
+  | none => exact ⟨fun eB h => Or.inl h, fun x B h => Or.inl h⟩
   | some mval =>
-    simp only [hmc] at hs
-    by_cases hmz : mval = 0
-    · rw [if_pos hmz] at hs
-      exact absurd hs (by simp)
-    rw [if_neg hmz] at hs
-    unfold denseInteractionSeedsGo at hs
-    rw [List.mem_flatMap] at hs
-    obtain ⟨i, _, hsi⟩ := hs
-    cases hpe : bi.payload[i]? with
-    | none => simp only [hpe] at hsi; exact absurd hsi (by simp)
-    | some e =>
-      cases hsb : facts.slotBound bi.busId mval (bi.payload.map DenseExpr.constValue?) i with
-      | none => simp only [hpe, hsb] at hsi; exact absurd hsi (by simp)
-      | some B =>
-        simp only [hpe, hsb] at hsi
-        have hmeval : (denseBIEval bi denv).multiplicity = mval :=
-          bi.multiplicity.constValue?_sound mval hmc denv
-        have hv : bs.accepts (denseBIEval bi denv) := by
-          apply hviol
-          rw [hmeval]
-          exact hmz
-        have hget : (denseBIEval bi denv).payload[i]? = some (e.eval denv) := by
-          show (bi.payload.map (fun t => t.eval denv))[i]? = some (e.eval denv)
-          rw [List.getElem?_map, hpe]
-          rfl
-        have hsb' : facts.slotBound (denseBIEval bi denv).busId (denseBIEval bi denv).multiplicity
-            (bi.payload.map DenseExpr.constValue?) i = some B := by
-          show facts.slotBound bi.busId (denseBIEval bi denv).multiplicity _ i = some B
-          rw [hmeval]
-          exact hsb
-        have hbound : (e.eval denv).val < B :=
-          facts.slotBound_sound (denseBIEval bi denv) (bi.payload.map DenseExpr.constValue?) i B
-            (e.eval denv) hsb' (denseMatches_evalPattern bi.payload denv) hv hget
-        exact denseSlotSeeds_sound bnd B e denv hbnd hbound s hsi
+    simp only
+    split_ifs with hz
+    · exact ⟨fun eB h => Or.inl h, fun x B h => Or.inl h⟩
+    · exact denseIFPrepGo_spec facts sc1 bis bi hbi mval hmc (by simpa using hz)
+        bi.payload 0 (by intro j; simp) st
 
-theorem denseAllSeeds_sound {bs : BusSemantics p} (facts : BusFacts p bs)
-    (bnd : VarId → Option Nat) (d : DenseConstraintSystem p) (denv : VarId → ZMod p)
-    (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
-    (hsat : d.satisfies bs denv) :
-    ∀ s ∈ denseAllSeeds bs facts bnd d, s.eval denv = 0 := by
-  intro s hs
-  unfold denseAllSeeds at hs
-  rw [HashedDedup.hashedEraseDups_eq] at hs
-  rcases List.mem_append.1 (List.mem_eraseDups.1 hs) with h | h
-  · obtain ⟨bi, hbi, hsi⟩ := List.mem_flatMap.1 h
-    exact denseInteractionSeeds_sound facts bnd bi denv hbnd (hsat.2 bi hbi) s hsi
-  · obtain ⟨c, hc, hsi⟩ := List.mem_flatMap.1 h
-    by_cases hp0 : p = 0
-    · exfalso
-      unfold denseSlotSeeds at hsi
-      rw [if_pos hp0] at hsi
-      exact absurd hsi (by simp)
-    · haveI : NeZero p := ⟨hp0⟩
-      have hc0 : (c.eval denv).val < 1 := by
-        rw [hsat.1 c hc, ZMod.val_zero]
+theorem denseIFPrep_spec {bs : BusSemantics p} (facts : BusFacts p bs) (sc1 : Int)
+    (bis : List (BusInteraction (DenseExpr p))) :
+    (∀ eB ∈ (denseIFPrep bs facts sc1 bis).slots, DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+    (∀ x B, (denseIFPrep bs facts sc1 bis).idx[x]? = some B →
+      DenseIFSlotWit bs facts bis (DenseExpr.var x) B) := by
+  have go : ∀ (rest : List (BusInteraction (DenseExpr p))), (∀ bi ∈ rest, bi ∈ bis) →
+      ∀ st : DenseIFPrep p,
+        (∀ eB ∈ (rest.foldl (denseIFPrepBi bs facts sc1) st).slots,
+          eB ∈ st.slots ∨ DenseIFSlotWit bs facts bis eB.1 eB.2) ∧
+        (∀ x B, (rest.foldl (denseIFPrepBi bs facts sc1) st).idx[x]? = some B →
+          st.idx[x]? = some B ∨ DenseIFSlotWit bs facts bis (DenseExpr.var x) B) := by
+    intro rest
+    induction rest with
+    | nil => intro _ st; exact ⟨fun eB h => Or.inl h, fun x B h => Or.inl h⟩
+    | cons bi rest' ih =>
+      intro hmem st
+      have hstep := denseIFPrepBi_spec facts sc1 bis bi (hmem bi (List.mem_cons_self ..)) st
+      obtain ⟨h1, h2⟩ := ih (fun b hb => hmem b (List.mem_cons_of_mem _ hb))
+        (denseIFPrepBi bs facts sc1 st bi)
+      refine ⟨fun eB h => ?_, fun x B h => ?_⟩
+      · rcases h1 eB (by simpa using h) with h' | h'
+        · exact hstep.1 eB h'
+        · exact Or.inr h'
+      · rcases h2 x B (by simpa using h) with h' | h'
+        · exact hstep.2 x B h'
+        · exact Or.inr h'
+  obtain ⟨h1, h2⟩ := go bis (fun _ h => h) ⟨[], ∅⟩
+  refine ⟨fun eB h => ?_, fun x B h => ?_⟩
+  · rcases h1 eB h with h' | h'
+    · exact absurd h' (by simp)
+    · exact h'
+  · rcases h2 x B h with h' | h'
+    · rw [Std.HashMap.getElem?_empty] at h'; exact absurd h' (by simp)
+    · exact h'
+
+/-! ## The two seed folds -/
+
+theorem denseIFSlots_keys (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) :
+    ∀ (l : List (DenseExpr p × Nat)) (st : DenseIFAcc),
+      ∀ k ∈ (denseIFSlots half pI idx l st).keys,
+        k ∈ st.keys ∨ ∃ eB ∈ l,
+          (⟨k.a⟩ : VarId) ∈ eB.1.vars ∧ (k.b = 0 ∨ (⟨k.b - 1⟩ : VarId) ∈ eB.1.vars) := by
+  intro l
+  induction l with
+  | nil => intro st k hk; exact Or.inl hk
+  | cons eB rest ih =>
+    intro st k hk
+    rw [denseIFSlots] at hk
+    rcases ih _ k hk with h | ⟨eB', hmem, h⟩
+    · rcases denseIFSlot_vars half pI idx eB.2 eB.1 st k h with h' | h'
+      · exact Or.inl h'
+      · exact Or.inr ⟨eB, List.mem_cons_self .., h'⟩
+    · exact Or.inr ⟨eB', List.mem_cons_of_mem _ hmem, h⟩
+
+theorem denseIFSlots_sound [NeZero p] (idx : Std.HashMap VarId Nat) (denv : VarId → ZMod p)
+    (hidx : ∀ v b, idx[v]? = some b → (denv v).val < b) :
+    ∀ (l : List (DenseExpr p × Nat)), (∀ eB ∈ l, (eB.1.eval denv).val < eB.2) →
+      ∀ st : DenseIFAcc,
+        ∀ k ∈ (denseIFSlots ((p - 1) / 2) (p : Int) idx l st).keys,
+          k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  intro l
+  induction l with
+  | nil => intro _ st k hk; exact Or.inl hk
+  | cons eB rest ih =>
+    intro hb st k hk
+    rw [denseIFSlots] at hk
+    rcases ih (fun e' he' => hb e' (List.mem_cons_of_mem _ he')) _ k hk with h | h
+    · exact denseIFSlot_sound idx eB.2 eB.1 denv hidx (hb eB (List.mem_cons_self ..)) st k h
+    · exact Or.inr h
+
+theorem denseIFConstraintSeeds_keys (half : Nat) (pI : Int) (idx : Std.HashMap VarId Nat) :
+    ∀ (l : List (DenseExpr p)) (st : DenseIFAcc),
+      ∀ k ∈ (denseIFConstraintSeeds half pI idx l st).keys,
+        k ∈ st.keys ∨ ∃ c ∈ l,
+          (⟨k.a⟩ : VarId) ∈ c.vars ∧ (k.b = 0 ∨ (⟨k.b - 1⟩ : VarId) ∈ c.vars) := by
+  intro l
+  induction l with
+  | nil => intro st k hk; exact Or.inl hk
+  | cons c rest ih =>
+    intro st k hk
+    rw [denseIFConstraintSeeds] at hk
+    rcases ih _ k hk with h | ⟨c', hmem, h⟩
+    · rcases denseIFSlot_vars half pI idx 1 c st k h with h' | h'
+      · exact Or.inl h'
+      · exact Or.inr ⟨c, List.mem_cons_self .., h'⟩
+    · exact Or.inr ⟨c', List.mem_cons_of_mem _ hmem, h⟩
+
+theorem denseIFConstraintSeeds_sound [NeZero p] (idx : Std.HashMap VarId Nat)
+    (denv : VarId → ZMod p) (hidx : ∀ v b, idx[v]? = some b → (denv v).val < b) :
+    ∀ (l : List (DenseExpr p)), (∀ c ∈ l, c.eval denv = 0) → ∀ st : DenseIFAcc,
+      ∀ k ∈ (denseIFConstraintSeeds ((p - 1) / 2) (p : Int) idx l st).keys,
+        k ∈ st.keys ∨ DenseIFKeyHolds denv k := by
+  intro l
+  induction l with
+  | nil => intro _ st k hk; exact Or.inl hk
+  | cons c rest ih =>
+    intro hc st k hk
+    rw [denseIFConstraintSeeds] at hk
+    rcases ih (fun c' hc' => hc c' (List.mem_cons_of_mem _ hc')) _ k hk with h | h
+    · have h1 : (c.eval denv).val < 1 := by
+        rw [hc c (List.mem_cons_self ..), ZMod.val_zero]
         omega
-      exact denseSlotSeeds_sound bnd 1 c denv hbnd hc0 s hsi
+      exact denseIFSlot_sound idx 1 c denv hidx h1 st k h
+    · exact Or.inr h
+
+/-! ## Materializing a key -/
+
+theorem denseIFExprOf_vars (negOne : ZMod p) (k : DenseIFKey) :
+    ∀ z ∈ (denseIFExprOf negOne k : DenseExpr p).vars,
+      z = (⟨k.a⟩ : VarId) ∨ (k.b ≠ 0 ∧ z = (⟨k.b - 1⟩ : VarId)) := by
+  intro z hz
+  unfold denseIFExprOf at hz
+  split_ifs at hz with hb
+  · simp only [DenseExpr.vars, List.mem_singleton] at hz
+    exact Or.inl hz
+  · simp only [DenseExpr.vars, List.mem_append, List.mem_singleton, List.nil_append] at hz
+    rcases hz with h | h
+    · exact Or.inl h
+    · exact Or.inr ⟨hb, h⟩
+
+theorem denseIFExprOf_eval [NeZero p] (denv : VarId → ZMod p) (k : DenseIFKey)
+    (h : DenseIFKeyHolds denv k) :
+    (denseIFExprOf (zmodNegOneP p) k : DenseExpr p).eval denv = 0 := by
+  unfold denseIFExprOf
+  split_ifs with hb
+  · show denv ⟨k.a⟩ = 0
+    exact h.1 hb
+  · show denv ⟨k.a⟩ + (zmodNegOneP p) * denv ⟨k.b - 1⟩ = 0
+    rw [zmodNegOneP_eq, h.2 hb]
+    ring
 
 /-! ## The pass -/
+
+theorem denseIFKeys_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) :
+    ∀ k ∈ denseIFKeys bs facts d,
+      (⟨k.a⟩ : VarId) ∈ d.occ ∧ (k.b = 0 ∨ (⟨k.b - 1⟩ : VarId) ∈ d.occ) := by
+  intro k hk
+  rw [denseIFKeys] at hk
+  have hk' := List.mem_reverse.1 hk
+  have hbus : ∀ e : DenseExpr p, (∃ bi ∈ d.busInteractions, e ∈ bi.payload) →
+      ∀ y ∈ e.vars, y ∈ d.occ := by
+    intro e he y hy
+    obtain ⟨bi, hbi, hep⟩ := he
+    exact List.mem_append_right _ (List.mem_flatMap.2
+      ⟨bi, hbi, List.mem_append_right _ (List.mem_flatMap.2 ⟨e, hep, hy⟩)⟩)
+  have hcs : ∀ e : DenseExpr p, e ∈ d.algebraicConstraints → ∀ y ∈ e.vars, y ∈ d.occ := by
+    intro e he y hy
+    exact List.mem_append_left _ (List.mem_flatMap.2 ⟨e, he, hy⟩)
+  rcases denseIFConstraintSeeds_keys _ _ _ d.algebraicConstraints _ k hk' with h | ⟨e, he, h⟩
+  · rcases denseIFSlots_keys _ _ _ _ _ k h with h' | ⟨eB, heB, h'⟩
+    · exact absurd h' (by simp)
+    · have hwit := (denseIFPrep_spec facts (denseIFSrep ((p - 1) / 2) (zmodOneP p))
+        d.busInteractions).1 eB (List.mem_reverse.1 heB)
+      have hmem := denseIFSlotWit_mem facts d.busInteractions eB.1 eB.2 hwit
+      exact ⟨hbus eB.1 hmem _ h'.1, h'.2.imp id (fun hh => hbus eB.1 hmem _ hh)⟩
+  · exact ⟨hcs e he _ h.1, h.2.imp id (fun hh => hcs e he _ hh)⟩
+
+theorem denseIFKeys_sound [NeZero p] (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) (denv : VarId → ZMod p) (hsat : d.satisfies bs denv) :
+    ∀ k ∈ denseIFKeys bs facts d, DenseIFKeyHolds denv k := by
+  intro k hk
+  rw [denseIFKeys] at hk
+  have hk' := List.mem_reverse.1 hk
+  have hbus : ∀ bi ∈ d.busInteractions, (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.accepts (denseBIEval bi denv) := fun bi hbi => hsat.2 bi hbi
+  have hidx : ∀ v b,
+      (denseIFPrep bs facts (denseIFSrep ((p - 1) / 2) (zmodOneP p)) d.busInteractions).idx[v]?
+        = some b → (denv v).val < b := by
+    intro v b hb
+    exact denseIFSlotWit_bound facts d.busInteractions denv hbus (DenseExpr.var v) b
+      ((denseIFPrep_spec facts (denseIFSrep ((p - 1) / 2) (zmodOneP p)) d.busInteractions).2 v b hb)
+  have hslots : ∀ eB ∈ (denseIFPrep bs facts (denseIFSrep ((p - 1) / 2) (zmodOneP p))
+      d.busInteractions).slots.reverse, (eB.1.eval denv).val < eB.2 := fun eB heB =>
+    denseIFSlotWit_bound facts d.busInteractions denv hbus eB.1 eB.2
+      ((denseIFPrep_spec facts (denseIFSrep ((p - 1) / 2) (zmodOneP p)) d.busInteractions).1 eB
+        (List.mem_reverse.1 heB))
+  rcases denseIFConstraintSeeds_sound _ denv hidx d.algebraicConstraints
+    (fun c' hc' => hsat.1 c' hc') _ k hk' with h | h
+  · rcases denseIFSlots_sound _ denv hidx _ hslots _ k h with h' | h'
+    · exact absurd h' (by simp)
+    · exact h'
+  · exact h
 
 theorem denseIntervalForceNew_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     ∀ c ∈ denseIntervalForceNew bs facts d, ∀ z ∈ c.vars, z ∈ d.occ := by
   intro c hc z hz
-  have hp := (List.mem_filter.1 (List.mem_of_mem_filter hc)).2
-  simp only [List.all_eq_true] at hp
-  have hz' := hp z hz
-  rw [Std.HashSet.contains_ofList] at hz'
-  exact List.contains_iff_mem.mp hz'
+  simp only [denseIntervalForceNew] at hc
+  split_ifs at hc with hp0 hempty
+  · exact absurd hc (by simp)
+  · exact absurd hc (by simp)
+  obtain ⟨k, hkmem, rfl⟩ := List.mem_map.1 hc
+  obtain ⟨h1, h2⟩ := denseIFKeys_vars bs facts d k (List.mem_of_mem_filter hkmem)
+  rcases denseIFExprOf_vars (zmodNegOneP p) k z hz with rfl | ⟨hbne, rfl⟩
+  · exact h1
+  · exact h2.resolve_left hbne
 
 theorem denseIntervalForceNew_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) (denv : VarId → ZMod p) (hsat : d.satisfies bs denv) :
     ∀ c ∈ denseIntervalForceNew bs facts d, c.eval denv = 0 := by
   intro c hc
-  have hcseed : c ∈ denseAllSeeds bs facts
-      (fun v => (denseBoundIdxBuild bs facts d.busInteractions)[v]?) d :=
-    List.mem_of_mem_filter (List.mem_of_mem_filter hc)
-  exact denseAllSeeds_sound facts (fun v => (denseBoundIdxBuild bs facts d.busInteractions)[v]?) d denv
-    (fun v B hb => denseBoundIdxBuild_lookup_sound facts d denv (fun bi hbi => hsat.2 bi hbi) v B hb)
-    hsat c hcseed
+  simp only [denseIntervalForceNew] at hc
+  split_ifs at hc with hp0 hempty
+  · exact absurd hc (by simp)
+  · exact absurd hc (by simp)
+  haveI : NeZero p := ⟨hp0⟩
+  obtain ⟨k, hkmem, rfl⟩ := List.mem_map.1 hc
+  exact denseIFExprOf_eval denv k
+    (denseIFKeys_sound bs facts d denv hsat k (List.mem_of_mem_filter hkmem))
 
 /-- The dense `intervalForce` pass: appends the entailed interval-forcing seeds. -/
 def denseIntervalForcePass : DenseVerifiedPassW p :=

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -210,8 +210,11 @@ these need no new proof.
    - ~~`dedup` constraint-side `List.dedup` O(C²·E)~~ **done (entry 104)**: bucketed
      proven-identical twin (`HashedDedup.hashedDedup`), keccak 6.6 s → noise.
    - ~~`intervalForce` seed filters / `eraseDups` / per-slot pattern re-maps~~ **done (entry
-     104)**: keccak 20.7 s → 1.1 s. (`walk`'s O(t²) with `maxTerms = 32` cap remains — bounded,
-     low value.)
+     104)**: keccak 20.7 s → 1.1 s. ~~`walk`'s O(t²)~~ **done (entry 172)**, with the rest of the
+     pass: the `occ` `HashSet` (vacuous — every seed variable comes from a term of an item of `d`),
+     the `bHash` bucket build over every constraint, the duplicated interaction sweep, and the
+     per-slot list pipeline are all gone. 0.32–0.34x on the pass; its residual is
+     `BusFacts.slotBound` dispatch (see R13(b)).
    - ~~`rootPairUnify` re-linearization per candidate var~~ **done (entry 104)** — factors
      linearized once per constraint. `anyVarBound` memoization across pairs still open (only
      matters if key-matched pairs are common; measure first).
@@ -723,6 +726,20 @@ instead of 256 (~30× on those scans). It needs a per-item degree analysis and a
 are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`).
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **A per-`(busId, multiplicity, pattern)` memo of the whole slot-bound vector** (entry 172,
+  intervalForce): rejected on the *keys*, not on a timing. `slotBoundImpl` reads one pattern
+  position per bus type (memory slot 0, bitwise slot 3, range-checker slot 1), but memory payloads
+  also carry constant pointers and timestamps that differ per interaction — so a memo keyed on the
+  whole pattern misses on nearly every hit that would matter, and keying on the relevant positions
+  is `BusFacts`-specific knowledge a pass does not have. The fix belongs at the interface (R13(b)).
+- **An `Array`-backed raw-term buffer for intervalForce's linearization** (entry 172), with an
+  in-place region scale for `mul` instead of the list accumulator. Built and measured first: keccak
+  63 vs 68 ms, wasm-eth `apc_012` 74 vs 81, identical output — real, but ~5 ms on a 2.4 s run
+  against the whole `Array.modify`/`toList`/index-arithmetic layer in the proof *plus* a
+  from-scratch `denseMergeTerms` equality. The list form is `denseLinearizeAcc` plus one changed
+  arm, so it inherits `Affine`/`Normalize`'s lemmas wholesale. Revisit only for a corpus with large
+  affine slots (present maximum 24 merged terms).
 
 - **An in-place `Array` like-term merge in normalize's materializer** (entry 171): a linear scan +
   `Array.set` buffer folded straight into the `toExpr` spine, instead of the shipped

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6584,3 +6584,86 @@ is **~22 % of what `normalize1` reports**. Nothing new is proposed here; the pla
 alternatives are in R5.
 
 **Worked: yes.**
+
+### 172. Runtime: intervalForce rebuilt — key-shaped seeds, one prepared interaction sweep, an O(t) window walk (0.32–0.34x on the pass, sha256 total 0.96x)
+
+Full redesign of the interval-forcing pass (`intervalForceRedesign.md` has the design, the
+attribution and the rejected alternatives). `intervalForce` is rank 3 of the corpus profile
+(3.82 s / 6.5 %, max 1.76 s on sha256 `apc_001`, nonzero in 162 of 202 APCs).
+
+WHAT THE MEASUREMENT SAID (throwaway `IO` probe in `denseRunCycleTimed`, per invocation, on the
+pass's own input; ms summed over all cleanup invocations):
+
+| phase | sha256 `apc_001` | keccak | wasm-eth `apc_012` |
+|---|---:|---:|---:|
+| `denseBoundIdxBuild` | 259 | 48 | 42 |
+| interaction seeds | 563 | 88 | 83 |
+| constraint seeds | 249 | 18 | 39 |
+| `HashSet.ofList d.occ` | **402** | 36 | 56 |
+| `bHash` constraint buckets | 126 | 8 | 10 |
+| filters + dedup | 53 | 3 | 2 |
+| **pass total** | **1780** | 210 | 234 |
+
+Two of those phases were pure waste. The `occ` filter is **vacuous**: `d.occ` is
+`algebraicConstraints.flatMap vars ++ busInteractions.flatMap denseBIVars`, and every seed variable
+comes from a term of a linearized payload slot or constraint *of `d`* — yet the pass built a
+`Std.HashSet VarId` over 168 k occurrences every invocation, on most of which there were **zero**
+seeds to filter. The already-a-constraint filter `bHash`ed all 200 k constraints — a full tree walk
+each — to answer a few thousand membership questions about expressions of exactly two shapes. The
+`perf` leaf-class table agreed with the direction: `alloc/free` 30.5 %, `refcount` 13.6 %,
+`list-ops` 11.9 % of in-pass samples.
+
+THE REBUILD (`IntervalForce.lean`; the old `denseSlotSeeds`/`denseWalk`/`denseProcTerms`/
+`denseBoundIdxBuild` layer is deleted, `srep`/`term_window`/`int_window`/`maxTerms` stay):
+1. **Seeds are keys.** A seed is only `x = 0` or `x − y = 0`, so it is carried as `DenseIFKey`
+   (two `Nat`s) with a `Std.HashSet` for dedup, and materialized as a `DenseExpr` once, at the end,
+   for survivors only. The constraint-membership filter became a shape-matching sweep (`.var v`, or
+   `.add (.var v) (.mul (.const c) (.var w))` with `c = −1`) that fails at the top node for
+   essentially every constraint, built only when the key list is nonempty.
+2. **The `occ` filter is gone** — discharged structurally in the proof instead.
+3. **One prepared interaction sweep** computes the constant multiplicity and the constant-payload
+   pattern once per interaction and calls `slotBound` once per slot — the union of what the bounds
+   index (bare-variable slots) and the seed sweep (every slot) each recomputed. Literal `.const`
+   slots never ask for a bound; bare `.var` slots whose bound cannot fire the one-term zero arm
+   (`B ≤ srep 1`, i.e. every 256-bounded memory limb) are decided there instead of in the seed pass
+   — keccak collects 890 slots per invocation instead of 14 393.
+4. **An early-aborting linearization**: `denseIFLin` is `denseLinearizeAcc` with one arm changed —
+   when the left factor of a product has terms, the right one only has to be *variable-free*, which
+   `denseIFConst` decides by aborting at the first `.var`. `x·y` fails after one variable instead
+   of after linearizing both factors.
+5. **`denseIFProc`** fuses the zero-drop, the `maxTerms` cap, the bound lookup (aborting at the
+   first unbounded variable, where `denseProcTerms` evaluated the whole tail first) and each term's
+   window `(mn, mx)`.
+6. **The walk is O(t), not O(t²)**: `denseMinSum (seen ++ rest)` is `m − mn_i` off the totals, and
+   the pair arm's is `m − mn_i − mn_j`, so no term list is ever rebuilt and the partner search
+   scans `seen` then `rest` instead of their append.
+
+PROOF SURFACE. The pass is proven **on its own terms**, not against the old implementation: the
+obligations are "every emitted key states a truth about the assignment" and "every emitted key
+mentions a variable of `d`", and neither needs the new pipeline to agree with `denseSlotSeeds` step
+for step — no merge-order, walk-order or dedup equality. `denseIFLin_eq` (via `denseIFConst_eq`)
+buys the whole `Affine`/`Normalize` layer; `denseIFProc_val` casts the integer value back and
+brackets each term with `term_window`; `int_window` pins the signed value to `[0, B)`; the two arms
+are `omega` over that window, with the sums-minus-excluded-terms identity a `List.Perm` split.
+`denseIFPrep_spec` gives both the collected slots and the index one witness (`DenseIFSlotWit`),
+which `BusFacts.slotBound_sound` turns into the value bound.
+
+NUMBERS (this 20-core box, serial, interleaved, 3 reps; `profile` per-pass ms; sha256 one shot):
+keccak `apc_001` **209 → 68 (0.33x)**, run total 2642 → 2455 (0.93x); wasm-eth `apc_012` 238 → 81
+(0.34x), 3072 → 2916 (0.95x); wasm-eth `apc_063` 196 → 65 (0.33x), 2603 → 2473 (0.95x);
+openvm-eth `apc_006` 31 → 10 (0.32x), 359 → 337 (0.94x); sha256 `apc_001` **1772 → 594 (0.34x)**,
+27 185 → 26 150 (0.96x). No other pass moves outside noise.
+VERIFIED: `opt-export` **byte-identical** on 25 cases — 8 openvm-eth, 8 wasm-eth, OpenVM keccak
+`apc_001`, sha256 `apc_001`, 6 SP1 rsp, SP1 keccak `apc_001`; `lake build` clean, no warnings;
+`check-proof-integrity` passes.
+
+RESIDUAL (keccak 68 ms, `IO` phase timers summed over 10 invocations): the prepared interaction
+sweep 42 ms, bus-slot seeds 5, constraint seeds 7, constraint keys 2, materialization 0. Stubbing
+the sweep's pushes and its index leaves it at 14 of 15 ms on cycle 0 — **the sweep is
+`BusFacts.slotBound` and nothing else**, and the cost is per-call dispatch (a record-field closure
+application plus `busMap`'s association-list `lookup`, once per slot). The fix is a `slotBounds`
+field answering one interaction at a time; that is `BusFacts.lean` + `OpenVmFacts.lean` +
+`Sp1Facts.lean`, i.e. ideas.md R13(b), and it serves every bound consumer. See ideas.md for the
+two dead ends recorded here (a pattern-keyed memo, and an `Array`-backed term buffer).
+
+**Worked: yes.**


### PR DESCRIPTION
Full redesign of `intervalForce`, rank 3 of the corpus runtime profile (3.82 s / 6.5 % of the
corpus, max 1.76 s on sha256 `apc_001`, nonzero in 162 of 202 APCs).

## What the measurement said

An `IO` phase probe in `denseRunCycleTimed`, on the pass's own input, summed over all cleanup
invocations (ms):

| phase | sha256 `apc_001` | keccak | wasm-eth `apc_012` |
|---|---:|---:|---:|
| `denseBoundIdxBuild` | 259 | 48 | 42 |
| interaction seeds | 563 | 88 | 83 |
| constraint seeds | 249 | 18 | 39 |
| `HashSet.ofList d.occ` | **402** | 36 | 56 |
| `bHash` constraint buckets | 126 | 8 | 10 |
| filters + dedup | 53 | 3 | 2 |
| **pass total** | **1780** | 210 | 234 |

Two phases were pure waste. The `occ` filter is **vacuous** — `d.occ` is
`algebraicConstraints.flatMap vars ++ busInteractions.flatMap denseBIVars`, and every seed variable
comes from a term of a linearized payload slot or constraint *of `d`* — yet it built a
`Std.HashSet VarId` over 168 k occurrences every invocation, on most of which there were zero seeds
to filter. The already-a-constraint filter `bHash`ed all 200 k constraints, a full tree walk each,
to answer a few thousand membership questions about expressions of exactly two shapes.

## The rebuild

- **Seeds are keys.** A seed is only `x = 0` or `x − y = 0`, so it is carried as `DenseIFKey` with a
  `HashSet` for dedup and materialized as a `DenseExpr` once, at the end, for survivors only. The
  constraint-membership filter is a shape match (`.var v`, or `.add (.var v) (.mul (.const c) (.var
  w))` with `c = −1`) that fails at the top node, built only when the key list is nonempty.
- **The `occ` filter is deleted**, discharged structurally in the proof instead.
- **One prepared interaction sweep** computes the constant multiplicity and the constant-payload
  pattern once per interaction and calls `slotBound` once per slot — the union of what the bounds
  index and the seed sweep each recomputed (`denseInteractionBound` rebuilt the pattern *per queried
  variable*). Literal `.const` slots never ask for a bound; bare `.var` slots whose bound cannot fire
  the one-term zero arm — every 256-bounded memory limb — are decided there rather than in the seed
  pass (keccak collects 890 slots per invocation instead of 14 393).
- **`denseIFLin` is `denseLinearizeAcc` with an early-aborting product**: when the left factor has
  terms the right one only has to be variable-free, which `denseIFConst` decides by aborting at the
  first `.var`, so `x*y` fails after one variable instead of after linearizing both factors.
- **`denseIFProc`** fuses the zero-drop, the `maxTerms` cap, the bound lookup (aborting at the first
  unbounded variable) and each term's window `(mn, mx)`.
- **The walk is O(t), not O(t²)**: `denseMinSum (seen ++ rest)` is `m − mn_i` off the totals, so no
  term list is rebuilt per term and the partner search scans `seen` then `rest`.

## Proof

Proven **on the pass's own terms**, not against the old implementation: the obligations are "every
emitted key states a truth about the assignment" and "every emitted key mentions a variable of `d`",
so no merge-order, walk-order or dedup equality is needed. `denseIFLin_eq` (via `denseIFConst_eq`)
buys the whole `Affine`/`Normalize` layer; `denseIFProc_val` casts the integer value back and
brackets each term with `term_window`; `int_window` pins the signed value to `[0, B)`; the two arms
are `omega` over that window, with the sums-minus-excluded-terms identity a `List.Perm` split.
`denseIFPrep_spec` gives the collected slots and the bounds index one witness, which
`BusFacts.slotBound_sound` turns into the value bound.

## Numbers

20-core box, serial, interleaved, 3 reps (sha256 one shot); `profile` per-pass ms.

| APC | `intervalForce` | | run total | |
|---|---:|---|---:|---|
| sha256 `apc_001` | 1772 → **594** | 0.34× | 27185 → 26150 | 0.96× |
| wasm-eth `apc_012` | 238 → **81** | 0.34× | 3072 → 2916 | 0.95× |
| keccak `apc_001` | 209 → **68** | 0.33× | 2642 → 2455 | 0.93× |
| wasm-eth `apc_063` | 196 → **65** | 0.33× | 2603 → 2473 | 0.95× |
| openvm-eth `apc_006` | 31 → **10** | 0.32× | 359 → 337 | 0.94× |

No other pass moves outside noise. **`opt-export` is byte-identical on 25 cases** (8 openvm-eth,
8 wasm-eth, OpenVM keccak `apc_001`, sha256 `apc_001`, 6 SP1 rsp, SP1 keccak `apc_001`), so
effectiveness cannot have moved. `lake build` clean with no warnings;
`Scripts/check-proof-integrity.sh` passes.

## Residual, and where it isn't

keccak 68 ms: prepared sweep 42, bus-slot seeds 5, constraint seeds 7, constraint keys 2. Stubbing
the sweep's pushes and its index leaves it at 14 of 15 ms on cycle 0 — **the sweep is
`BusFacts.slotBound` and nothing else**, and the cost is per-call dispatch: a record-field closure
application plus `busMap`'s association-list `lookup` (`OpenVmSemantics.lean:39`), once per *slot*.
The fix is a `slotBounds` field answering one interaction at a time — `BusFacts.lean` +
`OpenVmFacts.lean` + `Sp1Facts.lean`, i.e. `ideas.md` R13(b) — and it would serve every bound
consumer, so it is deliberately out of scope here. Two dead ends are recorded in `ideas.md`: a
pattern-keyed memo of the slot-bound vector (rejected on the keys), and an `Array`-backed raw-term
buffer (measured 5 ms better, not worth its proof layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)