### PR TITLE
ci: resolve the bench baseline once, pin every consumer to it, and name it

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -62,23 +62,31 @@ jobs:
         run: |
           runs=$(gh run list --workflow "Lean Action CI" --branch main --status success \
             --limit 50 --json databaseId,headSha)
-          # Take the PR's base commit when its build is still around (artifacts live 30 days),
-          # otherwise the newest main build — flagged `exact=false`, so the report can say the
-          # baseline is not this PR's base and the reader knows drift is in the numbers.
-          row=$(jq -c --arg s "$BASE_SHA" 'map(select(.headSha == $s)) | .[0] // empty' <<< "$runs")
-          exact=true
-          if [ -z "$row" ]; then
-            row=$(jq -c '.[0] // empty' <<< "$runs")
-            exact=false
-          fi
+          # Candidates: this PR's base commit first (the only baseline whose diff *is* this PR), then
+          # newest-first. Take the first whose binary still *exists*: a run stays listed forever but
+          # its artifact is pruned at 30 days, so on a long-lived PR the base run can be selectable
+          # with nothing to download -- which would leave the cells with no baseline while the report
+          # still named a sha. Checking availability here keeps the printed sha benchable.
+          ordered=$(jq -c --arg s "$BASE_SHA" \
+            '[.[] | select(.headSha == $s)] + [.[] | select(.headSha != $s)]' <<< "$runs")
           run_id=""; sha=""
