### PR TITLE
perf(zeroRegister): drop the always-true occ conjunct, memoize facts.zeroCell per bus (0.19x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/EntailedCheck.lean
@@ -165,6 +165,25 @@ theorem DensePassCorrect.denseFilterBusEntailed (d : DenseConstraintSystem p) (b
 
 /-! ## The append-only pass builder -/
 
+/-- The system with `new` appended to its constraints. -/
+def denseAddedCS (d : DenseConstraintSystem p) (new : List (DenseExpr p)) :
+    DenseConstraintSystem p :=
+  { d with algebraicConstraints := d.algebraicConstraints ++ new }
+
+/-- `List.append` is strict in its first argument, so an append-only pass that emits nothing would
+    otherwise copy the whole constraint list on every no-op invocation. -/
+def denseAddedCSFast (d : DenseConstraintSystem p) (new : List (DenseExpr p)) :
+    DenseConstraintSystem p :=
+  match new with
+  | [] => d
+  | _ => { d with algebraicConstraints := d.algebraicConstraints ++ new }
+
+@[csimp] theorem denseAddedCS_eq_fast : @denseAddedCS = @denseAddedCSFast := by
+  funext q d new
+  cases new with
+  | nil => simp [denseAddedCS, denseAddedCSFast]
+  | cons a t => rfl
+
 /-- Build a pass appending system-entailed constraints: the obligations are variable containment
     (`hvars`) and entailment on admissible satisfying assignments (`hsound`). -/
 def DenseVerifiedPassW.ofAddConstraints
@@ -177,17 +196,20 @@ def DenseVerifiedPassW.ofAddConstraints
     DenseVerifiedPassW p :=
   DenseVerifiedPassW.of
     (fun bs facts d =>
-      { d with algebraicConstraints := d.algebraicConstraints ++ news bs facts d })
+      denseAddedCS d (news bs facts d))
     (fun _ _ _ => [])
     (fun reg bs facts d hcov => by
       refine ⟨fun e he => ?_, hcov.2⟩
+      unfold denseAddedCS at he
       rcases List.mem_append.1 he with h | h
       · exact hcov.1 e h
       · intro i hi
         exact DenseConstraintSystem.occ_valid hcov i (hvars bs facts d e h i hi))
     (fun _ _ _ _ _ => by intro x hx; simp at hx)
-    (fun reg bs facts d _ => DensePassCorrect.denseAddConstraints d bs (news bs facts d)
-      (hvars bs facts d) (hsound bs facts d))
+    (fun reg bs facts d _ => by
+      unfold denseAddedCS
+      exact DensePassCorrect.denseAddConstraints d bs (news bs facts d)
+        (hvars bs facts d) (hsound bs facts d))
 
 /-! ## Check-rule passes -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ZeroRegister.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/ZeroRegister.lean
@@ -79,22 +79,282 @@ def denseCollectZeroCells (d : DenseConstraintSystem p) (bs : BusSemantics p) (f
           denv hadm c h
       · exact hacc denv hadm c h⟩
 
-/-- The filtered fixed-zero data-limb equalities the pass appends (`d.occ` bound once). -/
+/-- Membership in the collected list means membership in some pending interaction's cell
+    expressions. -/
+theorem denseCollectZeroCells_eq (d : DenseConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) :
+    ∀ (pending : List (BusInteraction (DenseExpr p))) (h : ∀ bi ∈ pending, bi ∈ d.busInteractions),
+      (denseCollectZeroCells d bs facts pending h).1
+        = pending.flatMap (denseCellZeroExprs bs facts)
+  | [], _ => rfl
+  | bi :: rest, h => by
+    show denseCellZeroExprs bs facts bi ++ (denseCollectZeroCells d bs facts rest _).1 = _
+    rw [denseCollectZeroCells_eq d bs facts rest, List.flatMap_cons]
+
+/-- Every variable of a cell expression is a variable of its interaction: the expression is a
+    payload slot (or the constant `0`, which has none). -/
+theorem denseCellZeroExprs_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (c : DenseExpr p)
+    (hc : c ∈ denseCellZeroExprs bs facts bi) : ∀ z ∈ c.vars, z ∈ denseBIVars bi := by
+  intro z hz
+  unfold denseCellZeroExprs at hc
+  split at hc
+  · exact absurd hc (by simp)
+  · split at hc
+    · exact absurd hc (by simp)
+    · split at hc
+      · rw [List.mem_map] at hc
+        obtain ⟨slot, _, rfl⟩ := hc
+        cases hpsl : bi.payload[slot]? with
+        | none => rw [hpsl] at hz; simp [DenseExpr.vars] at hz
+        | some e =>
+          rw [hpsl, Option.getD_some] at hz
+          exact List.mem_append_right _ (List.mem_flatMap.2 ⟨e, List.mem_of_getElem? hpsl, hz⟩)
+      · exact absurd hc (by simp)
+
+/-! ## The prepared-table scan equals the collect-then-filter form -/
+
+/-- The prepared address list of a bus id, as `denseZeroCellTable` stores it. -/
+private def wrapAddr (addrReq : List (Nat × ZMod p)) : List (Nat × DenseExpr p) :=
+  addrReq.map (fun ar => (ar.1, DenseExpr.const ar.2))
+
+/-- Only buses that declare a fixed-zero cell reach the table, with the shape `facts` gives. -/
+theorem denseZeroCellTable_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (id : Nat) (zc : DenseZeroCell p)
+    (h : (id, zc) ∈ denseZeroCellTable bs facts bis) :
+    ∃ addrReq dataSlots, facts.zeroCell id = some (addrReq, dataSlots) ∧
+      zc = (wrapAddr addrReq, dataSlots) := by
+  rw [denseZeroCellTable, List.mem_filterMap] at h
+  obtain ⟨id', _, hf⟩ := h
+  cases hzc : facts.zeroCell id' with
+  | none => rw [hzc] at hf; exact absurd hf (by simp)
+  | some ad =>
+    obtain ⟨addrReq, dataSlots⟩ := ad
+    rw [hzc] at hf
+    simp only [Option.some.injEq, Prod.mk.injEq] at hf
+    obtain ⟨rfl, rfl⟩ := hf
+    exact ⟨addrReq, dataSlots, hzc, rfl⟩
+
+/-- The seen-set fold only grows. -/
+theorem denseBusIds_mono (bis : List (BusInteraction (DenseExpr p))) :
+    ∀ (init : List Nat) (x : Nat), x ∈ init → x ∈ bis.foldl denseBusIdStep init := by
+  induction bis with
+  | nil => intro _ _ h; exact h
+  | cons bi rest ih =>
+    intro init x hx
+    refine ih (denseBusIdStep init bi) x ?_
+    unfold denseBusIdStep
+    split
+    · exact hx
+    · exact List.mem_cons_of_mem _ hx
+
+/-- Every interaction's bus id is in the seen set. -/
+theorem denseBusIds_mem (bis : List (BusInteraction (DenseExpr p))) :
+    ∀ (init : List Nat) (bi : BusInteraction (DenseExpr p)), bi ∈ bis →
+      bi.busId ∈ bis.foldl denseBusIdStep init := by
+  induction bis with
+  | nil => intro _ _ h; exact absurd h (by simp)
+  | cons b rest ih =>
+    intro init bi hbi
+    rcases List.mem_cons.1 hbi with rfl | hrest
+    · refine denseBusIds_mono rest (denseBusIdStep init bi) bi.busId ?_
+      unfold denseBusIdStep
+      split
+      · rename_i hcon; exact List.mem_of_elem_eq_true hcon
+      · exact List.mem_cons_self ..
+    · exact ih (denseBusIdStep init b) bi hrest
+
+/-- Every bus that declares a fixed-zero cell and carries an interaction is in the table. -/
+theorem denseZeroCellTable_complete (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (bi : BusInteraction (DenseExpr p)) (hbi : bi ∈ bis)
+    (addrReq : List (Nat × ZMod p)) (dataSlots : List Nat)
+    (hzc : facts.zeroCell bi.busId = some (addrReq, dataSlots)) :
+    (bi.busId, (wrapAddr addrReq, dataSlots)) ∈ denseZeroCellTable bs facts bis := by
+  rw [denseZeroCellTable, List.mem_filterMap]
+  exact ⟨bi.busId, denseBusIds_mem bis [] bi hbi, by rw [hzc]; rfl⟩
+
+/-- The prepared address test is the `zeroCell` address requirement. -/
+theorem denseAddrPinned_eq (payload : List (DenseExpr p)) (addrReq : List (Nat × ZMod p)) :
+    denseAddrPinned payload (wrapAddr addrReq)
+      = addrReq.all (fun ar => decide (payload[ar.1]? = some (DenseExpr.const ar.2))) := by
+  induction addrReq with
+  | nil => rfl
+  | cons ar rest ih =>
+    show denseAddrPinned payload ((ar.1, DenseExpr.const ar.2) :: wrapAddr rest) = _
+    rw [denseAddrPinned, List.all_cons, ih]
+    cases hp : payload[ar.1]? with
+    | none => simp
+    | some e => simp only [Option.some.injEq]; rfl
+
+/-- Folding the data slots accumulates the kept slot expressions in reverse. Slots outside the
+    payload contribute `const 0`, which `keep` rejects (`hkeep`). -/
+theorem denseZeroCellEmit_slots (keep : DenseExpr p → Bool)
+    (hkeep : keep (DenseExpr.const 0) = false) (payload : List (DenseExpr p)) (slots : List Nat) :
+    ∀ acc : List (DenseExpr p),
+      slots.foldl (fun a slot =>
+          match payload[slot]? with
+          | some e => if keep e then e :: a else a
+          | none => a) acc
+        = ((slots.map (fun slot => (payload[slot]?).getD (DenseExpr.const 0))).filter keep).reverse
+            ++ acc := by
+  induction slots with
+  | nil => intro acc; rfl
+  | cons s rest ih =>
+    intro acc
+    rw [List.map_cons, List.foldl_cons, ih]
+    cases hp : payload[s]? with
+    | none => simp [hkeep]
+    | some e =>
+      simp only [Option.getD_some, List.filter_cons]
+      cases keep e <;> simp
+
+private theorem not_zmodIsZero_eq (c : ZMod p) : (!zmodIsZero c) = decide (c ≠ 0) := by
+  show (!zmodIsZero c) = decide ¬(c = 0)
+  rw [zmodIsZero_eq, decide_not]
+
+/-- `denseCellZeroExprs` written in the table's prepared terms. -/
+theorem denseCellZeroExprs_of (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) (addrReq : List (Nat × ZMod p)) (dataSlots : List Nat)
+    (hzc : facts.zeroCell bi.busId = some (addrReq, dataSlots)) :
+    denseCellZeroExprs bs facts bi
+      = match bi.multiplicity.constValue? with
+        | none => []
+        | some c =>
+          if !zmodIsZero c && denseAddrPinned bi.payload (wrapAddr addrReq) then
+            dataSlots.map (fun slot => (bi.payload[slot]?).getD (DenseExpr.const 0))
+          else [] := by
+  rw [denseCellZeroExprs, hzc, denseAddrPinned_eq]
+  cases bi.multiplicity.constValue? with
+  | none => rfl
+  | some c => dsimp only; rw [not_zmodIsZero_eq]
+
+/-- One interaction's contribution to the sweep is its cell expressions, filtered and reversed. -/
+theorem denseZeroCellEmit_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (keep : DenseExpr p → Bool)
+    (hkeep : keep (DenseExpr.const 0) = false) (bi : BusInteraction (DenseExpr p)) (hbi : bi ∈ bis)
+    (acc : List (DenseExpr p)) :
+    denseZeroCellEmit (denseZeroCellTable bs facts bis) keep bi acc
+      = ((denseCellZeroExprs bs facts bi).filter keep).reverse ++ acc := by
+  -- The table entry the sweep finds first is sound, so it carries `facts.zeroCell`'s shape
+  -- whichever entry it is; completeness supplies one when the bus declares a cell.
+  have key : ∀ tbl : List (Nat × DenseZeroCell p),
+      (∀ id zc, (id, zc) ∈ tbl → ∃ addrReq dataSlots,
+        facts.zeroCell id = some (addrReq, dataSlots) ∧ zc = (wrapAddr addrReq, dataSlots)) →
+      (∀ addrReq dataSlots, facts.zeroCell bi.busId = some (addrReq, dataSlots) →
+        (bi.busId, (wrapAddr addrReq, dataSlots)) ∈ tbl) →
+      denseZeroCellEmit tbl keep bi acc
+        = ((denseCellZeroExprs bs facts bi).filter keep).reverse ++ acc := by
+    intro tbl
+    induction tbl with
+    | nil =>
+      intro _ hcomp
+      cases hzc : facts.zeroCell bi.busId with
+      | none => rw [denseZeroCellEmit, denseCellZeroExprs, hzc]; rfl
+      | some ad => exact absurd (hcomp ad.1 ad.2 (by rw [hzc])) (by simp)
+    | cons entry rest ih =>
+      intro hsound hcomp
+      obtain ⟨id, addr, slots⟩ := entry
+      show (if bi.busId == id then _ else denseZeroCellEmit rest keep bi acc) = _
+      by_cases hid : bi.busId = id
+      · subst hid
+        obtain ⟨addrReq, dataSlots, hzc, hshape⟩ :=
+          hsound bi.busId (addr, slots) (List.mem_cons_self ..)
+        simp only [Prod.mk.injEq] at hshape
+        obtain ⟨rfl, rfl⟩ := hshape
+        rw [if_pos (beq_self_eq_true _), denseCellZeroExprs_of bs facts bi _ _ hzc]
+        cases bi.multiplicity.constValue? with
+        | none => rw [List.filter_nil, List.reverse_nil, List.nil_append]
+        | some c =>
+          dsimp only
+          by_cases hcond : (!zmodIsZero c && denseAddrPinned bi.payload (wrapAddr addrReq)) = true
+          · rw [if_pos hcond, if_pos hcond]
+            exact denseZeroCellEmit_slots keep hkeep bi.payload slots acc
+          · rw [if_neg hcond, if_neg hcond, List.filter_nil, List.reverse_nil, List.nil_append]
+      · rw [if_neg (by simpa using hid)]
+        refine ih (fun i z hz => hsound i z (List.mem_cons_of_mem _ hz)) ?_
+        intro addrReq dataSlots hzc
+        rcases List.mem_cons.1 (hcomp addrReq dataSlots hzc) with heq | hrest
+        · exact absurd (congrArg Prod.fst heq) hid
+        · exact hrest
+  exact key (denseZeroCellTable bs facts bis) (denseZeroCellTable_sound bs facts bis)
+    (fun a s h => denseZeroCellTable_complete bs facts bis bi hbi a s h)
+
+/-- The whole sweep accumulates the filtered candidates in reverse. -/
+theorem denseZeroCellSweep_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) (keep : DenseExpr p → Bool)
+    (hkeep : keep (DenseExpr.const 0) = false) :
+    ∀ (todo : List (BusInteraction (DenseExpr p))), (∀ bi ∈ todo, bi ∈ bis) →
+      ∀ acc : List (DenseExpr p),
+        todo.foldl (fun a bi => denseZeroCellEmit (denseZeroCellTable bs facts bis) keep bi a) acc
+          = (todo.flatMap (fun bi => (denseCellZeroExprs bs facts bi).filter keep)).reverse ++ acc
+  | [], _, _ => rfl
+  | bi :: rest, hsub, acc => by
+    rw [List.foldl_cons,
+      denseZeroCellEmit_eq bs facts bis keep hkeep bi (hsub bi (List.mem_cons_self ..)) acc,
+      denseZeroCellSweep_eq bs facts bis keep hkeep rest
+        (fun b hb => hsub b (List.mem_cons_of_mem _ hb)),
+      List.flatMap_cons, List.reverse_append, List.append_assoc]
+
+/-- The prepared-table scan: one `facts.zeroCell` per distinct bus id, then one allocation-free
+    left-to-right sweep emitting the surviving candidates. -/
+def denseZeroRegisterNewFast (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : List (DenseExpr p) :=
+  match denseZeroCellTable bs facts d.busInteractions with
+  | [] => []
+  | tbl =>
+    (d.busInteractions.foldl
+      (fun acc bi => denseZeroCellEmit tbl (denseZeroPred d.algebraicConstraints) bi acc) []).reverse
+
+/-- The filtered fixed-zero data-limb equalities the pass appends. -/
 def denseZeroRegisterNew (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
     List (DenseExpr p) :=
-  let exprs := (denseCollectZeroCells d bs facts d.busInteractions (fun _ h => h)).1
-  let dVars := d.occ
-  exprs.filter (denseZeroPred d dVars)
+  (denseCollectZeroCells d bs facts d.busInteractions (fun _ h => h)).1.filter
+    (denseZeroPred d.algebraicConstraints)
 
-/-- Every variable of a surviving candidate occurs in `d` (the filter's third conjunct). -/
+/-- `denseZeroPred` rejects the constant `0`, which is what an out-of-range data slot yields. -/
+theorem denseZeroPred_const_zero (cs : List (DenseExpr p)) :
+    denseZeroPred cs (DenseExpr.const 0) = false := by
+  simp [denseZeroPred, DenseExpr.normalize, DenseExpr.fold, DenseExpr.isConstZero, zmodIsZero]
+
+/-- An empty table means no interaction is on a fixed-zero-cell bus, so the sweep emits nothing. -/
+private theorem foldl_emit_nil (keep : DenseExpr p → Bool)
+    (todo : List (BusInteraction (DenseExpr p))) (acc : List (DenseExpr p)) :
+    todo.foldl (fun a bi => denseZeroCellEmit [] keep bi a) acc = acc := by
+  induction todo generalizing acc with
+  | nil => rfl
+  | cons _ rest ih => exact ih acc
+
+@[csimp] theorem denseZeroRegisterNew_eq_fast :
+    @denseZeroRegisterNew = @denseZeroRegisterNewFast := by
+  funext q bs facts d
+  have hnew : denseZeroRegisterNew bs facts d
+      = d.busInteractions.flatMap (fun bi =>
+          (denseCellZeroExprs bs facts bi).filter (denseZeroPred d.algebraicConstraints)) := by
+    rw [denseZeroRegisterNew, denseCollectZeroCells_eq, List.filter_flatMap]
+  have hsweep := denseZeroCellSweep_eq bs facts d.busInteractions
+    (denseZeroPred d.algebraicConstraints) (denseZeroPred_const_zero _) d.busInteractions
+    (fun _ h => h) []
+  rw [List.append_nil] at hsweep
+  rw [hnew, denseZeroRegisterNewFast]
+  cases htbl : denseZeroCellTable bs facts d.busInteractions with
+  | nil =>
+    rw [htbl, foldl_emit_nil] at hsweep
+    dsimp only
+    exact List.reverse_eq_nil_iff.mp hsweep.symm
+  | cons e rest =>
+    rw [htbl] at hsweep
+    dsimp only
+    rw [hsweep, List.reverse_reverse]
+
+/-- Every variable of a surviving candidate occurs in `d`: candidates come from interaction
+    payloads. -/
 theorem denseZeroRegisterNew_vars (bs : BusSemantics p) (facts : BusFacts p bs)
     (d : DenseConstraintSystem p) :
     ∀ c ∈ denseZeroRegisterNew bs facts d, ∀ z ∈ c.vars, z ∈ d.occ := by
   intro c hc z hz
-  have hp : denseZeroPred d d.occ c = true := (List.mem_filter.1 hc).2
-  unfold denseZeroPred at hp
-  simp only [Bool.and_eq_true, List.all_eq_true] at hp
-  exact of_decide_eq_true (hp.2 z hz)
+  rw [denseZeroRegisterNew, denseCollectZeroCells_eq] at hc
+  obtain ⟨bi, hbi, hcbi⟩ := List.mem_flatMap.1 (List.mem_of_mem_filter hc)
+  exact DenseConstraintSystem.mem_occ_of_bi hbi (denseCellZeroExprs_vars bs facts bi c hcbi z hz)
 
 /-- Every surviving candidate evaluates to `0` on an admissible assignment. -/
 theorem denseZeroRegisterNew_sound (bs : BusSemantics p) (facts : BusFacts p bs)

--- a/ApcOptimizer/Implementation/OptimizerPasses/ZeroRegister.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/ZeroRegister.lean
@@ -28,10 +28,65 @@ def denseCellZeroExprs (bs : BusSemantics p) (facts : BusFacts p bs)
         dataSlots.map (fun slot => (bi.payload[slot]?).getD (DenseExpr.const 0))
       else []
 
-/-- Keep a candidate iff it is non-trivial, not already present, and all its variables occur in the
-    system. `dVars` is the occurrence list, passed in by the caller (not recomputed here). -/
-def denseZeroPred (d : DenseConstraintSystem p) (dVars : List VarId) (c : DenseExpr p) : Bool :=
-  !c.normalize.fold.isConstZero && !d.algebraicConstraints.contains c
-    && c.vars.all (fun z => decide (z ∈ dVars))
+/-- Keep a candidate iff it is non-trivial and not already present. Every variable of a candidate
+    occurs in the system by construction (it comes from an interaction payload), so no occurrence
+    test is needed — see `denseZeroRegisterNew_vars`. -/
+def denseZeroPred (cs : List (DenseExpr p)) (c : DenseExpr p) : Bool :=
+  !c.normalize.fold.isConstZero && !cs.contains c
+
+/-! ## Prepared per-invocation form
+
+`facts.zeroCell` depends only on the bus id, and on OpenVM it allocates a `ZMod` ring dictionary per
+call (the pinned address constants are `OfNat` numerals), so it must not run per interaction. -/
+
+/-- One bus's fixed-zero-cell shape with the pinned address constants already wrapped as
+    expressions: `(slot, const value)` pairs plus the data slots. -/
+abbrev DenseZeroCell (p : ℕ) := List (Nat × DenseExpr p) × List Nat
+
+/-- Add an interaction's bus id to the seen set. -/
+def denseBusIdStep (ids : List Nat) (bi : BusInteraction (DenseExpr p)) : List Nat :=
+  if ids.contains bi.busId then ids else bi.busId :: ids
+
+/-- The distinct bus ids of an interaction list (one entry per bus in the system, so the
+    `contains` stays on a handful of elements). -/
+def denseBusIds (bis : List (BusInteraction (DenseExpr p))) : List Nat :=
+  bis.foldl denseBusIdStep []
+
+/-- `facts.zeroCell`, evaluated once per distinct bus id and kept only for the buses that declare a
+    cell (typically just the memory bus). An empty table means the pass cannot fire. -/
+def denseZeroCellTable (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bis : List (BusInteraction (DenseExpr p))) : List (Nat × DenseZeroCell p) :=
+  (denseBusIds bis).filterMap (fun id =>
+    match facts.zeroCell id with
+    | none => none
+    | some (addrReq, dataSlots) =>
+      some (id, (addrReq.map (fun ar => (ar.1, DenseExpr.const ar.2)), dataSlots)))
+
+/-- Whether every prepared address slot of `addr` holds exactly its pinned expression. -/
+def denseAddrPinned (payload : List (DenseExpr p)) : List (Nat × DenseExpr p) → Bool
+  | [] => true
+  | (k, e) :: rest =>
+    match payload[k]? with
+    | none => false
+    | some e' => e' == e && denseAddrPinned payload rest
+
+/-- The data-slot expressions of `bi` that `keep` accepts, prepended to `acc`, if `bi` is an active
+    message pinned to a fixed-zero cell of one of the `tbl` buses; `acc` otherwise. -/
+def denseZeroCellEmit (tbl : List (Nat × DenseZeroCell p)) (keep : DenseExpr p → Bool)
+    (bi : BusInteraction (DenseExpr p)) (acc : List (DenseExpr p)) : List (DenseExpr p) :=
+  match tbl with
+  | [] => acc
+  | (id, addr, slots) :: rest =>
+    if bi.busId == id then
+      match bi.multiplicity.constValue? with
+      | none => acc
+      | some c =>
+        if !zmodIsZero c && denseAddrPinned bi.payload addr then
+          slots.foldl (fun a slot =>
+            match bi.payload[slot]? with
+            | some e => if keep e then e :: a else a
+            | none => a) acc
+        else acc
+    else denseZeroCellEmit rest keep bi acc
 
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -811,12 +811,22 @@ increasing effort:
   pass. Worth re-checking for the same shape elsewhere: a per-candidate scan of the whole remainder
   whose failure the outer loop cannot learn from.
 - **(c) Per-pass necessary-condition gates**, cheaper than the pass's own discovery. The ≥ 75 %-no-op
-  passes are `degenRange` (96 %, 1057 ms net), `zeroRegister` (96 %, 1101), `flagUnify` (95 %, 895),
-  `digitFold` (91 %, 1256), `xorEqExtract` (77 %, 497), `subsumedRange` (100 %, 414), `zeroMultBus`
-  (72 %), `oneHotAnnihilate` (67 %) — **≈ 5.3 s of corpus pass time**. A shared *per-cycle* digest is
-  the wrong first step: the system changes between passes within a cycle, so a cycle-start digest is
-  stale from the second pass on. Per-pass gates first, over the prepared interaction array of R13(b),
-  which is what makes them cheap.
+  passes are `degenRange` (96 %, 1057 ms net), ~~`zeroRegister` (96 %, 1101)~~ **done (entry 178)**,
+  0.186x on the pass, `flagUnify` (95 %, 895), `digitFold` (91 %, 1256), `xorEqExtract` (77 %, 497),
+  `subsumedRange` (100 %, 414), `zeroMultBus` (72 %), `oneHotAnnihilate` (67 %) — **≈ 5.3 s of corpus
+  pass time**. A shared *per-cycle* digest is the wrong first step: the system changes between passes
+  within a cycle, so a cycle-start digest is stale from the second pass on. Per-pass gates first, over
+  the prepared interaction array of R13(b), which is what makes them cheap.
+  **Two findings from entry 178 that generalize across this whole list.** (i) *Audit what a filter
+  conjunct is tested against, not how it reads.* `zeroRegister`'s cheapest-looking check,
+  `c.vars.all (· ∈ d.occ)`, was 55 % of the pass, because `d.occ` is whole-system — and the conjunct was
+  *provably always true*, since the candidates come from interaction payloads. Grep every pass for
+  `d.occ` at the top of a body. (ii) *`BusFacts` closures depend only on the bus id, and each call
+  allocates a `ZMod` dictionary* — memoizing `facts.zeroCell` over the ≤ ~6 distinct bus ids, with the
+  pinned constants pre-wrapped as `DenseExpr.const`, removed another 23 %. Soundness of such a memo
+  ("every entry agrees with `facts`") is enough to make the first match usable, so no `Nodup` obligation
+  is needed; completeness is only needed to justify *skipping*. This is R13(b) done per-pass, and
+  `slotBoundImpl` (16.4 % of the dictionary chain) is the same shape one step larger.
 - **(d) The discarded final cycle.** `denseIterateToFixpoint` returns the *pre-cycle* state when
   `sizeKey` does not decrease, so the whole last cycle is computed and thrown away: sha256 `apc_001`
   **646 ms (2.7 % of wall)**, wasm-eth `apc_012` 101 ms (3.9 %), keccak 36 ms. sha256's last two
@@ -848,6 +858,18 @@ the bucket is needed (701 matches producing 0 adoptions means `denseFuPairData?`
 multiplicity/`slotBound`/`splitAt`/no-wrap prefix rejects *late*), or a bucket restricted to the joint
 offset variables the certificate actually queries, which makes the build proportional to the match
 rather than to the system — the entry-176 shape one level finer.
+
+### zeroRegister residual after entry 178 (the prepared bus table)  ·  *runtime*
+
+248 ms corpus-wide, and **71 % of what is left is not the pass**: stubbing the new body to `[]` still
+reads 78 ms of sha256 `apc_001`'s 114, i.e. the `ofAddConstraints` record plus the degree guard (R5). The
+pass's own two halves are 12 ms of `denseBusIds` + table build and 20 ms of the emit sweep, both linear in
+the interaction count with a small constant. Fusing them into a single sweep (threading the bus-id memo
+through the accumulator) is the only remaining idea and is worth ~11 ms of a 22 s run against a
+threaded-state invariant in the proof — **deliberately left as sub-bar**. Two output-changing options
+were also declined as effectiveness questions, not runtime ones: the emit filter cannot see earlier
+survivors, so two interactions pinning the same expression emit the constraint twice; and the
+`normalize.fold.isConstZero` test measured at ~0 ms, so a `const`/`var` fast path buys nothing.
 
 ### tupleRange residual after entry 175 (the single-pass scan)  ·  *runtime*
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7007,3 +7007,64 @@ restricted to the joint offset variables actually queried, which would make the 
 the match rather than to the system.
 
 **Worked: yes.**
+
+### 178. Runtime: zeroRegister drops its `occ` scan and memoizes `facts.zeroCell` per bus (0.14–0.19x on the pass)
+
+`denseZeroRegisterNew` did two whole-system things per invocation, and the pass is a no-op in **96 %**
+of them (R15(c): 1101 ms net of the guard, the second-largest entry on that list).
+
+- `let dVars := d.occ` — the occurrence list of the *entire* system — was built only so the filter could
+  test `c.vars.all (· ∈ dVars)`. **That conjunct is always true.** Every candidate is
+  `(bi.payload[slot]?).getD (const 0)` for some `bi ∈ d.busInteractions`, so its variables are in
+  `denseBIVars bi ⊆ d.occ` by construction. Sized by dropping the conjunct: sha256 `apc_001`
+  **613 → 277 ms, 55 % of the pass**.
+- `facts.zeroCell bi.busId` ran **once per interaction** (12 452 of them on sha256, ×10 invocations).
+  On OpenVM that is `zeroCellImpl`, whose `some ([(0, 1), (1, 0)], [2, 3, 4, 5])` carries `ZMod p`
+  numerals, so every call builds the `ZMod.commRing` dictionary chain — nextBottlenecks' §B4 already
+  attributed 2.4 % of *all* allocations to `zeroCellImpl` and 2.7 % to `denseCellZeroExprs`.
+  `decide (c ≠ 0)` on the multiplicity is the same trap. Sized by stubbing the collection: another
+  **~140 ms, 23 %**.
+
+THE CHANGE: `denseBusIds` collects the distinct bus ids in one `foldl` (≤ ~6 of them, so its `contains`
+stays trivial); `denseZeroCellTable` calls `facts.zeroCell` once per id and keeps only the buses that
+declare a cell, with the pinned address constants **pre-wrapped** as `DenseExpr.const` so the
+per-interaction test allocates nothing. An empty table short-circuits the pass. `denseZeroCellEmit` then
+does one allocation-free sweep — bus id (one `Nat` compare) → `constValue?` and a dictionary-free
+`zmodIsZero` → `denseAddrPinned` (`==` on `DenseExpr`, no `Option`/`const` built) → emit, with the
+survivor predicate fused into the slot fold and `foldl`-accumulated (one `reverse` of the tiny candidate
+list restores the order). `denseZeroPred` loses the occ conjunct.
+
+WHY IT IS VALUE-IDENTICAL: `denseZeroCellTable`'s **soundness** (every entry agrees with
+`facts.zeroCell`) makes whichever entry the sweep finds first carry the right shape — no `Nodup`
+obligation — and its **completeness** (`denseBusIds_mem`) rules out skipping a bus that declares a cell.
+`denseZeroCellEmit_slots` needs `keep (const 0) = false`, which is exactly `denseZeroPred_const_zero`, so
+dropping the out-of-range slot branch is value-preserving. `denseCollectZeroCells_eq` reduces the old
+collection to a `flatMap` and `List.filter_flatMap` finishes `denseZeroRegisterNew_eq_fast` (`@[csimp]`,
+verified live in the C: the slow body has no caller but its own `___boxed`). The vars obligation is now
+`denseCellZeroExprs_vars` + `mem_occ_of_bi`.
+
+**Companion, shared:** `DenseVerifiedPassW.ofAddConstraints` built
+`{d with algebraicConstraints := d.algebraicConstraints ++ news …}` unconditionally, so **every** no-op
+invocation of every append-only pass copied the whole constraint list (`List.append` is strict in its
+first argument). It now goes through `denseAddedCS` with a `@[csimp]` twin returning `d` when nothing is
+emitted — `List.append_nil` plus structure eta, no new obligation. Sized at ~65 ms of sha256's
+`zeroRegister` on its own.
+
+NUMBERS (this 20-core box, serial, interleaved, 2 reps): sha256 `apc_001` **622/628 → 115/111 ms** on the
+pass, total 22 244 → 21 357 (0.96x); wasm-eth `apc_012` 82/83 → 17/15; `apc_063` 65/74 → 14/9; keccak
+`apc_001` 62/73 → 8/11; SP1 keccak 18/19 → 2/3. **Whole local corpus, 303 APCs interleaved: zeroRegister
+1333 → 248 ms (0.186x), wall 48.4 → 47.0 s (0.970x)**; the companion also moves `oneHotAnnihilate`
+297 → 264 (0.889x) and `xorEqExtract` 919 → 858 (0.934x).
+VERIFIED: final `vars / constraints / bus` **identical on all 303 corpus APCs**; `opt-export`
+byte-identical on sha256 `apc_001`, wasm-eth `apc_012`, keccak `apc_001`, SP1 keccak `apc_001` and SP1
+rsp `apc_001`; `lake build` clean with no warnings; `check-proof-integrity` passes on the three standard
+axioms with no unused theorem.
+
+WHERE THE REMAINING 114 ms GOES — stubbing the new body to `[]` reads **78 ms on sha256, i.e. 71 % of
+what is left is the framework plus the degree guard (R5), not this pass**. The pass's own residual is 12 ms
+of table build and 20 ms of sweep; fusing the two sweeps into one (threading the memo through the
+accumulator) is worth ~11 ms of a 22 s run against a threaded-state invariant in the proof, so it was
+**deliberately left**. The lesson worth keeping: the conjunct that looked like the pass's *cheapest*
+check was its most expensive line, because the datum it tested against was whole-system.
+
+**Worked: yes.**

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7052,9 +7052,13 @@ emitted — `List.append_nil` plus structure eta, no new obligation. Sized at ~6
 
 NUMBERS (this 20-core box, serial, interleaved, 2 reps): sha256 `apc_001` **622/628 → 115/111 ms** on the
 pass, total 22 244 → 21 357 (0.96x); wasm-eth `apc_012` 82/83 → 17/15; `apc_063` 65/74 → 14/9; keccak
-`apc_001` 62/73 → 8/11; SP1 keccak 18/19 → 2/3. **Whole local corpus, 303 APCs interleaved: zeroRegister
-1333 → 248 ms (0.186x), wall 48.4 → 47.0 s (0.970x)**; the companion also moves `oneHotAnnihilate`
-297 → 264 (0.889x) and `xorEqExtract` 919 → 858 (0.934x).
+`apc_001` 62/73 → 8/11; SP1 keccak 18/19 → 2/3. **Whole local corpus, 303 APCs interleaved (OpenVM 202, SP1
+101): zeroRegister 1333 → 248 ms (0.186x), wall 48.4 → 47.0 s (0.970x)**; the companion also moves
+`oneHotAnnihilate` 297 → 264 (0.889x) and `xorEqExtract` 919 → 858 (0.934x). Both VMs improve — OpenVM
+zeroRegister 1244 → 230 ms with wall 44.4 → 43.1 s (0.970x), SP1 89 → 18 ms (0.20x) with wall
+4.01 → 3.93 s (0.982x), since `Sp1Facts` has its own `zeroCellImpl`; SP1's only substantial case is
+keccak `apc_001` (19 → 3 ms on the pass) and the 100 `rsp` cases hold 0–5 ms each, so only their
+aggregate means anything.
 VERIFIED: final `vars / constraints / bus` **identical on all 303 corpus APCs**; `opt-export`
 byte-identical on sha256 `apc_001`, wasm-eth `apc_012`, keccak `apc_001`, SP1 keccak `apc_001` and SP1
 rsp `apc_001`; `lake build` clean with no warnings; `check-proof-integrity` passes on the three standard


### PR DESCRIPTION
`zeroRegister` is a no-op in **96 %** of its invocations, and it did two whole-system things in every one of them.

## 1. `d.occ` was built for a conjunct that is always true — 55 % of the pass

The filter tested `c.vars.all (· ∈ d.occ)`, so `denseZeroRegisterNew` built the occurrence list of the *entire* system (`constraints.flatMap vars ++ interactions.flatMap denseBIVars`) on every invocation. But every candidate is `(bi.payload[slot]?).getD (const 0)` for some `bi ∈ d.busInteractions`, so its variables are in `denseBIVars bi ⊆ d.occ` **by construction** — the conjunct can never fail. Dropping it: sha256 `apc_001` 613 → 277 ms. The `hvars` obligation is now discharged structurally by `denseCellZeroExprs_vars` + `mem_occ_of_bi`.

## 2. `facts.zeroCell` ran once per interaction — 23 % of the pass

12 452 interactions on sha256, ×10 invocations. On OpenVM that is `zeroCellImpl`, whose `some ([(0, 1), (1, 0)], [2, 3, 4, 5])` carries `ZMod p` numerals, so every call builds the `ZMod.commRing` dictionary chain (`nextBottlenecks` already put 2.4 % of *all* allocations on `zeroCellImpl` and 2.7 % on `denseCellZeroExprs`); `decide (c ≠ 0)` on the multiplicity is the same trap. `facts.zeroCell` depends only on the bus id, and an APC has ~6 of them.

`denseBusIds` collects the distinct ids in one `foldl`; `denseZeroCellTable` calls `facts.zeroCell` once per id, keeping only the buses that declare a cell with the pinned constants **pre-wrapped** as `DenseExpr.const`; an empty table short-circuits the pass; `denseZeroCellEmit` does one allocation-free sweep — bus id → `constValue?` and a dictionary-free `zmodIsZero` → `denseAddrPinned` → emit, with the survivor predicate fused into the slot fold.

**Value-identical** (`@[csimp] denseZeroRegisterNew_eq_fast`, verified live in the generated C). Table *soundness* makes whichever entry the sweep matches first carry `facts.zeroCell`'s shape, so there is no `Nodup` obligation; *completeness* (`denseBusIds_mem`) rules out skipping a bus that declares a cell; `denseZeroPred_const_zero` justifies dropping the out-of-range slot branch.

## Companion commit: `ofAddConstraints` no longer copies the constraint list for nothing

`List.append` is strict in its first argument, so `{d with algebraicConstraints := cs ++ news …}` copied the whole list on every no-op invocation of **every** append-only pass. Routed through `denseAddedCS` with a `@[csimp]` twin returning `d` itself when nothing is emitted (`List.append_nil` + structure eta; no new obligation on any pass).

## Numbers

This 20-core box, serial, interleaved, 2 reps:

| case | before | after | ratio |
|---|---:|---:|---:|
| sha256 `apc_001` (worst) | 622 / 628 | 115 / 111 | **0.18×** |
| wasm-eth `apc_012` | 82 / 83 | 17 / 15 | 0.19× |
| wasm-eth `apc_063` | 65 / 74 | 14 / 9 | 0.17× |
| keccak `apc_001` | 62 / 73 | 8 / 11 | 0.14× |
| SP1 keccak `apc_001` | 18 / 19 | 2 / 3 | 0.13× |

Whole local corpus, 303 APCs (OpenVM 202, SP1 101), interleaved:

| | before | after | ratio |
|---|---:|---:|---:|
| `zeroRegister` | 1333 ms | 248 ms | **0.186×** |
| `oneHotAnnihilate` (companion) | 297 | 264 | 0.889× |
| `xorEqExtract` (companion) | 919 | 858 | 0.934× |
| corpus wall | 48.4 s | 47.0 s | **0.970×** |

Both VMs improve. OpenVM (202 cases): `zeroRegister` 1244 → 230 ms, wall 44.4 → 43.1 s (0.970×). SP1 (101 cases): `zeroRegister` 89 → 18 ms (0.20×), wall 4.01 → 3.93 s (0.982×) — `Sp1Facts` has its own `zeroCellImpl`, so the same mechanism applies. SP1's only substantial case is keccak `apc_001` (19 → 3 ms on the pass, total 1135 → 1111); the 100 `rsp` cases are 3–236 ms each with 0–5 ms in the pass, so only their aggregate is meaningful there.

## Effectiveness

Unchanged by construction, and checked: final `vars / constraints / bus` **identical on all 303 local APCs**, and `opt-export` byte-identical on sha256 `apc_001`, wasm-eth `apc_012`, keccak `apc_001`, SP1 keccak `apc_001` and SP1 rsp `apc_001`.

`lake build` clean with no warnings; `Scripts/check-proof-integrity.sh` passes on the three standard axioms with no unused theorem; both code commits build standalone.

## What is left (deliberately)

Stubbing the new body to `[]` still reads **78 ms** of sha256's remaining 114 — **71 % of it is the shared framework plus the degree guard**, not this pass. The pass's own residual is 12 ms of table build and 20 ms of sweep; fusing the two sweeps would recover ~11 ms of a 22 s run against a threaded-state invariant in the proof. Two output-changing ideas were declined as effectiveness questions rather than runtime ones (the emit filter cannot see earlier survivors, so a duplicate pin emits twice; and `normalize.fold.isConstZero` measured at ~0 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
