### PR TITLE
perf(digitFold): plan the lookups, then bound only the keys they can query (0.40x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
@@ -376,17 +376,43 @@ def denseAddVars (bs : BusSemantics p) (facts : BusFacts p bs) (bi : BusInteract
       | none => T
     denseAddVars bs facts bi pr xs (denseGoCands bs facts bi pr i slot? pr.cands T1)
 
-/-- Collect bounds from every interaction's fact-bounded raw payload slots. -/
-def denseAddAll (bs : BusSemantics p) (facts : BusFacts p bs) :
+/-- The raw-variable payload entries a build is asked to bound; `none` asks for all of them. -/
+def denseKeptRawVars (keep? : Option (Std.HashSet VarId)) (bi : BusInteraction (DenseExpr p)) :
+    List VarId :=
+  match keep? with
+  | none => denseRawVarsOf bi
+  | some keep => (denseRawVarsOf bi).filter (fun i => keep.contains i)
+
+/-- Collect bounds from every interaction's fact-bounded raw payload slots, for the variables
+    `keep?` asks for. An interaction contributing none pays no `denseBiPrepOf` (with its
+    compound-slot linearizations) and no `facts` call.
+
+    Restricting the keys does not change the bound stored for a key that is kept: every insertion
+    for `i` happens on `i`'s own iteration, `denseInsertEntry` keeps the tightest of them, and the
+    minimum for one key is independent of every other. -/
+def denseAddAllWith (bs : BusSemantics p) (facts : BusFacts p bs)
+    (keep? : Option (Std.HashSet VarId)) :
     List (BusInteraction (DenseExpr p)) → Std.HashMap VarId Nat → Std.HashMap VarId Nat
   | [], T => T
   | bi :: rest, T =>
-    denseAddAll bs facts rest (denseAddVars bs facts bi (denseBiPrepOf bi) (denseRawVarsOf bi) T)
+    match denseKeptRawVars keep? bi with
+    | [] => denseAddAllWith bs facts keep? rest T
+    | vs => denseAddAllWith bs facts keep? rest (denseAddVars bs facts bi (denseBiPrepOf bi) vs T)
+
+def denseAddAll (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dbis : List (BusInteraction (DenseExpr p))) (T : Std.HashMap VarId Nat) :
+    Std.HashMap VarId Nat :=
+  denseAddAllWith bs facts none dbis T
+
+def denseBuildWith (bs : BusSemantics p) (facts : BusFacts p bs)
+    (keep? : Option (Std.HashSet VarId)) (dbis : List (BusInteraction (DenseExpr p))) :
+    Std.HashMap VarId Nat :=
+  denseAddAllWith bs facts keep? dbis ∅
 
 /-- Dense bounds-map build. -/
 def denseBuild (bs : BusSemantics p) (facts : BusFacts p bs)
     (dbis : List (BusInteraction (DenseExpr p))) : Std.HashMap VarId Nat :=
-  denseAddAll bs facts dbis ∅
+  denseBuildWith bs facts none dbis
 
 /-! ## Dense byte-pair recognizer -/
 
@@ -402,6 +428,37 @@ def densePairByteOps? (bs : BusSemantics p) (facts : BusFacts p bs)
           ∧ bi.multiplicity = DenseExpr.const 1
       then some (o1, o2) else none
     | none => none
+
+/-! ## The fold plan: the ladder forms to solve and the keys they will query -/
+
+/-- One operand's contribution: its ladder form (in reverse scan order) and its variables, when
+    `denseSolveOperand` would attempt it — a successful linearization with at least two terms. -/
+def denseFoldOperand (E : DenseExpr p) (acc : List (DenseLinExpr p) × Std.HashSet VarId) :
+    List (DenseLinExpr p) × Std.HashSet VarId :=
+  match denseLinearize E with
+  | none => acc
+  | some l =>
+    if l.terms.length < 2 then acc
+    else (l :: acc.1, l.terms.foldl (fun s t => s.insert t.1) acc.2)
+
+def denseFoldPlanGo (bs : BusSemantics p) (facts : BusFacts p bs) :
+    List (BusInteraction (DenseExpr p)) → List (DenseLinExpr p) × Std.HashSet VarId →
+      List (DenseLinExpr p) × Std.HashSet VarId
+  | [], acc => acc
+  | bi :: rest, acc =>
+    match densePairByteOps? bs facts bi with
+    | none => denseFoldPlanGo bs facts rest acc
+    | some (x, y) => denseFoldPlanGo bs facts rest (denseFoldOperand y (denseFoldOperand x acc))
+
+/-- The ladder forms of every recognized byte-pair check's operands, in scan order (interaction
+    order, first operand before second), paired with all their variables — which is exactly the set
+    of keys the solve can look a bound up for. Recognition and linearization happen here only; the
+    solve consumes the forms (`denseSolveLadders`) and the bounds map is built for the keys
+    (`denseBuildWith`). -/
+def denseFoldPlan (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dbis : List (BusInteraction (DenseExpr p))) : List (DenseLinExpr p) × Std.HashSet VarId :=
+  let acc := denseFoldPlanGo bs facts dbis ([], ∅)
+  (acc.1.reverse, acc.2)
 
 /-! ## Dense ladder recognition and grid solving -/
 
@@ -472,13 +529,37 @@ def denseFindFold (bs : BusSemantics p) (facts : BusFacts p bs) (denseBM : Std.H
         | some r => some r
         | none => denseFindFold bs facts denseBM rest
 
+/-- First planned ladder form with a forced digit, both sign interpretations in
+    `denseSolveOperand`'s order. Reads nothing but `bounds` and the form. -/
+def denseSolveLadders (bounds : Std.HashMap VarId Nat) :
+    List (DenseLinExpr p) → Option (VarId × ℕ)
+  | [] => none
+  | l :: rest =>
+    match denseAttemptLadder true bounds l with
+    | some r => some r
+    | none =>
+      match denseAttemptLadder false bounds l with
+      | some r => some r
+      | none => denseSolveLadders bounds rest
+
+/-- The planned scan: recognize and linearize the byte-pair operands once, bound only the keys those
+    forms can query, then solve the forms in scan order. `denseSolveLadders_eq_findFold` in
+    `Proofs/DigitFold.lean` is the equality with the interaction scan `denseFindFold`.
+
+    No ladder form means no lookup, so the bounds map is not built at all — the common case. -/
+def denseDigitFoldFind (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dbis : List (BusInteraction (DenseExpr p))) : Option (VarId × ℕ) :=
+  let plan := denseFoldPlan bs facts dbis
+  if plan.1.isEmpty then none
+  else denseSolveLadders (denseBuildWith bs facts (some plan.2) dbis) plan.1
+
 /-- Digit-fold transform: when a witness limb is forced to a compile-time constant by a byte check
     over a base-256 ladder (e.g. a limb pinned to `7`), substitute it away. One forced digit per
     invocation; identity if none found. -/
 def denseDigitFoldF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     DenseConstraintSystem p :=
   if 256 < p then
-    match denseFindFold bs facts (denseBuild bs facts d.busInteractions) d.busInteractions with
+    match denseDigitFoldFind bs facts d.busInteractions with
     | some (i, dd) => d.subst i (DenseExpr.const (dd : ZMod p))
     | none => d
   else d

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DigitFold.lean
@@ -262,13 +262,15 @@ theorem denseAddVars_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
         · exact hT
       exact ih _ (denseGoCands_soundAt bs facts bi i denv hob (denseBiPrepOf bi).cands _ hT1)
 
-/-- `addAll` preserves the invariant across every interaction. -/
-theorem denseAddAll_soundAt (bs : BusSemantics p) (facts : BusFacts p bs) (denv : VarId → ZMod p) :
+/-- `addAllWith` preserves the invariant across every interaction, for any key restriction —
+    which bounds are inserted is unconstrained by soundness. -/
+theorem denseAddAllWith_soundAt (bs : BusSemantics p) (facts : BusFacts p bs)
+    (keep? : Option (Std.HashSet VarId)) (denv : VarId → ZMod p) :
     ∀ (dbis : List (BusInteraction (DenseExpr p))),
       (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
         bs.accepts (denseBIEval bi denv)) →
       ∀ (T : Std.HashMap VarId Nat), DenseBMSoundAt denv T →
-        DenseBMSoundAt denv (denseAddAll bs facts dbis T) := by
+        DenseBMSoundAt denv (denseAddAllWith bs facts keep? dbis T) := by
   intro dbis
   induction dbis with
   | nil => intro _ T hT; exact hT
@@ -279,20 +281,40 @@ theorem denseAddAll_soundAt (bs : BusSemantics p) (facts : BusFacts p bs) (denv 
       have hrest : ∀ b ∈ rest, (denseBIEval b denv).multiplicity ≠ 0 →
           bs.accepts (denseBIEval b denv) :=
         fun b hb => hob b (List.mem_cons_of_mem _ hb)
-      unfold denseAddAll
-      exact ih hrest _ (denseAddVars_soundAt bs facts bi denv hbi (denseRawVarsOf bi) T hT)
+      unfold denseAddAllWith
+      split
+      · exact ih hrest T hT
+      · exact ih hrest _ (denseAddVars_soundAt bs facts bi denv hbi _ T hT)
+
+/-- `addAll` preserves the invariant across every interaction. -/
+theorem denseAddAll_soundAt (bs : BusSemantics p) (facts : BusFacts p bs) (denv : VarId → ZMod p) :
+    ∀ (dbis : List (BusInteraction (DenseExpr p))),
+      (∀ bi ∈ dbis, (denseBIEval bi denv).multiplicity ≠ 0 →
+        bs.accepts (denseBIEval bi denv)) →
+      ∀ (T : Std.HashMap VarId Nat), DenseBMSoundAt denv T →
+        DenseBMSoundAt denv (denseAddAll bs facts dbis T) :=
+  denseAddAllWith_soundAt bs facts none denv
 
 /-! ## The bounds-map soundness capstone -/
 
-/-- **Bounds-map soundness.** A bound stored by `denseBuild` for `i` is a strict upper bound
+/-- **Bounds-map soundness.** A bound stored by `denseBuildWith` for `i` is a strict upper bound
     on `denv i` for every assignment whose bus interactions are non-violating. -/
+theorem denseBuildWith_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (keep? : Option (Std.HashSet VarId)) (bis : List (BusInteraction (DenseExpr p)))
+    (i : VarId) (b : Nat)
+    (hlk : (denseBuildWith bs facts keep? bis)[i]? = some b) (denv : VarId → ZMod p)
+    (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
+      bs.accepts (denseBIEval bi denv)) : (denv i).val < b := by
+  unfold denseBuildWith at hlk
+  exact denseAddAllWith_soundAt bs facts keep? denv bis hbus ∅ (DenseBMSoundAt.empty denv) i b hlk
+
 theorem denseBuild_sound (bs : BusSemantics p) (facts : BusFacts p bs)
     (bis : List (BusInteraction (DenseExpr p))) (i : VarId) (b : Nat)
     (hlk : (denseBuild bs facts bis)[i]? = some b) (denv : VarId → ZMod p)
     (hbus : ∀ bi ∈ bis, (denseBIEval bi denv).multiplicity ≠ 0 →
-      bs.accepts (denseBIEval bi denv)) : (denv i).val < b := by
-  unfold denseBuild at hlk
-  exact denseAddAll_soundAt bs facts denv bis hbus ∅ (DenseBMSoundAt.empty denv) i b hlk
+      bs.accepts (denseBIEval bi denv)) : (denv i).val < b :=
+  denseBuildWith_sound bs facts none bis i b hlk denv hbus
+
 
 /-! # Correctness of the dense digit-fold pass (`denseDigitFoldPass`, `DigitFold.lean`), reducing
 the forced substitution to `DenseConstraintSystem.substF_denseCorrect` (`Proofs/DomainTable.lean`). -/
@@ -559,17 +581,117 @@ theorem denseFindFold_sound [NeZero p] (hp : 256 < p) (bs : BusSemantics p) (fac
                   exact denseSolveOperand_sound hp bounds y i dd hsy denv hB hby
               | none => rw [hsy] at h; dsimp only at h; exact ih hrest i dd h
 
-/-- If `denseFindFold` over the fact-built bounds map fires `(i, dd)`, every satisfying assignment
-    of `d` has `denv i = dd` (bounds validity from `denseBuild_sound`). -/
+/-! ## The planned scan is the interaction scan -/
+
+/-- The empty-plan guard is redundant: with no ladder form there is nothing to solve. -/
+theorem denseDigitFoldFind_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (dbis : List (BusInteraction (DenseExpr p))) :
+    denseDigitFoldFind bs facts dbis
+      = denseSolveLadders (denseBuildWith bs facts (some (denseFoldPlan bs facts dbis).2) dbis)
+          (denseFoldPlan bs facts dbis).1 := by
+  unfold denseDigitFoldFind
+  dsimp only
+  split_ifs with h
+  · have hnil : (denseFoldPlan bs facts dbis).1 = [] := by simpa using h
+    rw [hnil]; rfl
+  · rfl
+
+/-- The solve scans an append left to right. -/
+theorem denseSolveLadders_append (bounds : Std.HashMap VarId Nat)
+    (a b : List (DenseLinExpr p)) :
+    denseSolveLadders bounds (a ++ b)
+      = match denseSolveLadders bounds a with
+        | some r => some r
+        | none => denseSolveLadders bounds b := by
+  induction a with
+  | nil => rfl
+  | cons l rest ih =>
+    cases hT : denseAttemptLadder true bounds l with
+    | some r => simp [List.cons_append, denseSolveLadders, hT]
+    | none =>
+      cases hF : denseAttemptLadder false bounds l with
+      | some r => simp [List.cons_append, denseSolveLadders, hT, hF]
+      | none => simp [List.cons_append, denseSolveLadders, hT, hF, ih]
+
+/-- One operand appends the forms whose solve is exactly `denseSolveOperand` on it: the linearized
+    form when it has at least two terms, nothing otherwise. -/
+theorem denseFoldOperand_rev (bounds : Std.HashMap VarId Nat) (E : DenseExpr p)
+    (acc : List (DenseLinExpr p) × Std.HashSet VarId) :
+    ∃ fs, (denseFoldOperand E acc).1.reverse = acc.1.reverse ++ fs ∧
+      denseSolveLadders bounds fs = denseSolveOperand bounds E := by
+  unfold denseFoldOperand denseSolveOperand
+  cases hl : denseLinearize E with
+  | none => exact ⟨[], by simp, by simp [denseSolveLadders]⟩
+  | some l =>
+    by_cases h2 : l.terms.length < 2
+    · exact ⟨[], by simp [h2], by simp [h2, denseSolveLadders]⟩
+    · refine ⟨[l], by simp [h2], ?_⟩
+      cases hT : denseAttemptLadder true bounds l with
+      | some r => simp [denseSolveLadders, h2, hT]
+      | none =>
+        cases hF : denseAttemptLadder false bounds l with
+        | some r => simp [denseSolveLadders, h2, hT, hF]
+        | none => simp [denseSolveLadders, h2, hT, hF]
+
+/-- The plan walk, with any accumulator: solving the accumulated forms and then the walk's own is
+    solving the accumulator, then scanning the interactions. -/
+theorem denseSolveLadders_foldPlanGo (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bounds : Std.HashMap VarId Nat) :
+    ∀ (dbis : List (BusInteraction (DenseExpr p)))
+      (acc : List (DenseLinExpr p) × Std.HashSet VarId),
+      denseSolveLadders bounds ((denseFoldPlanGo bs facts dbis acc).1.reverse)
+        = match denseSolveLadders bounds acc.1.reverse with
+          | some r => some r
+          | none => denseFindFold bs facts bounds dbis := by
+  intro dbis
+  induction dbis with
+  | nil =>
+    intro acc
+    cases h : denseSolveLadders bounds acc.1.reverse <;>
+      simp [denseFoldPlanGo, denseFindFold, h]
+  | cons bi rest ih =>
+    intro acc
+    unfold denseFoldPlanGo denseFindFold
+    cases hb : densePairByteOps? bs facts bi with
+    | none => simpa using ih acc
+    | some xy =>
+      obtain ⟨x, y⟩ := xy
+      dsimp only
+      obtain ⟨fx, hfx, hsx⟩ := denseFoldOperand_rev bounds x acc
+      obtain ⟨fy, hfy, hsy⟩ := denseFoldOperand_rev bounds y (denseFoldOperand x acc)
+      rw [ih (denseFoldOperand y (denseFoldOperand x acc)), hfy, hfx, List.append_assoc,
+        denseSolveLadders_append, denseSolveLadders_append, hsx, hsy]
+      cases denseSolveLadders bounds acc.1.reverse with
+      | some r => rfl
+      | none =>
+        cases denseSolveOperand bounds x with
+        | some r => rfl
+        | none => cases denseSolveOperand bounds y <;> rfl
+
+/-- The planned solve is the interaction scan: the plan holds the ladder forms of both operands of
+    each recognized check in scan order, keeping exactly those `denseSolveOperand` would attempt (a
+    successful linearization with at least two terms), and `denseAttemptLadder` reads nothing but
+    `bounds` and the form. -/
+theorem denseSolveLadders_eq_findFold (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bounds : Std.HashMap VarId Nat) (dbis : List (BusInteraction (DenseExpr p))) :
+    denseSolveLadders bounds (denseFoldPlan bs facts dbis).1
+      = denseFindFold bs facts bounds dbis := by
+  have h := denseSolveLadders_foldPlanGo bs facts bounds dbis ([], ∅)
+  simpa using h
+
+/-- If the planned scan over the key-restricted bounds map fires `(i, dd)`, every satisfying
+    assignment of `d` has `denv i = dd` (bounds validity from `denseBuildWith_sound`). -/
 theorem denseDigitFoldFindFold_entails [NeZero p] (hp : 256 < p) (bs : BusSemantics p)
     (facts : BusFacts p bs) (d : DenseConstraintSystem p) (i : VarId) (dd : ℕ)
-    (h : denseFindFold bs facts (denseBuild bs facts d.busInteractions) d.busInteractions
-      = some (i, dd)) :
+    (h : denseDigitFoldFind bs facts d.busInteractions = some (i, dd)) :
     ∀ denv, d.satisfies bs denv → denv i = (dd : ZMod p) := by
   intro denv hsat
   have hbus := hsat.2
-  have hB : ∀ w bnd, (denseBuild bs facts d.busInteractions)[w]? = some bnd → (denv w).val < bnd :=
-    fun w bnd hlk => denseBuild_sound bs facts d.busInteractions w bnd hlk denv hbus
+  rw [denseDigitFoldFind_eq, denseSolveLadders_eq_findFold] at h
+  have hB : ∀ w bnd,
+      (denseBuildWith bs facts (some (denseFoldPlan bs facts d.busInteractions).2)
+        d.busInteractions)[w]? = some bnd → (denv w).val < bnd :=
+    fun w bnd hlk => denseBuildWith_sound bs facts _ d.busInteractions w bnd hlk denv hbus
   exact denseFindFold_sound hp bs facts _ denv hB d.busInteractions hbus i dd h
 
 /-! ## Reducing the point substitution to `substF` -/
@@ -607,7 +729,7 @@ theorem denseDigitFoldF_covered (reg : VarRegistry) (bs : BusSemantics p) (facts
   unfold denseDigitFoldF
   by_cases hp : 256 < p
   · rw [if_pos hp]
-    cases denseFindFold bs facts (denseBuild bs facts d.busInteractions) d.busInteractions with
+    cases denseDigitFoldFind bs facts d.busInteractions with
     | none => exact hcov
     | some idd =>
         obtain ⟨i, dd⟩ := idd
@@ -624,8 +746,7 @@ theorem denseDigitFoldF_correct (reg : VarRegistry) (bs : BusSemantics p) (facts
   by_cases hp : 256 < p
   · rw [if_pos hp]
     haveI : NeZero p := ⟨by omega⟩
-    cases hff : denseFindFold bs facts (denseBuild bs facts d.busInteractions)
-        d.busInteractions with
+    cases hff : denseDigitFoldFind bs facts d.busInteractions with
     | none => exact DensePassCorrect.refl reg.isInput d bs
     | some idd =>
         obtain ⟨i, dd⟩ := idd

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -790,11 +790,14 @@ that is a sound necessary condition changes nothing. Per-pass no-op ms, net of t
 increasing effort:
 
 - **(a) Eager whole-system prologues most invocations never use** — sized by stubbing the prologue to
-  `∅` via `@[implemented_by]` (upper bound; output wrong): `digitFold` **1480 → 468 ms** (68 % of the
-  pass) is `denseBuild`'s bounds map over every raw payload variable of every interaction, queried
-  only for the operands of `densePairByteOps?` hits, and the pass fires in **55 of 1443**
-  invocations — R9d's candidate-restricted shape, since entry 170 already measured that the
-  eager-over-every-variable version loses. `flagUnify` **1073 → 456 ms** (58 %) is
+  `∅` via `@[implemented_by]` (upper bound; output wrong). ~~`digitFold` **1480 → 468 ms** (68 % of the
+  pass)~~ **done (entry 176)**: 0.398x on the pass, every family improving, by planning the lookups in
+  one recognize-and-linearize walk and bounding only the keys that plan can query. Two lessons carry —
+  **fuse the planning walk with the work it plans** (keeping the pass's own walk alongside a separate
+  candidate walk measured 1.08–1.13x on SP1, where dense byte-pair checks made the duplicated
+  recognition cost more than the restriction saved), and **sweep the whole corpus per pass before
+  believing a representative set** (the OpenVM representatives all read as clean wins). Its residual is
+  in *digitFold residual after entry 176* below. `flagUnify` **1073 → 456 ms** (58 %) is
   `denseVarBucket DenseExpr.vars` read only inside `denseFuPairData?`, i.e. only once a same-key twin
   is found — **18 times in the whole corpus** — so here `denseThunkIf` is the fix and the `Thunk` note
   above does not bite (the value is almost never forced, unlike the `cands` dead end). Audit every
@@ -816,6 +819,19 @@ increasing effort:
   cycles cost 1.30 s and between them remove 1 variable, 3 interactions and 1 constraint. Nothing can
   know a cycle is fruitless without running it — this is not a separate lever, it is the argument for
   (a)–(c), since every pass in that cycle is a no-op invocation by construction.
+
+### digitFold residual after entry 176 (the planned bounds map)  ·  *runtime*
+
+570–591 ms corpus-wide, split with two more `@[implemented_by]` stubs: **linearize + ladder solve
+~282 ms**, **the restricted bounds sweep 115** (`denseBuildWith → ∅`: 591 → 476, concentrated in
+openvm-eth 54, keccak 19, SP1 rsp 19 — already ~10 ms each on sha256 and wasm-eth), **the degree guard
+~108** (R5, now 19 % of this pass), **the bare interaction walk ~65** (recognizer → `none`: 570 → 173,
+minus the guard). So the sweep — the obvious next target — is only 19 % of what is left, and the whole
+addressable remainder is ~0.8 % of corpus wall: **deliberately stopped as sub-bar**. If a corpus ever
+makes it matter: `denseTryLadder` sorts `l.terms` once per sign per form, and `denseAddVars` still
+resolves `denseVarSlot` per kept variable for interactions whose multiplicity is non-constant, where
+every bound is statically `none`. The lesson worth keeping is the method — stub the two halves
+separately before designing, because the named half was not the expensive one.
 
 ### tupleRange residual after entry 175 (the single-pass scan)  ·  *runtime*
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6884,5 +6884,64 @@ position cursor fixes it: `pre` holds no candidate of either kind and the emitte
 neither recognizer's bus, so the next search may resume immediately after it. Also unaddressed:
 `denseMatchByteSingle` runs `denseByteShape?` per position with no `@[csimp]` runtime twin (its
 `denseMatchRangeCheck` counterpart has one), which is what the surviving single pass now costs.
+**Worked: yes.**
+
+### 176. Runtime: digitFold plans its lookups, then bounds only those keys (0.29–0.67x on the pass)
+
+`denseDigitFoldF` built its `VarId → Nat` bounds map over **every raw payload variable of every bus
+interaction** (a `facts.slotBound` plus `denseProbedSlotBoundAtP` per entry) and then consulted it only
+for the two operands `densePairByteOps?` returns. The pass fires in **55 of 1443 corpus invocations**;
+the rest measured the whole system to answer nothing. Stubbing the map to `∅` (`@[implemented_by]`,
+output wrong, an upper bound on any fix) put **68 % of the pass** in that build: corpus 1480 → 468 ms.
+
+THE CHANGE: plan first, bound second. `denseFoldPlan` walks the interactions once and, for each
+recognized byte-pair check, linearizes both operands under `denseSolveOperand`'s own
+`2 ≤ terms.length` gate, keeping the ladder forms in scan order plus their variables — exactly the
+keys the solve can query, since `denseAttemptLadder` reads only `bounds` and the form at a
+`mergeSort` permutation of `l.terms`. `denseBuildWith … (some keys)` then builds for those keys only,
+and `denseSolveLadders` solves the planned forms in order. No form ⇒ no lookup ⇒ the map is never
+built, which is the common case. `denseBuild`/`denseAddAll` stay as `keep? := none` wrappers, so
+`CarryBranch`, `SeqzCollapse`, `HintCollapse` and `DegenRange` are untouched.
+
+WHY IT IS VALUE-IDENTICAL: restricting the keys cannot change a kept key's bound — every insertion for
+`i` happens on `i`'s own iteration of `denseAddVars` (including inside `denseGoCands`, which inserts at
+`i`, not at the probed candidate), computing a bound never reads the map, and `denseInsertEntry` keeps
+the tightest per key, so each key's value is the minimum over its own bounds and independent of the
+rest. The plan is a *superset* of the read set, which is the direction that matters: a missing key
+turns a `some` into a `none`. `denseSolveLadders_eq_findFold` is the equality with the interaction
+scan — a plan-walk induction over an arbitrary accumulator (`denseSolveLadders_foldPlanGo`), the
+per-operand contribution (`denseFoldOperand_rev`, an existential packaging the appended forms with
+their solve) and `denseSolveLadders_append`. **No obligation about the bounds themselves broke**: the
+pass's soundness constrains which bounds are *stored*, never which are enumerated.
+
+**SEQUENCING MATTERS HERE.** A first version kept `denseFindFold`'s own walk and added a separate
+candidate walk in front of it, so recognition and linearization ran twice. That measured **0.43–0.56x
+on OpenVM but 1.08–1.13x on SP1** (18 cases >1 ms slower, SP1 rsp wall 1.011x): SP1's byte-pair checks
+are dense while its whole-system sweep was comparatively cheap, so the duplicate cost more than the
+restriction saved. Fusing the two walks fixed it and improved OpenVM further. A corpus-wide per-pass
+sweep is what caught it — the OpenVM-only representatives all looked like wins.
+
+NUMBERS (this 20-core box, serial, interleaved, 3 reps, medians; sha256 2 reps): sha256 `apc_001`
+**517 → 182 ms** on the pass, total 23 650 → 23 117 (0.977x); wasm-eth `apc_012` 72 → 20, total
+0.978x; `apc_063` 57 → 16, 0.983x; keccak `apc_001` 90 → 36, 0.975x; openvm-eth `apc_071` 9 → 3,
+0.950x. **Whole local corpus, 303 APCs interleaved: digitFold 1472 → 586 ms (0.398x), wall
+50.6 → 49.7 s (0.981x)**, every family improving — wasm-eth 0.290x, sha256 0.345x, keccak 0.407x,
+openvm-eth 0.437x, SP1 keccak 0.604x, SP1 rsp 0.669x. Six cases read +2 ms in the single-shot corpus
+sweep; re-measured over 5 reps each they are 1 ms quantization on 0–4 ms passes (`apc_031` base
+`[1,4,4,4,2]` vs new `[0,0,1,0,3]`).
+VERIFIED: final `vars / constraints / bus` **identical on all 303 corpus APCs**; `opt-export`
+byte-identical on openvm-eth `apc_051` / `apc_026` / `apc_037` / `apc_071`, keccak `apc_001`,
+wasm-eth `apc_012`, sha256 `apc_001`, SP1 keccak `apc_001`, SP1 rsp `apc_029`; `lake build` clean with
+no warnings; `check-proof-integrity` passes on the three standard axioms.
+
+RESIDUAL, measured with two more stubs (corpus ms of the 570–591 the pass now costs): **linearize +
+ladder solve ~282**, **restricted bounds sweep 115** (`denseBuildWith → ∅`: 591 → 476; concentrated in
+openvm-eth 54, keccak 19, SP1 rsp 19 — already ~10 ms each on sha256 and wasm-eth), **degree guard
+~108** (R5's floor, now 19 % of this pass), **bare interaction walk ~65** (recognizer → `none`:
+570 → 173, minus the guard). So the sweep is only 19 % of what is left and the whole addressable
+remainder is ~0.8 % of corpus wall — sub-bar, deliberately stopped. If it is ever revisited:
+`denseTryLadder` sorts `l.terms` once per sign per form, and `denseAddVars` still resolves
+`denseVarSlot` per kept variable for interactions whose multiplicity is non-constant, where every
+bound is statically `none`.
 
 **Worked: yes.**


### PR DESCRIPTION
`digitFold` built its `VarId → Nat` bounds map over **every raw payload variable of every bus
interaction** — a `facts.slotBound` plus `denseProbedSlotBoundAtP` per entry — and then consulted it
only for the two operands `densePairByteOps?` returns. The pass fires in **55 of 1443 corpus
invocations**; the rest measured the whole system to answer nothing. Stubbing the map to `∅` put
**68 % of the pass** in that build.

## The change

Plan first, bound second.

- `denseFoldPlan` walks the interactions once and, for each recognized byte-pair check, linearizes
  both operands under `denseSolveOperand`'s own `2 ≤ terms.length` gate, keeping the ladder forms in
  scan order together with their variables — exactly the keys the solve can look up, since
  `denseAttemptLadder` reads only `bounds` and the form, at a `mergeSort` permutation of `l.terms`.
- `denseBuildWith … (some keys)` builds for those keys only; an interaction contributing none pays no
  `denseBiPrepOf` and no `facts` call.
- `denseSolveLadders` solves the planned forms in scan order. No form means no lookup, so the map is
  not built at all — the common case.

Recognition and linearization therefore happen **once**. `denseBuild`/`denseAddAll` stay as
`keep? := none` wrappers, so `CarryBranch`, `SeqzCollapse`, `HintCollapse` and `DegenRange` are
untouched.

## Why the output is unchanged

Restricting the keys cannot change a kept key's bound: every insertion for `i` happens on `i`'s own
iteration of `denseAddVars` (including inside `denseGoCands`, which inserts at `i`, not at the probed
candidate), computing a bound never reads the map, and `denseInsertEntry` keeps the tightest per key —
so each key's value is the minimum over its own bounds, independent of the rest. The plan is a
*superset* of the read set, which is the direction that matters: a missing key would turn a `some` into
a `none`.

`denseSolveLadders_eq_findFold` is the equality with the old interaction scan, proved by a plan-walk
induction over an arbitrary accumulator (`denseSolveLadders_foldPlanGo`) plus the per-operand
contribution (`denseFoldOperand_rev`) and `denseSolveLadders_append`. **No obligation about the bounds
themselves broke** — the pass's soundness constrains which bounds are *stored*, never which are
enumerated.

## Numbers

Interleaved against `main`, 3 reps, medians (sha256 2 reps):

| case | pass | total |
|---|---:|---:|
| sha256 `apc_001` | **517 → 182 ms** | 23 650 → 23 117 (0.977×) |
| wasm-eth `apc_012` | 72 → 20 | 0.978× |
| wasm-eth `apc_063` | 57 → 16 | 0.983× |
| keccak `apc_001` | 90 → 36 | 0.975× |
| openvm-eth `apc_071` | 9 → 3 | 0.950× |

**Whole local corpus, 303 APCs, interleaved: digitFold 1472 → 586 ms (0.398×), wall 50.6 → 49.7 s
(0.981×)**, with every family improving:

| family | digitFold | ratio |
|---|---:|---:|
| OpenVM wasm-eth | 365 → 106 | 0.290× |
| OpenVM sha256 | 516 → 178 | 0.345× |
| OpenVM keccak | 91 → 37 | 0.407× |
| OpenVM openvm-eth | 284 → 124 | 0.437× |
| SP1 keccak | 53 → 32 | 0.604× |
| SP1 rsp | 163 → 109 | 0.669× |

Six cases read +2 ms in the single-shot corpus sweep; re-measured over 5 reps each they are 1 ms
quantization on 0–4 ms passes (`apc_031` base `[1,4,4,4,2]` vs new `[0,0,1,0,3]`).

## Verification

- Final `vars / constraints / bus interactions` **identical on all 303 corpus APCs**.
- `opt-export` byte-identical on openvm-eth `apc_051` / `apc_026` / `apc_037` / `apc_071`, keccak
  `apc_001`, wasm-eth `apc_012`, sha256 `apc_001`, **SP1 keccak `apc_001`, SP1 rsp `apc_029`**.
- `lake build` clean with no warnings, no `sorry`; `Scripts/check-proof-integrity.sh` passes on the
  three standard axioms with no orphaned theorem.

## The sequencing trap, worth reading before the next pass of this kind

A first version kept `denseFindFold`'s own walk and added a separate candidate walk in front of it, so
recognition and linearization ran twice. It measured 0.43–0.56× on OpenVM and **1.08–1.13× on SP1** —
18 cases slower on the pass, SP1 rsp wall 1.011× — because SP1's byte-pair checks are dense while its
whole-system sweep was comparatively cheap, so the duplicate cost more than the restriction saved.
Fusing the two walks fixed it *and* improved OpenVM further. A corpus-wide per-pass sweep is what
caught it; the OpenVM representatives all read as clean wins.

## Residual, and why it stops here

Split with two more stubs: linearize + ladder solve ~282 ms, the restricted bounds sweep 115, the
degree guard ~108 (ideas.md R5, now 19 % of this pass), the bare interaction walk ~65. So the obvious
next target is 19 % of what is left and the whole addressable remainder is ~0.8 % of corpus wall —
sub-bar, deliberately left, and recorded in `ideas.md` with what to look at if a corpus ever makes it
matter.

Independent of #282 (branched off `main` so its baseline is clean); rebased onto `main` after that
merged, which is why `ideas.md`'s R15(a) retirement is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
