### PR TITLE
perf(flagUnify): scan for twins first, build the domain bucket only if one is found (0.55x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/FlagUnify.lean
@@ -136,34 +136,58 @@ def denseFuTargets (biX biY : BusInteraction (DenseExpr p)) (x : VarId) :
     | _, _ => []
   | _, _ => []
 
+/-- A matched pair of scaled checks: the earlier interaction, the current one, and their shared
+    carrier — the arguments the pair certificate is taken at. -/
+structure DenseFuMatch (p : ℕ) where
+  biX : BusInteraction (DenseExpr p)
+  biY : BusInteraction (DenseExpr p)
+  x : VarId
+
 /-- Scan the interactions: for each scaled-check candidate, find an earlier twin with the same key
-    and adopt every flag pair the certificate confirms, accumulating into `DenseSolved`. -/
-def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs)
-    (domIdx : Std.HashMap VarId (List (DenseExpr p))) :
-    List (BusInteraction (DenseExpr p)) → Std.HashMap UInt64 (List (DenseFUSeen p)) →
-      DenseSolved p → DenseSolved p
-  | [], _, σ => σ
-  | c :: rest, seen, σ =>
+    and record the match. Reads the interactions alone — `seen` grows the same way whether or not a
+    twin is found — so it runs before any domain bucket exists. Matches come out in scan order.
+    The `seen` insert must stay inside the branches: hoisting it above the lookup leaves `seen`
+    shared there, and every insert then copies the map. -/
+def denseFuScan : List (BusInteraction (DenseExpr p)) →
+    Std.HashMap UInt64 (List (DenseFUSeen p)) → List (DenseFuMatch p) → List (DenseFuMatch p)
+  | [], _, acc => acc.reverse
+  | c :: rest, seen, acc =>
     let cands := denseFuCandidates c
     match cands.findSome? (fun xk =>
         (seen.getD (denseFuKeyHash xk.2) []).findSome? (fun e =>
           if e.key == xk.2 then some (e, xk.1) else none)) with
     | some ex =>
-        -- pair-level work once; per-target checks share it (definitionally `denseFuCheck`)
-        match denseFuPairData? bs facts domIdx ex.1.bi c ex.2 with
-        | none =>
-            denseFuLoop bs facts domIdx rest
-              (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
-        | some d =>
-        let pairs := (denseFuTargets ex.1.bi c ex.2).filterMap (fun t =>
-          if denseFuCheckWith d t.2 t.1
-          then some (t.1, DenseExpr.var t.2) else none)
-        denseFuLoop bs facts domIdx rest
+        denseFuScan rest
           (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p))))
-          (σ.insertAll pairs)
+          (⟨ex.1.bi, c, ex.2⟩ :: acc)
     | none =>
-        denseFuLoop bs facts domIdx rest
-          (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) σ
+        denseFuScan rest
+          (denseFuInsertAll seen (cands.map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))) acc
+
+/-- Certify the recorded matches in scan order, adopting every flag pair confirmed, accumulating
+    into `DenseSolved`. -/
+def denseFuAdopt (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p))) :
+    List (DenseFuMatch p) → DenseSolved p → DenseSolved p
+  | [], σ => σ
+  | m :: rest, σ =>
+    -- pair-level work once; per-target checks share it (definitionally `denseFuCheck`)
+    match denseFuPairData? bs facts domIdx m.biX m.biY m.x with
+    | none => denseFuAdopt bs facts domIdx rest σ
+    | some d =>
+      let pairs := (denseFuTargets m.biX m.biY m.x).filterMap (fun t =>
+        if denseFuCheckWith d t.2 t.1
+        then some (t.1, DenseExpr.var t.2) else none)
+      denseFuAdopt bs facts domIdx rest (σ.insertAll pairs)
+
+/-- Scan and certificates composed, the form the soundness proof (`Proofs/FlagUnify.lean`) inducts
+    on. `denseFlagUnifyF` runs the two phases apart so that the domain bucket, read only by
+    `denseFuPairData?`, is never built when the scan found no match. -/
+def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs)
+    (domIdx : Std.HashMap VarId (List (DenseExpr p)))
+    (pending : List (BusInteraction (DenseExpr p)))
+    (seen : Std.HashMap UInt64 (List (DenseFUSeen p))) (σ : DenseSolved p) : DenseSolved p :=
+  denseFuAdopt bs facts domIdx (denseFuScan pending seen []) σ
 
 /-- Flag unification across duplicate scaled range checks. When two checks decompose over the same
     carrier `x` with equal coefficient (`k*x + R`, `k*x + R'`) and their offsets force flag `vy` to
