### PR TITLE
perf(guardDegree): thread a degree certificate and skip the items the output shares with its input (guard 0.31-0.37x, total 0.93-0.95x)

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -42,21 +42,21 @@ correctness theorems in `ApcOptimizer/Optimizer.lean` are projections of `optimi
 /-- Wrap every pass of a stage list in the degree guard, so degree safety holds uniformly
     (`guardAll_chain_respectsDeg`) with zero per-pass proof burden. -/
 def guardAll (b : DegreeBound) (l : List (String × DenseVerifiedPassW p)) :
-    List (String × DenseVerifiedPassW p) :=
+    List (String × DenseGuardedPassW p b) :=
   l.map (fun (n, f) => (n, f.guardDegree b))
 
 /-- Stage 1 of 3 (`preludePasses`, `cleanupPasses`, `codaPasses`): run once to canonicalize the
     freshly-parsed system. The three lists are the single source of truth for the pass sequence —
     `pipeline` folds them and the `profile` CLI (`Main.lean`) times the same lists, so they cannot
     drift. `String` labels name passes in the profiler only. -/
-def preludePasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
+def preludePasses (b : DegreeBound) : List (String × DenseGuardedPassW p b) :=
   guardAll b [ ("constFold0", denseConstantFoldPass) ]
 
 /-- Stage 2 of 3 (see `preludePasses`): the cleanup schedule, iterated to a fixpoint
     (`denseIterateToFixpoint`, no budget). Each entry's optimization is documented at its own
     definition. To add a pass, append one `(name, pass)` entry here (AGENTS.md →
     "Adding an optimization"). -/
-def cleanupPasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
+def cleanupPasses (b : DegreeBound) : List (String × DenseGuardedPassW p b) :=
   -- One primality decision per run, threaded to every prime-gated pass (each reads the `Bool` in
   -- O(1) instead of re-running `decide (Nat.Prime p)`).
   let pw := PrimeWitness.of p
@@ -92,7 +92,7 @@ def cleanupPasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
 /-- Stage 3 of 3 (see `preludePasses`): run once after the cleanup fixpoint. Order matters — the
     inline notes below flag the non-obvious sequencing; each pass's own definition documents what it
     does. -/
-def codaPasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
+def codaPasses (b : DegreeBound) : List (String × DenseGuardedPassW p b) :=
   let pw := PrimeWitness.of p
   guardAll b
   [ ("busPairCancelLate", denseBusPairCancelPass pw true),
@@ -123,8 +123,9 @@ between a single encode at entry and a single decode at output (no decode betwee
 /-- Every pass of a `guardAll`-built stage list respects the degree bound — one lemma covering all
     three stage lists, with no per-entry case analysis. -/
 theorem guardAll_chain_respectsDeg (b : DegreeBound) (l : List (String × DenseVerifiedPassW p)) :
-    DenseRespectsDeg b (denseChain ((guardAll b l).map (·.2))) := by
-  apply denseChain_respectsDeg
+    DenseRespectsDeg b (denseGuardedChain ((guardAll b l).map (·.2))).toPass := by
+  apply DenseGuardedPassW.toPass_respectsDeg
+  apply denseGuardedChain_respectsDeg
   intro f hf
   simp only [guardAll, List.map_map, List.mem_map] at hf
   obtain ⟨⟨n, g⟩, -, rfl⟩ := hf
@@ -134,10 +135,10 @@ theorem guardAll_chain_respectsDeg (b : DegreeBound) (l : List (String × DenseV
     (`denseIterateToFixpoint`, no budget — runs until the lexicographic dense size key stops
     shrinking), then the coda chain. -/
 def densePipeline (b : DegreeBound) : DenseVerifiedPassW p :=
-  DenseVerifiedPassW.andThen (denseChain ((preludePasses b).map (·.2)))
+  DenseVerifiedPassW.andThen (denseGuardedChain ((preludePasses b).map (·.2))).toPass
     (DenseVerifiedPassW.andThen
-      (denseIterateToFixpoint (denseChain ((cleanupPasses b).map (·.2))))
-      (denseChain ((codaPasses b).map (·.2))))
+      (denseIterateToFixpoint (denseGuardedChain ((cleanupPasses b).map (·.2))).toPass)
+      (denseGuardedChain ((codaPasses b).map (·.2))).toPass)
 
 theorem densePipeline_respectsDeg (b : DegreeBound) :
     DenseRespectsDeg b (densePipeline (p := p) b) := by
@@ -146,6 +147,10 @@ theorem densePipeline_respectsDeg (b : DegreeBound) :
     (DenseVerifiedPassW.andThen_respectsDeg
       (denseIterateToFixpoint_respectsDeg (guardAll_chain_respectsDeg b _))
       (guardAll_chain_respectsDeg b _))
+
+-- Past this point the pipeline is used only through its `DensePassResult` fields; sealing it keeps
+-- the elaborator from unfolding the whole 40-pass chain when it checks those projections.
+attribute [local irreducible] densePipeline
 
 /-- The circuit optimizer: encode once into the dense `VarId` representation, run `densePipeline`,
     then decode the result and its derivations once. `decode ∘ encode = id` turns the dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Measure.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Measure.lean
@@ -102,6 +102,110 @@ def DenseConstraintSystem.withinDegreeB (d : DenseConstraintSystem p) (b : Degre
     decide (bi.multiplicity.degree ≤ b.busInteractions) &&
       bi.payload.all (fun e => e.degree ≤ b.busInteractions))
 
+/-! ### The incremental degree check
+
+`withinDegreeB` runs after every pass, and most of what it walks it has already accepted: a pass
+rewrites a few items and physically shares the rest of the list, or appends and shares every old
+element. Given a certificate that the *input* system is within bound, `degOkFrom` scans the output
+list in lockstep with the input list and uses `withPtrEq` — core Lean, safe, inlined by the
+compiler to a bare `lean_ptr_addr` compare with no closure — to skip a whole shared suffix, or a
+single shared item, without walking it.
+
+`withPtrEq a b k h` *is* `k ()`, so these are hints and nothing more: `degOkFrom_eq` proves the
+result equals `withinDegreeB`. The definitions return their own specification
+(`{ r : Bool // r = … }`) because `withPtrEq`'s `h` obligation has to be discharged while the
+recursion is being elaborated; a `Subtype` whose only runtime field is a `Bool` is that `Bool`. -/
+
+/-- `withinDegreeB`'s per-constraint test. -/
+@[inline] def denseCsDegOk (bnd : Nat) (e : DenseExpr p) : Bool := e.degree ≤ bnd
+
+/-- `List.all` over `denseCsDegOk` without the per-interaction closure `List.all` allocates. -/
+def denseExprsDegOk (bnd : Nat) : List (DenseExpr p) → Bool
+  | [] => true
+  | e :: rest => denseCsDegOk bnd e && denseExprsDegOk bnd rest
+
+theorem denseExprsDegOk_eq (bnd : Nat) (l : List (DenseExpr p)) :
+    denseExprsDegOk bnd l = l.all (fun e => e.degree ≤ bnd) := by
+  induction l with
+  | nil => rfl
+  | cons e rest ih => rw [denseExprsDegOk, ih, List.all_cons, denseCsDegOk]
+
+/-- `withinDegreeB`'s per-interaction test. -/
+def denseBiDegOk (bnd : Nat) (bi : BusInteraction (DenseExpr p)) : Bool :=
+  decide (bi.multiplicity.degree ≤ bnd) && denseExprsDegOk bnd bi.payload
+
+/-- Lockstep degree scan of `ol` against a within-bound `dl`: a pointer-identical remaining list
+    ends the scan, a pointer-identical item is skipped, everything else is walked. -/
+def denseCsDegFrom (bnd : Nat) : (ol dl : List (DenseExpr p)) →
+    dl.all (denseCsDegOk bnd) = true → { r : Bool // r = ol.all (denseCsDegOk bnd) }
+  | [], _, _ => ⟨true, rfl⟩
+  | o :: ot, [], _ =>
+      ⟨denseCsDegOk bnd o && (denseCsDegFrom bnd ot [] rfl).1, by
+        rw [(denseCsDegFrom bnd ot [] rfl).2, List.all_cons]⟩
+  | o :: ot, x :: xt, hd =>
+      have hx : denseCsDegOk bnd x = true :=
+        ((Bool.and_eq_true _ _).mp (by rwa [List.all_cons] at hd)).1
+      have hxt : xt.all (denseCsDegOk bnd) = true :=
+        ((Bool.and_eq_true _ _).mp (by rwa [List.all_cons] at hd)).2
+      have hval : (withPtrEq o x (fun _ => denseCsDegOk bnd o) (fun h => by rw [h]; exact hx)
+            && (denseCsDegFrom bnd ot xt hxt).1) = (o :: ot).all (denseCsDegOk bnd) := by
+        show (denseCsDegOk bnd o && (denseCsDegFrom bnd ot xt hxt).1) = _
+        rw [(denseCsDegFrom bnd ot xt hxt).2, List.all_cons]
+      ⟨withPtrEq (o :: ot) (x :: xt)
+          (fun _ => withPtrEq o x (fun _ => denseCsDegOk bnd o) (fun h => by rw [h]; exact hx)
+            && (denseCsDegFrom bnd ot xt hxt).1)
+          (fun h => hval.trans (by rw [h]; exact hd)),
+        hval⟩
+
+/-- `denseCsDegFrom` for bus interactions. -/
+def denseBiDegFrom (bnd : Nat) : (ol dl : List (BusInteraction (DenseExpr p))) →
+    dl.all (denseBiDegOk bnd) = true → { r : Bool // r = ol.all (denseBiDegOk bnd) }
+  | [], _, _ => ⟨true, rfl⟩
+  | o :: ot, [], _ =>
+      ⟨denseBiDegOk bnd o && (denseBiDegFrom bnd ot [] rfl).1, by
+        rw [(denseBiDegFrom bnd ot [] rfl).2, List.all_cons]⟩
+  | o :: ot, x :: xt, hd =>
+      have hx : denseBiDegOk bnd x = true :=
+        ((Bool.and_eq_true _ _).mp (by rwa [List.all_cons] at hd)).1
+      have hxt : xt.all (denseBiDegOk bnd) = true :=
+        ((Bool.and_eq_true _ _).mp (by rwa [List.all_cons] at hd)).2
+      have hval : (withPtrEq o x (fun _ => denseBiDegOk bnd o) (fun h => by rw [h]; exact hx)
+            && (denseBiDegFrom bnd ot xt hxt).1) = (o :: ot).all (denseBiDegOk bnd) := by
+        show (denseBiDegOk bnd o && (denseBiDegFrom bnd ot xt hxt).1) = _
+        rw [(denseBiDegFrom bnd ot xt hxt).2, List.all_cons]
+      ⟨withPtrEq (o :: ot) (x :: xt)
+          (fun _ => withPtrEq o x (fun _ => denseBiDegOk bnd o) (fun h => by rw [h]; exact hx)
+            && (denseBiDegFrom bnd ot xt hxt).1)
+          (fun h => hval.trans (by rw [h]; exact hd)),
+        hval⟩
+
+/-- `withinDegreeB` in the shape `denseCsDegFrom`/`denseBiDegFrom` decide. -/
+theorem DenseConstraintSystem.withinDegreeB_eq_all (d : DenseConstraintSystem p) (b : DegreeBound) :
+    d.withinDegreeB b =
+      (d.algebraicConstraints.all (denseCsDegOk b.identities) &&
+        d.busInteractions.all (denseBiDegOk b.busInteractions)) := by
+  have hbi : (fun bi : BusInteraction (DenseExpr p) =>
+        decide (bi.multiplicity.degree ≤ b.busInteractions) &&
+          bi.payload.all (fun e => e.degree ≤ b.busInteractions))
+      = denseBiDegOk b.busInteractions := by
+    funext bi; rw [denseBiDegOk, denseExprsDegOk_eq]
+  rw [DenseConstraintSystem.withinDegreeB, hbi]
+  rfl
+
+/-- `withinDegreeB` on `out`, computed against a within-bound `d` so that items `out` shares with
+    `d` cost one pointer compare instead of an AST walk (`degOkFrom_eq`). -/
+def DenseConstraintSystem.degOkFrom (b : DegreeBound) (d out : DenseConstraintSystem p)
+    (h : d.withinDegreeB b = true) : Bool :=
+  (denseCsDegFrom b.identities out.algebraicConstraints d.algebraicConstraints
+      ((Bool.and_eq_true _ _).mp (d.withinDegreeB_eq_all b ▸ h)).1).1 &&
+  (denseBiDegFrom b.busInteractions out.busInteractions d.busInteractions
+      ((Bool.and_eq_true _ _).mp (d.withinDegreeB_eq_all b ▸ h)).2).1
+
+theorem DenseConstraintSystem.degOkFrom_eq (b : DegreeBound) (d out : DenseConstraintSystem p)
+    (h : d.withinDegreeB b = true) : d.degOkFrom b out h = out.withinDegreeB b := by
+  rw [DenseConstraintSystem.degOkFrom, (denseCsDegFrom ..).2, (denseBiDegFrom ..).2,
+    out.withinDegreeB_eq_all b]
+
 /-- The dense degree check equals the spec degree check on the decoded system. -/
 theorem VarRegistry.decodeCS_withinDegreeB (r : VarRegistry) (d : DenseConstraintSystem p)
     (b : DegreeBound) : (r.decodeCS d).withinDegreeB b = d.withinDegreeB b := by

--- a/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
@@ -51,12 +51,6 @@ abbrev DenseVerifiedPassW (p : ℕ) :=
   (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg →
     (bs : BusSemantics p) → (facts : BusFacts p bs) → DensePassResult reg d bs
 
-def DenseVerifiedPassW.id : DenseVerifiedPassW p :=
-  fun reg d hcov bs _ =>
-    { reg' := reg, out := d, derivs := [], ext := VarRegistry.Extends.refl reg, covered := hcov,
-      dcovered := by intro x hx; simp at hx,
-      correct := PassCorrect.refl (reg.decodeCS d) bs }
-
 /-- Sequential composition: run `f`, then `g` on its output; concatenate dense derivations (the
     `PassCorrect`s compose via registry-stability). -/
 def DenseVerifiedPassW.andThen (f g : DenseVerifiedPassW p) : DenseVerifiedPassW p :=
@@ -73,11 +67,14 @@ def DenseVerifiedPassW.andThen (f g : DenseVerifiedPassW p) : DenseVerifiedPassW
         have h := r1.correct.andThen r2.correct
         rwa [r2.reg'.decodeDerivs_append, r2.ext.decodeDerivs_eq r1.dcovered] }
 
-/-- Fold a list of dense passes into one (left to right; identity on `[]`). -/
-def denseChain (l : List (DenseVerifiedPassW p)) : DenseVerifiedPassW p :=
-  l.foldl DenseVerifiedPassW.andThen DenseVerifiedPassW.id
+/-! ## Degree guarding
 
-/-! ## Degree guarding -/
+The guard runs after every pass of every stage list, ~200–290 times per run, and `withinDegreeB` is
+a whole-system AST walk. Most of what it walks it has already accepted, so a *guarded* pass carries
+a `DenseDegCert` — an erased proof that its input is within bound, `none` if unknown — which lets
+`degOkFrom` (`Measure.lean`) skip the items the output shares with its input. The certificate is
+produced by the guard itself, so it establishes itself on the first invocation of a stage; the
+optimizer's input circuit is not assumed to be within bound. -/
 
 /-- A dense pass never pushes a within-bound decoded system past the degree bound `b`. -/
 def DenseRespectsDeg (b : DegreeBound) (f : DenseVerifiedPassW p) : Prop :=
@@ -86,41 +83,125 @@ def DenseRespectsDeg (b : DegreeBound) (f : DenseVerifiedPassW p) : Prop :=
     (reg.decodeCS d).withinDegree b →
     ((f reg d hcov bs facts).reg'.decodeCS (f reg d hcov bs facts).out).withinDegree b
 
+/-- An erased certificate that `d` is within bound `b`; `none` means "not known here". -/
+abbrev DenseDegCert (b : DegreeBound) (d : DenseConstraintSystem p) : Type :=
+  Option (PLift (d.withinDegreeB b = true))
+
+/-- The degree check, served from the input's certificate when there is one
+    (`denseDegCheck_eq`: the value never depends on which). -/
+def denseDegCheck (b : DegreeBound) (d out : DenseConstraintSystem p) (hd : DenseDegCert b d) :
+    Bool :=
+  match hd with
+  | none => out.withinDegreeB b
+  | some h => d.degOkFrom b out h.down
+
+theorem denseDegCheck_eq {b : DegreeBound} {d out : DenseConstraintSystem p}
+    {hd : DenseDegCert b d} : denseDegCheck b d out hd = out.withinDegreeB b := by
+  cases hd with
+  | none => rfl
+  | some h => exact d.degOkFrom_eq b out h.down
+
+/-- A pass result together with a certificate for its output. -/
+structure DenseGuardedResult (b : DegreeBound) (reg : VarRegistry) (d : DenseConstraintSystem p)
+    (bs : BusSemantics p) where
+  res : DensePassResult reg d bs
+  cert : DenseDegCert b res.out
+
+/-- A degree-guarded dense pass: threads the certificate alongside the system. -/
+abbrev DenseGuardedPassW (p : ℕ) (b : DegreeBound) :=
+  (reg : VarRegistry) → (d : DenseConstraintSystem p) → d.CoveredBy reg → DenseDegCert b d →
+    (bs : BusSemantics p) → (facts : BusFacts p bs) → DenseGuardedResult b reg d bs
+
 /-- Degree guard on the dense system (no decode): if the output would exceed `b`, keep the input.
     The dense check equals the spec check (`decodeCS_withinDegreeB`). -/
 def DenseVerifiedPassW.guardDegree (b : DegreeBound) (f : DenseVerifiedPassW p) :
-    DenseVerifiedPassW p :=
-  fun reg d hcov bs facts =>
+    DenseGuardedPassW p b :=
+  fun reg d hcov hd bs facts =>
     let r := f reg d hcov bs facts
-    if r.out.withinDegreeB b then r
-    else { reg' := reg, out := d, derivs := [], ext := VarRegistry.Extends.refl reg,
-           covered := hcov, dcovered := by intro x hx; simp at hx,
-           correct := PassCorrect.refl (reg.decodeCS d) bs }
+    if hok : denseDegCheck b d r.out hd = true then
+      ⟨r, some ⟨denseDegCheck_eq ▸ hok⟩⟩
+    else
+      ⟨{ reg' := reg, out := d, derivs := [], ext := VarRegistry.Extends.refl reg,
+         covered := hcov, dcovered := by intro x hx; simp at hx,
+         correct := PassCorrect.refl (reg.decodeCS d) bs }, hd⟩
+
+/-- Forget the certificate: run the guarded pass with no knowledge about its input. -/
+def DenseGuardedPassW.toPass {b : DegreeBound} (g : DenseGuardedPassW p b) : DenseVerifiedPassW p :=
+  fun reg d hcov bs facts => (g reg d hcov none bs facts).res
+
+/-- `DenseRespectsDeg` for a guarded pass, for every input certificate. -/
+def DenseGuardedRespectsDeg (b : DegreeBound) (g : DenseGuardedPassW p b) : Prop :=
+  ∀ (reg : VarRegistry) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg)
+    (hd : DenseDegCert b d) (bs : BusSemantics p) (facts : BusFacts p bs),
+    (reg.decodeCS d).withinDegree b →
+    ((g reg d hcov hd bs facts).res.reg'.decodeCS
+      (g reg d hcov hd bs facts).res.out).withinDegree b
+
+theorem DenseGuardedPassW.toPass_respectsDeg {b : DegreeBound} {g : DenseGuardedPassW p b}
+    (h : DenseGuardedRespectsDeg b g) : DenseRespectsDeg b g.toPass :=
+  fun reg d hcov bs facts hin => h reg d hcov none bs facts hin
 
 theorem DenseVerifiedPassW.guardDegree_respectsDeg {b : DegreeBound} (f : DenseVerifiedPassW p) :
-    DenseRespectsDeg b (f.guardDegree b) := by
-  intro reg d hcov bs facts hin
+    DenseGuardedRespectsDeg b (f.guardDegree b) := by
+  intro reg d hcov hd bs facts hin
   simp only [DenseVerifiedPassW.guardDegree]
-  by_cases hok : (f reg d hcov bs facts).out.withinDegreeB b = true
-  · rw [if_pos hok]
+  by_cases hok : denseDegCheck b d (f reg d hcov bs facts).out hd = true
+  · rw [dif_pos hok]
     refine (Circuit.withinDegreeB_iff _ _).1 ?_
     rw [(f reg d hcov bs facts).reg'.decodeCS_withinDegreeB]
-    exact hok
-  · rw [if_neg hok]
+    exact denseDegCheck_eq ▸ hok
+  · rw [dif_neg hok]
     exact hin
+
+/-- Guarded sequential composition: `DenseVerifiedPassW.andThen` with the certificate threaded from
+    `f`'s output into `g`'s input, so only the first pass of a chain pays a full walk. -/
+def DenseGuardedPassW.andThen {b : DegreeBound} (f g : DenseGuardedPassW p b) :
+    DenseGuardedPassW p b :=
+  fun reg d hcov hd bs facts =>
+    let r1 := f reg d hcov hd bs facts
+    let r2 := g r1.res.reg' r1.res.out r1.res.covered r1.cert bs facts
+    ⟨{ reg' := r2.res.reg'
+       out := r2.res.out
+       derivs := r1.res.derivs ++ r2.res.derivs
+       ext := r1.res.ext.trans r2.res.ext
+       covered := r2.res.covered
+       dcovered := DenseDerivations.coveredBy_append
+         (DenseDerivations.CoveredBy.mono r2.res.ext r1.res.dcovered) r2.res.dcovered
+       correct := by
+         have h := r1.res.correct.andThen r2.res.correct
+         rwa [r2.res.reg'.decodeDerivs_append, r2.res.ext.decodeDerivs_eq r1.res.dcovered] },
+     r2.cert⟩
+
+def DenseGuardedPassW.id {b : DegreeBound} : DenseGuardedPassW p b :=
+  fun reg d hcov hd bs _ =>
+    ⟨{ reg' := reg, out := d, derivs := [], ext := VarRegistry.Extends.refl reg, covered := hcov,
+       dcovered := by intro x hx; simp at hx,
+       correct := PassCorrect.refl (reg.decodeCS d) bs }, hd⟩
+
+/-- Fold a list of guarded dense passes into one (left to right; identity on `[]`). -/
+def denseGuardedChain {b : DegreeBound} (l : List (DenseGuardedPassW p b)) :
+    DenseGuardedPassW p b :=
+  l.foldl DenseGuardedPassW.andThen DenseGuardedPassW.id
+
+theorem DenseGuardedPassW.andThen_respectsDeg {b : DegreeBound} {f g : DenseGuardedPassW p b}
+    (hf : DenseGuardedRespectsDeg b f) (hg : DenseGuardedRespectsDeg b g) :
+    DenseGuardedRespectsDeg b (f.andThen g) := by
+  intro reg d hcov hd bs facts hin
+  exact hg _ _ _ _ bs facts (hf reg d hcov hd bs facts hin)
 
 theorem DenseVerifiedPassW.andThen_respectsDeg {b : DegreeBound} {f g : DenseVerifiedPassW p}
     (hf : DenseRespectsDeg b f) (hg : DenseRespectsDeg b g) : DenseRespectsDeg b (f.andThen g) := by
   intro reg d hcov bs facts hin
   exact hg _ _ _ bs facts (hf reg d hcov bs facts hin)
 
-theorem denseChain_respectsDeg {b : DegreeBound} {l : List (DenseVerifiedPassW p)}
-    (h : ∀ f ∈ l, DenseRespectsDeg b f) : DenseRespectsDeg b (denseChain l) := by
-  unfold denseChain
-  suffices H : ∀ (l : List (DenseVerifiedPassW p)) (init : DenseVerifiedPassW p),
-      DenseRespectsDeg b init → (∀ f ∈ l, DenseRespectsDeg b f) →
-      DenseRespectsDeg b (l.foldl DenseVerifiedPassW.andThen init) by
-    exact H l DenseVerifiedPassW.id (fun _ _ _ _ _ h => h) h
+theorem denseGuardedChain_respectsDeg {b : DegreeBound} {l : List (DenseGuardedPassW p b)}
+    (h : ∀ f ∈ l, DenseGuardedRespectsDeg b f) :
+    DenseGuardedRespectsDeg b (denseGuardedChain l) := by
+  unfold denseGuardedChain
+  suffices H : ∀ (l : List (DenseGuardedPassW p b)) (init : DenseGuardedPassW p b),
+      DenseGuardedRespectsDeg b init → (∀ f ∈ l, DenseGuardedRespectsDeg b f) →
+      DenseGuardedRespectsDeg b (l.foldl DenseGuardedPassW.andThen init) by
+    exact H l DenseGuardedPassW.id (fun _ _ _ _ _ _ h => h) h
   intro l
   induction l with
   | nil => intro init hinit _; simpa using hinit
@@ -128,7 +209,7 @@ theorem denseChain_respectsDeg {b : DegreeBound} {l : List (DenseVerifiedPassW p
       intro init hinit hall
       rw [List.foldl_cons]
       exact ih (init.andThen g)
-        (DenseVerifiedPassW.andThen_respectsDeg hinit (hall g (List.mem_cons_self ..)))
+        (DenseGuardedPassW.andThen_respectsDeg hinit (hall g (List.mem_cons_self ..)))
         (fun f hf => hall f (List.mem_cons_of_mem _ hf))
 
 /-! ## Dense fixpoint

--- a/Main.lean
+++ b/Main.lean
@@ -271,31 +271,33 @@ A pass's reported time is the pass and nothing else: `denseApplyTimed` adds no w
 derivation list — it threads `reg`/`out`/`coverage` and drops `derivs`, while `pipeline` appends
 them at every `andThen` and decodes them at the exit. -/
 
-/-- The threaded dense cleanup state: the registry, the dense system, and its coverage proof (erased
-    at runtime — it just lets `DenseVerifiedPassW` application typecheck). -/
-abbrev DenseProfState (p : ℕ) :=
-  Σ' (reg : VarRegistry) (d : DenseConstraintSystem p), d.CoveredBy reg
+/-- The threaded dense cleanup state: the registry, the dense system, its coverage proof (erased at
+    runtime — it just lets `DenseGuardedPassW` application typecheck) and its degree certificate. -/
+abbrev DenseProfState (p : ℕ) (b : DegreeBound) :=
+  Σ' (reg : VarRegistry) (d : DenseConstraintSystem p) (_ : d.CoveredBy reg), DenseDegCert b d
 
 /-- Apply one dense pass and return the threaded state plus elapsed milliseconds.
 
     `IO.lazyPure fn` is `pure (fn ())`, so the application — and with it the whole pass — runs
     between the two clock reads; that is all it is here for (a plain `let` the compiler may float
     across an IO action would not be timed at all). Nothing further needs forcing: Lean is strict,
-    so the returned `DensePassResult`'s `out` is already a fully built `DenseConstraintSystem`
+    so the returned result's `out` is already a fully built `DenseConstraintSystem`
     (two `List`s of `DenseExpr`, no `Thunk` anywhere in the type), and its remaining fields are
     `Prop`s, erased at runtime. -/
-def denseApplyTimed {p : ℕ} (pass : DenseVerifiedPassW p) (st : DenseProfState p)
-    (bs : BusSemantics p) (facts : BusFacts p bs) : IO (DenseProfState p × Nat) := do
+def denseApplyTimed {p : ℕ} {b : DegreeBound} (pass : DenseGuardedPassW p b)
+    (st : DenseProfState p b) (bs : BusSemantics p) (facts : BusFacts p bs) :
+    IO (DenseProfState p b × Nat) := do
   let t0 ← IO.monoMsNow
-  let r ← IO.lazyPure (fun _ => pass st.1 st.2.1 st.2.2 bs facts)
+  let r ← IO.lazyPure (fun _ => pass st.1 st.2.1 st.2.2.1 st.2.2.2 bs facts)
   let t1 ← IO.monoMsNow
-  pure (⟨r.reg', r.out, r.covered⟩, t1 - t0)
+  pure (⟨r.res.reg', r.res.out, r.res.covered, r.cert⟩, t1 - t0)
 
 /-- Run one dense stage's passes in order (prelude/coda; the cleanup stage iterates the cycle to a
     fixpoint below), threading the dense state and accumulating per-pass elapsed time. -/
-def denseRunCycleTimed {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
-    (st : DenseProfState p) (bs : BusSemantics p) (facts : BusFacts p bs)
-    (acc : Std.HashMap String Nat) (verbose : Bool := false) : IO (DenseProfState p × Std.HashMap String Nat) := do
+def denseRunCycleTimed {p : ℕ} {b : DegreeBound} (passes : List (String × DenseGuardedPassW p b))
+    (st : DenseProfState p b) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (acc : Std.HashMap String Nat) (verbose : Bool := false) :
+    IO (DenseProfState p b × Std.HashMap String Nat) := do
   let mut s := st
   let mut a := acc
   for (name, pass) in passes do
@@ -312,13 +314,14 @@ def denseRunCycleTimed {p : ℕ} (passes : List (String × DenseVerifiedPassW p)
     otherwise return the pre-cycle state. Reports each iteration's dense sizes and wall time.
     Terminates by well-founded recursion on the threaded key `k` (the current state's `sizeKey`),
     which strictly decreases at every recursive call — no fuel, no `partial`. -/
-def denseProfileLoop {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
-    (st : DenseProfState p) (bs : BusSemantics p) (facts : BusFacts p bs)
+def denseProfileLoop {p : ℕ} {b : DegreeBound} (passes : List (String × DenseGuardedPassW p b))
+    (st : DenseProfState p b) (bs : BusSemantics p) (facts : BusFacts p bs)
     (acc : Std.HashMap String Nat) (iter : Nat) (k : Nat ×ₗ Nat ×ₗ Nat)
     (verbose : Bool := false) :
-    IO (DenseProfState p × Std.HashMap String Nat × Nat) := do
+    IO (DenseProfState p b × Std.HashMap String Nat × Nat) := do
   let t0 ← IO.monoMsNow
-  let (st', acc') ← denseRunCycleTimed passes st bs facts acc verbose
+  -- `denseIterateToFixpoint` re-enters the cycle through `toPass`, i.e. with no certificate.
+  let (st', acc') ← denseRunCycleTimed passes ⟨st.1, st.2.1, st.2.2.1, none⟩ bs facts acc verbose
   let t1 ← IO.monoMsNow
   IO.println s!"  cycle {iter}: {st'.2.1.varCount} vars, {st'.2.1.busInteractions.length} bus, \
     {st'.2.1.algebraicConstraints.length} constraints ({t1 - t0} ms)"
@@ -351,7 +354,7 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : Circuit p)
     e.2.varCount + e.2.algebraicConstraints.length + e.2.busInteractions.length)
   let tEnc1 ← IO.monoMsNow
   IO.println s!"  encode: {tEnc1 - tEnc0} ms"
-  let st0 : DenseProfState p := ⟨e.1, e.2, VarRegistry.empty.encodeCS_covered cs⟩
+  let st0 : DenseProfState p b := ⟨e.1, e.2, VarRegistry.empty.encodeCS_covered cs, none⟩
   -- Prelude (dense, run once).
   let (st0, acc) ← denseRunCycleTimed (preludePasses (p := p) b) st0 bs facts ∅
   -- Step the dense cleanup fixpoint (the SAME `cleanupPasses` list the optimizer runs), threading
@@ -359,7 +362,9 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : Circuit p)
   let (stF, acc, iters) ←
     denseProfileLoop (cleanupPasses (p := p) b) st0 bs facts acc 0 st0.2.1.sizeKey verbose
   -- Coda (dense, run once).
-  let (stF, acc) ← denseRunCycleTimed (codaPasses (p := p) b) stF bs facts acc
+  -- The three stage lists are composed with `DenseVerifiedPassW.andThen`, so each starts fresh.
+  let (stF, acc) ← denseRunCycleTimed (codaPasses (p := p) b)
+    ⟨stF.1, stF.2.1, stF.2.2.1, none⟩ bs facts acc
   -- Decode once at the pipeline output (reported on its own line).
   let tDec0 ← IO.monoMsNow
   let csAfter ← IO.lazyPure (fun _ => stF.1.decodeCS stF.2.1)

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -392,20 +392,25 @@ index gate**  ·  domainFold **done (entry 167)**, reencode open:
      components and use Markowitz in purely affine components; this could safely extend dynamic
      scheduling below the coarse 8192-row gate.
 
-**R5. Framework: track "pass returned input unchanged" and skip the per-pass degree check**  ·
-*medium value, one framework change*. Every pass is `guardDegree`-wrapped, and the guard runs
-`withinDegreeB` — a full AST walk — on every pass output, ~30×/cycle, ~245×/run
-(`FactPass.lean:98`), even though most invocations return `cs` itself (the #146 measurement: ~61 %
-of invocations are no-op full scans). Add an `unchanged : Option (out = cs ∧ derivs = [])` field
-(default `none`) to `PassResult`; no-op branches supply `some ⟨rfl, rfl⟩`; `guardDegree` returns
-`r` directly when set (out = cs is within-degree by the pipeline invariant — provable, not
-pointer magic); `andThen` propagates; `iterateToFixpoint` skips both `sizeKey` recomputations
-when the whole cycle is unchanged, and carries the previous cycle's `sizeKey` forward instead of
-recomputing `cs.sizeKey` (`FactPass.lean:77`, one redundant O(E) HashSet build per cycle today).
-**Now the single largest line item of a rebuilt pass** (entry 173): after hintCollapse's rebuild the
-guard is ~103 ms of its 178 ms on sha256 `apc_001` — **58 % of the pass**, and 9 of its 10
-invocations return the input untouched. Every pass rebuilt to a cheap sweep hits this floor next;
-sizing it on that case first is one `IO` timer.
+**R5. Framework: the per-pass degree check**  ·  **done for the sharing half (entry 175)**; what is
+left is per-pass degree proofs. `guardDegree` wraps every stage-list entry and used to run
+`withinDegreeB` — a whole-system AST walk — 200–290×/run. Entry 175 threads an erased degree
+certificate through the guarded stage lists and scans the output's item list in lockstep with the
+input's, skipping a pointer-identical remaining list or item (`degOkFrom`, `Measure.lean`): the guard
+went 0.31–0.37x, total **0.93–0.95x** on four cases, byte-identical, with no pass-side change. That
+also retires the `unchanged : Option (out = cs)` variant listed here before — pointer lockstep
+reaches 65 % of *nodes* and subsumes whole-invocation no-ops.
+   What remains is the 30–39 % of nodes in genuinely rebuilt items — `normalize1/2`, `constFold0/1/2`,
+   `gauss`, `domainBatch`, in that order — and the only lever left is **not checking them at all**:
+   a pass that provably cannot raise the degree can carry `DenseRespectsDeg b f` (for all `b`) and
+   hand the certificate straight through. Sized with `sorry` certificates: the easy set
+   (`constFold*` + the drop passes) is **~1 % of the run** (keccak `constFold1` 66 → 55 ms), so it
+   only pays if `normalize` and `gauss` are included, and those need real per-pass degree theorems.
+   `degreeGuardRefactor.md` (untracked) has the fuller plan, including why the ∀-`b` quantification
+   blocks a whole class of passes. Two smaller residuals, both measured: threading the certificate
+   through `denseIterateToFixpointFrom` (~0.5 % of keccak, needs a second copy of the fixpoint proof)
+   and the `withPtrEq` cursor's inability to resync after a drop or prepend (structural, not fixable
+   in the safe fragment — see entry 175's dead ends).
 
 **R6. Cross-cycle dirtiness (the real fix for no-op rescans)**  ·  *large refactor; the cheap
 slice is now a measured dead end*. **Do not build a cross-cycle negative-memo for domainBatch**:
@@ -764,6 +769,20 @@ instead of 256 (~30× on those scans). It needs a per-item degree analysis and a
 are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`).
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **Sub-expression sharing in the degree guard** (entry 175): descending into an unmatched item and
+  pointer-comparing aligned `add`-spine subtrees is sound (every subterm of a certified expression is
+  certified) and recovers **0.01 % of the guard's nodes** — the passes that rebuild items
+  (`normalize`, `constFold`, `gauss`, `digitFold`) materialize fresh trees all the way down. Item- and
+  list-level pointer identity is all the sharing there is.
+- **An unboxed `UInt64` walk for the degree check** (entry 175): the C is a pure register recursion
+  with no boxed `Nat` and no refcount traffic, and it measures **flat** — that walk is memory-bound on
+  the AST. Also: a `Nat` literal above the scalar range (`2^32`) in a per-item comparison costs
+  `lean_cstr_to_nat` *per call* and made the same change 5 % worse before the cap moved to 65536.
+- **Resynchronizing a `withPtrEq` lockstep cursor** (entry 175): `withPtrEq a b k h` is
+  definitionally `k ()`, so a pointer test may only skip work already known to be `true` — its
+  outcome cannot steer control flow. Any scan that must *search* for the matching item (after a drop
+  or a prepend) needs pointer identity as a `Bool`, i.e. `unsafe`/`implemented_by`.
 
 - **Deferring a per-invocation index's force to its first query** (entry 174, busPairCancel's
   `cands`): the counters say it is queried 2 498 times in sha256 cycle 1, 0 times in cycles 8–10 and

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6835,3 +6835,86 @@ of setup and the pass total does not change — `Thunk.get`'s `lean_mark_mt` wal
 invocations that do query it costs what the four that do not save.
 
 **Worked: yes.**
+
+### 175. Runtime: guardDegree made incremental — a threaded degree certificate and a pointer-lockstep scan (guard 0.31–0.37x, total 0.93–0.95x on four cases)
+
+`guardDegree` is not a pass but the wrapper `guardAll` puts on every entry of the three stage lists,
+so it runs 200–290 whole-system `withinDegreeB` walks per run. `guardDegreeRedesign.md` has the
+design, the node-level attribution and the dead ends.
+
+WHAT IT COSTS NOW: against a build with the guard deleted (`if true then r`, `sorry` on
+`guardDegree_respectsDeg`), interleaved: openvm-eth `apc_006` 315 → 285 ms (0.905x), wasm-eth
+`apc_012` 2653 → 2425 (0.914x), keccak `apc_001` 2203 → 2018 (0.916x). The guard is **8–10 % of
+total wall**, up from the 6–7 % measured before entries 171–174 — those rewrites cut the passes, not
+the guard, so its share grew. That is the ceiling for everything below.
+
+WHERE THE REDUNDANCY IS: a throwaway probe classified every AST node the guard visits by how a
+lockstep scan against the input system would treat it (probe uses unsafe pointer identity; the
+shipped code uses core Lean's safe `withPtrEq`). Of 7.79 M / 64.9 M / 36.1 M nodes (apc_006 /
+apc_012 / keccak): **35–45 % sit in a remaining list that *is* the input's remaining list**, another
+**23–25 % in an item pointer-identical to the aligned input item**, and 30–39 % are genuinely
+rebuilt. Most of the guard's work is re-deciding degrees it has already accepted.
+
+THE CHANGE:
+1. **A degree certificate threaded through the guarded stage lists.** `DenseDegCert b d :=
+   Option (PLift (d.withinDegreeB b = true))` — the proof is erased, so a certificate is a
+   constructor tag at runtime. `guardAll` now returns `DenseGuardedPassW p b` (system + certificate
+   in, result + certificate out) and *produces* `some` whenever its own check passes, so the
+   certificate establishes itself on the first invocation of a stage; the optimizer's input circuit
+   is not assumed within bound. Stage-list entries stay plain `DenseVerifiedPassW`, so AGENTS.md's
+   one-line pass-adding contract is unchanged; `DenseGuardedPassW.toPass` feeds `none` and hands the
+   chain back to `denseIterateToFixpoint` and `pipeline`.
+2. **A sharing-aware check** (`degOkFrom`, `Measure.lean`): walk the output's item list in lockstep
+   with the input's, using `withPtrEq` at two granularities — a pointer-identical *remaining list*
+   ends the scan, a pointer-identical *item* skips its AST walk. `withPtrEq a b k h` is
+   definitionally `k ()`, so these are hints only: `degOkFrom_eq` proves the result equals
+   `withinDegreeB` and the compiler emits a bare `lean_ptr_addr` compare with no closure. Each
+   definition returns its own specification (`{ r : Bool // r = ol.all ok }`) because `withPtrEq`'s
+   `h` obligation must be discharged while the recursion is elaborated; a one-field `Subtype` is
+   that field. Two monomorphic copies (constraints, interactions) keep the per-item test a direct
+   call, which also removes the boxed closure `List.all` allocated per item.
+3. `attribute [local irreducible] densePipeline` after `densePipeline_respectsDeg`: the extra
+   definitional layer pushed `optimizerWithBusFacts_correct`'s `change`s past the heartbeat limit.
+   Sealing the pipeline where it is used only through its `DensePassResult` fields takes that file
+   from 8.7 s to 1.3 s — faster than before the change.
+
+NUMBERS (20-core box, serial, interleaved, 2–3 reps; sha256 one shot per rep, first rep discarded as
+cold): openvm-eth `apc_006` 315 → 293 ms (**0.930x**), wasm-eth `apc_012` 2653 → 2510 (**0.946x**),
+keccak `apc_001` 2203 → 2075 (**0.942x**), sha256 `apc_001` 24 055 → 22 563 (**0.938x**). That
+recovers 63–73 % of the guard's cost (guard 0.31–0.37x). Per pass, what shrinks is the entries that
+share their items (`carryBranch`, `bytePack`, `busPairCancel`, `tautoBus`, `disconnected`,
+`rootPairUnify`); what still pays is the entries that rebuild everything (`normalize1/2`,
+`constFold0/1/2`, `gauss`, `domainBatch`). A pass that shares nothing pays two pointer compares per
+item on top of the walk it would have done anyway.
+VERIFIED: `opt-export` **byte-identical** on 8 cases — openvm-eth `apc_006` / `apc_100`, wasm-eth
+`apc_012` / `apc_063`, OpenVM keccak `apc_001`, SP1 keccak `apc_001`, SP1 rsp `apc_001` / `apc_002`;
+`lake build` clean, no warnings; `check-proof-integrity` passes (no `sorry`, three standard axioms).
+
+DEAD ENDS, all measured on this revision:
+* **Sub-expression lockstep down `add` spines** — sound (every subterm of a certified expression is
+  certified, and an `add` node needs only a Boolean from each child), and worth **0.01 % of nodes**:
+  the passes that rebuild items materialize fresh trees all the way down. This is the only idea that
+  could have attacked the residual from inside the guard.
+* **An unboxed `UInt64` honest walk** (`denseDegU` saturating at 65536, one prepared machine-word
+  bound per invocation; the C is a pure register recursion — no boxed `Nat`, no `lean_dec`).
+  Implemented and measured **flat** (apc_012 2507 vs 2492, keccak 2079 vs 2098, apc_006 292 vs 293).
+  The honest walk is memory-bound on the AST, not arithmetic-bound. Note for other hot `Nat`
+  comparisons: a first version capped at `2^32` was **5 % worse** because Lean emits
+  `lean_cstr_to_nat("4294967296")` *per call* for a literal above the scalar range.
+* **Per-pass degree monotonicity (ideas.md R5's "no check at all")** — sized with `sorry`-certified
+  entries for `constFold0/1/2`, `constFoldEnd`, `dedup`, `dedupLate`, `trivialConstr`,
+  `zeroMultBus`, `tautoBus`, `subsumedRange`, `subsumedCheck`, `disconnected`: keccak `constFold1`
+  66 → 55 ms, `constFold2` 59 → 52, `constFold0` 38 → 34, nothing else moves — **~22 ms of 2075
+  (1 %)**, inside the noise on the total. The drop passes gain nothing (lockstep already serves
+  them). `DenseExpr.fold`'s monotonicity is a 15-line lemma but it needs a mixed
+  guarded/certified stage list, and the big walkers (`gauss`, `normalize1/2`, `domainBatch`) need
+  real per-pass degree theorems.
+* **Threading the certificate through `denseIterateToFixpointFrom`** — the first cleanup pass
+  (`degenRange`) then stops paying a full walk: ~10 ms of keccak (0.5 %), against a second copy of
+  the fixpoint definition and its `respectsDeg` induction.
+* **Resynchronizing the lockstep cursor after a drop or a prepend** — impossible in the safe
+  fragment: `withPtrEq` may only skip work whose value is already known `true`, so the pointer test
+  cannot be observed and the cursor must advance blindly. `domainBatch` and `dedup`, both
+  drop-and-append passes, are the two largest residual walkers because of exactly this.
+
+**Worked: yes.**


### PR DESCRIPTION
`guardDegree` is not a pass but the wrapper `guardAll` puts on **every** entry of `preludePasses` /
`cleanupPasses` / `codaPasses`, so `withinDegreeB` — a whole-system AST walk — runs **200–290 times
per run**. Against a build with the guard deleted it is **8–10 % of total wall** (it grew from the
6–7 % measured earlier: #276–#280 cut the passes, not the guard).

A probe classifying every AST node the guard visits says most of that work re-decides degrees it has
already accepted. Of 7.79 M / 64.9 M / 36.1 M nodes (openvm-eth `apc_006` / wasm-eth `apc_012` /
keccak `apc_001`): **35–45 % sit in a remaining list that *is* the input's remaining list**, another
**23–25 % in an item pointer-identical to the aligned input item**, and only 30–39 % are genuinely
rebuilt.

## The change

1. **A degree certificate threaded through the guarded stage lists.**
   `DenseDegCert b d := Option (PLift (d.withinDegreeB b = true))` — the proof is erased, so a
   certificate is a constructor tag at runtime. `guardAll` now returns `DenseGuardedPassW p b`
   (system + certificate in, result + certificate out) and *produces* `some` whenever its own check
   passes, so the certificate establishes itself on the first invocation of a stage — the optimizer's
   input circuit is still not assumed within bound. Stage-list entries stay plain
   `DenseVerifiedPassW`, so AGENTS.md's one-line pass-adding contract is unchanged;
   `DenseGuardedPassW.toPass` feeds `none` and hands the chain back to `denseIterateToFixpoint` and
   `pipeline`.
2. **A sharing-aware check** (`DenseConstraintSystem.degOkFrom`, `Measure.lean`): walk the output's
   item list in lockstep with the input's, using core Lean's `withPtrEq` at two granularities — a
   pointer-identical *remaining list* ends the scan, a pointer-identical *item* skips its AST walk.
   `withPtrEq a b k h` is definitionally `k ()`, so these are hints and nothing more: `degOkFrom_eq`
   proves the result equals `withinDegreeB`, and the compiler emits a bare `lean_ptr_addr` compare
   with no closure allocation. Each definition returns its own specification
   (`{ r : Bool // r = ol.all ok }`) because `withPtrEq`'s `h` obligation has to be discharged while
   the recursion is elaborated; a one-runtime-field `Subtype` is that field. Two monomorphic copies
   (constraints, interactions) keep the per-item test a direct call, which also removes the boxed
   closure `List.all` allocated per item.
3. `attribute [local irreducible] densePipeline` after `densePipeline_respectsDeg` — the extra
   definitional layer pushed `optimizerWithBusFacts_correct`'s `change`s past the heartbeat limit.
   Sealing the pipeline where it is used only through its `DensePassResult` fields takes that file
   from 8.7 s to 1.3 s, faster than before this change.

`Main.lean`'s `profile` threads the certificate the same way the pipeline does (dropped at the three
stage boundaries and at each fixpoint iteration), so the reported per-pass times stay faithful.

## Numbers

20-core box, serial, interleaved, 2–3 reps; sha256 one shot per rep (first discarded as cold):

| APC | main 75bf56f | this branch | total | guard |
|---|---:|---:|---:|---:|
| openvm-eth `apc_006` | 315 ms | 293 | **0.930×** | 30 → 8 ms |
| wasm-eth `apc_012` | 2653 | 2510 | **0.946×** | 228 → 85 |
| keccak `apc_001` | 2203 | 2075 | **0.942×** | 185 → 57 |
| sha256 `apc_001` | 24055 | 22563 | **0.938×** | — |

That recovers 63–73 % of the guard's cost. What shrinks per pass is the entries that share their
items (`carryBranch`, `bytePack`, `busPairCancel`, `tautoBus`, `disconnected`, `rootPairUnify`); what
still pays is the entries that rebuild everything (`normalize1/2`, `constFold0/1/2`, `gauss`,
`domainBatch`). A pass that shares nothing pays two pointer compares per item on top of the walk it
would have done anyway.

## Verification

- `opt-export` **byte-identical** on 8 cases: openvm-eth `apc_006` / `apc_100`, wasm-eth `apc_012` /
  `apc_063`, OpenVM keccak `apc_001`, SP1 keccak `apc_001`, SP1 rsp `apc_001` / `apc_002`. This is a
  pure runtime change, so effectiveness cannot move.
- `lake build` clean, no warnings; `Scripts/check-proof-integrity.sh` passes (no `sorry`; the
  correctness theorems rest on `propext`, `Classical.choice`, `Quot.sound`).

## Measured dead ends (recorded in `agent-docs/`)

- **Sub-expression lockstep down `add` spines** — sound (every subterm of a certified expression is
  certified), worth **0.01 % of nodes**: the rebuild passes materialize fresh trees all the way down.
- **An unboxed `UInt64` honest walk** (pure register recursion in the C) — measured **flat**: that
  walk is memory-bound on the AST. A first version capped at `2^32` was 5 % *worse* because Lean
  emits `lean_cstr_to_nat` per call for a literal above the scalar range.
- **Per-pass degree monotonicity (no check at all)** — sized with `sorry` certificates: the easy set
  (`constFold*` plus the drop passes) is **~1 % of the run**; it only pays with `normalize` and
  `gauss`, which need real per-pass degree theorems.
- **Certificate through `denseIterateToFixpointFrom`** — ~0.5 % of keccak, against a second copy of
  the fixpoint definition and its induction.
- **Resynchronizing the lockstep cursor after a drop or prepend** — impossible in the safe fragment:
  `withPtrEq`'s outcome cannot steer control flow.

Draft: opening for the CI benchmark and effectiveness run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)