### PR TITLE
perf(busPairCancel): a prepared checked-form memo, canonical affine keys and one prepared address array (0.61–0.89x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseq.lean
@@ -212,41 +212,50 @@ def densePtrReductionsFast (T : DenseTwoRootMap p) (E : DenseExpr p) :
   | none => rfl
   | some L => dsimp only; rw [HashedDedup.hashedEraseDups_eq]
 
-/-! ## Nonzero-constant differences -/
+/-! ## Nonzero-constant differences, by canonical term key
 
-/-- The two forms differ by a nonzero field constant (checked structurally after normalization). -/
-def denseConstDiffNZ (a b : DenseLinExpr p) : Bool :=
-  let d := (a.add (b.scale (-1))).norm
-  d.terms.isEmpty && decide (d.const ≠ 0)
+Two linear forms differ by a nonzero constant exactly when their *canonical* terms — merged,
+zero-dropped, sorted by variable — agree and their constants do not. A key is derived once per
+expression, so the certificate arms below compare an integer and a list instead of normalizing
+`a − b` per compared pair. Soundness is `denseKeyDiffNZ_sound` (`Proofs/AddrDiseq.lean`). -/
 
-/-- Boxed twin: called from the nested `any`/`any` over branch pairs, and the `-1`, the `add`, the
-    `scale`, the `norm` and the `≠ 0` each derive their own instance chain. One shared
-    `DenseZModOps p` covers all five. -/
-def denseConstDiffNZWith (ops : DenseZModOps p) (a b : DenseLinExpr p) : Bool :=
-  let d := (a.addWith ops (b.scaleWith ops ops.negOne)).normWith ops
-  d.terms.isEmpty && decide (d.const ≠ ops.zero)
+/-- The canonical form of a linear form's terms: merged, zero-dropped, sorted by variable. -/
+def denseTermKey (l : DenseLinExpr p) : List (VarId × ZMod p) :=
+  l.norm.terms.mergeSort (fun a b => decide (a.1.index ≤ b.1.index))
 
-def denseConstDiffNZFast (a b : DenseLinExpr p) : Bool :=
-  denseConstDiffNZWith denseZModOps a b
+/-- Hash *of the canonical key*, which gates the list compare: unequal hashes are unequal keys, and
+    that is the common case. -/
+def denseTermKeyHash (k : List (VarId × ZMod p)) : UInt64 :=
+  k.foldl (fun h t => mixHash h (mixHash (hash t.1) (hash t.2.val))) 0
 
-theorem denseConstDiffNZWith_eq (ops : DenseZModOps p) (a b : DenseLinExpr p) :
-    denseConstDiffNZWith ops a b = denseConstDiffNZ a b := by
-  simp only [denseConstDiffNZWith, denseConstDiffNZ, DenseLinExpr.addWith_eq,
-    DenseLinExpr.scaleWith_eq, DenseLinExpr.normWith_eq, ops.negOne_eq, ops.zero_eq]
+/-- The two forms differ by a nonzero field constant. -/
+def denseKeyDiffNZ (a b : DenseLinExpr p) : Bool :=
+  let ka := denseTermKey a
+  let kb := denseTermKey b
+  (denseTermKeyHash ka == denseTermKeyHash kb && decide (ka = kb)) && decide (a.const ≠ b.const)
 
-@[csimp] theorem denseConstDiffNZ_eq_fast : @denseConstDiffNZ = @denseConstDiffNZFast := by
-  funext p a b
-  exact (denseConstDiffNZWith_eq denseZModOps a b).symm
+/-- One two-root reduction, keyed: the canonical key of its branches with that key's hash, plus the
+    two branch constants. Both branches differ from each other only by a constant
+    (`densePtrReductions_key`), so one key describes the pair and the four branch-pair differences
+    of `denseRedKeysNeq` are four constant comparisons. -/
+def denseRedKey (r : DenseLinExpr p × DenseLinExpr p) :
+    UInt64 × List (VarId × ZMod p) × ZMod p × ZMod p :=
+  let k := denseTermKey r.1
+  (denseTermKeyHash k, k, r.1.const, r.2.const)
+
+/-- All four branch-pair differences of two keyed reductions are nonzero constants. -/
+def denseRedKeysNeq (r r' : UInt64 × List (VarId × ZMod p) × ZMod p × ZMod p) : Bool :=
+  ((r.1 == r'.1 && decide (r.2.1 = r'.2.1)) &&
+    (decide (r.2.2.1 ≠ r'.2.2.1) && decide (r.2.2.1 ≠ r'.2.2.2))) &&
+    (decide (r.2.2.2 ≠ r'.2.2.1) && decide (r.2.2.2 ≠ r'.2.2.2))
 
 /-! ## The expression- and address-level certificates -/
 
 /-- Two dense expressions provably evaluate differently: some two-root reduction of each yields
     four branch-pair differences that are all nonzero field constants. -/
 def denseExprTwoRootNeq (T : DenseTwoRootMap p) (e e' : DenseExpr p) : Bool :=
-  (densePtrReductions T e).any (fun red =>
-    (densePtrReductions T e').any (fun red' =>
-      denseConstDiffNZ red.1 red'.1 && denseConstDiffNZ red.1 red'.2 &&
-      denseConstDiffNZ red.2 red'.1 && denseConstDiffNZ red.2 red'.2))
+  ((densePtrReductions T e).map denseRedKey).any (fun r =>
+    ((densePtrReductions T e').map denseRedKey).any (denseRedKeysNeq r))
 
 /-- Some address slot of `S` and `bi` provably evaluates differently: the two interactions have
     different addresses. -/
@@ -266,35 +275,9 @@ def denseAddrAffineNeq (shape : MemoryBusShape) (S bi : BusInteraction (DenseExp
     match S.payload[slot]?, bi.payload[slot]? with
     | some e, some e' =>
       (match denseLinearize e, denseLinearize e' with
-       | some L, some L' => denseConstDiffNZ L L'
+       | some L, some L' => denseKeyDiffNZ L L'
        | _, _ => false)
     | _, _ => false)
-
-/-- One `DenseZModOps p` above the slot scan: each slot otherwise derives three instance chains
-    (two linearizations and the constant-difference test). -/
-def denseAddrAffineNeqWith (ops : DenseZModOps p) (shape : MemoryBusShape)
-    (S bi : BusInteraction (DenseExpr p)) : Bool :=
-  shape.addressFields.any (fun slot =>
-    match S.payload[slot]?, bi.payload[slot]? with
-    | some e, some e' =>
-      (match denseLinearizeWith ops e, denseLinearizeWith ops e' with
-       | some L, some L' => denseConstDiffNZWith ops L L'
-       | _, _ => false)
-    | _, _ => false)
-
-def denseAddrAffineNeqFast (shape : MemoryBusShape) (S bi : BusInteraction (DenseExpr p)) : Bool :=
-  denseAddrAffineNeqWith denseZModOps shape S bi
-
-theorem denseAddrAffineNeqWith_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
-    (S bi : BusInteraction (DenseExpr p)) :
-    denseAddrAffineNeqWith ops shape S bi = denseAddrAffineNeq shape S bi := by
-  simp only [denseAddrAffineNeqWith, denseAddrAffineNeq, denseLinearizeWith_eq,
-    denseConstDiffNZWith_eq]
-
-@[csimp] theorem denseAddrAffineNeq_eq_fast :
-    @denseAddrAffineNeq = @denseAddrAffineNeqFast := by
-  funext p shape S bi
-  exact (denseAddrAffineNeqWith_eq denseZModOps shape S bi).symm
 
 /-! ## The nonzero-witness (register-vs-RAM) address-disequality certificate -/
 
@@ -352,9 +335,9 @@ structure DenseNonzeroWits (p : ℕ) where
   index : Std.HashMap UInt64 (List (DenseLinExpr p))
 
 /-- Collect every reciprocal-witness linear form from the constraint list. -/
-def DenseNonzeroWits.build (constraints : List (DenseExpr p)) : DenseNonzeroWits p where
-  wits := constraints.flatMap denseReciprocalWits?
-  index := denseNZIndexOf (constraints.flatMap denseReciprocalWits?)
+def DenseNonzeroWits.build (constraints : List (DenseExpr p)) : DenseNonzeroWits p :=
+  let w := constraints.flatMap denseReciprocalWits?
+  ⟨w, denseNZIndexOf w⟩
 
 /-- `Σ_{f ∈ fields} (m.payload[f] − S.payload[f])` as a dense linear form; `none` if any listed
     slot is absent from either payload or is nonlinear. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/AddrDiseqPre.lean
@@ -16,16 +16,24 @@ namespace ApcOptimizer.Dense
 variable {p : ℕ}
 
 /-- Prepared per-address-slot data: the raw slot expression plus its lazily-computed constant
-    value, linear form, and two-root reductions. -/
+    value, linear form, canonical term key (with the key's hash) and keyed two-root reductions.
+    The keys are what make the affine and two-root arms integer-and-list comparisons instead of a
+    normalization per compared pair (`denseTermKey`, `AddrDiseq.lean`). -/
 structure DenseSlotPre (p : ℕ) where
   expr : DenseExpr p
   cval : Thunk (Option (ZMod p))
   lin : Thunk (Option (DenseLinExpr p))
-  reds : Thunk (List (DenseLinExpr p × DenseLinExpr p))
+  key : Thunk (UInt64 × List (VarId × ZMod p))
+  reds : Thunk (List (UInt64 × List (VarId × ZMod p) × ZMod p × ZMod p))
 
 def denseSlotPrep (T : DenseTwoRootMap p) (e : DenseExpr p) : DenseSlotPre p :=
-  ⟨e, Thunk.pure e.constValue?, Thunk.mk fun _ => denseLinearize e,
-   Thunk.mk fun _ => densePtrReductions T e⟩
+  let lin : Thunk (Option (DenseLinExpr p)) := Thunk.mk fun _ => denseLinearize e
+  ⟨e, Thunk.pure e.constValue?, lin,
+   Thunk.mk fun _ =>
+     match lin.get with
+     | some L => let k := denseTermKey L; (denseTermKeyHash k, k)
+     | none => (0, []),
+   Thunk.mk fun _ => (densePtrReductions T e).map denseRedKey⟩
 
 /-- Prepared per-interaction address data relative to one memory-bus shape: the bus id, the
     multiplicity constant, and the prepared slot record at each of the shape's address fields. -/
@@ -38,6 +46,18 @@ def denseAddrPrep (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (bi : BusInteraction (DenseExpr p)) : DenseAddrPre p :=
   ⟨bi.busId, Thunk.mk fun _ => denseMultConst bi,
    shape.addressFields.map (fun slot => (bi.payload[slot]?).map (denseSlotPrep T))⟩
+
+/-- One prepared array for *every* memory bus at once: a position gets its own bus's shape, and a
+    position on no memory bus gets a bus-id-only stub. Sound for every candidate bus because every
+    test reads `busId` first and answers there (`denseMidRefutedP`/`densePreRefutedP` refute, and
+    `denseProvRecvP` fails) whenever the compared position is off the candidate's bus — so a record
+    prepared under another bus's shape, or not prepared at all, is never looked into. -/
+def denseAddrPrepAll (memShape : Nat → Option MemoryBusShape) (T : DenseTwoRootMap p)
+    (arr : Array (BusInteraction (DenseExpr p))) : Array (DenseAddrPre p) :=
+  arr.map (fun bi =>
+    match memShape bi.busId with
+    | some shape => denseAddrPrep shape T bi
+    | none => ⟨bi.busId, Thunk.pure none, []⟩)
 
 /-! ## The prepared certificate tests
 
@@ -73,14 +93,15 @@ def denseAddrConstsEqP (a b : DenseAddrPre p) : Bool :=
 def denseAddrAffineNeqP (a b : DenseAddrPre p) : Bool :=
   denseSlotsAny (fun sa sb =>
     match sa.lin.get, sb.lin.get with
-    | some L, some L' => denseConstDiffNZ L L'
+    | some L, some L' =>
+      let ka := sa.key.get
+      let kb := sb.key.get
+      (ka.1 == kb.1 && decide (ka.2 = kb.2)) && decide (L.const ≠ L'.const)
     | _, _ => false) a.slots b.slots
 
 def denseAddrTwoRootNeqP (a b : DenseAddrPre p) : Bool :=
   denseSlotsAny (fun sa sb =>
-    sa.reds.get.any (fun red => sb.reds.get.any (fun red' =>
-      denseConstDiffNZ red.1 red'.1 && denseConstDiffNZ red.1 red'.2 &&
-      denseConstDiffNZ red.2 red'.1 && denseConstDiffNZ red.2 red'.2))) a.slots b.slots
+    sa.reds.get.any (fun r => sb.reds.get.any (denseRedKeysNeq r))) a.slots b.slots
 
 /-- `denseDiffSumOver` over prepared slot pairs (same fold, linearizations read from the prep). -/
 def denseDiffSumP : List (Option (DenseSlotPre p) × Option (DenseSlotPre p)) →

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancel.lean
@@ -42,6 +42,38 @@ theorem denseEmittedChecks_covered (unjust : List Nat) (bcBus? : Option (Nat × 
         exact denseMkByteCheck_covered reg spec bcBus e (hRpay e (List.mem_of_getElem? hget))
   · exact absurd hbi (by simp)
 
+/-- Every checked form the basis channel offers is bounded under any environment that satisfies the
+    remaining region: the form is a prepared record of a live position other than the dropped pair,
+    at one of that interaction's payload slots, and `denseFormBoundAt_sound` turns the interaction's
+    acceptance into the bound. This is what `denseDropFormWits_mem` was for the witness channel. -/
+theorem denseDropFormBasis_bound {bs : BusSemantics p} (facts : BusFacts p bs)
+    (fidx : Array (List Nat)) (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
+    (S R : BusInteraction (DenseExpr p))
+    {A B C : List (BusInteraction (DenseExpr p))}
+    (horig : ∀ bi ∈ denseLiveSeg arr alive 0 arr.size, bi ≠ S → bi ≠ R → bi ∈ A ++ B ++ C)
+    (emitted : List (BusInteraction (DenseExpr p))) (denv : VarId → ZMod p)
+    (hbus : ∀ bi ∈ A ++ B ++ C ++ emitted,
+      (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)) :
+    ∀ v, ∀ LB ∈ denseDropFormBasis fidx (denseBuildFormBounds bs facts arr) arr alive S R v,
+      (LB.1.eval denv).val < LB.2 := by
+  intro v LB hLB
+  rw [denseDropFormBasis, List.mem_flatMap] at hLB
+  obtain ⟨k, _, hmem⟩ := hLB
+  split_ifs at hmem with hk hcond
+  case neg => exact absurd hmem (by simp)
+  case neg => exact absurd hmem (by simp)
+  rw [denseBuildFormBounds, Array.getElem?_map, Array.getElem?_eq_getElem hk] at hmem
+  have hmem' : LB ∈ denseFormBoundsOf facts arr[k] := hmem
+  rw [denseFormBoundsOf, List.mem_filterMap] at hmem'
+  obtain ⟨i, _, hfb⟩ := hmem'
+  rw [Bool.and_eq_true, Bool.and_eq_true] at hcond
+  obtain ⟨⟨hal, hnS⟩, hnR⟩ := hcond
+  refine denseFormBoundAt_sound facts arr[k] i LB.1 LB.2 hfb denv
+    (hbus arr[k] (List.mem_append_left _ (horig arr[k]
+      (denseLiveSeg_mem arr alive 0 arr.size k _ (Nat.zero_le _) (by omega) hal
+        (Array.getElem?_eq_getElem hk))
+      (fun he => by simp [he] at hnS) (fun he => by simp [he] at hnR))))
+
 /-! One accepted drop, consumed by `denseCancelLoop`. The erased proof fields `step`/`covNew` are
 quantified over `isInput`/`reg` with the current system's coverage as hypothesis, so the loop stays
 `reg`-free at the data level. -/
@@ -81,8 +113,10 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
     (candsOf : VarId → List (DenseExpr p))
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ cs0.algebraicConstraints)
     (fidxT bidxT : Thunk (Array (List Nat)))
+    (fbndT : Thunk (Array (Thunk (List (DenseLinExpr p × Nat)))))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
+    (hfbnd : fbndT.get = denseBuildFormBounds bs facts arr)
     (iP jP : Nat) (S R : BusInteraction (DenseExpr p)) (slots : List Nat) (bound : Nat)
     (checks : List (BusInteraction (DenseExpr p)))
     (checksNew : List (BusInteraction (DenseExpr p))) (hchecksNew : checksNew = checksOld ++ checks)
@@ -97,7 +131,8 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
       denseMidRefuted ops shape T busId S m0 = true)
     (hshield : denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 iP) = true)
     (hchk : denseCheckCancel ops deep bs facts M domIdx candsOf
-      (denseDropWits facts bidxT.get arr alive S R checksOld checks) (denseDropFormWits fidxT.get arr alive S R)
+      (denseDropWits facts bidxT.get arr alive S R checksOld checks)
+      (denseDropFormBasis fidxT.get fbndT.get arr alive S R)
       busId shape slots bound S R checks = true) :
     DenseDropResult cs0 bs arr alive checksOld := by
   let A := denseLiveSeg arr alive 0 iP
@@ -139,10 +174,12 @@ def denseMkDropResult (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (fac
       denseCheckCancel_sound isInput (denseMkCs cs0 arr alive checksOld) bs facts hp1 deep hdeep ops
         reg hsys busId shape hshape slots bound T hTtworoot hTnonzero M hM domIdx candsOf
         (denseDropWits facts bidxT.get arr alive S R checksOld checks)
-        (denseDropFormWits fidxT.get arr alive S R)
+        (denseDropFormBasis fidxT.get fbndT.get arr alive S R)
         A S B R (C' ++ checksOld) hslots checks hsplit hdomIdx hcands
         (denseDropWits_mem facts bidxT.get arr alive S R checksOld checks horig hchecks)
-        (denseDropFormWits_mem fidxT.get arr alive S R horig checks) hmid hshield hchk
+        (fun denv hbus => hfbnd ▸ denseDropFormBasis_bound facts fidxT.get arr alive S R horig
+          checks denv hbus)
+        hmid hshield hchk
     decreases := ?_
     covNew := fun reg hsys => by
       refine ⟨hsys.1, ?_⟩
@@ -185,21 +222,23 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (bcBus? : Option (Nat × ByteXorSpec p))
     (fidxT bidxT : Thunk (Array (List Nat)))
+    (fbndT : Thunk (Array (Thunk (List (DenseLinExpr p × Nat)))))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
+    (hfbnd : fbndT.get = denseBuildFormBounds bs facts arr)
     (idx : Std.HashMap UInt64 (List Nat))
     (preT : Thunk (Array (DenseAddrPre p)))
-    (hpreT : preT.get = arr.map (denseAddrPrep shape T.get.tworoot))
+    (hpreT : DensePreArrOk shape T busId arr preT.get)
     (kT : Thunk (DenseKeyIdx p))
     (hkT : kT.get = denseKeyIdxBuild shape busId arr)
     (i : Nat) : Option (DenseDropResult cs0 bs arr alive checksOld) :=
   if hi : i < arr.size then
     let S := arr[i]
     let next := fun (_ : Unit) => denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId
-      shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT arr alive
-      checksOld hsz idx preT hpreT kT hkT (i + 1)
+      shape hshape T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT fbndT arr alive
+      checksOld hsz hfbnd idx preT hpreT kT hkT (i + 1)
     if haliveS : alive[i]?.getD false = true then
-    if decide (S.busId = busId) &&
+    if hSguard : decide (S.busId = busId) &&
         decide (denseMultConst S = some (denseSetNewMult ops shape)) then
       match hfm : denseFirstMatchAt M arr alive busId S i (idx.getD
           (mixHash (hash busId)
@@ -218,8 +257,11 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           | none => next ()
           | some preS =>
           have hpreS : preS = denseAddrPrep shape T.get.tworoot S := by
-            rw [hpreT, Array.getElem?_map, hSget] at hps
-            exact (Option.some.inj hps).symm
+            obtain ⟨m, hm, _, hex⟩ := hpreT.2 i S hSget
+            rw [Option.some.inj (hps.symm.trans hm)]
+            refine hex (of_decide_eq_true ?_)
+            rw [Bool.and_eq_true] at hSguard
+            exact hSguard.1
           if hRT : (denseRegionTests ops shape T busId arr alive preT.get hpreT kT.get hkT
               S preS hpreS i j hij).val = true then
           have hmid : ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
@@ -234,16 +276,17 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           | some (slots, bound) =>
           if hchk0 : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
               (denseDropWits facts bidxT.get arr alive S R checksOld [])
-              (denseDropFormWits fidxT.get arr alive S R)
+              (denseDropFormBasis fidxT.get fbndT.get arr alive S R)
               busId shape slots bound S R [] = true then
             some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
               hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
-              fidxT bidxT arr alive checksOld hsz i j S R slots bound [] checksOld
+              fidxT bidxT fbndT arr alive checksOld hsz hfbnd i j S R slots bound [] checksOld
               (List.append_nil checksOld).symm (fun reg _ bi hbi => absurd hbi (by simp))
               false 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk0)
           else
           let unjust := denseUnjustifiedSlots bound deep domIdxT.get.val candsT.get.lookup bs facts
-            (denseDropWits facts bidxT.get arr alive S R checksOld []) (denseDropFormWits fidxT.get arr alive S R)
+            (denseDropWits facts bidxT.get arr alive S R checksOld [])
+            (denseDropFormBasis fidxT.get fbndT.get arr alive S R)
             slots R
           let checks : List (BusInteraction (DenseExpr p)) :=
             match unjust, bcBus? with
@@ -253,11 +296,12 @@ def denseFindCancelGoIdx (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (
           if !checks.isEmpty && (aggressive || decide (S.payload = R.payload)) then
             if hchk : denseCheckCancel ops deep bs facts M domIdxT.get.val candsT.get.lookup
                 (denseDropWits facts bidxT.get arr alive S R checksOld checks)
-                (denseDropFormWits fidxT.get arr alive S R)
+                (denseDropFormBasis fidxT.get fbndT.get arr alive S R)
                 busId shape slots bound S R checks = true then
               some (denseMkDropResult cs0 bs facts hp1 deep hdeep ops busId shape hshape T hTtworoot
                 hTnonzero M hM domIdxT.get.val domIdxT.get.property candsT.get.lookup hcands
-                fidxT bidxT arr alive checksOld hsz i j S R slots bound checks (checksOld ++ checks) rfl
+                fidxT bidxT fbndT arr alive checksOld hsz hfbnd i j S R slots bound checks
+                (checksOld ++ checks) rfl
                 (fun reg hRpay bi hbi => denseEmittedChecks_covered unjust bcBus? R reg hRpay bi hbi)
                 true 0 i hij hjlt hSget hR haliveS hRalive hslots hmid hshield hchk)
             else next ()
@@ -285,36 +329,39 @@ def denseFindCancel (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (candsT : Thunk (DenseVarCsIdx p))
     (hcands : ∀ x, ∀ c ∈ candsT.get.lookup x, c ∈ cs0.algebraicConstraints)
     (fidxT bidxT : Thunk (Array (List Nat)))
+    (fbndT : Thunk (Array (Thunk (List (DenseLinExpr p × Nat)))))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
     (checksOld : List (BusInteraction (DenseExpr p))) (hsz : alive.size = arr.size)
+    (hfbnd : fbndT.get = denseBuildFormBounds bs facts arr)
     (idx : Std.HashMap UInt64 (List Nat))
     (bcBus? : Option (Nat × ByteXorSpec p)) (resumeIdx resumePos : Nat) :
     Nat → (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p))) →
     (∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape, facts.memShape busId = some shape →
-      t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+      DensePreArrOk shape T busId arr t.get ∧
       kt.get = denseKeyIdxBuild shape busId arr) →
     Option (DenseDropResult cs0 bs arr alive checksOld)
   | _, [], _ => none
   | curIdx, (busId, preT, kT) :: rest, hpre =>
     if curIdx < resumeIdx then
       denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
-        hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos (curIdx + 1) rest
+        hcands fidxT bidxT fbndT arr alive checksOld hsz hfbnd idx bcBus? resumeIdx resumePos
+        (curIdx + 1) rest
         (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
     else
       let startPos := if curIdx = resumeIdx then resumePos else 0
       match hshape : facts.memShape busId with
       | some shape =>
         match denseFindCancelGoIdx cs0 bs facts hp1 deep hdeep aggressive ops busId shape hshape
-            T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT arr alive checksOld
-            hsz idx preT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).1
+            T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? fidxT bidxT fbndT arr alive checksOld
+            hsz hfbnd idx preT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).1
             kT (hpre busId preT kT (List.mem_cons_self ..) shape hshape).2 startPos with
         | some dr => some { dr with dropIdx := curIdx }
         | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-            domIdxT candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-            (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
+            domIdxT candsT hcands fidxT bidxT fbndT arr alive checksOld hsz hfbnd idx bcBus? resumeIdx
+            resumePos (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
       | none => denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM
-          domIdxT candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos
-          (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
+          domIdxT candsT hcands fidxT bidxT fbndT arr alive checksOld hsz hfbnd idx bcBus? resumeIdx
+          resumePos (curIdx + 1) rest (fun b t kt hbt => hpre b t kt (List.mem_cons_of_mem _ hbt))
 
 /-! The materialized final system plus (erased) correctness and coverage proofs that
 `denseCancelLoop` returns. -/
@@ -341,11 +388,13 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     (bcBus? : Option (Nat × ByteXorSpec p))
     (preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)))
     (fidxT bidxT : Thunk (Array (List Nat)))
+    (fbndT : Thunk (Array (Thunk (List (DenseLinExpr p × Nat)))))
     (arr : Array (BusInteraction (DenseExpr p)))
+    (hfbnd : fbndT.get = denseBuildFormBounds bs facts arr)
     (idx : Std.HashMap UInt64 (List Nat))
     (hpre : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
       facts.memShape busId = some shape →
-      t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+      DensePreArrOk shape T busId arr t.get ∧
       kt.get = denseKeyIdxBuild shape busId arr)
     (alive : Array Bool) (checksOld : List (BusInteraction (DenseExpr p)))
     (hsz : alive.size = arr.size) (resumeIdx resumePos : Nat)
@@ -355,7 +404,8 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
       (denseMkCs cs0 arr alive checksOld).CoveredBy reg) :
     DenseCancelBundle cs0 bs :=
   match hfc : denseFindCancel cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT
-      candsT hcands fidxT bidxT arr alive checksOld hsz idx bcBus? resumeIdx resumePos 0 preBuses hpre with
+      candsT hcands fidxT bidxT fbndT arr alive checksOld hsz hfbnd idx bcBus? resumeIdx resumePos 0
+      preBuses hpre with
   | none =>
     { out := { cs0 with
         busInteractions := denseLiveArr arr alive hsz 0 arr.size (by omega) ++ checksOld }
@@ -373,7 +423,8 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
     let nextIdx := if dr.emitted then 0 else dr.dropIdx
     let nextPos := if dr.emitted then 0 else dr.dropPos
     denseCancelLoop cs0 bs facts hp1 deep hdeep aggressive ops T hTtworoot hTnonzero M hM domIdxT candsT
-      hcands bcBus? preBuses fidxT bidxT arr idx hpre (denseTombstone alive dr.dropI dr.dropJ)
+      hcands bcBus? preBuses fidxT bidxT fbndT arr hfbnd idx hpre
+      (denseTombstone alive dr.dropI dr.dropJ)
       dr.checksNew dr.sizeNew nextIdx nextPos
       (fun isInput reg hcs0 => (hcur isInput reg hcs0).andThen (dr.step isInput reg (hsyscov reg hcs0)))
       (fun reg hcs0 => dr.covNew reg (hsyscov reg hcs0))
@@ -385,7 +436,7 @@ def denseCancelLoop (cs0 : DenseConstraintSystem p) (bs : BusSemantics p) (facts
 def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVerifiedPassW p :=
   fun reg d hcov bs facts =>
   if hp1 : (1 : ZMod p) ≠ 0 then
-    let busIds := (d.busInteractions.map (fun bi => bi.busId)).dedup
+    let busIds := denseBusIdsOf d.busInteractions
     let deep : Bool := pw.isPrime
     let arr := d.busInteractions.toArray
     let ops : DenseZModOps p := denseZModOps
@@ -438,18 +489,21 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
     let fidxT : Thunk (Array (List Nat)) := denseThunkIf eager fun _ => denseBuildFormIdx bs nvars arr
     let bidxT : Thunk (Array (List Nat)) :=
       denseThunkIf eager fun _ => denseBuildBoundIdx bs facts nvars arr
+    let fbndT : Thunk (Array (Thunk (List (DenseLinExpr p × Nat)))) :=
+      denseThunkIf eager fun _ => denseBuildFormBounds bs facts arr
     let bcBus? := busIds.findSome? (fun k => match facts.byteXorSpec k with
       | some spec => if spec.bound = 256 then some (k, spec) else none
       | none => none)
     -- One prepared certificate array per declared bus, shared across every region scan and
     -- resume of this invocation (the thunk is forced only when a matched pair reaches a scan).
+    let preAllT : Thunk (Array (DenseAddrPre p)) :=
+      denseThunkIf eager fun _ => denseAddrPrepAll facts.memShape T.get.tworoot arr
     let preBuses : List (Nat × Thunk (Array (DenseAddrPre p)) × Thunk (DenseKeyIdx p)) :=
       busIds.filterMap (fun busId => (facts.memShape busId).map (fun shape =>
-        (busId, denseThunkIf eager (fun _ => arr.map (denseAddrPrep shape T.get.tworoot)),
-         denseThunkIf eager (fun _ => denseKeyIdxBuild shape busId arr))))
+        (busId, preAllT, denseThunkIf eager (fun _ => denseKeyIdxBuild shape busId arr))))
     have hpreBuses : ∀ busId t kt, (busId, t, kt) ∈ preBuses → ∀ shape,
         facts.memShape busId = some shape →
-        t.get = arr.map (denseAddrPrep shape T.get.tworoot) ∧
+        DensePreArrOk shape T busId arr t.get ∧
         kt.get = denseKeyIdxBuild shape busId arr := by
       intro busId t kt hmem shape hshape
       obtain ⟨b, _hb, hsome⟩ := List.mem_filterMap.mp hmem
@@ -462,7 +516,11 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
           subst hb
           rw [hshape] at hms
           obtain rfl := Option.some.inj hms
-          exact ⟨by rw [← ht]; exact denseThunkIf_get _ _, by rw [← hkt]; exact denseThunkIf_get _ _⟩
+          refine ⟨?_, by rw [← hkt]; exact denseThunkIf_get _ _⟩
+          rw [← ht, show (denseThunkIf eager
+                (fun _ => denseAddrPrepAll facts.memShape T.get.tworoot arr)).get
+              = denseAddrPrepAll facts.memShape T.get.tworoot arr from denseThunkIf_get _ _]
+          exact denseAddrPrepAll_ok facts.memShape shape T _ hshape arr
     have hcur0 : ∀ (isInput : VarId → Bool) (reg : VarRegistry), d.CoveredBy reg →
         DensePassCorrect isInput d (denseMkCs d arr alive []) [] bs :=
       fun isInput _ _ => by
@@ -471,8 +529,8 @@ def denseBusPairCancelPass (pw : PrimeWitness p) (aggressive : Bool) : DenseVeri
         (denseMkCs d arr alive []).CoveredBy reg :=
       fun _ hcs0 => by rw [denseMkCs_all d arr rfl alive halltrue]; exact hcs0
     let bundle := denseCancelLoop d bs facts hp1 deep (fun h => pw.correct h) aggressive ops
-      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? preBuses fidxT bidxT arr idx hpreBuses
-      alive [] hsz 0 0 hcur0 hsyscov0
+      T hTtworoot hTnonzero M hM domIdxT candsT hcands bcBus? preBuses fidxT bidxT fbndT arr
+      (denseThunkIf_get _ _) idx hpreBuses alive [] hsz 0 0 hcur0 hsyscov0
     { reg' := reg
       out := bundle.out
       derivs := []

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelCheck.lean
@@ -106,27 +106,34 @@ def denseShieldScanSegP {α : Type} (P Q : α → Bool) (preArr : Array α) (ali
       | none => r
     else r
 
-theorem denseShieldScanSegP_eq {α : Type} (f : BusInteraction (DenseExpr p) → α)
-    (P Q : α → Bool) (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) :
+/-- `denseShieldScanSegP` is `denseShieldScanW` over the live segment, given per-position agreement
+    of both tests (see `denseLiveAllSegP_eqOf`). -/
+theorem denseShieldScanSegP_eqOf {α : Type} (P Q : α → Bool)
+    (P' Q' : BusInteraction (DenseExpr p) → Bool)
+    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) (preArr : Array α)
+    (hsz : preArr.size = arr.size)
+    (hpt : ∀ (q : Nat) (m0 : BusInteraction (DenseExpr p)), arr[q]? = some m0 →
+      ∃ m, preArr[q]? = some m ∧ P m = P' m0 ∧ Q m = Q' m0) :
     ∀ (lo n : Nat),
-      denseShieldScanSegP P Q (arr.map f) alive lo n
-        = denseShieldScanW (fun m => P (f m)) (fun m => Q (f m))
-            (denseLiveSeg arr alive lo n) := by
+      denseShieldScanSegP P Q preArr alive lo n
+        = denseShieldScanW P' Q' (denseLiveSeg arr alive lo n) := by
   intro lo n
   induction n generalizing lo with
   | zero => rfl
   | succ n ih =>
-      rw [denseShieldScanSegP, ih (lo + 1), Array.getElem?_map]
+      rw [denseShieldScanSegP, ih (lo + 1)]
       cases halive : alive[lo]?.getD false with
       | false => rw [denseLiveSeg_skip arr alive lo n halive, if_neg (by simp)]
       | true =>
           rw [if_pos rfl]
           cases harr : arr[lo]? with
           | some m0 =>
-              rw [denseLiveSeg_peel arr alive lo n m0 halive harr]
-              rfl
+              obtain ⟨m, hm, hP, hQ⟩ := hpt lo m0 harr
+              rw [denseLiveSeg_peel arr alive lo n m0 halive harr, hm, denseShieldScanW]
+              simp only [hP, hQ]
           | none =>
-              rw [denseLiveSeg, halive, harr, if_pos rfl]
+              rw [Array.getElem?_eq_none (by rw [hsz]; exact Array.getElem?_eq_none_iff.1 harr),
+                denseLiveSeg, halive, harr, if_pos rfl]
               simp
 
 /-- Single-value byte check on `e`, emitted through `spec` (multiplicity `1`). -/
@@ -168,11 +175,12 @@ def denseEmitOk (ops : DenseZModOps p) (bs : BusSemantics p) (facts : BusFacts p
 def denseUnjustifiedSlots (bound : Nat) (deep : Bool)
     (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
+    (facts : BusFacts p bs) (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (slots : List Nat) (R : BusInteraction (DenseExpr p)) : List Nat :=
   slots.filter (fun slot =>
     match R.payload[slot]? with
-    | some e => !denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e
+    | some e => !denseByteJustifiedW bound deep domIdx candsOf bs facts wits fbasis e
     | none => false)
 
 /-- The per-candidate certificate: bus/multiplicity/payload of the pair, the emitted checks'
@@ -183,7 +191,8 @@ def denseCheckCancel (ops : DenseZModOps p) (deep : Bool) (bs : BusSemantics p)
     (facts : BusFacts p bs)
     (M : Thunk (DenseEqConstraintMap p))
     (domIdx : Std.HashMap VarId (List (DenseExpr p))) (candsOf : VarId → List (DenseExpr p))
-    (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
+    (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (busId : Nat) (shape : MemoryBusShape) (slots : List Nat) (bound : Nat)
     (S R : BusInteraction (DenseExpr p))
     (checks : List (BusInteraction (DenseExpr p))) : Bool :=
@@ -192,6 +201,6 @@ def denseCheckCancel (ops : DenseZModOps p) (deep : Bool) (bs : BusSemantics p)
     decide (denseMultConst R = some (denseGetPreviousMult ops shape)) &&
   densePayloadEntailedEq M S.payload R.payload &&
   checks.all (denseEmitOk ops bs facts busId shape slots R) &&
-  denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fwits slots R
+  denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fbasis slots R
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelIndex.lean
@@ -16,6 +16,11 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
+/-- The distinct bus ids of an interaction list, in `List.dedup` order (last occurrence wins), built
+    without materializing one id per interaction. -/
+def denseBusIdsOf (bis : List (BusInteraction (DenseExpr p))) : List Nat :=
+  bis.foldr (fun bi acc => if acc.contains bi.busId then acc else bi.busId :: acc) []
+
 /-- Structural hash of a payload (order-sensitive). -/
 def densePayloadHash (pl : List (DenseExpr p)) : UInt64 :=
   pl.foldl (fun h e => mixHash h e.bHash) 7
@@ -25,21 +30,31 @@ def densePayloadHash (pl : List (DenseExpr p)) : UInt64 :=
 def denseAddrHash (shape : MemoryBusShape) (pl : List (DenseExpr p)) : UInt64 :=
   shape.addressFields.foldl (fun h slot => mixHash h ((pl[slot]?).elim 5 DenseExpr.bHash)) 7
 
+def denseRecvIndexGo {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
+    (ops : DenseZModOps p) (arr : Array (BusInteraction (DenseExpr p))) :
+    Nat → Std.HashMap UInt64 (List Nat) → Std.HashMap UInt64 (List Nat)
+  | 0, m => m
+  | n + 1, m =>
+    denseRecvIndexGo facts aggressive ops arr n
+      (match arr[n]? with
+       | none => m
+       | some bi =>
+         match facts.memShape bi.busId with
+         | some shape =>
+           if decide (denseMultConst bi = some (denseGetPreviousMult ops shape)) then
+             let h := mixHash (hash bi.busId)
+               (if aggressive then denseAddrHash shape bi.payload else densePayloadHash bi.payload)
+             m.insert h (n :: m.getD h [])
+           else m
+         | none => m)
+
 /-- Ascending positions of the candidate receives (multiplicity `-shape.setNewMult`) on every
     memory-shaped bus, keyed by bus id mixed with the payload hash (`densePayloadHash`, or
     `denseAddrHash` when `aggressive`). One build serves the whole sweep. -/
 def denseRecvIndexAll {bs : BusSemantics p} (facts : BusFacts p bs) (aggressive : Bool)
     (ops : DenseZModOps p) (arr : Array (BusInteraction (DenseExpr p))) :
     Std.HashMap UInt64 (List Nat) :=
-  (arr.toList.zipIdx).foldr (fun bij m =>
-    match facts.memShape bij.1.busId with
-    | some shape =>
-      if decide (denseMultConst bij.1 = some (denseGetPreviousMult ops shape)) then
-        let h := mixHash (hash bij.1.busId)
-          (if aggressive then denseAddrHash shape bij.1.payload else densePayloadHash bij.1.payload)
-        m.insert h (bij.2 :: m.getD h [])
-      else m
-    | none => m) ∅
+  denseRecvIndexGo facts aggressive ops arr arr.size ∅
 
 /-- Does any position hold a send whose receive bucket is non-empty? A cheap over-approximation of
     "this invocation can accept a drop", short-circuiting at the first hit. It decides only whether

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelJustify.lean
@@ -176,48 +176,57 @@ def denseFormBoundAt {bs : BusSemantics p} (facts : BusFacts p bs)
   funext q bs facts bi i
   simp [denseFormBoundAt, denseFormBoundAtImpl]
 
+/-- The checked linear forms of an interaction's payload slots, with their bounds — the only thing
+    the basis reduction ever asks of a witness interaction. A pure function of the interaction, so
+    the pass prepares it once per position (`denseBuildFormBounds`) instead of re-deriving it at
+    every node of the reduction below. -/
+def denseFormBoundsOf {bs : BusSemantics p} (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : List (DenseLinExpr p × Nat) :=
+  (List.range bi.payload.length).filterMap (denseFormBoundAt facts bi)
+
 /-- Fuel-bounded basis reduction: is `L`'s value provably `< bound − used` via per-variable bounds
-    (finish arm) after subtracting integer multiples of range-checked slot forms from `fwits`? -/
-def denseBasisReduceGo (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSemantics p}
-    (facts : BusFacts p bs) (fwits : VarId → List (BusInteraction (DenseExpr p))) :
+    (finish arm) after subtracting integer multiples of the checked forms `fbasis` offers for one of
+    `L`'s variables? -/
+def denseBasisReduceGo (bound : Nat) (bnd : VarId → Option Nat)
+    (fbasis : VarId → List (DenseLinExpr p × Nat)) :
     Nat → Nat → DenseLinExpr p → Bool
   | 0, _, _ => false
   | fuel + 1, used, L =>
     (match L.natBound bnd with
      | some M => decide (used + M < bound) && decide (used + M < p)
      | none => false) ||
-    (L.terms.map Prod.fst).any (fun v =>
-      (fwits v).any (fun bi =>
-        (List.range bi.payload.length).any (fun i =>
-          match denseFormBoundAt facts bi i with
-          | none => false
-          | some (Lf, Bf) =>
-            let cF := IntervalForce.srep (Lf.coeff v)
-            let μi := IntervalForce.srep (L.coeff v) / cF
-            if cF ≠ 0 ∧ 0 < μi ∧ cF * μi = IntervalForce.srep (L.coeff v) then
-              denseBasisReduceGo bound bnd facts fwits fuel (used + μi.toNat * (Bf - 1))
-                ((L.add (Lf.scale (-(μi.toNat : ZMod p)))).norm)
-            else false)))
+    -- `L.coeff v` is invariant across the candidate forms, and `L.terms.map Prod.fst` would
+    -- allocate a variable list per node: both are hoisted out of the inner scan.
+    L.terms.any (fun t =>
+      let v := t.1
+      let cL := IntervalForce.srep (L.coeff v)
+      (fbasis v).any (fun LB =>
+        let cF := IntervalForce.srep (LB.1.coeff v)
+        let μi := cL / cF
+        if cF ≠ 0 ∧ 0 < μi ∧ cF * μi = cL then
+          denseBasisReduceGo bound bnd fbasis fuel (used + μi.toNat * (LB.2 - 1))
+            ((L.add (LB.1.scale (-(μi.toNat : ZMod p)))).norm)
+        else false))
 
 /-- Basis justification: `e` linearizes to a form the fuel-bounded reduction proves `< bound`. -/
-def denseBasisJustified (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSemantics p}
-    (facts : BusFacts p bs) (fwits : VarId → List (BusInteraction (DenseExpr p)))
-    (e : DenseExpr p) : Bool :=
+def denseBasisJustified (bound : Nat) (bnd : VarId → Option Nat)
+    (fbasis : VarId → List (DenseLinExpr p × Nat)) (e : DenseExpr p) : Bool :=
   match denseLinearize e with
-  | some L => denseBasisReduceGo bound bnd facts fwits basisFuel 0 L.norm
+  | some L => denseBasisReduceGo bound bnd fbasis basisFuel 0 L.norm
   | none => false
 
 /-- Is `e` provably a byte under every assignment satisfying the remaining system? Tries, in order:
     a constant `< bound`; a variable with a bus-fact bound `≤ bound`; (when `deep`) a
     selector-flag-domain deep justification or a single-variable finite-domain justification; an
-    affine recomposition of bounded limbs; or a basis reduction against range-checked slot forms
-    (`fwits`). Remaining interactions are consulted through `wits`; `domIdx`/`candsOf` are
-    precomputed per-variable indexes (passed as values — a closure payload would be re-evaluated
-    per call, cf. `agent-docs/log.md` entry 106). -/
+    affine recomposition of bounded limbs; or a basis reduction against the range-checked slot forms
+    `fbasis` offers per variable. Remaining interactions are consulted through `wits`;
+    `domIdx`/`candsOf` are precomputed per-variable indexes (passed as values — a closure payload
+    would be re-evaluated per call, cf. `agent-docs/log.md` entry 106). -/
 def denseByteJustifiedW (bound : Nat) (deep : Bool)
     (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
+    (facts : BusFacts p bs) (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (e : DenseExpr p) : Bool :=
   match e.constValue? with
   | some c => decide (c.val < bound)
@@ -232,18 +241,19 @@ def denseByteJustifiedW (bound : Nat) (deep : Bool)
      | _ => false) ||
     (deep && decide (256 ≤ bound) && denseDomainByteJustified domIdx e) ||
     denseAffineJustified bound (fun x => denseFindVarBound bs facts (wits x) x) e ||
-    denseBasisJustified bound (fun x => denseFindVarBound bs facts (wits x) x) facts fwits e
+    denseBasisJustified bound (fun x => denseFindVarBound bs facts (wits x) x) fbasis e
 
 /-- Are all of `R`'s payload entries at the declared byte slots justified (through the witness
     lookup `wits` and precomputed `domIdx`/`candsOf`, see `denseByteJustifiedW`)? -/
 def denseRecvSlotsJustified (bound : Nat) (deep : Bool)
     (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
-    (facts : BusFacts p bs) (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
+    (facts : BusFacts p bs) (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (slots : List Nat) (R : BusInteraction (DenseExpr p)) : Bool :=
   slots.all (fun slot =>
     match R.payload[slot]? with
-    | some e => denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e
+    | some e => denseByteJustifiedW bound deep domIdx candsOf bs facts wits fbasis e
     | none => true)
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelLive.lean
@@ -223,19 +223,34 @@ def denseLiveAllSegP {α : Type} (preArr : Array α) (alive : Array Bool)
     (if alive[lo]?.getD false then (preArr[lo]?).elim true P else true)
       && denseLiveAllSegP preArr alive P (lo + 1) n
 
-theorem denseLiveAllSegP_eq {α : Type} (f : BusInteraction (DenseExpr p) → α)
-    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool) (P : α → Bool) :
+/-- `(denseLiveSeg ..).all` on a derived per-position array, without requiring the array to *be*
+    a map of it: a per-position agreement
+    between `P` on the derived record and `Q` on the interaction suffices. What the caller gains is
+    the freedom to derive nothing at positions where `Q` holds anyway (`denseAddrPrepAll`'s off-bus
+    stubs). -/
+theorem denseLiveAllSegP_eqOf {α : Type} (arr : Array (BusInteraction (DenseExpr p)))
+    (alive : Array Bool) (preArr : Array α) (P : α → Bool)
+    (Q : BusInteraction (DenseExpr p) → Bool) (hsz : preArr.size = arr.size)
+    (hpt : ∀ (q : Nat) (m0 : BusInteraction (DenseExpr p)), arr[q]? = some m0 →
+      ∃ m, preArr[q]? = some m ∧ P m = Q m0) :
     ∀ (lo n : Nat),
-      denseLiveAllSegP (arr.map f) alive P lo n
-        = (denseLiveSeg arr alive lo n).all (fun m => P (f m)) := by
+      denseLiveAllSegP preArr alive P lo n = (denseLiveSeg arr alive lo n).all Q := by
   intro lo n
   induction n generalizing lo with
   | zero => rfl
   | succ n ih =>
-      rw [denseLiveAllSegP, denseLiveSeg, ih (lo + 1), List.all_append, Array.getElem?_map]
+      rw [denseLiveAllSegP, denseLiveSeg, ih (lo + 1), List.all_append]
       cases halive : alive[lo]?.getD false
       · simp
-      · cases harr : arr[lo]? <;> simp [Option.elim]
+      · cases harr : arr[lo]? with
+        | none =>
+            rw [Array.getElem?_eq_none (by rw [hsz]; exact Array.getElem?_eq_none_iff.1 harr)]
+            simp
+        | some m0 =>
+            obtain ⟨m, hm, hPQ⟩ := hpt lo m0 harr
+            rw [hm]
+            simp only [Option.elim, hPQ]
+            simp
 
 /-- The logical constraint system at a point in the loop: the original system with its interactions
     replaced by the live projection followed by the checks emitted so far. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusPairCancelWits.lean
@@ -8,7 +8,7 @@ set_option autoImplicit false
 
 The per-invocation position indices the acceptance test consults for bound-deriving witnesses
 (`denseBuildBoundIdx`/`denseDropWits`) and range-checked-form witnesses
-(`denseBuildFormIdx`/`denseDropFormWits`), plus the `_mem` layer proving every returned witness is a
+(`denseBuildFormIdx`/`denseDropFormBasis`), plus the `_mem` layer proving every returned witness is a
 live interaction other than the dropped pair (the `hwits`/`hfwits` shape `denseCheckCancel_sound`
 takes).
 
@@ -52,25 +52,40 @@ def denseInteractionBoundPat (bs : BusSemantics p) (facts : BusFacts p bs)
   funext q bs facts bi m pat i
   simp [denseInteractionBoundPat, denseInteractionBoundPatImpl]
 
+def denseBuildBoundStep (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (k : Nat) (m : Array (List Nat)) : Array (List Nat) :=
+  match bi.multiplicity.constValue? with
+  | none => m
+  | some mval =>
+    if zmodIsZero mval then m
+    else
+      let pat := bi.payload.map DenseExpr.constValue?
+      bi.payload.foldl (fun m e =>
+        match e with
+        | .var v =>
+          -- skip repeated occurrences of the same variable within one payload
+          if ((m[v.index]?).getD []).head? = some k then m
+          else
+            match denseInteractionBoundPat bs facts bi (some mval) pat v with
+            | some _ => m.modify v.index (k :: ·)
+            | none => m
+        | _ => m) m
+
+def denseBuildBoundGo (bs : BusSemantics p) (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (DenseExpr p))) : Nat → Array (List Nat) → Array (List Nat)
+  | 0, m => m
+  | n + 1, m =>
+    denseBuildBoundGo bs facts arr n
+      (match arr[n]? with
+       | none => m
+       | some bi => denseBuildBoundStep bs facts bi n m)
+
 /-- Candidate positions of bound-deriving interactions, per variable (ascending), built once per
     invocation. Untrusted — `denseDropWitsIdxGo` re-checks liveness, the dropped pair, and the bound
     at every use. -/
 def denseBuildBoundIdx (bs : BusSemantics p) (facts : BusFacts p bs) (nvars : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) : Array (List Nat) :=
-  (arr.toList.zipIdx).foldr (fun bik m =>
-    let bi := bik.1
-    let mval? := bi.multiplicity.constValue?
-    let pat := bi.payload.map DenseExpr.constValue?
-    bi.payload.foldl (fun m e =>
-      match e with
-      | .var v =>
-        -- skip repeated occurrences of the same variable within one payload
-        if ((m[v.index]?).getD []).head? = some bik.2 then m
-        else
-          match denseInteractionBoundPat bs facts bi mval? pat v with
-          | some _ => m.modify v.index (bik.2 :: ·)
-          | none => m
-      | _ => m) m) (Array.replicate nvars [])
+  denseBuildBoundGo bs facts arr arr.size (Array.replicate nvars [])
 
 /-- The scan behind `denseDropWits`: the first of `v`'s indexed candidate positions (ascending,
     skipping dead entries and the dropped pair) that still derives a `denseInteractionBound` for
@@ -115,35 +130,52 @@ def denseDropWits {bs : BusSemantics p} (facts : BusFacts p bs)
     | some bi => bi :: emitted
     | none => emitted
 
+def denseBuildFormStep (bs : BusSemantics p) (bi : BusInteraction (DenseExpr p)) (k : Nat)
+    (m : Array (List Nat)) : Array (List Nat) :=
+  if bs.isStateful bi.busId then m
+  else
+    bi.payload.foldl (fun m e =>
+      if e.isSingleVar then m
+      else
+        e.vars.dedup.foldl (fun m v =>
+          let cur := (m[v.index]?).getD []
+          if cur.length < 4 then m.modify v.index (k :: ·) else m) m) m
+
+def denseBuildFormGo (bs : BusSemantics p) (arr : Array (BusInteraction (DenseExpr p)))
+    (n : Nat) (m : Array (List Nat)) : Array (List Nat) :=
+  if h : n < arr.size then
+    denseBuildFormGo bs arr (n + 1) (denseBuildFormStep bs arr[n] n m)
+  else m
+  termination_by arr.size - n
+
 /-- Candidate positions for range-checked forms, per variable: interactions on a *stateless* bus
     carrying a compound payload slot mentioning the variable, at most four per variable. Untrusted —
-    `denseDropFormWits` re-checks liveness and the dropped pair at every use. -/
+    `denseDropFormBasis` re-checks liveness and the dropped pair at every use. -/
 def denseBuildFormIdx (bs : BusSemantics p) (nvars : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) : Array (List Nat) :=
-  (arr.toList.zipIdx).foldl (fun m bik =>
-    if bs.isStateful bik.1.busId then m
-    else
-      bik.1.payload.foldl (fun m e =>
-        if e.isSingleVar then m
-        else
-          e.vars.dedup.foldl (fun m v =>
-            let cur := (m[v.index]?).getD []
-            if cur.length < 4 then m.modify v.index (bik.2 :: ·) else m) m) m)
-      (Array.replicate nvars [])
+  denseBuildFormGo bs arr 0 (Array.replicate nvars [])
 
-/-- The range-checked-form witness lookup for a candidate drop: the indexed candidate positions
-    for `v`, re-checked live and distinct from the dropped pair — the interactions
-    `denseBasisJustified` mines for bounded linear forms. -/
-def denseDropFormWits (fidx : Array (List Nat))
+/-- One lazily-derived checked-form record per position, shared across every candidate and every
+    node of every basis reduction of this invocation. `denseFormBoundAt` is a pure function of
+    `(interaction, slot)`, and the reduction re-asked for it at every node of its fuel-bounded DFS —
+    this is the memo that removes that. Forced only at the positions a query reaches. -/
+def denseBuildFormBounds (bs : BusSemantics p) (facts : BusFacts p bs)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    Array (Thunk (List (DenseLinExpr p × Nat))) :=
+  arr.map (fun bi => Thunk.mk (fun _ => denseFormBoundsOf facts bi))
+
+/-- The basis channel for a candidate drop: the prepared checked forms of `v`'s indexed positions,
+    under the live / distinct-from-the-pair gate the reduction's soundness needs. -/
+def denseDropFormBasis (fidx : Array (List Nat))
+    (fbnd : Array (Thunk (List (DenseLinExpr p × Nat))))
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
-    (S R : BusInteraction (DenseExpr p)) (v : VarId) :
-    List (BusInteraction (DenseExpr p)) :=
-  ((fidx[v.index]?).getD []).filterMap (fun k =>
+    (S R : BusInteraction (DenseExpr p)) (v : VarId) : List (DenseLinExpr p × Nat) :=
+  ((fidx[v.index]?).getD []).flatMap (fun k =>
     if h : k < arr.size then
       if alive[k]?.getD false && !decide (arr[k] = S) && !decide (arr[k] = R) then
-        some arr[k]
-      else none
-    else none)
+        (fbnd[k]?).elim [] Thunk.get
+      else []
+    else [])
 
 /-! ### The `_mem` proof layer
 
@@ -232,26 +264,5 @@ theorem denseDropWits_mem {bs : BusSemantics p} (facts : BusFacts p bs)
     | none =>
       rw [hfb] at hbi
       exact List.mem_append_right _ hbi
-
-/-- Every form witness is in the remaining region (the index entry is re-checked at use). -/
-theorem denseDropFormWits_mem (fidx : Array (List Nat))
-    (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
-    (S R : BusInteraction (DenseExpr p))
-    {A B C : List (BusInteraction (DenseExpr p))}
-    (horig : ∀ bi ∈ denseLiveSeg arr alive 0 arr.size, bi ≠ S → bi ≠ R → bi ∈ A ++ B ++ C)
-    (emitted : List (BusInteraction (DenseExpr p))) :
-    ∀ v, ∀ bi ∈ denseDropFormWits fidx arr alive S R v, bi ∈ A ++ B ++ C ++ emitted := by
-  intro v bi hbi
-  rw [denseDropFormWits, List.mem_filterMap] at hbi
-  obtain ⟨k, _, heq⟩ := hbi
-  split_ifs at heq with hk hcond
-  · obtain rfl := Option.some.inj heq
-    rw [Bool.and_eq_true, Bool.and_eq_true] at hcond
-    obtain ⟨⟨hal, hnS⟩, hnR⟩ := hcond
-    refine List.mem_append_left _ (horig arr[k]
-      (denseLiveSeg_mem arr alive 0 arr.size k _ (Nat.zero_le _) (by omega) hal
-        (Array.getElem?_eq_getElem hk)) ?_ ?_)
-    · exact fun he => by simp [he] at hnS
-    · exact fun he => by simp [he] at hnR
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusUnify.lean
@@ -124,21 +124,8 @@ One record per memory-bus interaction, built once per invocation. `cval` / `lin`
 data the certificates of `AddrDiseq.lean` re-derive per compared pair; `linSig` / `redSig` are the
 order-insensitive term signatures that let the sweep decide the same tests by comparing integers.
 Two linear forms differ by a nonzero constant exactly when their normalized term lists agree and
-their constants do not, so equal signature + different constant is `denseConstDiffNZ` up to a hash
-collision — and a collision can only over-report a refutation, which the verifier catches. Both
-branches of one two-root reduction differ by a constant, hence share one signature. -/
-
-/-- The canonical form of a linear form's terms: merged, zero-dropped, sorted by variable. Two
-    forms differ by a nonzero constant (`denseConstDiffNZ`) exactly when their canonical terms are
-    equal and their constants are not, so this list *is* the affine/two-root comparison. -/
-def denseBUTermKey (l : DenseLinExpr p) : List (VarId × ZMod p) :=
-  l.norm.terms.mergeSort (fun a b => decide (a.1.index ≤ b.1.index))
-
-/-- Hash *of the canonical key*, which gates the list compare: unequal hashes are unequal keys,
-    and that is the overwhelmingly common case. Deriving it from the key rather than from the term
-    list makes the gate's soundness `congrArg` and saves a second `norm`. -/
-def denseBUKeyHash (k : List (VarId × ZMod p)) : UInt64 :=
-  k.foldl (fun h t => mixHash h (mixHash (hash t.1) (hash t.2.val))) 0
+their constants do not (`denseKeyDiffNZ`), so the arms compare an integer and a list. Both branches
+of one two-root reduction differ by a constant, hence share one signature. -/
 
 structure DenseBUSlot (p : ℕ) where
   expr : DenseExpr p
@@ -162,13 +149,12 @@ structure DenseBUPre (p : ℕ) where
 
 def denseBUSlotPrep (T : DenseTwoRootMap p) (e : DenseExpr p) : DenseBUSlot p :=
   let lin := denseLinearize e
-  let key := match lin with | some L => denseBUTermKey L | none => []
+  let key := match lin with | some L => denseTermKey L | none => []
   { expr := e, eHash := e.bHash, cval := e.constValue?
     lin := lin
     linKey := key
-    linSig := denseBUKeyHash key
-    reds := (densePtrReductions T e).map
-      (fun r => let k := denseBUTermKey r.1; (denseBUKeyHash k, k, r.1.const, r.2.const)) }
+    linSig := denseTermKeyHash key
+    reds := (densePtrReductions T e).map denseRedKey }
 
 /-- Assemble a prepared interaction from its slot records. -/
 def denseBUOfSlots (bi : BusInteraction (DenseExpr p))
@@ -220,8 +206,7 @@ def denseBUConstsNeq (a b : DenseBUPre p) : Bool :=
     match sa.cval, sb.cval with | some c, some c' => decide (c ≠ c') | _, _ => false)
     a.slots b.slots
 
-/-- `denseConstDiffNZ` on two prepared slots: the canonical keys agree and the constants do not.
-    The hash short-circuits the list compare. -/
+/-- `denseKeyDiffNZ` on two prepared slots: the canonical keys agree and the constants do not. -/
 @[inline] def denseBUAffineNeqSlot (sa sb : DenseBUSlot p) : Bool :=
   match sa.lin, sb.lin with
   | some L, some L' =>
@@ -231,10 +216,7 @@ def denseBUConstsNeq (a b : DenseBUPre p) : Bool :=
 /-- One key compare per reduction pair decides all four branch differences, which differ only in
     their constants. -/
 @[inline] def denseBUTwoRootNeqSlot (sa sb : DenseBUSlot p) : Bool :=
-  sa.reds.any (fun r => sb.reds.any (fun r' =>
-    ((r.1 == r'.1 && decide (r.2.1 = r'.2.1)) &&
-      (decide (r.2.2.1 ≠ r'.2.2.1) && decide (r.2.2.1 ≠ r'.2.2.2))) &&
-      (decide (r.2.2.2 ≠ r'.2.2.1) && decide (r.2.2.2 ≠ r'.2.2.2))))
+  sa.reds.any (fun r => sb.reds.any (denseRedKeysNeq r))
 
 /-- `denseAddrAffineNeq` on prepared records. -/
 def denseBUAffineNeq (a b : DenseBUPre p) : Bool :=

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseq.lean
@@ -16,21 +16,39 @@ namespace ApcOptimizer.Dense
 
 variable {p : ℕ}
 
-/-! ## Nonzero-constant differences -/
+/-! ## Nonzero-constant differences, by canonical term key
 
-/-- Two dense linear forms whose difference is a nonzero constant evaluate differently. -/
-theorem denseConstDiffNZ_sound (a b : DenseLinExpr p) (h : denseConstDiffNZ a b = true)
-    (denv : VarId → ZMod p) : a.eval denv ≠ b.eval denv := by
-  unfold denseConstDiffNZ at h
-  simp only [Bool.and_eq_true] at h
-  obtain ⟨hterms, hconst⟩ := h
-  have hd : ((a.add (b.scale (-1))).norm).eval denv = a.eval denv - b.eval denv := by
-    rw [DenseLinExpr.norm_eval, DenseLinExpr.add_eval, DenseLinExpr.scale_eval]; ring
-  have hd2 : ((a.add (b.scale (-1))).norm).eval denv = ((a.add (b.scale (-1))).norm).const := by
-    simp only [DenseLinExpr.eval, List.isEmpty_iff.1 hterms, List.map_nil, List.sum_nil, add_zero]
+`denseKeyDiffNZ` compares per-form canonical keys (`denseTermKey`: merged, zero-dropped, sorted by
+variable). Equal keys make the two forms' normalized term lists permutations of each other, hence
+equal in value, so the whole difference is the (differing) constants. -/
+
+theorem denseTermKey_perm (a b : DenseLinExpr p) (h : denseTermKey a = denseTermKey b) :
+    a.norm.terms.Perm b.norm.terms := by
+  have ha := List.mergeSort_perm a.norm.terms (fun x y => decide (x.1.index ≤ y.1.index))
+  have hb := List.mergeSort_perm b.norm.terms (fun x y => decide (x.1.index ≤ y.1.index))
+  unfold denseTermKey at h
+  rw [h] at ha
+  exact ha.symm.trans hb
+
+/-- A linear form's value is its constant plus the sum over its *normalized* terms. -/
+private theorem denseLin_eval_norm (a : DenseLinExpr p) (denv : VarId → ZMod p) :
+    a.eval denv = a.const + (a.norm.terms.map (fun t => t.2 * denv t.1)).sum := by
+  rw [← DenseLinExpr.norm_eval a denv]; rfl
+
+/-- Equal canonical keys and different constants force different values. -/
+theorem denseKeyNeq_sound (a b : DenseLinExpr p) (hk : denseTermKey a = denseTermKey b)
+    (hc : a.const ≠ b.const) (denv : VarId → ZMod p) : a.eval denv ≠ b.eval denv := by
+  have hsum : (a.norm.terms.map (fun t => t.2 * denv t.1)).sum
+      = (b.norm.terms.map (fun t => t.2 * denv t.1)).sum :=
+    ((denseTermKey_perm a b hk).map _).sum_eq
   intro heq
-  have hz : ((a.add (b.scale (-1))).norm).const = 0 := by rw [← hd2, hd, heq, sub_self]
-  exact (of_decide_eq_true hconst) hz
+  rw [denseLin_eval_norm a denv, denseLin_eval_norm b denv, hsum] at heq
+  exact hc (add_right_cancel heq)
+
+theorem denseKeyDiffNZ_sound (a b : DenseLinExpr p) (h : denseKeyDiffNZ a b = true)
+    (denv : VarId → ZMod p) : a.eval denv ≠ b.eval denv := by
+  simp only [denseKeyDiffNZ, Bool.and_eq_true, decide_eq_true_eq] at h
+  exact denseKeyNeq_sound a b h.1.2 h.2 denv
 
 /-! ## Address-slot glue: a per-slot value (dis)equality forces an address (dis)equality -/
 
@@ -99,7 +117,7 @@ theorem denseAddrAffineNeq_sound (reg : VarRegistry) (shape : MemoryBusShape)
           simp only [hL, hL'] at hcond
           refine denseAddr_slot_neq shape S bi denv hslot hSp hbp ?_
           rw [denseLinearize_eval e L hL denv, denseLinearize_eval e' L' hL' denv]
-          exact denseConstDiffNZ_sound L L' hcond denv
+          exact denseKeyDiffNZ_sound L L' hcond denv
 
 /-! ## The two-root map: the lookup-wise soundness invariant -/
 
@@ -293,24 +311,55 @@ theorem densePtrReductions_sound {dcs : List (DenseExpr p)}
       · left; rw [hEL, hsplit, hr, hb1, he1]; ring
       · right; rw [hEL, hsplit, hr, hb2, he2]; ring
 
+/-- Both branch forms of a reduction differ by a constant, so they share a canonical key. -/
+theorem densePtrBranchesOf_key (k : ZMod p) (A : DenseLinExpr p) (δ cx : ZMod p)
+    (rest : DenseLinExpr p) :
+    denseTermKey (densePtrBranchesOf k A δ cx rest).2
+      = denseTermKey (densePtrBranchesOf k A δ cx rest).1 := by
+  unfold denseTermKey densePtrBranchesOf DenseLinExpr.norm DenseLinExpr.add DenseLinExpr.scale
+  simp
+
+theorem densePtrReductions_key {T : DenseTwoRootMap p} {E : DenseExpr p} {b1 b2 : DenseLinExpr p}
+    (h : (b1, b2) ∈ densePtrReductions T E) : denseTermKey b2 = denseTermKey b1 := by
+  unfold densePtrReductions at h
+  cases hL : denseLinearize E with
+  | none => rw [hL] at h; simp at h
+  | some L =>
+    rw [hL, List.mem_filterMap] at h
+    obtain ⟨v, _, hmatch⟩ := h
+    cases htm : T.map[v]? with
+    | none => rw [htm] at hmatch; simp at hmatch
+    | some kAδ =>
+      obtain ⟨k, A, δ⟩ := kAδ
+      rw [htm] at hmatch
+      simp only [Option.some.injEq] at hmatch
+      rw [show b1 = (densePtrBranchesOf k A δ (L.coeff v) (L.others v)).1 from
+            (congrArg Prod.fst hmatch).symm,
+          show b2 = (densePtrBranchesOf k A δ (L.coeff v) (L.others v)).2 from
+            (congrArg Prod.snd hmatch).symm]
+      exact densePtrBranchesOf_key k A δ (L.coeff v) (L.others v)
+
 theorem denseExprTwoRootNeq_sound {dcs : List (DenseExpr p)}
     (T : DenseTwoRootMap p) (hT : T.Sound dcs) (e e' : DenseExpr p)
     (h : denseExprTwoRootNeq T e e' = true) (denv : VarId → ZMod p)
     (hcon : ∀ c ∈ dcs, c.eval denv = 0) : e.eval denv ≠ e'.eval denv := by
   unfold denseExprTwoRootNeq at h
-  rw [List.any_eq_true] at h
+  rw [List.any_map, List.any_eq_true] at h
   obtain ⟨⟨a1, a2⟩, hred, hinner⟩ := h
-  rw [List.any_eq_true] at hinner
+  rw [Function.comp_apply, List.any_map, List.any_eq_true] at hinner
   obtain ⟨⟨b1, b2⟩, hred', hchk⟩ := hinner
-  simp only [Bool.and_eq_true] at hchk
-  obtain ⟨⟨⟨h11, h12⟩, h21⟩, h22⟩ := hchk
+  simp only [Function.comp_apply, denseRedKeysNeq, denseRedKey, Bool.and_eq_true, beq_iff_eq,
+    decide_eq_true_eq] at hchk
+  obtain ⟨⟨⟨_, hkeq⟩, h11, h12⟩, h21, h22⟩ := hchk
+  have hka : denseTermKey a2 = denseTermKey a1 := densePtrReductions_key hred
+  have hkb : denseTermKey b2 = denseTermKey b1 := densePtrReductions_key hred'
   have hev := densePtrReductions_sound T hT e a1 a2 hred denv hcon
   have hev' := densePtrReductions_sound T hT e' b1 b2 hred' denv hcon
   rcases hev with ha | ha <;> rcases hev' with hb | hb <;> rw [ha, hb]
-  · exact denseConstDiffNZ_sound a1 b1 h11 denv
-  · exact denseConstDiffNZ_sound a1 b2 h12 denv
-  · exact denseConstDiffNZ_sound a2 b1 h21 denv
-  · exact denseConstDiffNZ_sound a2 b2 h22 denv
+  · exact denseKeyNeq_sound a1 b1 hkeq h11 denv
+  · exact denseKeyNeq_sound a1 b2 (by rw [hkeq, ← hkb]) h12 denv
+  · exact denseKeyNeq_sound a2 b1 (by rw [hka, hkeq]) h21 denv
+  · exact denseKeyNeq_sound a2 b2 (by rw [hka, hkeq, ← hkb]) h22 denv
 
 /-- Some address slot's two interactions provably differ, so the addresses differ. -/
 theorem denseAddrTwoRootNeq_sound (reg : VarRegistry) (shape : MemoryBusShape)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseqPre.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/AddrDiseqPre.lean
@@ -83,7 +83,9 @@ theorem denseAddrAffineNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
     denseAddrAffineNeqP (denseAddrPrep shape T S) (denseAddrPrep shape T m)
       = denseAddrAffineNeq shape S m :=
-  denseSlotsAny_eq T S m _ _ (fun _ _ => rfl) shape.addressFields
+  denseSlotsAny_eq T S m _ _ (fun e e' => by
+    unfold denseSlotPrep denseKeyDiffNZ
+    cases denseLinearize e <;> cases denseLinearize e' <;> rfl) shape.addressFields
 
 theorem denseAddrTwoRootNeqP_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
     (S m : BusInteraction (DenseExpr p)) :
@@ -143,5 +145,38 @@ theorem denseProvRecvP_eq (ops : DenseZModOps p) (shape : MemoryBusShape)
   unfold denseProvRecvP denseProvRecv
   rw [denseAddrConstsEqP_eq]
   rfl
+
+/-! ## Off-bus records
+
+A prepared record for a position on another bus is only ever asked for its `busId`: the mid and pre
+tests answer `true` on their first arm and `denseProvRecvP` answers `false`. That is what lets one
+prepared array serve every memory bus, with a bus-id-only stub off all of them
+(`denseAddrPrepAll`). -/
+
+theorem denseMidRefutedP_offBus (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (busId : Nat)
+    (a b : DenseAddrPre p) (h : b.busId ≠ busId) : denseMidRefutedP ops nw busId a b = true := by
+  unfold denseMidRefutedP
+  rw [decide_eq_true h]
+  simp
+
+theorem densePreRefutedP_offBus (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (busId : Nat)
+    (setMult : ZMod p) (a b : DenseAddrPre p) (h : b.busId ≠ busId) :
+    densePreRefutedP ops nw busId setMult a b = true := by
+  unfold densePreRefutedP
+  rw [denseMidRefutedP_offBus ops nw busId a b h]
+  simp
+
+theorem denseProvRecvP_offBus (busId : Nat) (getPrevMult : ZMod p) (a b : DenseAddrPre p)
+    (h : b.busId ≠ busId) : denseProvRecvP busId getPrevMult a b = false := by
+  unfold denseProvRecvP
+  rw [decide_eq_false h]
+  simp
+
+theorem denseProvRecv_offBus (ops : DenseZModOps p) (shape : MemoryBusShape) (busId : Nat)
+    (S m : BusInteraction (DenseExpr p)) (h : m.busId ≠ busId) :
+    denseProvRecv ops shape busId S m = false := by
+  unfold denseProvRecv
+  rw [decide_eq_false h]
+  simp
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelCheck.lean
@@ -292,7 +292,8 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (hTnonzero : T.get.nonzero = DenseNonzeroWits.build d.algebraicConstraints)
     (M : Thunk (DenseEqConstraintMap p)) (hM : M.get.Sound d.algebraicConstraints)
     (domIdx : Std.HashMap VarId (List (DenseExpr p))) (candsOf : VarId → List (DenseExpr p))
-    (wits fwits : VarId → List (BusInteraction (DenseExpr p)))
+    (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (A : List (BusInteraction (DenseExpr p))) (S : BusInteraction (DenseExpr p))
     (B : List (BusInteraction (DenseExpr p))) (R : BusInteraction (DenseExpr p))
     (C : List (BusInteraction (DenseExpr p)))
@@ -302,10 +303,12 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ d.algebraicConstraints)
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ d.algebraicConstraints)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ A ++ B ++ C ++ checks)
-    (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ A ++ B ++ C ++ checks)
+    (hfb : ∀ (denv : VarId → ZMod p), (∀ bi ∈ A ++ B ++ C ++ checks,
+        (denseBIEval bi denv).multiplicity ≠ 0 → bs.accepts (denseBIEval bi denv)) →
+      ∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2)
     (hmid : ∀ m0 ∈ B, denseMidRefuted ops shape T busId S m0 = true)
     (hshield : denseShieldOk ops shape T busId S A = true)
-    (h : denseCheckCancel ops deep bs facts M domIdx candsOf wits fwits busId shape slots bound S R checks
+    (h : denseCheckCancel ops deep bs facts M domIdx candsOf wits fbasis busId shape slots bound S R checks
       = true) :
     DensePassCorrect isInput d { d with busInteractions := A ++ B ++ C ++ checks } [] bs := by
   unfold denseCheckCancel at h
@@ -323,8 +326,8 @@ theorem denseCheckCancel_sound (isInput : VarId → Bool)
     (fun ck hck => denseEmitOk_sound ops bs facts busId shape slots R ck
       (List.all_eq_true.mp hemit ck hck) (of_decide_eq_true hRb) hRmEv)
     (fun denv hall hbus => denseRecvSlotsJustified_sound bound deep d.algebraicConstraints domIdx
-      candsOf bs facts (A ++ B ++ C ++ checks) wits fwits slots R hdeep hdomIdx hcands hwits hfwits
-      hjust denv hall hbus)
+      candsOf bs facts (A ++ B ++ C ++ checks) wits fbasis slots R hdeep hdomIdx hcands hwits
+      hjust denv (hfb denv hbus) hall hbus)
     hsplit
     (of_decide_eq_true hSb) (of_decide_eq_true hRb)
     (of_decide_eq_true hSm) (of_decide_eq_true hRm)

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelJustify.lean
@@ -405,14 +405,13 @@ theorem denseFormBoundAt_sound {bs : BusSemantics p} (facts : BusFacts p bs)
 /-- Fuel-bounded induction: at each step it either finishes on the plain per-variable natural bound,
     or subtracts an integer multiple `μ` of a range-checked slot form accounting `μ·(B_F − 1)`
     against the budget (exact `DenseLinExpr` algebra). -/
-theorem denseBasisReduceGo_sound (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSemantics p}
-    (facts : BusFacts p bs) (fwits : VarId → List (BusInteraction (DenseExpr p)))
+theorem denseBasisReduceGo_sound (bound : Nat) (bnd : VarId → Option Nat)
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (denv : VarId → ZMod p)
     (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
-    (hfw : ∀ v, ∀ bi ∈ fwits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.accepts (denseBIEval bi denv)) :
+    (hfb : ∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2) :
     ∀ (fuel used : Nat) (L : DenseLinExpr p),
-      denseBasisReduceGo bound bnd facts fwits fuel used L = true →
+      denseBasisReduceGo bound bnd fbasis fuel used L = true →
       ∃ n : ℕ, L.eval denv = (n : ZMod p) ∧ n + used < bound ∧ n + used < p := by
   intro fuel
   induction fuel with
@@ -447,54 +446,47 @@ theorem denseBasisReduceGo_sound (bound : Nat) (bnd : VarId → Option Nat) {bs 
             omega
     ·
       rw [List.any_eq_true] at hstep
-      obtain ⟨v, _, hstep⟩ := hstep
+      obtain ⟨t, _, hstep⟩ := hstep
+      dsimp only at hstep
       rw [List.any_eq_true] at hstep
-      obtain ⟨bi, hbi, hstep⟩ := hstep
-      rw [List.any_eq_true] at hstep
-      obtain ⟨i, _, hstep⟩ := hstep
-      cases hfb : denseFormBoundAt facts bi i with
-      | none => rw [hfb] at hstep; simp at hstep
-      | some LfBf =>
-        obtain ⟨Lf, Bf⟩ := LfBf
-        rw [hfb] at hstep
-        simp only at hstep
-        split_ifs at hstep with hcond
-        obtain ⟨n', heval', hb', hp'⟩ := ih _ _ hstep
-        haveI : NeZero p := ⟨by omega⟩
-        have hef : (Lf.eval denv).val < Bf :=
-          denseFormBoundAt_sound facts bi i Lf Bf hfb denv (hfw v bi hbi)
-        set μ := (IntervalForce.srep (L.coeff v) / IntervalForce.srep (Lf.coeff v)).toNat with hμ
-        have hdecomp : L.eval denv
-            = (μ : ZMod p) * Lf.eval denv + ((L.add (Lf.scale (-(μ : ZMod p)))).norm).eval denv := by
-          rw [DenseLinExpr.norm_eval, DenseLinExpr.add_eval, DenseLinExpr.scale_eval]
-          ring
-        refine ⟨μ * (Lf.eval denv).val + n', ?_, ?_, ?_⟩
-        · rw [hdecomp, heval']
-          push_cast
-          rw [ZMod.natCast_val, ZMod.cast_id]
-        · have hmul : μ * (Lf.eval denv).val ≤ μ * (Bf - 1) :=
-            Nat.mul_le_mul_left _ (by omega)
-          omega
-        · have hmul : μ * (Lf.eval denv).val ≤ μ * (Bf - 1) :=
-            Nat.mul_le_mul_left _ (by omega)
-          omega
+      obtain ⟨LB, hLB, hstep⟩ := hstep
+      split_ifs at hstep with hcond
+      obtain ⟨n', heval', hb', hp'⟩ := ih _ _ hstep
+      haveI : NeZero p := ⟨by omega⟩
+      have hef : (LB.1.eval denv).val < LB.2 := hfb t.1 LB hLB
+      set μ := (IntervalForce.srep (L.coeff t.1) / IntervalForce.srep (LB.1.coeff t.1)).toNat
+        with hμ
+      have hdecomp : L.eval denv
+          = (μ : ZMod p) * LB.1.eval denv
+            + ((L.add (LB.1.scale (-(μ : ZMod p)))).norm).eval denv := by
+        rw [DenseLinExpr.norm_eval, DenseLinExpr.add_eval, DenseLinExpr.scale_eval]
+        ring
+      refine ⟨μ * (LB.1.eval denv).val + n', ?_, ?_, ?_⟩
+      · rw [hdecomp, heval']
+        push_cast
+        rw [ZMod.natCast_val, ZMod.cast_id]
+      · have hmul : μ * (LB.1.eval denv).val ≤ μ * (LB.2 - 1) :=
+          Nat.mul_le_mul_left _ (by omega)
+        omega
+      · have hmul : μ * (LB.1.eval denv).val ≤ μ * (LB.2 - 1) :=
+          Nat.mul_le_mul_left _ (by omega)
+        omega
 
 /-- If `e` linearizes to a form the fuel-bounded reduction proves `< bound`, then `e` is a byte/limb
     under any assignment respecting the bounds and never violating the witness interactions. -/
-theorem denseBasisJustified_sound (bound : Nat) (bnd : VarId → Option Nat) {bs : BusSemantics p}
-    (facts : BusFacts p bs) (fwits : VarId → List (BusInteraction (DenseExpr p)))
+theorem denseBasisJustified_sound (bound : Nat) (bnd : VarId → Option Nat)
+    (fbasis : VarId → List (DenseLinExpr p × Nat))
     (e : DenseExpr p) (denv : VarId → ZMod p)
     (hbnd : ∀ v b, bnd v = some b → (denv v).val < b)
-    (hfw : ∀ v, ∀ bi ∈ fwits v, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.accepts (denseBIEval bi denv))
-    (h : denseBasisJustified bound bnd facts fwits e = true) : (e.eval denv).val < bound := by
+    (hfb : ∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2)
+    (h : denseBasisJustified bound bnd fbasis e = true) : (e.eval denv).val < bound := by
   unfold denseBasisJustified at h
   cases hL : denseLinearize e with
   | none => rw [hL] at h; simp at h
   | some L =>
     rw [hL] at h
     obtain ⟨n, heval, hb, hp'⟩ :=
-      denseBasisReduceGo_sound bound bnd facts fwits denv hbnd hfw basisFuel 0 L.norm h
+      denseBasisReduceGo_sound bound bnd fbasis denv hbnd hfb basisFuel 0 L.norm h
     haveI : NeZero p := ⟨by omega⟩
     rw [denseLinearize_eval e L hL denv, ← DenseLinExpr.norm_eval, heval, ZMod.val_natCast,
       Nat.mod_eq_of_lt (by omega)]
@@ -513,14 +505,15 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all : List (Dense
     (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (DenseExpr p)))
-    (wits fwits : VarId → List (BusInteraction (DenseExpr p))) (e : DenseExpr p)
+    (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat)) (e : DenseExpr p)
     (hdeep : deep = true → p.Prime)
     (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ all)
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
-    (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ rest)
-    (h : denseByteJustifiedW bound deep domIdx candsOf bs facts wits fwits e = true)
+    (h : denseByteJustifiedW bound deep domIdx candsOf bs facts wits fbasis e = true)
     (denv : VarId → ZMod p)
+    (hfb : ∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.accepts (denseBIEval bi denv)) :
@@ -575,9 +568,9 @@ theorem denseByteJustifiedW_sound (bound : Nat) (deep : Bool) (all : List (Dense
       exact denseAffineJustified_sound bound (fun x => denseFindVarBound bs facts (wits x) x) e denv
         (fun v b hb => denseFindVarBound_sound bs facts (wits v) v b hb denv (hbusW v)) h
     ·
-      exact denseBasisJustified_sound bound (fun x => denseFindVarBound bs facts (wits x) x) facts
-        fwits e denv (fun v b hb => denseFindVarBound_sound bs facts (wits v) v b hb denv (hbusW v))
-        (fun v bi hbi => hbus bi (hfwits v bi hbi)) h
+      exact denseBasisJustified_sound bound (fun x => denseFindVarBound bs facts (wits x) x)
+        fbasis e denv (fun v b hb => denseFindVarBound_sound bs facts (wits v) v b hb denv (hbusW v))
+        hfb h
 
 /-- If every declared byte slot of `R` is justified, then at every such slot the evaluated payload
     entry of `R` (under any `denv` zeroing `all` and never violating the remaining witnessed
@@ -586,14 +579,15 @@ theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all : List (D
     (domIdx : Std.HashMap VarId (List (DenseExpr p)))
     (candsOf : VarId → List (DenseExpr p)) (bs : BusSemantics p)
     (facts : BusFacts p bs) (rest : List (BusInteraction (DenseExpr p)))
-    (wits fwits : VarId → List (BusInteraction (DenseExpr p))) (slots : List Nat)
+    (wits : VarId → List (BusInteraction (DenseExpr p)))
+    (fbasis : VarId → List (DenseLinExpr p × Nat)) (slots : List Nat)
     (R : BusInteraction (DenseExpr p)) (hdeep : deep = true → p.Prime)
     (hdomIdx : ∀ v, ∀ c ∈ denseVarBucketLookup domIdx v, c ∈ all)
     (hcands : ∀ x, ∀ c ∈ candsOf x, c ∈ all)
     (hwits : ∀ v, ∀ bi ∈ wits v, bi ∈ rest)
-    (hfwits : ∀ v, ∀ bi ∈ fwits v, bi ∈ rest)
-    (h : denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fwits slots R = true)
+    (h : denseRecvSlotsJustified bound deep domIdx candsOf bs facts wits fbasis slots R = true)
     (denv : VarId → ZMod p)
+    (hfb : ∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2)
     (hall : ∀ c' ∈ all, c'.eval denv = 0)
     (hbus : ∀ bi ∈ rest, (denseBIEval bi denv).multiplicity ≠ 0 →
       bs.accepts (denseBIEval bi denv)) :
@@ -609,7 +603,7 @@ theorem denseRecvSlotsJustified_sound (bound : Nat) (deep : Bool) (all : List (D
     rw [he] at hget' hcheck
     simp only [Option.map_some, Option.some.injEq] at hget'
     subst hget'
-    exact denseByteJustifiedW_sound bound deep all domIdx candsOf bs facts rest wits fwits e hdeep
-      hdomIdx hcands hwits hfwits hcheck denv hall hbus
+    exact denseByteJustifiedW_sound bound deep all domIdx candsOf bs facts rest wits fbasis e hdeep
+      hdomIdx hcands hwits hcheck denv hfb hall hbus
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusPairCancelKeyIdx.lean
@@ -763,14 +763,41 @@ theorem denseArrEntry_of_mem {q : Nat} {l : List Nat} (h : q ∈ l) :
   obtain ⟨k, hk⟩ := List.mem_iff_getElem?.mp h
   exact ⟨k, by rw [List.getElem?_toArray]; exact hk⟩
 
+/-- What a prepared address array must satisfy to serve candidate bus `busId`: it covers every
+    position, carries each position's own bus id, and *is* the exact `denseAddrPrep` record wherever
+    the position is on `busId`. Off-bus records are only ever asked for that bus id, which is what
+    lets one array serve every memory bus (`denseAddrPrepAll_ok`). -/
+def DensePreArrOk (shape : MemoryBusShape) (T : Thunk (DenseAddrCerts p)) (busId : Nat)
+    (arr : Array (BusInteraction (DenseExpr p))) (preArr : Array (DenseAddrPre p)) : Prop :=
+  preArr.size = arr.size ∧
+  ∀ (q : Nat) (m0 : BusInteraction (DenseExpr p)), arr[q]? = some m0 →
+    ∃ m, preArr[q]? = some m ∧ m.busId = m0.busId ∧
+      (m0.busId = busId → m = denseAddrPrep shape T.get.tworoot m0)
+
+theorem denseAddrPrepAll_ok (memShape : Nat → Option MemoryBusShape) (shape : MemoryBusShape)
+    (T : Thunk (DenseAddrCerts p)) (busId : Nat) (hshape : memShape busId = some shape)
+    (arr : Array (BusInteraction (DenseExpr p))) :
+    DensePreArrOk shape T busId arr (denseAddrPrepAll memShape T.get.tworoot arr) := by
+  refine ⟨by simp [denseAddrPrepAll], fun q m0 hq => ?_⟩
+  refine ⟨_, by rw [denseAddrPrepAll, Array.getElem?_map, hq]; rfl, ?_, ?_⟩
+  · show (match memShape m0.busId with
+      | some sh => denseAddrPrep sh T.get.tworoot m0
+      | none => (⟨m0.busId, Thunk.pure none, []⟩ : DenseAddrPre p)).busId = m0.busId
+    cases memShape m0.busId <;> rfl
+  · intro hbus
+    show (match memShape m0.busId with
+      | some sh => denseAddrPrep sh T.get.tworoot m0
+      | none => (⟨m0.busId, Thunk.pure none, []⟩ : DenseAddrPre p))
+        = denseAddrPrep shape T.get.tworoot m0
+    rw [hbus, hshape]
+
 /-- What one candidate's scan pair establishes. The two arrays need only be ascending and jointly
     cover every position that is not already mid-refuted; which arrays those are — the candidate's
     key bucket plus the symbolic positions, or all of the bus's positions — is the caller's choice. -/
 theorem denseScanDecide_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
-    (preArr : Array (DenseAddrPre p))
-    (hpre : preArr = arr.map (denseAddrPrep shape T.get.tworoot))
+    (preArr : Array (DenseAddrPre p)) (hok : DensePreArrOk shape T busId arr preArr)
     (S : BusInteraction (DenseExpr p)) (preS : DenseAddrPre p)
     (hpreS : preS = denseAddrPrep shape T.get.tworoot S)
     (i j : Nat) (hij : i < j) (b s : Array Nat)
@@ -785,49 +812,75 @@ theorem denseScanDecide_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
     (∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
         denseMidRefuted ops shape T busId S m0 = true) ∧
       denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
+  obtain ⟨hpsz, hpre⟩ := hok
   rw [denseScanDecide, Bool.and_eq_true, Bool.and_eq_true] at hw
   obtain ⟨⟨hmidB, hmidS⟩, hshieldB⟩ := hw
-  -- the prepared record at a position is the prepared record of the interaction there
-  have hentry : ∀ (q : Nat) m, preArr[q]? = some m →
-      ∃ m0, arr[q]? = some m0 ∧ m = denseAddrPrep shape T.get.tworoot m0 := by
-    intro q m hm
-    rw [hpre, Array.getElem?_map] at hm
-    cases hq : arr[q]? with
-    | none => rw [hq] at hm; exact absurd hm (by simp)
-    | some m0 => rw [hq] at hm; exact ⟨m0, rfl, (Option.some.inj hm).symm⟩
+  -- an on-bus position carries the exact prepared record; an off-bus one answers on the bus-id arm
+  have hmidPt : ∀ (q : Nat) (m0 : BusInteraction (DenseExpr p)), arr[q]? = some m0 →
+      ∃ m, preArr[q]? = some m ∧
+        denseMidRefutedP ops T.get.nonzero busId preS m
+          = denseMidRefuted ops shape T busId S m0 := by
+    intro q m0 hq
+    obtain ⟨m, hm, hbid, hexact⟩ := hpre q m0 hq
+    refine ⟨m, hm, ?_⟩
+    by_cases hbus : m0.busId = busId
+    · rw [hexact hbus, hpreS, denseMidRefutedP_eq]
+    · rw [denseMidRefutedP_offBus ops T.get.nonzero busId preS m (by rw [hbid]; exact hbus),
+        denseMidRefuted_of_crossBus ops shape T busId S m0 hbus]
+  have hshieldPt : ∀ (q : Nat) (m0 : BusInteraction (DenseExpr p)), arr[q]? = some m0 →
+      ∃ m, preArr[q]? = some m ∧
+        densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS m
+          = densePreRefuted ops shape T busId S m0 ∧
+        denseProvRecvP busId (denseGetPreviousMult ops shape) preS m
+          = denseProvRecv ops shape busId S m0 := by
+    intro q m0 hq
+    obtain ⟨m, hm, hbid, hexact⟩ := hpre q m0 hq
+    refine ⟨m, hm, ?_, ?_⟩
+    · by_cases hbus : m0.busId = busId
+      · rw [hexact hbus, hpreS, densePreRefutedP_eq]
+      · rw [densePreRefutedP_offBus ops T.get.nonzero busId (denseSetNewMult ops shape) preS m
+              (by rw [hbid]; exact hbus),
+          densePreRefuted_of_midRefuted ops shape T busId S m0
+            (denseMidRefuted_of_crossBus ops shape T busId S m0 hbus)]
+    · by_cases hbus : m0.busId = busId
+      · rw [hexact hbus, hpreS, denseProvRecvP_eq]
+      · rw [denseProvRecvP_offBus busId (denseGetPreviousMult ops shape) preS m
+              (by rw [hbid]; exact hbus),
+          denseProvRecv_offBus ops shape busId S m0 hbus]
   -- the mid `all` and the shield fold, converted to the forms `denseMkDropResult` consumes
   have hmidOf : denseLiveAllSegP preArr alive
       (denseMidRefutedP ops T.get.nonzero busId preS) (i + 1) (j - i - 1) = true →
       ∀ m0 ∈ denseLiveSeg arr alive (i + 1) (j - i - 1),
         denseMidRefuted ops shape T busId S m0 = true := by
     intro hmidA
-    rw [hpre, denseLiveAllSegP_eq] at hmidA
-    intro m0 hm0
-    have h := List.all_eq_true.mp hmidA m0 hm0
-    rw [hpreS] at h
-    rwa [denseMidRefutedP_eq] at h
+    rw [denseLiveAllSegP_eqOf arr alive preArr _ (denseMidRefuted ops shape T busId S) hpsz
+      hmidPt] at hmidA
+    exact fun m0 hm0 => List.all_eq_true.mp hmidA m0 hm0
   have hshieldOf : (denseShieldScanSegP
       (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
       (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
       preArr alive 0 i).2 = true →
       denseShieldOk ops shape T busId S (denseLiveSeg arr alive 0 i) = true := by
     intro hshieldA
-    rw [hpre, denseShieldScanSegP_eq] at hshieldA
-    have hP : (fun m => densePreRefutedP ops T.get.nonzero busId
-          (denseSetNewMult ops shape) preS (denseAddrPrep shape T.get.tworoot m))
-        = densePreRefuted ops shape T busId S :=
-      funext fun m => by rw [hpreS]; exact densePreRefutedP_eq ops shape T busId S m
-    have hQ : (fun m => denseProvRecvP busId (denseGetPreviousMult ops shape) preS
-          (denseAddrPrep shape T.get.tworoot m))
-        = denseProvRecv ops shape busId S :=
-      funext fun m => by rw [hpreS]; exact denseProvRecvP_eq ops shape T.get.tworoot busId S m
-    rw [hP, hQ, denseShieldScanW_eq] at hshieldA
+    rw [denseShieldScanSegP_eqOf _ _ (densePreRefuted ops shape T busId S)
+        (denseProvRecv ops shape busId S) arr alive preArr hpsz
+        (fun q m0 hq => (hshieldPt q m0 hq).imp
+          (fun _ h => ⟨h.1, h.2.1, h.2.2⟩)),
+      denseShieldScanW_eq] at hshieldA
     exact hshieldA
+  -- every position the prepared array answers for is a position of `arr`
+  have hidx : ∀ (q : Nat) (m : DenseAddrPre p), preArr[q]? = some m → ∃ m0, arr[q]? = some m0 := by
+    intro q m hm
+    have hq : q < preArr.size := by
+      by_contra hc
+      rw [Array.getElem?_eq_none (Nat.le_of_not_lt hc)] at hm
+      exact absurd hm (by simp)
+    exact ⟨arr[q], Array.getElem?_eq_getElem (by omega)⟩
   -- the mid region
   have hmidPos : ∀ q, i + 1 ≤ q → q < j → alive[q]?.getD false = true →
       ∀ m, preArr[q]? = some m → denseMidRefutedP ops T.get.nonzero busId preS m = true := by
     intro q hq1 hq2 hal m hme
-    obtain ⟨m0, hq, rfl⟩ := hentry q m hme
+    obtain ⟨m0, hq⟩ := hidx q m hme
     rcases hclass q m0 hq with ⟨k, hkq⟩ | ⟨k, hkq⟩ | href
     · exact denseLiveAllGated_sound _ preArr alive b (i + 1) j _ _ hmidB k q
         (denseLowerBound_le_of_le hbs hkq hq1) (denseLowerBound_lt_of_lt hbs hkq hq2) hkq hq1 hq2
@@ -835,7 +888,9 @@ theorem denseScanDecide_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
     · exact denseLiveAllGated_sound _ preArr alive s (i + 1) j _ _ hmidS k q
         (denseLowerBound_le_of_le hss hkq hq1) (denseLowerBound_lt_of_lt hss hkq hq2) hkq hq1 hq2
         hal _ hme
-    · rw [hpreS, denseMidRefutedP_eq]; exact href
+    · obtain ⟨m', hm', hPQ⟩ := hmidPt q m0 hq
+      rw [Option.some.inj (hm'.symm.trans hme)] at hPQ
+      rw [hPQ]; exact href
   -- the shield region
   obtain ⟨q0, hq0, habB, habS⟩ := denseShieldEarly_sound
     (densePreRefutedP ops T.get.nonzero busId (denseSetNewMult ops shape) preS)
@@ -845,11 +900,13 @@ theorem denseScanDecide_sound (ops : DenseZModOps p) (shape : MemoryBusShape)
       (i + 1) (le_refl _) (by omega)), ?_⟩
   refine hshieldOf (denseShieldScanSegP_true_of _ _ preArr alive q0 i
     (fun q hq => (hq0 q hq).2) (fun q hqi hgt hal m hme => ?_) (fun r hr => (hq0 r hr).1))
-  obtain ⟨m0, hq, rfl⟩ := hentry q m hme
+  obtain ⟨m0, hq⟩ := hidx q m hme
   rcases hclass q m0 hq with ⟨k, hkq⟩ | ⟨k, hkq⟩ | href
   · exact habB k q (denseLowerBound_lt_of_lt hbs hkq hqi) hkq hgt hqi hal _ hme
   · exact habS k q (denseLowerBound_lt_of_lt hss hkq hqi) hkq hgt hqi hal _ hme
-  · rw [hpreS, densePreRefutedP_eq]
+  · obtain ⟨m', hm', hPQ, _⟩ := hshieldPt q m0 hq
+    rw [Option.some.inj (hm'.symm.trans hme)] at hPQ
+    rw [hPQ]
     exact densePreRefuted_of_midRefuted ops shape T busId S m0 href
 
 /-! ## The combined region test
@@ -866,8 +923,7 @@ consumes. -/
 def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
     (T : Thunk (DenseAddrCerts p)) (busId : Nat)
     (arr : Array (BusInteraction (DenseExpr p))) (alive : Array Bool)
-    (preArr : Array (DenseAddrPre p))
-    (hpre : preArr = arr.map (denseAddrPrep shape T.get.tworoot))
+    (preArr : Array (DenseAddrPre p)) (hok : DensePreArrOk shape T busId arr preArr)
     (kIdx : DenseKeyIdx p) (hkIdx : kIdx = denseKeyIdxBuild shape busId arr)
     (S : BusInteraction (DenseExpr p)) (preS : DenseAddrPre p)
     (hpreS : preS = denseAddrPrep shape T.get.tworoot S)
@@ -889,7 +945,7 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
           (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
           preArr alive (kIdx.byKeyA.getD (denseKeyHash kS) #[]) kIdx.symA i j, by
         intro hw
-        refine denseScanDecide_sound ops shape T busId arr alive preArr hpre S preS hpreS i j hij
+        refine denseScanDecide_sound ops shape T busId arr alive preArr hok S preS hpreS i j hij
           _ _ (by rw [hbA, List.toList_toArray]; exact hsound.sorted_key _)
           (by rw [hsA, List.toList_toArray]; exact hsound.sorted_sym) (fun q m0 hq => ?_) hw
         by_cases hbus : m0.busId = busId
@@ -914,7 +970,7 @@ def denseRegionTests (ops : DenseZModOps p) (shape : MemoryBusShape)
           (denseProvRecvP busId (denseGetPreviousMult ops shape) preS)
           preArr alive kIdx.allA #[] i j, by
         intro hw
-        refine denseScanDecide_sound ops shape T busId arr alive preArr hpre S preS hpreS i j hij
+        refine denseScanDecide_sound ops shape T busId arr alive preArr hok S preS hpreS i j hij
           _ _ (by rw [haA, List.toList_toArray]; exact hsound.sorted_all) (by simp)
           (fun q m0 hq => ?_) hw
         by_cases hbus : m0.busId = busId

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusUnify.lean
@@ -241,38 +241,6 @@ theorem denseBUNonzeroNeq_eq (shape : MemoryBusShape) (T : DenseTwoRootMap p)
   rw [denseBUDiffSum_eq]
   rfl
 
-/-! ## Canonical term keys
-
-`denseConstDiffNZ a b` holds when `a − b` has no terms and a nonzero constant. The engine decides
-that by comparing `denseBUTermKey` — the merged, zero-dropped, *sorted* term list — so equal keys
-mean the two forms' normalized terms are permutations of each other, hence evaluate equally, and
-the whole difference is the (differing) constants. Only this direction is needed: the engine may
-refute less than `denseConstDiffNZ` would, never more. -/
-
-theorem denseBUTermKey_perm (a b : DenseLinExpr p) (h : denseBUTermKey a = denseBUTermKey b) :
-    a.norm.terms.Perm b.norm.terms := by
-  have ha := List.mergeSort_perm a.norm.terms (fun x y => decide (x.1.index ≤ y.1.index))
-  have hb := List.mergeSort_perm b.norm.terms (fun x y => decide (x.1.index ≤ y.1.index))
-  unfold denseBUTermKey at h
-  rw [h] at ha
-  exact ha.symm.trans hb
-
-/-- A linear form's value is its constant plus the sum over its *normalized* terms. -/
-private theorem denseBU_eval_norm (a : DenseLinExpr p) (denv : VarId → ZMod p) :
-    a.eval denv = a.const + (a.norm.terms.map (fun t => t.2 * denv t.1)).sum := by
-  rw [← DenseLinExpr.norm_eval a denv]; rfl
-
-/-- Equal canonical keys and different constants force different values — the engine's replacement
-    for `denseConstDiffNZ_sound`. -/
-theorem denseBUKeyNeq_sound (a b : DenseLinExpr p) (hk : denseBUTermKey a = denseBUTermKey b)
-    (hc : a.const ≠ b.const) (denv : VarId → ZMod p) : a.eval denv ≠ b.eval denv := by
-  have hsum : (a.norm.terms.map (fun t => t.2 * denv t.1)).sum
-      = (b.norm.terms.map (fun t => t.2 * denv t.1)).sum :=
-    ((denseBUTermKey_perm a b hk).map _).sum_eq
-  intro heq
-  rw [denseBU_eval_norm a denv, denseBU_eval_norm b denv, hsum] at heq
-  exact hc (add_right_cancel heq)
-
 /-! ## The affine and two-root arms -/
 
 theorem denseBUAffineNeq_sound (shape : MemoryBusShape) (T : DenseTwoRootMap p)
@@ -306,41 +274,13 @@ theorem denseBUAffineNeq_sound (shape : MemoryBusShape) (T : DenseTwoRootMap p)
           obtain ⟨⟨_, hkey⟩, hconst⟩ := hcond
           refine denseAddr_slot_neq shape S m denv hslot hSp hbp ?_
           rw [denseLinearize_eval e L hL denv, denseLinearize_eval e' L' hL' denv]
-          exact denseBUKeyNeq_sound L L' hkey hconst denv
-
-/-- Both branch forms of a reduction differ by a constant, so they share a canonical key. -/
-theorem densePtrBranchesOf_key (k : ZMod p) (A : DenseLinExpr p) (δ cx : ZMod p)
-    (rest : DenseLinExpr p) :
-    denseBUTermKey (densePtrBranchesOf k A δ cx rest).2
-      = denseBUTermKey (densePtrBranchesOf k A δ cx rest).1 := by
-  unfold denseBUTermKey densePtrBranchesOf DenseLinExpr.norm DenseLinExpr.add DenseLinExpr.scale
-  simp
-
-theorem densePtrReductions_key {T : DenseTwoRootMap p} {E : DenseExpr p} {b1 b2 : DenseLinExpr p}
-    (h : (b1, b2) ∈ densePtrReductions T E) : denseBUTermKey b2 = denseBUTermKey b1 := by
-  unfold densePtrReductions at h
-  cases hL : denseLinearize E with
-  | none => rw [hL] at h; simp at h
-  | some L =>
-    rw [hL, List.mem_filterMap] at h
-    obtain ⟨v, _, hmatch⟩ := h
-    cases htm : T.map[v]? with
-    | none => rw [htm] at hmatch; simp at hmatch
-    | some kAδ =>
-      obtain ⟨k, A, δ⟩ := kAδ
-      rw [htm] at hmatch
-      simp only [Option.some.injEq] at hmatch
-      rw [show b1 = (densePtrBranchesOf k A δ (L.coeff v) (L.others v)).1 from
-            (congrArg Prod.fst hmatch).symm,
-          show b2 = (densePtrBranchesOf k A δ (L.coeff v) (L.others v)).2 from
-            (congrArg Prod.snd hmatch).symm]
-      exact densePtrBranchesOf_key k A δ (L.coeff v) (L.others v)
+          exact denseKeyNeq_sound L L' hkey hconst denv
 
 /-- A stored reduction entry comes from an actual `densePtrReductions` pair, with the stored key
     the canonical key of both its branches and the stored constants their constants. -/
 theorem denseBUSlot_reds_mem {T : DenseTwoRootMap p} {e : DenseExpr p}
     {r : UInt64 × List (VarId × ZMod p) × ZMod p × ZMod p} (h : r ∈ (denseBUSlotPrep T e).reds) :
-    ∃ b1 b2, (b1, b2) ∈ densePtrReductions T e ∧ r.2.1 = denseBUTermKey b1 ∧
+    ∃ b1 b2, (b1, b2) ∈ densePtrReductions T e ∧ r.2.1 = denseTermKey b1 ∧
       r.2.2.1 = b1.const ∧ r.2.2.2 = b2.const := by
   simp only [denseBUSlotPrep, List.mem_map] at h
   obtain ⟨⟨b1, b2⟩, hmem, rfl⟩ := h
@@ -371,19 +311,19 @@ theorem denseBUTwoRootNeq_sound {dcs : List (DenseExpr p)} (shape : MemoryBusSha
       obtain ⟨rb, hrb, hchk⟩ := List.any_eq_true.1 hinner
       obtain ⟨a1, a2, hared, hakey, hac1, hac2⟩ := denseBUSlot_reds_mem hra
       obtain ⟨b1, b2, hbred, hbkey, hbc1, hbc2⟩ := denseBUSlot_reds_mem hrb
-      simp only [Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq] at hchk
+      simp only [denseRedKeysNeq, Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq] at hchk
       obtain ⟨⟨⟨_, hkeq⟩, h11, h12⟩, h21, h22⟩ := hchk
-      have hka : denseBUTermKey a2 = denseBUTermKey a1 := densePtrReductions_key hared
-      have hkb : denseBUTermKey b2 = denseBUTermKey b1 := densePtrReductions_key hbred
-      have hkab : denseBUTermKey a1 = denseBUTermKey b1 := by rw [← hakey, ← hbkey]; exact hkeq
+      have hka : denseTermKey a2 = denseTermKey a1 := densePtrReductions_key hared
+      have hkb : denseTermKey b2 = denseTermKey b1 := densePtrReductions_key hbred
+      have hkab : denseTermKey a1 = denseTermKey b1 := by rw [← hakey, ← hbkey]; exact hkeq
       have hev := densePtrReductions_sound T hT e a1 a2 hared denv hcon
       have hev' := densePtrReductions_sound T hT e' b1 b2 hbred denv hcon
       refine denseAddr_slot_neq shape S m denv hslot hSp hbp ?_
       rcases hev with ha | ha <;> rcases hev' with hb | hb <;> rw [ha, hb]
-      · exact denseBUKeyNeq_sound a1 b1 hkab (by rw [← hac1, ← hbc1]; exact h11) denv
-      · exact denseBUKeyNeq_sound a1 b2 (by rw [hkab, ← hkb]) (by rw [← hac1, ← hbc2]; exact h12) denv
-      · exact denseBUKeyNeq_sound a2 b1 (by rw [hka, hkab]) (by rw [← hac2, ← hbc1]; exact h21) denv
-      · exact denseBUKeyNeq_sound a2 b2 (by rw [hka, hkab, ← hkb])
+      · exact denseKeyNeq_sound a1 b1 hkab (by rw [← hac1, ← hbc1]; exact h11) denv
+      · exact denseKeyNeq_sound a1 b2 (by rw [hkab, ← hkb]) (by rw [← hac1, ← hbc2]; exact h12) denv
+      · exact denseKeyNeq_sound a2 b1 (by rw [hka, hkab]) (by rw [← hac2, ← hbc1]; exact h21) denv
+      · exact denseKeyNeq_sound a2 b2 (by rw [hka, hkab, ← hkb])
           (by rw [← hac2, ← hbc2]; exact h22) denv
 
 /-! ## The verifier -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/RedundantByteDrop.lean
@@ -102,8 +102,8 @@ theorem denseRedundantByteDropF_correct (pw : PrimeWitness p) (bs : BusSemantics
         (fun x c hc => denseVarBucket_mem DenseExpr.vars d.algebraicConstraints x c hc)
         (fun v bi'' hbi'' =>
           denseVarBucket_mem denseBIVars (denseByteDropBase bs facts d) v bi'' hbi'')
-        (fun _ bi'' hbi'' => absurd hbi'' (by simp))
         (List.all_eq_true.mp hjust e he) denv
+        (fun _ LB hLB => absurd hLB (by simp))
         (fun c hc => hsat.1 c hc) hbusbase
 
 /-- The dense redundant byte-check drop pass; transform `denseRedundantByteDropF`

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -440,7 +440,11 @@ computes the same boolean while touching only the positions above the last prova
 Design (b) (a maintained per-address-key `pending` bit with recompute-on-drop) is therefore
 **retired**: the early exit gets the same asymptotics with no cross-candidate state, no drop
 invalidation, and a value-identical transformation of the existing fold.
-   **What is left in the pass (6.4 s on sha256 `apc_001`, measured post-153)**, in order:
+   **Entries 167 and 174 rebuilt the pass twice more** (windowed region scans + scoped two-root
+   table + in-place tombstones, then the prepared checked-form memo + canonical affine keys + one
+   shared prepared address array): sha256 `apc_001` 6.4 s → 1.65 s. What is left is in
+   *busPairCancel residual after entry 174* below. The pre-167 list is kept for the shapes it names:
+   **What was left in the pass (6.4 s on sha256 `apc_001`, measured post-153)**, in order:
    the surviving certificate evaluations — `denseAddrNonzeroNeqP` is allocation- and
    allocation-bound (`denseIsZeroLin`'s zero test is dictionary-free since entry 156, but
    `denseDiffSumP` still rebuilds the chain per subset, 4 subsets per compared pair on a
@@ -674,15 +678,16 @@ eager back-substitution's exponent). What is left, LBR shares of the *new* pass 
   active-degree index back. The scheduler is 3.8 % of the pass, so it is affordable — but measure the
   bus trade before doing it.
 
-**R14. The per-invocation index lifecycle is now the dominant cost of the index-heavy passes**  ·
-*measured 2026-08-02 on the rebuilt busPairCancel; cross-pass, framework-level effort*. After that
-pass was rebuilt (windowed region scans, scoped two-root table, in-place tombstones, non-allocating
-`constValue?`, per-invocation eagerness decision — 0.36–0.60x), its remaining profile is **~45 %
-building, marking and freeing `O(system)` indexes**, not scanning: on sha256 `apc_001` it constructs
-seven of them (receive index, per-bus key index, per-bus prepared address records, bound-witness
-index, form-witness index, candidate-constraint index, single-variable domain buckets) on **each of
-11 invocations**, while the last five invocations produce **nine drops between them**. `entry` alone
-is 14 % of the pass and 57 % of that is `lean_dec_ref_cold` freeing exactly those structures.
+**R14. The per-invocation index lifecycle is the dominant cost of the index-heavy passes**  ·
+*measured 2026-08-02, re-measured 2026-08-04 (entry 174); cross-pass, framework-level effort*.
+On busPairCancel after **two** rebuilds the index builds are ~800 ms of its 1 647 ms on sha256
+`apc_001` — seven of them (receive index, per-bus key index, one prepared address array,
+bound-witness index, form-witness index, candidate-constraint index, single-variable domain buckets)
+on **each of 11 invocations**, while the last five invocations produce **nine drops between them**.
+Entry 174's counters make the waste concrete: `DenseVarCsIdx.lookup` is called 2 498 times in sha256
+cycle 1, **0 times in cycles 8–10 and the coda, and once in the whole keccak run** — and the index is
+built every time. (The obvious per-index fix, deferring the force to the first query, is a **measured
+wash**: see the dead ends.)
 
 Every index-heavy pass has the same shape — the indexes are a pure function of the system, the
 system barely changes across the terminal cycles, and the pass framework's type
@@ -698,8 +703,8 @@ its output, keyed by a cheap system fingerprint, and hand it back on the next in
   a `∀ c ∈ lookup v, c ∈ cs.algebraicConstraints` obligation, which a fingerprint on
   `cs.algebraicConstraints` does not discharge — those either stay per-invocation or need the
   membership proof carried in the cache.
-- Sizing before building: on sha256 `apc_001` busPairCancel would save on the order of 1 s of its
-  3.2 s; the same lever exists in reencode, domainBatch, gauss and flagFold, whose per-invocation
+- Sizing before building: on sha256 `apc_001` busPairCancel would save on the order of 0.7 s of its
+  1.65 s; the same lever exists in reencode, domainBatch, gauss and flagFold, whose per-invocation
   index builds were never separately attributed.
 - The cheap slice that is already **done** and should be done first everywhere else: decide
   *eagerness* per invocation instead of caching across them (`denseThunkIf` + a cheap
@@ -717,6 +722,28 @@ and in `run` alike. Consequences, all measured on busPairCancel:
      (3672 → 3966 ms);
    - so the decision belongs at the call site, per invocation (`denseThunkIf`, above). `Thunk.pure`
      and `Thunk.mk` have the same `.get`, so the choice is invisible to every proof.
+
+### busPairCancel residual after entry 174 (the checked-form memo + canonical keys)  ·  *runtime*
+
+The pass is 1 647 ms of sha256 `apc_001`, 140 ms of keccak, 238 ms of wasm-eth `apc_012`. Phase
+timers put the sha256 remainder at: **index setup ~800 ms**, byte justification ~430, region tests
+~230, `guardDegree` 85. Ranked, with what each needs:
+
+- **R12 for `cands` and `domIdx`** — 294 ms of the setup in `Std.HashMap VarId` probes and inserts;
+  `VarId.index`-keyed arrays should halve it. Both carry a `∀ c ∈ lookup v, c ∈ constraints`
+  obligation, so each needs its builder's soundness restated over arrays.
+- **The bound side of the justification, memoized like the form side** (entry 174 change 1).
+  `bnd v = denseFindVarBound bs facts (wits v) v` is recomputed at every DFS node for every term, and
+  each call re-runs `denseInteractionBound`'s `payload.map constValue?` plus a `slotBound`. A
+  per-position `(multiplicity constant, constant pattern)` record is the shared R13(b) item.
+- **An allocation-free basis channel.** `denseDropFormBasis` allocates a `flatMap` list per node; a
+  higher-order channel (`VarId → ((DenseLinExpr × Nat) → Bool) → Bool`) removes it at the cost of an
+  existential spec. Worth ~70 ms of the 430.
+- **`bidx` is 200 ms of setup** and its per-(interaction, payload variable) `facts.slotBound` call is
+  ~0.5 µs, most of it dispatch — R13(b) again, and (e)'s array-backed `busMap` lookup.
+- The region tests' residual after canonical keys is the `denseShieldEarly` walk itself plus the
+  constant-slot compares; there is no index left to sharpen without a *per-slot affine* key index
+  (which would let wasm-eth's symbolic-address-key candidates use sparse buckets instead of `allA`).
 
 ### domainBatch: a staged evaluator for the box scan  ·  *runtime*  ·  medium value
 
@@ -737,6 +764,23 @@ instead of 256 (~30× on those scans). It needs a per-item degree analysis and a
 are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`).
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **Deferring a per-invocation index's force to its first query** (entry 174, busPairCancel's
+  `cands`): the counters say it is queried 2 498 times in sha256 cycle 1, 0 times in cycles 8–10 and
+  the coda, and **once in the whole keccak run**, so its 198 ms of build looks pure waste. Passing
+  `fun x => candsT.get.lookup x` instead of `candsT.get.lookup` (which forces the thunk where the
+  *closure* is built) with `Thunk.mk` moves all 198 ms out of setup and into the first query — and
+  the pass total is unchanged, 2 224 → 2 224 ms. `Thunk.get`'s `lean_mark_mt` walk over the index on
+  the seven invocations that do query it costs what the four that do not save. The `Thunk` note below
+  predicts this; the lesson is that it applies to *conditional* forcing too, not just to eagerness.
+- **Merging busPairCancel's two byte-justification sweeps** (entry 174): `denseCheckCancel`'s last
+  conjunct (`denseRecvSlotsJustified` = `slots.all justified`) and the `denseUnjustifiedSlots`
+  (`slots.filter (¬ justified)`) on the next line are the same per-slot predicate at the same
+  `wits`/`fbasis`, and the phase timers had `chk` ≈ `unjust` in **every** invocation — so splitting
+  `denseCheckCancel` at that conjunct and reading the verdict off `unjust.isEmpty` was worth ~570 ms
+  of the pass. Sequencing killed it: with the prepared checked-form memo in place first, both sweeps
+  share the memo and the second costs what the first does, so the merge is worth ~50 ms and not its
+  own split lemma. Re-propose only if the justification ever becomes expensive again.
 
 - **Scanning constraints before the bus in hintCollapse's code array** (entry 173), to skip the bus
   walk when nothing can fire: rejected on the structure of the codes, not on a timing. Without the

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6755,3 +6755,83 @@ prefilter in place of the counting walk (it cannot decide a global property, and
 variables are common — thousands would pass, each then needing the ~23 ms global check).
 
 **Worked: yes.**
+
+### 174. Runtime: busPairCancel round two — a prepared checked-form memo, canonical affine keys and one prepared address array (0.61–0.89x on the pass, sha256 total 0.97x)
+
+Second full redesign of the pair cancellation (`busPairCancelRedesign.md` has the design and the
+attribution; round one is #267). `busPairCancel` was again the top pass on sha256 `apc_001`
+(2 682 ms of 24 965, 10.7 %), plus 202 ms for the aggressive coda instance.
+
+**The round-one attribution ("index-lifecycle-bound, ~45 % building/marking/freeing seven
+`O(system)` indexes") no longer held** — the shared `constValue?`/`ZMod`/`substF` work landed since
+had cut the index builds. Fresh `IO` phase timers plus `probeStart`/`probeEnd` nanosecond timers
+around the four in-loop phases and per-candidate counters put the pass at: **byte justification
+1 172 ms (43 %)**, index setup 960 (35 %), region tests 350 (13 %), `guardDegree` 85, the rest ~150.
+On keccak and wasm-eth `apc_012` justification is 7 and 11 ms and setup is ~45 % — three different
+villains on three cases.
+
+**Effectively all of the justification is `denseBasisJustified`**: stubbing it to `false`
+(`@[implemented_by]`) zeroes every `chk`/`unjust` column. And the cost is where nothing is achieved
+— cycles 6–10 plus the coda spend **1 030 ms justifying ~19 candidates each and drop 9 pairs
+between them**, ~7.5 ms per candidate. `denseFormBoundAt facts bi i` is a pure function of
+`(interaction, slot)` — multiplicity constant, `payload.map constValue?`, `slotBound`,
+`denseLinearize`, `norm` — and the fuel-bounded DFS re-derived it at *every node*, for every
+variable, witness, slot, justified slot, candidate and invocation. LBR leaves on the
+justification-framed samples agreed: 43 % allocator/refcount, 15 % `denseLinearizeAcc` and friends,
+4.7 % `constValueImpl`, 2.8 % `slotBound` — `denseFormBoundAt`'s body and its garbage, nothing else.
+
+THE CHANGES:
+1. **Prepared checked-form records.** `fwits` had exactly one consumer and only ever wanted those
+   forms, so the channel *becomes* the derived one: `denseBuildFormBounds` puts one lazily-forced
+   `Thunk (List (DenseLinExpr × Nat))` per position, `denseDropFormBasis` gathers `v`'s indexed
+   positions under the old live/≠S/≠R gate, and `denseBasisReduceGo` loses `facts` entirely. The
+   soundness obligation gets *simpler*: `∀ v, ∀ LB ∈ fbasis v, (LB.1.eval denv).val < LB.2` arrives
+   ready-made instead of `denseFormBoundAt_sound` running inside the induction.
+2. **Canonical affine slot keys.** `denseConstDiffNZ a b` normalized `a − b` per compared pair; two
+   forms differ by a nonzero constant exactly when their merged, zero-dropped, variable-sorted terms
+   agree and their constants do not. `denseTermKey`/`denseTermKeyHash`/`denseKeyDiffNZ` moved out of
+   busUnify into `AddrDiseq.lean` (busUnify had them as `denseBU*`), `denseAddrAffineNeq` and
+   `denseExprTwoRootNeq` are stated on keys, and `DenseSlotPre` memoizes the key per slot. One key
+   compare decides all four two-root branch differences (`densePtrReductions_key`: both branches
+   differ only by a constant). `denseConstDiffNZ` and its `_sound` are gone.
+3. **One prepared address array for every memory bus** (`denseAddrPrepAll`): a position gets its own
+   bus's shape and a bus-id-only stub if it is on no memory bus. Sound because a position off the
+   candidate's bus is refuted on the bus-id arm (`denseMidRefutedP_offBus` and friends) — and is not
+   even in that bus's key index. `hpre` weakens from `preArr = arr.map (denseAddrPrep shape T)` to
+   `DensePreArrOk`, which needed pointwise versions of the two scan-equality lemmas
+   (`denseLiveAllSegP_eqOf`, `denseShieldScanSegP_eqOf`).
+4. **Index-build cleanups**: `denseRecvIndexAll`/`denseBuildBoundIdx`/`denseBuildFormIdx` walk the
+   array by index instead of folding `arr.toList.zipIdx` (three 12–71 k-element intermediate pair
+   lists per invocation); `denseBuildBoundIdx` gates on the multiplicity before building the
+   constant pattern; `denseBusIdsOf` replaces `(bis.map (·.busId)).dedup`; `DenseNonzeroWits.build`
+   computes its `flatMap` once instead of twice (it was written out in both fields).
+5. **Two micros in the reduction**: `L.coeff v` is invariant across the candidate forms and was
+   recomputed twice per form; `L.terms.map Prod.fst` allocated a variable list per node.
+
+NUMBERS (this 20-core box, serial, interleaved, 3 reps; sha256 one shot; `profile` per-pass ms,
+medians): sha256 `apc_001` **2682 → 1647 (0.61x)**, run 24 965 → 24 262 (0.97x); keccak `apc_001`
+195 → 140 (0.72x), 2377 → 2257 (0.95x); wasm-eth `apc_012` 283 → 238 (0.84x), 2803 → 2718 (0.97x);
+wasm-eth `apc_063` 274 → 245 (0.89x); wasm-eth `apc_036` 274 → 240 (0.88x); openvm-eth `apc_006`
+16 → 16. `busPairCancelLate` 202 → 112 on sha256. No other pass moves outside noise.
+VERIFIED: `opt-export` **byte-identical** on 14 cases — openvm-eth `apc_006` / `apc_037` /
+`apc_071` / `apc_100`, wasm-eth `apc_012` / `apc_028` / `apc_036` / `apc_063`, OpenVM keccak
+`apc_001`, sha256 `apc_001`, SP1 keccak `apc_001`, SP1 rsp `apc_001` / `apc_003` / `apc_005`;
+`lake build` clean, no warnings; `check-proof-integrity` passes.
+
+RESIDUAL (sha256, phase timers): index setup ~800 ms is now the largest item (`bidx` 200,
+`cands` 200, `fidx` 120, `domIdx` 96, `certs` 100, `prep` ~35 after (3)), justification ~430,
+region tests ~230, `guardDegree` 85. See ideas.md for what is sized and left: R12 arrays for
+`cands`/`domIdx`, the same memo shape on the *bound* side, and an allocation-free basis channel.
+
+DEAD ENDS, each measured: **merging the two justification sweeps** — `denseCheckCancel`'s
+`denseRecvSlotsJustified` (`slots.all`) and the `denseUnjustifiedSlots` (`slots.filter ¬`) on the
+next line are the same predicate at the same witnesses, and `chk` ≈ `unjust` in every invocation, so
+splitting `denseCheckCancel` at that conjunct looked worth ~570 ms — but after change (1) both
+sweeps share the memo and it is worth ~50, not worth its own split lemma. **`cands` left lazy past
+the eagerness decision**: `DenseVarCsIdx.lookup` is called 2 498 times in sha256 cycle 1, **0 times
+in cycles 8–10 and the coda, and once in the whole keccak run**, so its 198 ms looks wasted; moving
+the force to the first query (`fun x => candsT.get.lookup x` with `Thunk.mk`) moves all 198 ms out
+of setup and the pass total does not change — `Thunk.get`'s `lean_mark_mt` walk on the seven
+invocations that do query it costs what the four that do not save.
+
+**Worked: yes.**


### PR DESCRIPTION
`busPairCancel` was again the top pass on sha256 `apc_001` — **2682 ms of 24 965 (10.7 %)**, plus
202 ms for the aggressive coda instance. Round one (#267) left it recorded as
"index-lifecycle-bound"; **that attribution no longer held**, so this started from a fresh
measurement.

## Where the time actually was

`IO` phase timers plus `probeStart`/`probeEnd` nanosecond timers around the four in-loop phases and
per-candidate counters (throwaway probe, not committed):

| item | sha256 | keccak | wasm-eth `apc_012` |
|---|---:|---:|---:|
| **byte justification** | **1172 ms (43 %)** | 7 ms | 11 ms |
| per-invocation index setup | 960 ms (35 %) | ~45 % | ~45 % |
| region tests | 350 ms (13 %) | 25 % | **43 %** |
| `guardDegree` (framework) | 85 ms | small | small |

Three different villains on three cases. **Effectively all of the justification is
`denseBasisJustified`** — stubbing it to `false` zeroes every justification column — and the cost is
where nothing is achieved: **cycles 6–10 plus the coda spend 1030 ms justifying ~19 candidates each
and drop nine pairs between them**, ~7.5 ms per candidate. `denseFormBoundAt facts bi i` is a pure
function of `(interaction, slot)` — multiplicity constant, `payload.map constValue?`, `slotBound`,
`denseLinearize`, `norm` — re-derived at *every node* of the fuel-bounded DFS, for every variable,
witness, slot, justified slot, candidate and invocation.

## What changed

1. **Prepared checked-form records.** `fwits` had exactly one consumer and only ever wanted those
   forms, so the channel becomes the derived one: `denseBuildFormBounds` puts one lazily-forced
   `Thunk (List (DenseLinExpr × Nat))` per position, `denseDropFormBasis` gathers `v`'s indexed
   positions under the old live/≠S/≠R gate, and `denseBasisReduceGo` loses `facts` entirely. The
   soundness obligation gets *simpler* — the bound arrives ready-made instead of
   `denseFormBoundAt_sound` running inside the induction.
2. **Canonical affine slot keys.** Two forms differ by a nonzero constant exactly when their merged,
   zero-dropped, variable-sorted terms agree and their constants do not, so a key derived once per
   expression replaces `denseConstDiffNZ`'s per-pair `(a.add (b.scale (-1))).norm`. busUnify already
   had the representation *and* the soundness lemma as `denseBU*`; they move up into
   `AddrDiseq.lean` and both passes read them from there. One key compare decides all four two-root
   branch-pair differences (`densePtrReductions_key`). `denseConstDiffNZ`/`_sound` are deleted.
3. **One prepared address array for every memory bus** (`denseAddrPrepAll`) with a bus-id-only stub
   off all of them: a position off the candidate's bus is refuted on the bus-id arm — and is not even
   in that bus's key index. `hpre` weakens from `preArr = arr.map (denseAddrPrep shape T)` to
   `DensePreArrOk`, which needed pointwise versions of the two scan-equality lemmas.
4. **Index-build cleanups**: the three untrusted builds walk the array by index instead of folding
   `arr.toList.zipIdx` (three 12–71 k-element intermediate pair lists per invocation);
   `denseBuildBoundIdx` gates on the multiplicity before building the constant pattern;
   `denseBusIdsOf` drops the intermediate id list; `DenseNonzeroWits.build` computes its `flatMap`
   once instead of twice.
5. Two micros in the reduction (invariant `L.coeff v` hoisted, no per-node variable list).

## Numbers

Interleaved (`bench.sh`), 3 reps on the cheap representatives, one shot on sha256, serial; medians:

| case | pass before | after | ratio | run before | after |
|---|---:|---:|---:|---:|---:|
| **sha256 `apc_001`** | 2682 | **1647** | **0.61×** | 24 965 | 24 262 (0.97×) |
| keccak `apc_001` | 195 | **140** | 0.72× | 2377 | 2257 |
| wasm-eth `apc_012` | 283 | **238** | 0.84× | 2803 | 2718 |
| wasm-eth `apc_063` | 274 | **245** | 0.89× | 2344 | 2343 |
| wasm-eth `apc_036` | 274 | **240** | 0.88× | 2341 | 2336 |

`busPairCancelLate` 202 → 112 ms on sha256. No other pass moves outside noise on any case.

**Effectiveness unchanged**: `opt-export` byte-identical on 14 cases across both VMs — openvm-eth
`apc_006`/`apc_037`/`apc_071`/`apc_100`, wasm-eth `apc_012`/`apc_028`/`apc_036`/`apc_063`, OpenVM
keccak `apc_001`, sha256 `apc_001`, SP1 keccak `apc_001`, SP1 rsp `apc_001`/`apc_003`/`apc_005`.

`lake build` clean with no warnings; `Scripts/check-proof-integrity.sh` passes (no `sorry`, the three
standard axioms, no unused theorems).

## Two measured dead ends (recorded in `ideas.md`)

- **Merging the two justification sweeps** — `denseCheckCancel`'s last conjunct and the
  `denseUnjustifiedSlots` on the next line are the same predicate at the same witnesses, and
  `chk` ≈ `unjust` in every invocation, so it looked worth ~570 ms. After change 1 both sweeps share
  the memo and it is worth ~50. Sequencing decided it, not the idea.
- **Deferring `cands`' force to its first query** — the counters say `DenseVarCsIdx.lookup` runs
  2498 times in sha256 cycle 1, **0 times in cycles 8–10 and the coda, and once in the whole keccak
  run**, so its 198 ms of build looks pure waste; moving the force to the first query moves all
  198 ms out of setup and the pass total does not change. `Thunk.get`'s `lean_mark_mt` walk on the
  invocations that do query it costs what the ones that do not save.

## Left for a next round (sized, in `ideas.md`)

Index setup is now the largest item (~800 ms of sha256's 1647): R12 arrays for `cands`/`domIdx`
(294 ms), the same memo shape applied to the *bound* side of the justification (R13(b) at the
`BusFacts` interface), an allocation-free basis channel (~70 ms), and a per-slot *affine* key index
for wasm-eth's symbolic-address-key candidates. Separately: **`guardDegree` is 13.1 % of the whole
sha256 run** (1963 of 14 951 LBR samples) — framework-level, `ideas.md` R5, and the largest
cross-pass item this session surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)