@@ -172,10 +196,11 @@ def denseFuLoop (bs : BusSemantics p) (facts : BusFacts p bs)
 def denseFlagUnifyF (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
   if pw.isPrime = true then
-    let σ := denseFuLoop bs facts
-        (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
-        DenseSolved.empty
-    if σ.map.isEmpty then d else d.substF σ.fn
+    let ms := denseFuScan d.busInteractions ∅ []
+    if ms.isEmpty then d else
+      let σ := denseFuAdopt bs facts
+          (denseVarBucket DenseExpr.vars d.algebraicConstraints) ms DenseSolved.empty
+      if σ.map.isEmpty then d else d.substF σ.fn
   else d
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/FlagUnify.lean
@@ -334,6 +334,135 @@ theorem denseFuInsertAll_seen {S : List (BusInteraction (DenseExpr p))} :
         · exact hacc (denseFuKeyHash e0.key) e hmem'
       · exact hacc hsh e hmem
 
+/-- Every match the scan records pairs two interactions of the scanned system: the current one is
+    pending, the twin comes out of the `seen` buckets. -/
+theorem denseFuScan_mem {S : List (BusInteraction (DenseExpr p))} :
+    ∀ (pending : List (BusInteraction (DenseExpr p)))
+      (seen : Std.HashMap UInt64 (List (DenseFUSeen p))) (acc : List (DenseFuMatch p)),
+      (∀ bi ∈ pending, bi ∈ S) →
+      (∀ hsh e, e ∈ seen.getD hsh [] → e.bi ∈ S) →
+      (∀ m ∈ acc, m.biX ∈ S ∧ m.biY ∈ S) →
+      ∀ m ∈ denseFuScan pending seen acc, m.biX ∈ S ∧ m.biY ∈ S := by
+  intro pending
+  induction pending with
+  | nil =>
+      intro seen acc _ _ hacc m hm
+      rw [denseFuScan] at hm
+      exact hacc m (List.mem_reverse.1 hm)
+  | cons c rest ih =>
+      intro seen acc hpend hseen hacc
+      have hcmem : c ∈ S := hpend c (List.mem_cons_self ..)
+      have hrest : ∀ bi ∈ rest, bi ∈ S := fun bi h => hpend bi (List.mem_cons_of_mem _ h)
+      have hseen' : ∀ hsh e, e ∈ (denseFuInsertAll seen
+          ((denseFuCandidates c).map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))).getD hsh [] →
+          e.bi ∈ S := by
+        refine denseFuInsertAll_seen _ seen hseen ?_
+        intro e' he'
+        obtain ⟨xk', _hxk', rfl⟩ := List.mem_map.1 he'
+        exact hcmem
+      rw [denseFuScan]
+      cases hf : (denseFuCandidates c).findSome? (fun xk =>
+          (seen.getD (denseFuKeyHash xk.2) []).findSome? (fun e =>
+            if e.key == xk.2 then some (e, xk.1) else none)) with
+      | none =>
+          simp only []
+          exact ih _ acc hrest hseen' hacc
+      | some ex =>
+          simp only []
+          obtain ⟨xk, _hxkmem, hinner⟩ := List.exists_of_findSome?_eq_some hf
+          obtain ⟨e, hemem, hif⟩ := List.exists_of_findSome?_eq_some hinner
+          by_cases hk : (e.key == xk.2) = true
+          · rw [if_pos hk] at hif
+            simp only [Option.some.injEq] at hif
+            have hexbi : ex.1.bi ∈ S := by
+              rw [← hif]; exact hseen (denseFuKeyHash xk.2) e hemem
+            refine ih _ _ hrest hseen' ?_
+            intro m hm
+            rcases List.mem_cons.1 hm with rfl | hm'
+            · exact ⟨hexbi, hcmem⟩
+            · exact hacc m hm'
+          · rw [if_neg hk] at hif
+            exact absurd hif (by simp)
+
+/-- Certifying the recorded matches is sound: the solution map stays entailed (a) and
+    occurrence-closed (b), each adopted `vy = vx` justified by `denseFuCheck_sound`. -/
+theorem denseFuAdopt_sound [Fact p.Prime] (bs : BusSemantics p)
+    (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
+    ∀ (ms : List (DenseFuMatch p)) (σ : DenseSolved p),
+      (∀ m ∈ ms, m.biX ∈ d.busInteractions ∧ m.biY ∈ d.busInteractions) →
+      (∀ denv, d.satisfies bs denv → ∀ i t, σ.fn i = some t → denv i = t.eval denv) →
+      (∀ i t, σ.fn i = some t → ∀ z ∈ t.vars, z ∈ d.occ) →
+      (∀ denv, d.satisfies bs denv → ∀ i t,
+          (denseFuAdopt bs facts
+              (denseVarBucket DenseExpr.vars d.algebraicConstraints) ms σ).fn i
+            = some t → denv i = t.eval denv) ∧
+      (∀ i t, (denseFuAdopt bs facts
+          (denseVarBucket DenseExpr.vars d.algebraicConstraints) ms σ).fn i
+          = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
+  intro ms
+  induction ms with
+  | nil => intro σ _ hσs hσv; exact ⟨hσs, hσv⟩
+  | cons m rest ih =>
+      intro σ hms hσs hσv
+      obtain ⟨hexbi, hcmem⟩ := hms m (List.mem_cons_self ..)
+      have hrest : ∀ m' ∈ rest, m'.biX ∈ d.busInteractions ∧ m'.biY ∈ d.busInteractions :=
+        fun m' h => hms m' (List.mem_cons_of_mem _ h)
+      rw [denseFuAdopt]
+      cases hd0 : denseFuPairData? bs facts
+          (denseVarBucket DenseExpr.vars d.algebraicConstraints) m.biX m.biY m.x with
+      | none =>
+          simp only []
+          exact ih σ hrest hσs hσv
+      | some d0 =>
+          simp only []
+          refine ih (σ.insertAll _) hrest ?_ ?_
+          ·
+            intro denv hsat i t hti
+            refine DenseSolved.insertAll_preserves _ σ
+              (fun i' t' h' => hσs denv hsat i' t' h') ?_ i t hti
+            intro pr hpr
+            obtain ⟨tt, _htt, hpif⟩ := List.mem_filterMap.1 hpr
+            by_cases hck : denseFuCheckWith d0 tt.2 tt.1 = true
+            · rw [if_pos hck] at hpif
+              simp only [Option.some.injEq] at hpif
+              rw [← hpif]
+              show denv tt.1 = denv tt.2
+              have hfc : denseFuCheck bs facts
+                  (denseVarBucket DenseExpr.vars d.algebraicConstraints)
+                  m.biX m.biY m.x tt.2 tt.1 = true := by
+                unfold denseFuCheck; rw [hd0]; exact hck
+              exact denseFuCheck_sound bs facts
+                  (denseVarBucket DenseExpr.vars d.algebraicConstraints) m.biX m.biY m.x
+                tt.2 tt.1 hfc denv (fun v c' hc' => hsat.1 c'
+                  (denseVarBucket_mem DenseExpr.vars d.algebraicConstraints v c' hc'))
+                (hsat.2 m.biX hexbi) (hsat.2 m.biY hcmem)
+            · rw [if_neg hck] at hpif
+              exact absurd hpif (by simp)
+          ·
+            intro i t hti
+            refine DenseSolved.insertAll_preserves
+              (Q := fun i t => ∀ z ∈ t.vars, z ∈ d.occ) _ σ hσv ?_ i t hti
+            intro pr hpr
+            obtain ⟨tt, _htt, hpif⟩ := List.mem_filterMap.1 hpr
+            by_cases hck : denseFuCheckWith d0 tt.2 tt.1 = true
+            · rw [if_pos hck] at hpif
+              simp only [Option.some.injEq] at hpif
+              rw [← hpif]
+              intro z hz
+              simp only [DenseExpr.vars, List.mem_singleton] at hz
+              subst hz
+              have hfc : denseFuCheck bs facts
+                  (denseVarBucket DenseExpr.vars d.algebraicConstraints)
+                  m.biX m.biY m.x tt.2 tt.1 = true := by
+                unfold denseFuCheck; rw [hd0]; exact hck
+              exact DenseConstraintSystem.mem_occ_of_bi hexbi (by
+                simp only [denseBIVars, List.mem_append]
+                exact Or.inr (denseFuCheck_vars bs facts
+                    (denseVarBucket DenseExpr.vars d.algebraicConstraints)
+                  m.biX m.biY m.x tt.2 tt.1 hfc))
+            · rw [if_neg hck] at hpif
+              exact absurd hpif (by simp)
+
 /-- The flagUnify scan loop is sound: the final solution map is entailed (a) and occurrence-closed
     (b), each adopted `vy = vx` justified by `denseFuCheck_sound`. -/
 theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
@@ -351,99 +480,15 @@ theorem denseFuLoop_sound [Fact p.Prime] (bs : BusSemantics p)
       (∀ i t, (denseFuLoop bs facts
           (denseVarBucket DenseExpr.vars d.algebraicConstraints) pending seen σ).fn i
           = some t → ∀ z ∈ t.vars, z ∈ d.occ) := by
-  intro pending
-  induction pending with
-  | nil =>
-      intro seen σ _ _ hσs hσv
-      exact ⟨hσs, hσv⟩
-  | cons c rest ih =>
-      intro seen σ hpend hseen hσs hσv
-      have hcmem : c ∈ d.busInteractions := hpend c (List.mem_cons_self ..)
-      have hrest : ∀ bi ∈ rest, bi ∈ d.busInteractions :=
-        fun bi h => hpend bi (List.mem_cons_of_mem _ h)
-      have hseen' : ∀ hsh e, e ∈ (denseFuInsertAll seen
-          ((denseFuCandidates c).map (fun xk => (⟨c, xk.1, xk.2⟩ : DenseFUSeen p)))).getD hsh [] →
-          e.bi ∈ d.busInteractions := by
-        refine denseFuInsertAll_seen _ seen hseen ?_
-        intro e' he'
-        obtain ⟨xk', _hxk', rfl⟩ := List.mem_map.1 he'
-        exact hcmem
-      rw [denseFuLoop]
-      cases hf : (denseFuCandidates c).findSome? (fun xk =>
-          (seen.getD (denseFuKeyHash xk.2) []).findSome? (fun e =>
-            if e.key == xk.2 then some (e, xk.1) else none)) with
-      | none =>
-          simp only []
-          exact ih _ σ hrest hseen' hσs hσv
-      | some ex =>
-          simp only []
-          cases hd0 : denseFuPairData? bs facts
-              (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2 with
-          | none =>
-              simp only []
-              exact ih _ σ hrest hseen' hσs hσv
-          | some d0 =>
-              simp only []
-              obtain ⟨xk, _hxkmem, hinner⟩ := List.exists_of_findSome?_eq_some hf
-              obtain ⟨e, hemem, hif⟩ := List.exists_of_findSome?_eq_some hinner
-              by_cases hk : (e.key == xk.2) = true
-              · rw [if_pos hk] at hif
-                simp only [Option.some.injEq] at hif
-                have hexbi : ex.1.bi ∈ d.busInteractions := by
-                  rw [← hif]; exact hseen (denseFuKeyHash xk.2) e hemem
-                refine ih _ (σ.insertAll _) hrest hseen' ?_ ?_
-                ·
-                  intro denv hsat i t hti
-                  refine DenseSolved.insertAll_preserves _ σ
-                    (fun i' t' h' => hσs denv hsat i' t' h') ?_ i t hti
-                  intro pr hpr
-                  obtain ⟨tt, _htt, hpif⟩ := List.mem_filterMap.1 hpr
-                  by_cases hck : denseFuCheckWith d0 tt.2 tt.1 = true
-                  · rw [if_pos hck] at hpif
-                    simp only [Option.some.injEq] at hpif
-                    rw [← hpif]
-                    show denv tt.1 = denv tt.2
-                    have hfc : denseFuCheck bs facts
-                        (denseVarBucket DenseExpr.vars d.algebraicConstraints)
-                        ex.1.bi c ex.2 tt.2 tt.1 = true := by
-                      unfold denseFuCheck; rw [hd0]; exact hck
-                    exact denseFuCheck_sound bs facts
-                        (denseVarBucket DenseExpr.vars d.algebraicConstraints) ex.1.bi c ex.2
-                      tt.2 tt.1 hfc denv (fun v c' hc' => hsat.1 c'
-                        (denseVarBucket_mem DenseExpr.vars d.algebraicConstraints v c' hc'))
-                      (hsat.2 ex.1.bi hexbi) (hsat.2 c hcmem)
-                  · rw [if_neg hck] at hpif
-                    exact absurd hpif (by simp)
-                ·
-                  intro i t hti
-                  refine DenseSolved.insertAll_preserves
-                    (Q := fun i t => ∀ z ∈ t.vars, z ∈ d.occ) _ σ hσv ?_ i t hti
-                  intro pr hpr
-                  obtain ⟨tt, _htt, hpif⟩ := List.mem_filterMap.1 hpr
-                  by_cases hck : denseFuCheckWith d0 tt.2 tt.1 = true
-                  · rw [if_pos hck] at hpif
-                    simp only [Option.some.injEq] at hpif
-                    rw [← hpif]
-                    intro z hz
-                    simp only [DenseExpr.vars, List.mem_singleton] at hz
-                    subst hz
-                    have hfc : denseFuCheck bs facts
-                        (denseVarBucket DenseExpr.vars d.algebraicConstraints)
-                        ex.1.bi c ex.2 tt.2 tt.1 = true := by
-                      unfold denseFuCheck; rw [hd0]; exact hck
-                    exact DenseConstraintSystem.mem_occ_of_bi hexbi (by
-                      simp only [denseBIVars, List.mem_append]
-                      exact Or.inr (denseFuCheck_vars bs facts
-                          (denseVarBucket DenseExpr.vars d.algebraicConstraints)
-                        ex.1.bi c ex.2 tt.2 tt.1 hfc))
-                  · rw [if_neg hck] at hpif
-                    exact absurd hpif (by simp)
-              · rw [if_neg hk] at hif
-                exact absurd hif (by simp)
+  intro pending seen σ hpend hseen hσs hσv
+  rw [denseFuLoop]
+  exact denseFuAdopt_sound bs facts d _ σ
+    (denseFuScan_mem pending seen [] hpend hseen (by simp)) hσs hσv
 
 /-! ## The dense `flagUnify` pass -/
 
-/-- `denseFlagUnifyF` re-expressed with the loop's solution map named, for the proofs below. -/
+/-- `denseFlagUnifyF` re-expressed with the loop's solution map named, for the proofs below. The
+    scan's empty-match gate is redundant on values: no match adopts nothing. -/
 theorem denseFlagUnifyF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     denseFlagUnifyF pw bs facts d
@@ -454,7 +499,15 @@ theorem denseFlagUnifyF_eq (pw : PrimeWitness p) (bs : BusSemantics p) (facts : 
            else d.substF (denseFuLoop bs facts
                (denseVarBucket DenseExpr.vars d.algebraicConstraints) d.busInteractions ∅
                 DenseSolved.empty).fn)
-         else d) := rfl
+         else d) := by
+  by_cases hp : pw.isPrime = true
+  · cases hms : denseFuScan d.busInteractions
+        (∅ : Std.HashMap UInt64 (List (DenseFUSeen p))) [] with
+    | nil =>
+        simp [denseFlagUnifyF, denseFuLoop, hp, hms, denseFuAdopt, DenseSolved.empty]
+    | cons m rest =>
+        simp [denseFlagUnifyF, denseFuLoop, hp, hms]
+  · simp [denseFlagUnifyF, hp]
 
 /-- The final loop solution map is entailed and occurrence-closed (`denseFuLoop_sound` at `∅`). -/
 theorem denseFlagUnify_loop_invariant [Fact p.Prime] (bs : BusSemantics p)

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -797,12 +797,16 @@ increasing effort:
   candidate walk measured 1.08–1.13x on SP1, where dense byte-pair checks made the duplicated
   recognition cost more than the restriction saved), and **sweep the whole corpus per pass before
   believing a representative set** (the OpenVM representatives all read as clean wins). Its residual is