-          if [ -n "$row" ]; then
-            run_id=$(jq -r '.databaseId' <<< "$row")
-            sha=$(jq -r '.headSha' <<< "$row")
-          fi
+          for i in $(seq 0 9); do
+            cand=$(jq -c ".[$i] // empty" <<< "$ordered")
+            [ -n "$cand" ] || break
+            rid=$(jq -r '.databaseId' <<< "$cand")
+            live=$(gh api "repos/$GH_REPO/actions/runs/$rid/artifacts" \
+              --jq '[.artifacts[] | select(.name == "apc-optimizer-bin" and .expired == false)]
+                    | length' 2>/dev/null || echo 0)
+            if [ "${live:-0}" -gt 0 ]; then
+              run_id=$rid
+              sha=$(jq -r '.headSha' <<< "$cand")
+              break
+            fi
+          done
+          exact=false
+          if [ -n "$sha" ] && [ "$sha" = "$BASE_SHA" ]; then exact=true; fi
           if [ -z "$run_id" ]; then
-            echo "::warning::no successful main build to bench against; PR-only report"
-            exact=false
+            echo "::warning::no main build with a live apc-optimizer-bin artifact; PR-only report"
           elif [ "$exact" != true ]; then
             echo "::warning::baseline is main $sha, not this PR's base commit $BASE_SHA; \
           size changes and the runtime row may be main's own drift"
@@ -284,10 +292,16 @@ jobs:
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "psha=$(cut -c1-7 <<< "$PR_SHA")" >> "$GITHUB_OUTPUT"
+          # The footer names a baseline only if one was actually benched. A resolved sha is not
+          # enough: a cell can still fail to download it or time out, and then every set falls back
+          # to PR-only markdown -- naming a sha there would describe a comparison that never ran.
+          bsha="$BASE_SHA"
+          if ! ls main/*.json > /dev/null 2>&1; then bsha=""; fi
+          echo "bsha=$bsha" >> "$GITHUB_OUTPUT"
           # One line of prose when the comparison is against something other than this PR's base, so
           # a reader does not attribute main's own drift to the PR (see the `baseline` job).
           drift=""
-          if [ -n "$BASE_SHA" ] && [ "$BASE_EXACT" != true ]; then
+          if [ -n "$bsha" ] && [ "$BASE_EXACT" != true ]; then
             drift="**The baseline is not this PR's base commit**, so a changed size or a large \
           runtime delta may be main's own drift rather than this PR -- verify against a freshly \
           built base before believing either."
@@ -323,7 +337,7 @@ jobs:
                   && github.event.number || '' }}
           note: >-
             openvm-eth + wasm-eth + keccak + sha256 + sp1/rsp + sp1/keccak, PR `${{ steps.base.outputs.psha }}`
-            ${{ needs.baseline.outputs.sha && format('vs main `{0}`', needs.baseline.outputs.sha)
+            ${{ steps.base.outputs.bsha && format('vs main `{0}`', steps.base.outputs.bsha)
                  || '(no main baseline binary)' }}.
             ${{ steps.base.outputs.drift }}
             Effectiveness is exact. Each set's two sides are benched back to back on one runner, so

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -49,16 +49,18 @@ jobs:
       contents: read
       actions: read
     outputs:
+      # `baseline_*` is what the whole suite benches against; `is_pr_base` says whether that happens
+      # to be this PR's own base commit (the ideal) or a stand-in (drift is then in the numbers).
       run_id: ${{ steps.pick.outputs.run_id }}
-      sha: ${{ steps.pick.outputs.sha }}
-      exact: ${{ steps.pick.outputs.exact }}
+      baseline_sha: ${{ steps.pick.outputs.baseline_sha }}
+      is_pr_base: ${{ steps.pick.outputs.is_pr_base }}
     steps:
       - name: Resolve the main build to bench against
         id: pick
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           runs=$(gh run list --workflow "Lean Action CI" --branch main --status success \
             --limit 50 --json databaseId,headSha)
@@ -67,9 +69,9 @@ jobs:
           # its artifact is pruned at 30 days, so on a long-lived PR the base run can be selectable
           # with nothing to download -- which would leave the cells with no baseline while the report
           # still named a sha. Checking availability here keeps the printed sha benchable.
-          ordered=$(jq -c --arg s "$BASE_SHA" \
+          ordered=$(jq -c --arg s "$PR_BASE_SHA" \
             '[.[] | select(.headSha == $s)] + [.[] | select(.headSha != $s)]' <<< "$runs")
-          run_id=""; sha=""
+          run_id=""; baseline_sha=""
           for i in $(seq 0 9); do
             cand=$(jq -c ".[$i] // empty" <<< "$ordered")
             [ -n "$cand" ] || break
@@ -79,23 +81,24 @@ jobs:
                     | length' 2>/dev/null || echo 0)
             if [ "${live:-0}" -gt 0 ]; then
               run_id=$rid
-              sha=$(jq -r '.headSha' <<< "$cand")
+              baseline_sha=$(jq -r '.headSha' <<< "$cand")
               break
             fi
           done
-          exact=false
-          if [ -n "$sha" ] && [ "$sha" = "$BASE_SHA" ]; then exact=true; fi
+          is_pr_base=false
+          if [ -n "$baseline_sha" ] && [ "$baseline_sha" = "$PR_BASE_SHA" ]; then is_pr_base=true; fi
           if [ -z "$run_id" ]; then
             echo "::warning::no main build with a live apc-optimizer-bin artifact; PR-only report"
-          elif [ "$exact" != true ]; then
-            echo "::warning::baseline is main $sha, not this PR's base commit $BASE_SHA; \
-          size changes and the runtime row may be main's own drift"
+          elif [ "$is_pr_base" != true ]; then
+            echo "::warning::baseline is main $baseline_sha, not this PR's base commit \
+          $PR_BASE_SHA; size changes and the runtime row may be main's own drift"
           fi
-          echo "baseline: run=$run_id sha=$sha exact=$exact (base $BASE_SHA)"
+          echo "baseline: run=$run_id sha=$baseline_sha is_pr_base=$is_pr_base \
+          (pr base $PR_BASE_SHA)"
           {
             echo "run_id=$run_id"
-            echo "sha=${sha:0:7}"
-            echo "exact=$exact"
+            echo "baseline_sha=${baseline_sha:0:7}"
+            echo "is_pr_base=$is_pr_base"
           } >> "$GITHUB_OUTPUT"
 
   # Effectiveness over the full OpenVM (openvm-eth, wasm-eth) and SP1 (rsp) sets plus the keccak and
@@ -143,7 +146,7 @@ jobs:
       # Exactly the run the `baseline` job resolved -- no second query, so this cell cannot bench a
       # different commit than the report names. A missing artifact leaves no baseline at all, which
       # `report` already renders as PR-only; that is the honest outcome, unlike a silent swap.
-      - name: Baseline binary (main ${{ needs.baseline.outputs.sha }})
+      - name: Baseline binary (main ${{ needs.baseline.outputs.baseline_sha }})
         if: needs.baseline.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -151,7 +154,8 @@ jobs:
           gh run download "${{ needs.baseline.outputs.run_id }}" -n apc-optimizer-bin -D bin-main \
             || true
           if [ ! -f bin-main/apc-optimizer ]; then
-            echo "::warning::baseline artifact for main ${{ needs.baseline.outputs.sha }} \
+            echo "::warning::baseline artifact for main \
+          ${{ needs.baseline.outputs.baseline_sha }} \
           is unavailable; PR-only report"
           fi
       - name: Effectiveness, both sides (${{ matrix.group.sets }})
@@ -237,7 +241,7 @@ jobs:
           path: bin-target
       - run: chmod +x bin-target/apc-optimizer
       # The same resolved baseline the effectiveness cells use (see the `baseline` job).
-      - name: Baseline binary (main ${{ needs.baseline.outputs.sha }})
+      - name: Baseline binary (main ${{ needs.baseline.outputs.baseline_sha }})
         if: needs.baseline.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -285,23 +289,23 @@ jobs:
       # The baseline sha comes from the `baseline` job -- the same run every cell downloaded.
       # Resolving it again here is what let the footer name a commit nobody benched.
       - name: Comment inputs
-        id: base
+        id: note
         env:
-          BASE_SHA: ${{ needs.baseline.outputs.sha }}
-          BASE_EXACT: ${{ needs.baseline.outputs.exact }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          BASELINE_SHA: ${{ needs.baseline.outputs.baseline_sha }}
+          BASELINE_IS_PR_BASE: ${{ needs.baseline.outputs.is_pr_base }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "psha=$(cut -c1-7 <<< "$PR_SHA")" >> "$GITHUB_OUTPUT"
+          echo "pr_sha=$(cut -c1-7 <<< "$PR_HEAD_SHA")" >> "$GITHUB_OUTPUT"
           # The footer names a baseline only if one was actually benched. A resolved sha is not
           # enough: a cell can still fail to download it or time out, and then every set falls back
           # to PR-only markdown -- naming a sha there would describe a comparison that never ran.
-          bsha="$BASE_SHA"
-          if ! ls main/*.json > /dev/null 2>&1; then bsha=""; fi
-          echo "bsha=$bsha" >> "$GITHUB_OUTPUT"
+          benched_sha="$BASELINE_SHA"
+          if ! ls main/*.json > /dev/null 2>&1; then benched_sha=""; fi
+          echo "benched_sha=$benched_sha" >> "$GITHUB_OUTPUT"
           # One line of prose when the comparison is against something other than this PR's base, so
           # a reader does not attribute main's own drift to the PR (see the `baseline` job).
           drift=""
-          if [ -n "$bsha" ] && [ "$BASE_EXACT" != true ]; then
+          if [ -n "$benched_sha" ] && [ "$BASELINE_IS_PR_BASE" != true ]; then
             drift="**The baseline is not this PR's base commit**, so a changed size or a large \
           runtime delta may be main's own drift rather than this PR -- verify against a freshly \
           built base before believing either."
@@ -336,10 +340,12 @@ jobs:
           pr: ${{ github.event.pull_request.head.repo.full_name == github.repository
                   && github.event.number || '' }}
           note: >-
-            openvm-eth + wasm-eth + keccak + sha256 + sp1/rsp + sp1/keccak, PR `${{ steps.base.outputs.psha }}`
-            ${{ steps.base.outputs.bsha && format('vs main `{0}`', steps.base.outputs.bsha)
+            openvm-eth + wasm-eth + keccak + sha256 + sp1/rsp + sp1/keccak,
+            PR `${{ steps.note.outputs.pr_sha }}`
+            ${{ steps.note.outputs.benched_sha
+                 && format('vs main `{0}`', steps.note.outputs.benched_sha)
                  || '(no main baseline binary)' }}.
-            ${{ steps.base.outputs.drift }}
+            ${{ steps.note.outputs.drift }}
             Effectiveness is exact. Each set's two sides are benched back to back on one runner, so
             the runtime row is comparable -- but coarse: benchmark.py runs cases in parallel. For
             per-pass detail: `gh workflow run "Runtime Bench" -f pr=${{ github.event.number }}`.

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -31,9 +31,68 @@ jobs:
           path: .lake/build/bin/apc-optimizer
           retention-days: 30
 
+  # One baseline for the whole workflow, resolved once and named in the report.
+  #
+  # Every consumer used to run its own `gh run list --branch main --status success --limit 1`: the
+  # three effectiveness cells, the runtime cell, and the report footer — five independent
+  # resolutions, free to land on five different commits, with the footer stating whichever the
+  # *report* job happened to see. Measured on PR #278: one effectiveness cell benched a days-old
+  # main binary (4-5x slower per case, and a different circuit on 3 of its 200 cases) while the
+  # footer labelled the comparison with main's current sha. That reads as a -90% runtime win plus an
+  # effectiveness regression, neither of which existed — and it takes a re-run against a freshly
+  # built main to find that out. So: resolve here, prefer the PR's own base commit (the only baseline
+  # whose diff *is* this PR), and hand every consumer the same run id.
+  baseline:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      run_id: ${{ steps.pick.outputs.run_id }}
+      sha: ${{ steps.pick.outputs.sha }}
+      exact: ${{ steps.pick.outputs.exact }}
+    steps:
+      - name: Resolve the main build to bench against
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          runs=$(gh run list --workflow "Lean Action CI" --branch main --status success \
+            --limit 50 --json databaseId,headSha)
+          # Take the PR's base commit when its build is still around (artifacts live 30 days),
+          # otherwise the newest main build — flagged `exact=false`, so the report can say the
+          # baseline is not this PR's base and the reader knows drift is in the numbers.
+          row=$(jq -c --arg s "$BASE_SHA" 'map(select(.headSha == $s)) | .[0] // empty' <<< "$runs")
+          exact=true
+          if [ -z "$row" ]; then
+            row=$(jq -c '.[0] // empty' <<< "$runs")
+            exact=false
+          fi
+          run_id=""; sha=""
+          if [ -n "$row" ]; then
+            run_id=$(jq -r '.databaseId' <<< "$row")
+            sha=$(jq -r '.headSha' <<< "$row")
+          fi
+          if [ -z "$run_id" ]; then
+            echo "::warning::no successful main build to bench against; PR-only report"
+            exact=false
+          elif [ "$exact" != true ]; then
+            echo "::warning::baseline is main $sha, not this PR's base commit $BASE_SHA; \
+          size changes and the runtime row may be main's own drift"
+          fi
+          echo "baseline: run=$run_id sha=$sha exact=$exact (base $BASE_SHA)"
+          {
+            echo "run_id=$run_id"
+            echo "sha=${sha:0:7}"
+            echo "exact=$exact"
+          } >> "$GITHUB_OUTPUT"
+
   # Effectiveness over the full OpenVM (openvm-eth, wasm-eth) and SP1 (rsp) sets plus the keccak and
   # sha256 stress sets. One cell per benchmark group, and each cell benches **both sides itself** --
-  # this PR's binary then the latest main build, back to back on the same runner.
+  # this PR's binary then the `baseline` job's main build, back to back on the same runner.
   #
   # Circuit sizes are deterministic, so for effectiveness the sides needn't share a runner. But
   # benchmark.py also reports each side's wall time, and the report assembles those into the runtime
@@ -43,7 +102,7 @@ jobs:
   # baseline/PR pair is forced onto one machine.
   effectiveness:
     if: github.event_name == 'pull_request'
-    needs: build
+    needs: [build, baseline]
     runs-on: warp-ubuntu-2404-x64-32x
     # Per group, since a cell now runs its sets twice. Measured: the sha256 cell is ~170 s for one
     # side, the others under a minute -- so this is headroom for the stress case growing, not a
@@ -73,16 +132,20 @@ jobs:
         with:
           name: apc-optimizer-bin
           path: bin-pr
-      - name: Latest-main binary
+      # Exactly the run the `baseline` job resolved -- no second query, so this cell cannot bench a
+      # different commit than the report names. A missing artifact leaves no baseline at all, which
+      # `report` already renders as PR-only; that is the honest outcome, unlike a silent swap.
+      - name: Baseline binary (main ${{ needs.baseline.outputs.sha }})
+        if: needs.baseline.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          run_id=$(gh run list --workflow "Lean Action CI" --branch main --status success \
-            --limit 1 --json databaseId -q '.[0].databaseId // empty')
-          if [ -n "$run_id" ]; then
-            gh run download "$run_id" -n apc-optimizer-bin -D bin-main || true
+          gh run download "${{ needs.baseline.outputs.run_id }}" -n apc-optimizer-bin -D bin-main \
+            || true
+          if [ ! -f bin-main/apc-optimizer ]; then
+            echo "::warning::baseline artifact for main ${{ needs.baseline.outputs.sha }} \
+          is unavailable; PR-only report"
           fi
-          if [ ! -f bin-main/apc-optimizer ]; then echo "no latest-main binary; PR-only report"; fi
       - name: Effectiveness, both sides (${{ matrix.group.sets }})
         env:
           SETS: ${{ matrix.group.sets }}
@@ -152,7 +215,7 @@ jobs:
   # Feeds the collapsed runtime detail (slowest cases + per-stage) in the report comment.
   bench-runtime:
     if: github.event_name == 'pull_request'
-    needs: build
+    needs: [build, baseline]
     runs-on: warp-ubuntu-2404-x64-32x
     timeout-minutes: 10
     permissions:
@@ -165,13 +228,14 @@ jobs:
           name: apc-optimizer-bin
           path: bin-target
       - run: chmod +x bin-target/apc-optimizer
-      - name: Latest-main binary
+      # The same resolved baseline the effectiveness cells use (see the `baseline` job).
+      - name: Baseline binary (main ${{ needs.baseline.outputs.sha }})
+        if: needs.baseline.outputs.run_id != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          run_id=$(gh run list --workflow "Lean Action CI" --branch main --status success \
-            --limit 1 --json databaseId -q '.[0].databaseId // empty')
-          if [ -n "$run_id" ] && gh run download "$run_id" -n apc-optimizer-bin -D bin-base; then
+          if gh run download "${{ needs.baseline.outputs.run_id }}" -n apc-optimizer-bin \
+              -D bin-base; then
             chmod +x bin-base/apc-optimizer
           fi
       - name: Runtime, top-10 sequential (per-stage + slowest)
@@ -192,7 +256,7 @@ jobs:
   # openvm-eth, the collapsed runtime detail from bench-runtime. Runs even if a job was skipped.
   report:
     if: always() && github.event_name == 'pull_request'
-    needs: [effectiveness, bench-runtime]
+    needs: [baseline, effectiveness, bench-runtime]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -210,16 +274,25 @@ jobs:
       - uses: actions/download-artifact@v4
         with: { name: bench-runtime, path: rt }
         continue-on-error: true
-      - name: Baseline sha
+      # The baseline sha comes from the `baseline` job -- the same run every cell downloaded.
+      # Resolving it again here is what let the footer name a commit nobody benched.
+      - name: Comment inputs
         id: base
         env:
-          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ needs.baseline.outputs.sha }}
+          BASE_EXACT: ${{ needs.baseline.outputs.exact }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          rid=$(gh run list --workflow "Lean Action CI" --branch main --status success \
-            --limit 1 --json databaseId -q '.[0].databaseId // empty')
-          sha=""; [ -n "$rid" ] && sha=$(gh run view "$rid" --json headSha -q .headSha | cut -c1-7)
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "psha=$(cut -c1-7 <<< '${{ github.event.pull_request.head.sha }}')" >> "$GITHUB_OUTPUT"
+          echo "psha=$(cut -c1-7 <<< "$PR_SHA")" >> "$GITHUB_OUTPUT"
+          # One line of prose when the comparison is against something other than this PR's base, so
+          # a reader does not attribute main's own drift to the PR (see the `baseline` job).
+          drift=""
+          if [ -n "$BASE_SHA" ] && [ "$BASE_EXACT" != true ]; then
+            drift="**The baseline is not this PR's base commit**, so a changed size or a large \
+          runtime delta may be main's own drift rather than this PR -- verify against a freshly \
+          built base before believing either."
+          fi
+          echo "drift=$drift" >> "$GITHUB_OUTPUT"
       - name: Assemble comment
         run: |
           : > bench.md
@@ -250,8 +323,9 @@ jobs:
                   && github.event.number || '' }}
           note: >-
             openvm-eth + wasm-eth + keccak + sha256 + sp1/rsp + sp1/keccak, PR `${{ steps.base.outputs.psha }}`
-            ${{ steps.base.outputs.sha && format('vs main `{0}`', steps.base.outputs.sha)
+            ${{ needs.baseline.outputs.sha && format('vs main `{0}`', needs.baseline.outputs.sha)
                  || '(no main baseline binary)' }}.
+            ${{ steps.base.outputs.drift }}
             Effectiveness is exact. Each set's two sides are benched back to back on one runner, so
             the runtime row is comparable -- but coarse: benchmark.py runs cases in parallel. For
             per-pass detail: `gh workflow run "Runtime Bench" -f pr=${{ github.event.number }}`.


### PR DESCRIPTION
The effectiveness cells, the runtime cell and the report footer each ran their own
`gh run list --workflow "Lean Action CI" --branch main --status success --limit 1` +
`gh run download` — **five independent resolutions of "latest main"**, free to land on five different
commits, with the footer stating whichever the *report* job happened to see.

## What that cost, measured on #278

That PR's wasm-eth + sp1/rsp cell benched a days-old main binary while the footer named main's current
sha. The comment reported:

- wasm-eth `145.9 s → 14.2 s (-90%)` and SP1 rsp `41.1 s → 2344 ms (-94%)`, for a change worth ~4%
  end-to-end. For scale: 14.2 s over 100 wasm-eth cases is 0.14 s/case, against ~2.9 s/case of real
  optimizer work.
- *"Circuit sizes changed on 3 of 200 cases"* — i.e. an apparent effectiveness regression.

Neither was real. The three flagged cases are identical between that PR and current main, verified
with CI's own `apc-optimizer-bin` artifact for `f928949` and CI's own `compare` command:

| case | metric | CI's "main" column | current-main artifact | that PR |
|---|---|---:|---:|---:|
| wasm-eth `apc_006_pc0x2E88F0` | bus interactions | 1358 | **1359** | **1359** |
| sp1 rsp `apc_024_pc0x7818d838` | constraints | 175 | **177** | **177** |
| sp1 rsp `apc_040_pc0x782023cc` | constraints | 175 | **177** | **177** |

Five consecutive main builds all produce 177/1359, 15 repeats are stable, and the optimizer is a
deterministic pure function (no `Task.spawn` in the implementation, no unsafe pointer tricks) — so a
same-binary difference cannot be real work. In the cell's own JSON the `before` and `powdr` rows agree
between the sides; only the `apc-optimizer` row differs, i.e. the baseline side computed it. A
~6-day-old main build (`f38461c8`) *does* produce 1358, and takes 12.9 s / 15.9 s on wasm-eth
`apc_036` / `apc_012` where current main takes ~2.9 s — which with benchmark.py's parallel contention
accounts for the runtime row.

The comment said nothing about the baseline being stale, so the only way to find out was to re-run
the whole comparison by hand against a freshly built main.

## The change

- **A `baseline` job resolves one main build for the whole workflow**, preferring the PR's own base
  commit (`github.event.pull_request.base.sha` — the only baseline whose diff *is* the PR) and falling
  back to the newest successful main build with `exact=false` plus a `::warning::`. Outputs
  `run_id` / `sha` / `exact`.
- **Both bench jobs download exactly that `run_id`.** No cell can bench a commit the report does not
  name. A missing artifact still degrades to the existing PR-only report — the honest outcome, unlike
  a silent swap.
- **The report no longer re-resolves the baseline** (that step is what let the footer name a commit
  nobody benched) and adds one line to the comment when the baseline is not the PR's base, so a reader
  cannot attribute main's own drift to the PR.

`Runtime Bench` and `Effectiveness Bench` (dispatch-only) build both sides from a checked-out ref and
were never affected — on #278 Runtime Bench read 0.96× total / 0.11× on the pass, matching the local
interleaved bench exactly.

## Validation

Workflow changes only prove themselves by running, so I exercised the pieces directly:

- YAML parses; job graph is `build, baseline → effectiveness, bench-runtime → report`.
- Extracted the resolver script and **ran it against this repo** in three states: base commit present
  → `exact=true` with the right run id (`f928949` → run `30860391781`); unknown base → falls back to
  newest main (`f2eaac6`) with the warning and `exact=false`; current main tip → `exact=true`.
- Extracted and ran the comment-input step for all three states: the drift line appears only when the
  baseline is stale, and it is a single line (embedded newlines would corrupt `$GITHUB_OUTPUT`, which
  is why it is built in the step rather than inside the YAML expression).
- Downloaded the artifact the pinned resolution selects and confirmed it reproduces current-main
  results (177 constraints on `rsp/apc_024`).

Caveat: this PR's own run will show `exact=true` (its base `f2eaac6` has a successful main build), so
the warning path is exercised by the local case above rather than by this run. The CI trap itself is
recorded in `agent-docs/ideas.md` (landed with #278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)