-  in *digitFold residual after entry 176* below. `flagUnify` **1073 → 456 ms** (58 %) is
-  `denseVarBucket DenseExpr.vars` read only inside `denseFuPairData?`, i.e. only once a same-key twin
-  is found — **18 times in the whole corpus** — so here `denseThunkIf` is the fix and the `Thunk` note
-  above does not bite (the value is almost never forced, unlike the `cands` dead end). Audit every
-  pass for this shape: an index built at the top of the body, consumed inside a certificate a
-  prefilter rarely reaches.
+  in *digitFold residual after entry 176* below. ~~`flagUnify` **1073 → 456 ms** (58 %)~~ **done
+  (entry 177)**, 0.546x on the pass: the scan runs first and the bucket is built only when it recorded a
+  twin. **An earlier version of this item said a `Thunk` was the fix here; that was wrong.**
+  `denseVarBucket` stores the *items themselves* (`VarBucket.lean:23`), so a bucket over
+  `d.algebraicConstraints` aliases every expression tree in the system, and forcing a `Thunk.mk` over it
+  `lean_mark_mt`s that whole graph — after which `lean_is_exclusive` is `false` for those objects forever
+  and reset/reuse is dead for the rest of the run. Split the phases instead; its residual is in
+  *flagUnify residual after entry 177* below. Audit every pass for this shape: an index built at the top
+  of the body, consumed inside a certificate a prefilter rarely reaches — and check what the index
+  *holds* before reaching for laziness.
 - **(b) A quadratic rescan inside a no-op pass** — `tupleRange`, **done (entry 175)**, 0.08x on the
   pass. Worth re-checking for the same shape elsewhere: a per-candidate scan of the whole remainder
   whose failure the outer loop cannot learn from.
@@ -832,6 +836,18 @@ makes it matter: `denseTryLadder` sorts `l.terms` once per sign per form, and `d
 resolves `denseVarSlot` per kept variable for interactions whose multiplicity is non-constant, where
 every bound is statically `none`. The lesson worth keeping is the method — stub the two halves
 separately before designing, because the named half was not the expensive one.
+
+### flagUnify residual after entry 177 (the scanned-then-built bucket)  ·  *runtime*
+
+576 ms corpus-wide against a 456 ms `∅`-stub bound, and the whole gap is **sha256**. gdb hit counts on
+`denseFuAdopt`: wasm-eth `apc_012` finds a twin in **0 of 9** invocations, keccak **0 of 10** — those
+reach the bound, and what is left there is the scan itself — while sha256 finds matches in **6 of 11**,
+**701 of them, every one failing the certificate**, so it still builds the bucket six times (0.587x on
+that case, which is 571 of the 1054 ms baseline). Two levers, both unsized: a cheaper pre-filter before
+the bucket is needed (701 matches producing 0 adoptions means `denseFuPairData?`'s
+multiplicity/`slotBound`/`splitAt`/no-wrap prefix rejects *late*), or a bucket restricted to the joint
+offset variables the certificate actually queries, which makes the build proportional to the match
+rather than to the system — the entry-176 shape one level finer.
 
 ### tupleRange residual after entry 175 (the single-pass scan)  ·  *runtime*
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -6945,3 +6945,65 @@ remainder is ~0.8 % of corpus wall — sub-bar, deliberately stopped. If it is e
 bound is statically `none`.
 
 **Worked: yes.**
+
+### 177. Runtime: flagUnify scans for twins before building its domain bucket (0.39–0.65x on the pass)
+
+`denseFlagUnifyF` built `denseVarBucket DenseExpr.vars d.algebraicConstraints` — a whole-system
+per-variable index — on **every** invocation and passed it to `denseFuLoop` as `domIdx`. It is read at
+exactly one place (inside `denseFuPairData?`), which the loop reaches only once a same-key twin has been
+found, and the pass changes its output in **18 of 1443 corpus invocations**. Stubbing the bucket to `∅`
+(upper bound) measured corpus **1073 → 456 ms, 58 % of the pass**. Same shape as entry 176's digitFold
+prologue; this is R15(a)'s second half.
+
+THE CHANGE: split the loop into its two independent halves. `denseFuScan` walks the interactions with
+the same candidates, key search and `denseFuInsertAll`, recording each match `(biX, biY, x)` in scan
+order — `seen` grows identically in all three of the old branches, so the scan never depended on
+`domIdx`. `denseFuAdopt` certifies the recorded matches in order. `denseFlagUnifyF` runs the scan first
+and returns the input when it found nothing. `denseFuLoop` keeps its signature as
+`denseFuAdopt … (denseFuScan …)` — the form the proof inducts on — and the adopt phase recomputes
+nothing the scan did (the digitFold trap, avoided by construction here).
+
+WHY IT IS VALUE-IDENTICAL: `seen` and the match list are functions of the interactions alone, and `σ`
+receives the same `insertAll` calls with the same pair lists in the same order, so the empty-match gate
+is value-redundant (`denseFlagUnifyF_eq`). Soundness splits the same way: `denseFuScan_mem` (both
+interactions of a recorded match belong to the system) feeds `denseFuAdopt_sound`, which is the old
+inner argument unchanged. `denseFuCheck_sound`/`denseFuCheck_vars` stay live through it.
+
+**NO `Thunk` — deliberately.** `denseVarBucket` stores the *items themselves* (`VarBucket.lean:23`), so
+with `items = d.algebraicConstraints` the bucket aliases every expression tree in the system. Forcing a
+`Thunk.mk` over it runs `lean_thunk_get_core` → `lean_mark_mt`, which walks transitively and marks that
+whole graph multi-threaded; `lean_is_exclusive` then returns `false` for those objects **forever**
+(4.30 `lean_is_exclusive`: `lean_is_st(o) && rc == 1`, else `false`), so reset/reuse cannot rebuild them
+in place and every downstream pass pays. `Thunk.pure` avoids the mark but also the laziness. The
+two-phase split avoids the hazard instead of betting on how often it triggers. **Correcting R15(a)**,
+which said a `Thunk` was the fix here.
+
+**A second exclusivity trap, measured:** hoisting `let seen' := denseFuInsertAll seen …` above the key
+lookup is value-identical and **3.1x slower on sha256 (581 → 1812 ms)** — with `seen` still live at the
+lookup its refcount is above one, so `Std.HashMap.insert` loses exclusivity and copies the whole map per
+interaction. The insert must stay inside each branch; the code carries a comment saying so.
+
+NUMBERS (this 20-core box, serial, interleaved, 3 reps, medians; sha256 2 reps): sha256 `apc_001`
+**584 → 336 ms** on the pass, total 22 331 → 22 014 (0.986x); wasm-eth `apc_063` 45 → 14, 0.991x;
+`apc_012` 55 → 21, 0.988x; keccak `apc_001` 42 → 22, 0.990x; openvm-eth `apc_005` (fires) 12 → 9,
+0.995x; `apc_071` 3 → 2. **Whole local corpus, 303 APCs interleaved: flagUnify 1054 → 576 ms (0.546x),
+wall 48.4 → 47.9 s (0.991x)**, every family improving — wasm-eth 0.386x, SP1 keccak 0.429x, SP1 rsp
+0.464x, keccak 0.541x, sha256 0.587x, openvm-eth 0.651x. One case read +2 ms in the single-shot corpus
+sweep (SP1 rsp `apc_019`); 5 reps give base `[0,0,0,1,1]` vs new `[0,0,0,0,1]`.
+VERIFIED: final `vars / constraints / bus` **identical on all 303 corpus APCs**; `opt-export`
+byte-identical on openvm-eth `apc_005` / `apc_015` / `apc_067` / `apc_009` / `apc_075`, wasm-eth
+`apc_011` / `apc_012`, keccak `apc_001`, sha256 `apc_001`; `lake build` clean with no warnings;
+`check-proof-integrity` passes on the three standard axioms with no unused theorem.
+
+WHY IT STOPS AT 0.546x and not the 456 ms bound — gdb hit counts on `denseFuAdopt` (entered once per
+invocation with ≥1 match, i.e. once per bucket build) and on its `denseFuPairData?` call site:
+wasm-eth `apc_012` **0 of 9** invocations find a match, keccak **0 of 10**, openvm-eth `apc_005` 2 of 6
+(64 matches) — those cases hit the stub bound and their residual is the scan itself. **sha256 finds
+matches in 6 of its 11 invocations — 701 of them, every one failing the certificate** — so it still
+builds the bucket 6 times and reaches only 0.587x, and since sha256 is 571 of the 1054 ms baseline it
+sets the corpus number. The next lever there is either a cheaper pre-filter (701 matches, 0 adoptions,
+so `denseFuPairData?`'s multiplicity/`slotBound`/`splitAt`/no-wrap prefix rejects late) or a bucket
+restricted to the joint offset variables actually queried, which would make the build proportional to
+the match rather than to the system.
+
+**Worked: yes.**


### PR DESCRIPTION
`denseFlagUnifyF` built `denseVarBucket DenseExpr.vars d.algebraicConstraints` — a whole-system
per-variable index — on **every** invocation and passed it to the loop as `domIdx`. It is read at
exactly one place, inside `denseFuPairData?`, which the loop reaches only once a same-key twin has been
found; the pass changes its output in **18 of 1443 corpus invocations**. Stubbing the bucket to `∅` put
**58 % of the pass** in that build.

## The change

The loop splits into its two independent halves:

- **`denseFuScan`** walks the interactions with the same candidates, the same key search and the same
  `denseFuInsertAll`, recording each match `(biX, biY, x)` in scan order. `seen` grows identically in
  all three of the old branches, so the scan never depended on `domIdx`.
- **`denseFuAdopt`** certifies the recorded matches in order — the old inner half, verbatim.
- **`denseFlagUnifyF`** runs the scan first and returns the input when it recorded nothing, so the
  bucket is built only on invocations that can use it.

`denseFuLoop` keeps its signature as `denseFuAdopt … (denseFuScan …)`, which is what the soundness proof
inducts on, and the adopt phase recomputes nothing the scan did.

## Why the output is unchanged

`seen` and the match list are functions of the interactions alone, and `σ` receives the same
`insertAll` calls with the same pair lists in the same order — so the empty-match gate is redundant on
values (`denseFlagUnifyF_eq`). Soundness splits the same way: **`denseFuScan_mem`** (both interactions
of a recorded match belong to the system) feeds **`denseFuAdopt_sound`** (the old argument, unchanged,
justified by `denseFuCheck_sound`).

## Two exclusivity traps, both measured

Worth reading before the next pass of this kind — neither is about thunks being slow to allocate.

1. **No `Thunk` here.** `denseVarBucket` stores the *items themselves* (`VarBucket.lean:23`), so a
   bucket over `d.algebraicConstraints` aliases every expression tree in the system. Forcing a
   `Thunk.mk` over it runs `lean_thunk_get_core` → `lean_mark_mt`, which walks transitively and marks
   that whole graph multi-threaded; `lean_is_exclusive` then returns `false` for those objects **forever**
   (4.30: `lean_is_st(o) && rc == 1`, else `false`), so reset/reuse cannot rebuild them in place and
   every downstream pass pays. `Thunk.pure` avoids the mark but also the laziness. The phase split
   avoids the hazard instead of betting on how often it triggers. This corrects `ideas.md` R15(a),
   which recommended a `Thunk` here.
2. **The `seen` insert must stay inside each branch of the scan.** Hoisting
   `let seen' := denseFuInsertAll seen …` above the key lookup is value-identical and **3.1× slower on
   sha256 (581 → 1812 ms)**: with `seen` still live at the lookup its refcount is above one, so
   `Std.HashMap.insert` loses exclusivity and copies the whole map per interaction. The code carries a
   comment saying so.

## Numbers

Interleaved against `main` (7e9ff99), 3 reps, medians (sha256 2 reps):

| case | pass | total |
|---|---:|---:|
| sha256 `apc_001` | **584 → 336 ms** | 22 331 → 22 014 (0.986×) |
| wasm-eth `apc_063` | 45 → 14 | 0.991× |
| wasm-eth `apc_012` | 55 → 21 | 0.988× |
| keccak `apc_001` | 42 → 22 | 0.990× |
| openvm-eth `apc_005` (fires) | 12 → 9 | 0.995× |

**Whole local corpus, 303 APCs, interleaved: flagUnify 1054 → 576 ms (0.546×), wall 48.4 → 47.9 s
(0.991×)**, every family improving:

| family | flagUnify | ratio |
|---|---:|---:|
| OpenVM wasm-eth | 236 → 91 | 0.386× |
| SP1 keccak | 7 → 3 | 0.429× |
| SP1 rsp | 28 → 13 | 0.464× |
| OpenVM keccak | 37 → 20 | 0.541× |
| OpenVM sha256 | 571 → 335 | 0.587× |
| OpenVM openvm-eth | 175 → 114 | 0.651× |

One case read +2 ms in the single-shot corpus sweep (SP1 rsp `apc_019`); at 5 reps it is
base `[0,0,0,1,1]` vs new `[0,0,0,0,1]`.

## Verification

- Final `vars / constraints / bus interactions` **identical on all 303 corpus APCs**.
- `opt-export` byte-identical on openvm-eth `apc_005` / `apc_015` / `apc_067` / `apc_009` / `apc_075`,
  wasm-eth `apc_011` / `apc_012`, keccak `apc_001`, sha256 `apc_001` — six of those fire the pass.
- `lake build` clean, no warnings, no `sorry`; `check-proof-integrity.sh` passes on the three standard
  axioms with no unused theorem.

## Why it stops at 0.546× and not the 456 ms bound

gdb hit counts on `denseFuAdopt` (entered once per invocation with ≥1 match, i.e. once per bucket
build): wasm-eth `apc_012` finds a twin in **0 of 9** invocations, keccak **0 of 10** — those hit the
stub bound, and what remains there is the scan itself. **sha256 finds matches in 6 of its 11
invocations — 701 of them, every one failing the certificate** — so it still builds the bucket six times
and reaches 0.587×; since sha256 is 571 of the 1054 ms baseline, it sets the corpus number. Recorded in
`ideas.md` with the two unsized levers (a cheaper pre-filter, since 701 matches producing 0 adoptions
means `denseFuPairData?` rejects late; or a bucket restricted to the joint offset variables the
certificate actually queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
