### PR TITLE
perf(degenRange): one allocation-free sweep instead of five recognizer passes (0.28x on the pass)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DegenRange.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DegenRange.lean
@@ -42,6 +42,12 @@ variable {p : ℕ}
 /-- `v·(v − 1)` as a dense expression. -/
 def denseBoolC (v : DenseExpr p) : DenseExpr p := .mul v (.add v (.const (-1)))
 
+/-- The `-1` numeral alone pulls the `ZMod.commRing` chain into every emitted constraint. -/
+def denseBoolCImpl (v : DenseExpr p) : DenseExpr p := .mul v (.add v (.const (zmodNegOneP p)))
+
+@[csimp] theorem denseBoolC_eq_impl : @denseBoolC = @denseBoolCImpl := by
+  funext q v; rw [denseBoolC, denseBoolCImpl, zmodNegOneP_eq]
+
 /-- Recognizes a degenerate-width range check: width-0 (`c = 0`) forces its value slot to `0`;
     width-1 (`c = 1`, on a prime field) makes its value boolean, returning `v·(v−1) = 0`. -/
 def denseRangeEq? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
@@ -56,16 +62,97 @@ def denseRangeEq? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
     else none
   | _ => none
 
+/-- The `DenseExpr` equalities against `const 0` / `const 1` put a `ZMod.commRing` chain at this
+    recognizer's *entry*, ahead of the payload-shape test, so every interaction paid it. The tag
+    matches gate first and the literal tests go through the dictionary-free primitives; the
+    `facts` lookups (an assoc-list scan each) come after the cheaper `ZMod` tests. -/
+def denseRangeEqImpl? (one : Bool) (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p) :=
+  match bi.payload, bi.multiplicity with
+  | [v, .const c], .const m =>
+    if zmodIsOne m then
+      if zmodIsZero c && facts.zeroRangeEq bi.busId then some v
+      else if one && zmodIsOne c && facts.varRangeBus bi.busId && v.degree ≤ 1 then
+        some (denseBoolC v)
+      else none
+    else none
+  | _, _ => none
+
+@[csimp] theorem denseRangeEq_eq_impl : @denseRangeEq? = @denseRangeEqImpl? := by
+  funext q one bs facts bi
+  obtain ⟨busId, mult, payload⟩ := bi
+  simp only [denseRangeEq?, denseRangeEqImpl?]
+  rcases payload with _ | ⟨v, tl⟩
+  · cases mult <;> simp
+  rcases tl with _ | ⟨c, tl⟩
+  · cases mult <;> simp
+  rcases tl with _ | ⟨w, tl⟩
+  case cons => cases mult <;> simp
+  cases c with
+  | var _ => cases mult <;> simp
+  | add _ _ => cases mult <;> simp
+  | mul _ _ => cases mult <;> simp
+  | const k =>
+    cases mult with
+    | var _ => simp
+    | add _ _ => simp
+    | mul _ _ => simp
+    | const m =>
+      simp only [DenseExpr.const.injEq, zmodIsOne_eq, zmodIsZero_eq, Bool.and_eq_true,
+        decide_eq_true_eq]
+      split_ifs <;> tauto
+
+def DenseExpr.isBareVar : DenseExpr p → Bool
+  | .var _ => true
+  | _ => false
+
+/-- Does some slot hold a bare variable? A pre-filter for `denseBoolCheck?`, which emits only when
+    its value slot does — allocation-free, unlike the pattern it guards. -/
+def denseHasBareVar : List (DenseExpr p) → Bool
+  | [] => false
+  | e :: rest => e.isBareVar || denseHasBareVar rest
+
+/-- `payload.map constValue?` without `mapTR`'s reversal pass. -/
+def denseConstPattern : List (DenseExpr p) → List (Option (ZMod p))
+  | [] => []
+  | e :: rest => e.constValue? :: denseConstPattern rest
+
+theorem denseConstPattern_eq (l : List (DenseExpr p)) :
+    denseConstPattern l = l.map DenseExpr.constValue? := by
+  induction l with
+  | nil => rfl
+  | cons e t ih => rw [denseConstPattern, List.map_cons, ih]
+
+/-- No bare variable anywhere means no slot is one, which is what makes the pre-filter exact. -/
+theorem denseHasBareVar_getElem? (l : List (DenseExpr p)) (h : denseHasBareVar l = false)
+    (i : Nat) (x : VarId) : l[i]? ≠ some (DenseExpr.var x) := by
+  induction l generalizing i with
+  | nil => simp
+  | cons e t ih =>
+    rw [denseHasBareVar, Bool.or_eq_false_iff] at h
+    cases i with
+    | zero =>
+      simp only [List.getElem?_cons_zero, ne_eq, Option.some.injEq]
+      intro he
+      rw [he] at h
+      exact absurd h.1 (by simp [DenseExpr.isBareVar])
+    | succ n => simpa using ih h.2 n
+
 def denseBoolCheckImpl? {bs : BusSemantics p} (facts : BusFacts p bs)
     (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p) :=
-  match facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
-  | some (valSlot, bound) =>
-    if (match bi.multiplicity with | .const c => zmodIsOne c | _ => false) && bound == 2 then
-      match bi.payload[valSlot]? with
-      | some (DenseExpr.var x) => some (denseBoolC (DenseExpr.var x))
-      | _ => none
+  match bi.multiplicity with
+  | .const m =>
+    if zmodIsOne m && denseHasBareVar bi.payload then
+      match facts.rangeCheckAt bi.busId (denseConstPattern bi.payload) with
+      | some (valSlot, bound) =>
+        if bound == 2 then
+          match bi.payload[valSlot]? with
+          | some (DenseExpr.var x) => some (denseBoolC (DenseExpr.var x))
+          | _ => none
+        else none
+      | none => none
     else none
-  | none => none
+  | _ => none
 
 /-- The booleanity `x·(x−1)` of a width-1 (`bound = 2`) check whose value slot is a bare variable
     `x`. -/
@@ -82,11 +169,39 @@ def denseBoolCheck? {bs : BusSemantics p} (facts : BusFacts p bs)
 
 @[csimp] theorem denseBoolCheck_q_eq_impl : @denseBoolCheck? = @denseBoolCheckImpl? := by
   funext q bs facts bi
-  unfold denseBoolCheck? denseBoolCheckImpl?
-  cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
-  | none => rfl
-  | some vb =>
-    obtain ⟨valSlot, bound⟩ := vb
-    cases bi.multiplicity <;> simp
+  simp only [denseBoolCheck?, denseBoolCheckImpl?, denseConstPattern_eq]
+  cases hm : bi.multiplicity with
+  | var _ | add _ _ | mul _ _ =>
+    cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+    | none => rfl
+    | some vb => obtain ⟨valSlot, bound⟩ := vb; simp
+  | const m =>
+    by_cases hm1 : m = 1
+    case neg =>
+      cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+      | none => simp [zmodIsOne_eq, hm1]
+      | some vb => obtain ⟨valSlot, bound⟩ := vb; simp [zmodIsOne_eq, hm1]
+    case pos =>
+      subst hm1
+      by_cases hbv : denseHasBareVar bi.payload = true
+      case pos => simp [zmodIsOne_eq, hbv]
+      case neg =>
+        simp only [Bool.not_eq_true] at hbv
+        simp only [zmodIsOne_eq, hbv, decide_true, Bool.and_false]
+        cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+        | none => rfl
+        | some vb =>
+          obtain ⟨valSlot, bound⟩ := vb
+          simp only [true_and]
+          split
+          · cases hg : bi.payload[valSlot]? with
+            | none => rfl
+            | some e =>
+              cases e with
+              | var x => exact absurd hg (denseHasBareVar_getElem? bi.payload hbv valSlot x)
+              | const _ => rfl
+              | add _ _ => rfl
+              | mul _ _ => rfl
+          · rfl
 
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/EntailedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/EntailedCheck.lean
@@ -31,4 +31,174 @@ def denseCheckRewriteF (recs : List (BusInteraction (DenseExpr p) → Option (De
       d.algebraicConstraints ++ denseGroupEmit recs d.busInteractions }
     : DenseConstraintSystem p).filterBus (fun bi => recs.all (fun r => (r bi).isNone))
 
+/-! ## The fused single-sweep twin
+
+`denseGroupEmit` runs each recognizer twice (`filterMap`, then `filter` to shrink the input of the
+next one) and `filterBus` runs the whole set once more, so a two-rule pass applies five recognizers
+per interaction. One sweep recording the first recognizer to fire carries all three answers. -/
+
+/-- Index of the first recognizer that fires on `bi`, with its constraint; `k` is the index of the
+    head of `recs`. -/
+def denseFirstHit (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p))) (k : Nat)
+    (bi : BusInteraction (DenseExpr p)) : Option (Nat × DenseExpr p) :=
+  match recs with
+  | [] => none
+  | r :: rest =>
+    match r bi with
+    | some e => some (k, e)
+    | none => denseFirstHit rest (k + 1) bi
+
+/-- The hits over `bis`, in reverse interaction order; interactions no recognizer claims allocate
+    nothing, which is the whole point on a pass that recognizes nothing in most invocations. -/
+def denseScanHits (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (bis : List (BusInteraction (DenseExpr p))) (acc : List (Nat × DenseExpr p)) :
+    List (Nat × DenseExpr p) :=
+  match bis with
+  | [] => acc
+  | bi :: rest =>
+    match denseFirstHit recs 0 bi with
+    | some ke => denseScanHits recs rest (ke :: acc)
+    | none => denseScanHits recs rest acc
+
+/-- Constraints of the hits claimed by the head recognizer. -/
+def denseTakeHead (hits : List (Nat × DenseExpr p)) : List (DenseExpr p) :=
+  hits.filterMap fun ke => if ke.1 = 0 then some ke.2 else none
+
+/-- Drop the head recognizer's hits and renumber the rest, so the hits of `r :: rest` over `bis`
+    become the hits of `rest` over the interactions `r` left behind (`denseUnshift_hits`). -/
+def denseUnshift (hits : List (Nat × DenseExpr p)) : List (Nat × DenseExpr p) :=
+  hits.filterMap fun ke => match ke.1 with | 0 => none | j + 1 => some (j, ke.2)
+
+/-- Regroup interaction-ordered hits by recognizer, restoring `denseGroupEmit`'s order over a list
+    as long as the number of hits rather than of interactions. -/
+def denseRegroup (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (hits : List (Nat × DenseExpr p)) : List (DenseExpr p) :=
+  match recs with
+  | [] => []
+  | _ :: rest => denseTakeHead hits ++ denseRegroup rest (denseUnshift hits)
+
+def denseCheckRewriteFImpl (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  match denseScanHits recs d.busInteractions [] with
+  | [] => d
+  | hits =>
+    { algebraicConstraints := d.algebraicConstraints ++ denseRegroup recs hits.reverse,
+      busInteractions := d.busInteractions.filter fun bi => (denseFirstHit recs 0 bi).isNone }
+
+/-! ### `denseCheckRewriteF = denseCheckRewriteFImpl` -/
+
+/-- The hits over `bis` in interaction order — what `denseScanHits` accumulates reversed. -/
+def denseHitsFrom (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p))) (k : Nat)
+    (bis : List (BusInteraction (DenseExpr p))) : List (Nat × DenseExpr p) :=
+  bis.filterMap (denseFirstHit recs k)
+
+/-- Starting the numbering one higher shifts every index by one. -/
+theorem denseFirstHit_succ (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (k : Nat) (bi : BusInteraction (DenseExpr p)) :
+    denseFirstHit recs (k + 1) bi
+      = (denseFirstHit recs k bi).map (fun ke => (ke.1 + 1, ke.2)) := by
+  induction recs generalizing k with
+  | nil => rfl
+  | cons r rest ih =>
+    rw [denseFirstHit, denseFirstHit]
+    cases r bi with
+    | none => exact ih (k + 1)
+    | some e => rfl
+
+theorem denseScanHits_eq (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (bis : List (BusInteraction (DenseExpr p))) (acc : List (Nat × DenseExpr p)) :
+    denseScanHits recs bis acc = (denseHitsFrom recs 0 bis).reverse ++ acc := by
+  induction bis generalizing acc with
+  | nil => rfl
+  | cons bi rest ih =>
+    rw [denseScanHits, denseHitsFrom, List.filterMap_cons]
+    cases denseFirstHit recs 0 bi with
+    | none => simpa [denseHitsFrom] using ih acc
+    | some ke => simpa [denseHitsFrom, List.reverse_cons] using ih (ke :: acc)
+
+theorem denseTakeHead_hits (r : BusInteraction (DenseExpr p) → Option (DenseExpr p))
+    (rest : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (bis : List (BusInteraction (DenseExpr p))) :
+    denseTakeHead (denseHitsFrom (r :: rest) 0 bis) = bis.filterMap r := by
+  induction bis with
+  | nil => rfl
+  | cons bi tail ih =>
+    rw [denseHitsFrom, List.filterMap_cons, denseFirstHit, List.filterMap_cons]
+    cases hr : r bi with
+    | some e => simpa [denseTakeHead] using ih
+    | none =>
+      rw [denseFirstHit_succ]
+      cases denseFirstHit rest 0 bi with
+      | none => simpa [denseTakeHead] using ih
+      | some ke => simpa [denseTakeHead] using ih
+
+theorem denseUnshift_hits (r : BusInteraction (DenseExpr p) → Option (DenseExpr p))
+    (rest : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (bis : List (BusInteraction (DenseExpr p))) :
+    denseUnshift (denseHitsFrom (r :: rest) 0 bis)
+      = denseHitsFrom rest 0 (bis.filter fun bi => (r bi).isNone) := by
+  induction bis with
+  | nil => rfl
+  | cons bi tail ih =>
+    rw [denseHitsFrom, List.filterMap_cons, denseFirstHit]
+    cases hr : r bi with
+    | some e => simpa [denseUnshift, List.filter_cons, hr] using ih
+    | none =>
+      rw [denseFirstHit_succ, List.filter_cons_of_pos (by simp [hr])]
+      cases hf : denseFirstHit rest 0 bi with
+      | none => simpa [denseUnshift, denseHitsFrom, hf] using ih
+      | some ke => simpa [denseUnshift, denseHitsFrom, hf] using ih
+
+theorem denseRegroup_hits (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (bis : List (BusInteraction (DenseExpr p))) :
+    denseRegroup recs (denseHitsFrom recs 0 bis) = denseGroupEmit recs bis := by
+  induction recs generalizing bis with
+  | nil => rfl
+  | cons r rest ih =>
+    rw [denseRegroup, denseGroupEmit, denseTakeHead_hits, denseUnshift_hits, ih]
+
+/-- `recs.all` over the recognizers is the sweep's own miss test. -/
+theorem denseFirstHit_isNone (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p)))
+    (k : Nat) (bi : BusInteraction (DenseExpr p)) :
+    (denseFirstHit recs k bi).isNone = recs.all fun r => (r bi).isNone := by
+  induction recs generalizing k with
+  | nil => rfl
+  | cons r rest ih =>
+    rw [denseFirstHit, List.all_cons]
+    cases r bi with
+    | none => simpa using ih (k + 1)
+    | some e => rfl
+
+theorem denseRegroup_nil (recs : List (BusInteraction (DenseExpr p) → Option (DenseExpr p))) :
+    denseRegroup recs ([] : List (Nat × DenseExpr p)) = [] := by
+  induction recs with
+  | nil => rfl
+  | cons r rest ih => rw [denseRegroup, denseTakeHead, denseUnshift]; simpa using ih
+
+@[csimp] theorem denseCheckRewriteF_eq_impl : @denseCheckRewriteF = @denseCheckRewriteFImpl := by
+  funext q recs d
+  rw [denseCheckRewriteFImpl, denseScanHits_eq, List.append_nil]
+  have hkeep : (fun bi => recs.all fun r => (r bi).isNone)
+      = fun bi => (denseFirstHit recs 0 bi).isNone :=
+    funext fun bi => (denseFirstHit_isNone recs 0 bi).symm
+  cases hh : (denseHitsFrom recs 0 d.busInteractions).reverse with
+  | cons a t =>
+    have hrev : (a :: t).reverse = denseHitsFrom recs 0 d.busInteractions := by
+      rw [← hh, List.reverse_reverse]
+    show denseCheckRewriteF recs d
+      = { algebraicConstraints := d.algebraicConstraints ++ denseRegroup recs (a :: t).reverse,
+          busInteractions := d.busInteractions.filter fun bi => (denseFirstHit recs 0 bi).isNone }
+    rw [hrev, denseRegroup_hits, denseCheckRewriteF, DenseConstraintSystem.filterBus, hkeep]
+  | nil =>
+    have hnil : denseHitsFrom recs 0 d.busInteractions = [] := by
+      simpa using congrArg List.reverse hh
+    have hall : ∀ bi ∈ d.busInteractions, (recs.all fun r => (r bi).isNone) = true := by
+      intro bi hbi
+      rw [← denseFirstHit_isNone]
+      have := List.filterMap_eq_nil_iff.1 (by simpa [denseHitsFrom] using hnil)
+      simpa using this bi hbi
+    show denseCheckRewriteF recs d = d
+    rw [denseCheckRewriteF, DenseConstraintSystem.filterBus,
+      List.filter_eq_self.2 hall, ← denseRegroup_hits, hnil, denseRegroup_nil, List.append_nil]
+
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -212,8 +212,9 @@ and rebuilds both item lists on every invocation whether or not an expression ch
 profile-harness frame** (the per-cycle size line the profiler prints); the optimizer itself pays only
 the fixpoint's own `sizeKey`. The per-pass columns are unaffected (entry 164). Also: a pointer-only
 no-op probe reads 20.9 % where structural equality reads 42 %, because `normalize`/`constFold`/
-`degenRange`/`carryBranch`/`intervalForce`/`busPairCancel` rebuild their lists unconditionally — use
-structural equality with a pointer-identity shortcut.
+`carryBranch`/`intervalForce`/`busPairCancel` rebuild their lists unconditionally — use structural
+equality with a pointer-identity shortcut. (`degenRange` no longer does, entry 179: it returns the
+input object when its sweep recognizes nothing.)
 
 ### Open runtime ideas, priority order
 
@@ -519,6 +520,21 @@ per corpus**. Three things worth carrying forward:
 - **Where a twin already exists, edit only the twin**; the in-place edit costs proof work and buys
   no runtime.
 
+**R9e (new, found in entry 179; cheap, several passes).** A recognizer that compares an expression
+against a `DenseExpr.const` numeral pays the dictionary chain at its **entry**, not at the
+comparison: `denseRangeEq?___redArg`'s first two statements were `ZMod_commRing` +
+`Ring_toAddGroupWithOne`, *ahead* of the `[v, c]` payload-shape test that rejects most interactions —
+so the gate written first is not the gate that runs first. The fix is mechanical: match the
+constructor as a tag (`| .const c =>`) and test the literal with `zmodIsOne`/`zmodIsZero`. Scan the
+first ~14 lines of each `___redArg` body in the IR for `ZMod_commRing`; that finds, still live,
+`denseSubsumedCheckOf` / `denseSubsumedRangeCheck?` (SubsumedCheck), `denseIdentityPairAt` /
+`denseOrIdentityOperand` / `denseIdentitySubstF` (IdentitySubst), `denseIsByteCompl` /
+`denseSvCheckWith?` / `denseComplExpr` (ByteCheckPack), `denseAsBytePair` / `denseSplitBytePairF`
+(SplitBytePair) and `densePairByteOps?` / `denseSlotBoundAt` / `denseInteractionBound` (DigitFold) —
+every one of them a per-interaction recognizer. Corpus stakes are small per pass (subsumedRange 418
+ms, digitFold 583, identitySubst 127, redundantByteDrop 360, splitBytePair 47), so batch them rather
+than opening one PR each.
+
 **R9b. What is left, and why it is expensive.** Its `rootPairUnify` half is **superseded by entry
 170**, which rebuilt the pass (0.13–0.53×): the per-candidate chain builders are gone with the
 per-candidate work itself, and the surviving `⁻¹` is one call per distinct coefficient value.
@@ -811,10 +827,13 @@ increasing effort:
   pass. Worth re-checking for the same shape elsewhere: a per-candidate scan of the whole remainder
   whose failure the outer loop cannot learn from.
 - **(c) Per-pass necessary-condition gates**, cheaper than the pass's own discovery. The ≥ 75 %-no-op
-  passes are `degenRange` (96 %, 1057 ms net), ~~`zeroRegister` (96 %, 1101)~~ **done (entry 178)**,
+  passes are ~~`degenRange` (96 %, 1057)~~ **done (entry 179)**, 0.278x on the pass,
+  ~~`zeroRegister` (96 %, 1101)~~ **done (entry 178)**,
   0.186x on the pass, `flagUnify` (95 %, 895), `digitFold` (91 %, 1256), `xorEqExtract` (77 %, 497),
   `subsumedRange` (100 %, 414), `zeroMultBus` (72 %), `oneHotAnnihilate` (67 %) — **≈ 5.3 s of corpus
-  pass time**. A shared *per-cycle* digest is the wrong first step: the system changes between passes
+  pass time**. Entry 179 is the case where the gate and the pass turned out to be the same code: once
+  the sweep is one allocation-free tag-check pass that returns its input on a miss, no cheaper
+  necessary condition beats it. A shared *per-cycle* digest is the wrong first step: the system changes between passes
   within a cycle, so a cycle-start digest is stale from the second pass on. Per-pass gates first, over
   the prepared interaction array of R13(b), which is what makes them cheap.
   **Two findings from entry 178 that generalize across this whole list.** (i) *Audit what a filter

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7072,3 +7072,73 @@ accumulator) is worth ~11 ms of a 22 s run against a threaded-state invariant in
 check was its most expensive line, because the datum it tested against was whole-system.
 
 **Worked: yes.**
+
+### 179. Runtime: degenRange becomes one allocation-free sweep (0.28x on the pass)
+
+`degenRange` is the only `ofCheckRules` instance, and R15(c) had it at **96 % no-op invocations,
+1057 ms of corpus pass time net of the degree guard** — the largest entry left on that list. Three
+independent costs, each visible in the generated C before any profiling; attribution by stubbing the
+rule list on keccak `apc_001` (68–75 ms in the pass): rule0 ≈ 34 ms, rule1 ≈ 21 ms, framework +
+degree guard + unconditional list rebuild ≈ 19 ms.
+
+- **Each recognizer ran three times per interaction.** `denseGroupEmit` does `bis.filterMap r`, then
+  `bis.filter (r · |>.isNone)` — a second application of `r` on every interaction — and
+  `filterBus (recs.all …)` a third. Two rules ⇒ five recognizer applications per interaction.
+- **rule0 built a `ZMod` dictionary at function entry.** `denseRangeEq?` compares
+  `bi.multiplicity = DenseExpr.const 1` and `c = DenseExpr.const 0`, so `ZMod_commRing` +
+  `Ring_toAddGroupWithOne` were the *first two statements* of `denseRangeEq?___redArg`, ahead of the
+  `[v, c]` payload test — every interaction paid it, including the 5-slot memory ones, three times.
+- **rule1 materialized a pattern nobody reads.** `facts.rangeCheckAt` is a closure field, so
+  `payload.map constValue?` is a strict argument: one `List (Option (ZMod p))` per interaction, built
+  by `mapTR` and reversed, with a `constValueImpl` traversal per slot — then discarded, always on
+  OpenVM, where `rangeCheckAt` is constantly `none`.
+
+THE CHANGE, three `@[csimp]` twins, so **`Proofs/DegenRange.lean` is untouched** and no
+`DenseCheckRule` obligation moved. (i) `denseCheckRewriteFImpl` (`EntailedCheck.lean`) sweeps once:
+`denseFirstHit` returns the index and constraint of the first recognizer to fire, `denseScanHits`
+accumulates **only hits** (misses allocate nothing), and no hits ⇒ return `d` itself — which also
+drops the `algebraicConstraints ++ []` copy and the `filterBus` rebuild that every no-op invocation
+paid. Hits are regrouped by `denseRegroup`/`denseTakeHead`/`denseUnshift` over a list as long as the
+number of *hits*. (ii) `denseRangeEqImpl?` matches `[v, .const c]` / `.const m` as tags first and
+tests literals with `zmodIsOne`/`zmodIsZero`, with the `facts` assoc-list lookups moved after the
+cheaper `ZMod` tests; `denseBoolCImpl` does the same for `-1`. (iii) `denseBoolCheckImpl?` gates on
+literal-1 multiplicity and an allocation-free `denseHasBareVar` scan before building the pattern,
+which is then `denseConstPattern` (no `mapTR` reversal).
+
+WHY IT IS VALUE-IDENTICAL: `denseScanHits_eq` reduces the scan to
+`(bis.filterMap (denseFirstHit recs 0)).reverse ++ acc`; `denseUnshift_hits` is the induction that
+makes the regrouping work — the hits of `r :: rest` over `bis`, unshifted, are exactly the hits of
+`rest` over `bis.filter (r · |>.isNone)`, which is `denseGroupEmit`'s own recursion — and
+`denseTakeHead_hits` gives the head group as `bis.filterMap r`, both needing
+`denseFirstHit_succ` (numbering from `k+1` shifts every index by one). `denseFirstHit_isNone` shows
+the sweep's miss test *is* `recs.all`, so the survivor filter needs no second pass; the no-op branch
+then needs `List.filter_eq_self` plus `denseRegroup_nil` and structure eta. The recognizer twins are
+`zmodIsOne_eq`/`zmodIsZero_eq` rewrites plus case splits, and `denseHasBareVar_getElem?` is what
+makes the bare-var pre-filter exact (no slot can be `some (.var x)` if no element is).
+
+NUMBERS (this 20-core box, serial, interleaved per case, whole local corpus of 303 APCs — OpenVM 202,
+SP1 101): **degenRange 1354 → 377 ms (0.278x), wall 46 781 → 45 930 (0.982x)**; OpenVM 1215 → 348
+(0.286x) with wall 0.980x, SP1 139 → 29 (0.209x). Per case: sha256 `apc_001` **562 → 181 ms** (total
+21 507 → 21 182), wasm-eth `apc_012` 74 → 23, keccak `apc_001` 71 → 18, `apc_063` 54 → 17, `apc_036`
+53 → 20, `apc_037` 52 → 16, `apc_006` 49 → 13, SP1 keccak 34 → 9. No other pass moves outside
+interleave noise.
+VERIFIED: per-cycle `vars / bus / constraints` **identical on all 303 corpus APCs**; `opt-export`
+byte-identical on sha256 `apc_001`, keccak `apc_001`, wasm-eth `apc_012`, SP1 keccak `apc_001` and
+SP1 rsp `apc_001`; `lake build` clean with no warnings; `check-proof-integrity` passes on the three
+standard axioms with no unused theorem. All four twins verified live in the C (the slow bodies have
+no caller but their own `___boxed`, and `ofCheckRules` calls `denseCheckRewriteFImpl`).
+
+WHERE THE REMAINING 377 ms GOES: re-profiled on keccak, the pass's own frames fall from **302 to 41
+samples** (2.0 % → 0.3 % of the run) against a reported 24 ms, and the rules-stubbed floor was
+17–20 ms — so **~70 % of what is left is the framework plus the degree guard (R5)**, not this pass.
+Inside the 41 samples: `denseRangeEqImpl?` 29 %, `denseConstPattern` + `constValueImpl` 24 %,
+`denseScanHits` + `denseFirstHit` 12 %.
+
+Two lessons. **A recognizer's numerals are its entry cost, not its match cost:** anything comparing
+against `DenseExpr.const 0`/`1` derives the dictionary chain *before* the shape test that would have
+rejected the interaction, so the gate you wrote first is not the gate that runs first — check the C.
+And **R15(c)'s "necessary-condition gate" can be the sweep itself**: once the sweep is one
+allocation-free tag-check pass that returns the input on a miss, no cheaper necessary condition
+beats it, so the gate and the pass are the same code.
+
+**Worked: yes.**


### PR DESCRIPTION
`degenRange` is the only `ofCheckRules` instance, and R15(c) had it at **96 % no-op invocations,
1057 ms of corpus pass time net of the degree guard** — the largest entry left on that list. Three
independent costs, each visible in the generated C; attribution by stubbing the rule list on keccak
`apc_001` (68–75 ms in the pass): rule0 ≈ 34 ms, rule1 ≈ 21 ms, framework + degree guard +
unconditional list rebuild ≈ 19 ms.

- **Each recognizer ran three times per interaction.** `denseGroupEmit` does `bis.filterMap r`, then
  `bis.filter (r · |>.isNone)` — a second application on every interaction — and
  `filterBus (recs.all …)` a third. Two rules ⇒ five recognizer applications per interaction.
- **rule0 built a `ZMod` dictionary at function entry.** `denseRangeEq?` compares
  `bi.multiplicity = DenseExpr.const 1` and `c = DenseExpr.const 0`, so `ZMod_commRing` +
  `Ring_toAddGroupWithOne` were the *first two statements* of `denseRangeEq?___redArg`, ahead of the
  `[v, c]` payload test — every interaction paid it, including the 5-slot memory ones.
- **rule1 materialized a pattern nobody reads.** `facts.rangeCheckAt` is a closure field, so
  `payload.map constValue?` is a strict argument: one `List (Option (ZMod p))` per interaction, built
  by `mapTR` and reversed, then discarded — always on OpenVM, where `rangeCheckAt` is constantly
  `none`.

## The change

Three `@[csimp]` twins, so **`Proofs/DegenRange.lean` is untouched** and no `DenseCheckRule`
obligation moved.

1. `denseCheckRewriteFImpl` (`EntailedCheck.lean`) sweeps once: `denseFirstHit` returns the index and
   constraint of the first recognizer to fire, `denseScanHits` accumulates **only hits** (a miss
   allocates nothing), and no hits ⇒ return `d` itself — which also drops the
   `algebraicConstraints ++ []` copy and the `filterBus` rebuild that every no-op invocation paid.
   Hits are regrouped over a list as long as the number of *hits*.
2. `denseRangeEqImpl?` matches `[v, .const c]` / `.const m` as tags first and tests literals with
   `zmodIsOne`/`zmodIsZero`, with the `facts` assoc-list lookups after the cheaper `ZMod` tests;
   `denseBoolCImpl` does the same for `-1`.
3. `denseBoolCheckImpl?` gates on a literal-1 multiplicity and an allocation-free `denseHasBareVar`
   scan before building the pattern, which is then `denseConstPattern` (no `mapTR` reversal).

**Why it is value-identical.** `denseScanHits_eq` reduces the scan to
`(bis.filterMap (denseFirstHit recs 0)).reverse ++ acc`; `denseUnshift_hits` is the induction that
makes the regrouping work — the hits of `r :: rest` over `bis`, unshifted, are exactly the hits of
`rest` over `bis.filter (r · |>.isNone)`, which is `denseGroupEmit`'s own recursion — and
`denseTakeHead_hits` gives the head group as `bis.filterMap r`, both needing `denseFirstHit_succ`.
`denseFirstHit_isNone` shows the sweep's miss test *is* `recs.all`, so the survivor filter needs no
second pass. `denseHasBareVar_getElem?` is what makes the bare-var pre-filter exact.

## Numbers

Local 20-core box, serial, interleaved per case, whole local corpus of 303 APCs (OpenVM 202, SP1 101):

| | before | after | ratio |
|---|---:|---:|---:|
| **degenRange, corpus** | **1354 ms** | **377 ms** | **0.278x** |
| degenRange, OpenVM | 1215 | 348 | 0.286x |
| degenRange, SP1 | 139 | 29 | 0.209x |
| corpus wall | 46 781 | 45 930 | 0.982x |

Per case: sha256 `apc_001` **562 → 181 ms** (total 21 507 → 21 182), wasm-eth `apc_012` 74 → 23,
keccak `apc_001` 71 → 18, `apc_063` 54 → 17, `apc_036` 53 → 20, `apc_037` 52 → 16, `apc_006` 49 → 13,
SP1 keccak 34 → 9. No other pass moves outside interleave noise.

**Is the corpus wall real?** Yes — four independent interleaved reps: wall
0.980 / 0.982 / 0.983 / 0.979x, pass 0.283 / 0.278 / 0.266 / 0.281x, best-of-3 per case 0.980x wall
and 0.256x pass. This needs saying because the *baseline* itself drifts 46 252–46 781 ms (±0.6 %)
between reps, so only the harness's per-case pairing separates a 2 % effect from that. The ~900 ms of
wall equals the ~980 ms taken out of the pass, which is what removing serial work should look like.

The win also tracks pass weight, and nothing pays for it — bucketed by baseline `degenRange` ms:

| baseline degenRange | n | wall ratio (two reps) |
|---|---:|---:|
| ≥ 20 ms | 8 | 0.979x / 0.981x |
| 5–19 ms | ~19 | 0.974x / 0.986x |
| 1–4 ms | ~126 | 0.985x / 0.974x |
| 0 ms | ~150 | 1.004x / 1.009x |

Per-case sign test on wall: 151–153 faster, 85–91 slower, 61–65 tied. Note this clears the land bar on
the per-pass clause (0.32x on the worst case), not the ≥ 5 % end-to-end one — a rank-16 pass cannot
move the whole corpus by more than this.

## Verified

- Per-cycle `vars / bus / constraints` **identical on all 303 corpus APCs**.
- `opt-export` byte-identical on sha256 `apc_001`, keccak `apc_001`, wasm-eth `apc_012`, SP1 keccak
  `apc_001` and SP1 rsp `apc_001`.
- `lake build` clean with no warnings; `Scripts/check-proof-integrity.sh` passes on the three standard
  axioms with no unused theorem.
- All four twins live in the C: the slow bodies have no caller but their own `___boxed`, and
  `ofCheckRules` calls `denseCheckRewriteFImpl`.

## Residual

Re-profiled on keccak, the pass's own frames fall from **302 to 41 samples** (2.0 % → 0.3 % of the
run) against a reported 24 ms, and the rules-stubbed floor was 17–20 ms — so **~70 % of what is left
is the framework plus the degree guard (R5)**, not this pass. R15(c)'s per-pass gate is moot here: the
sweep *is* the gate. Left on the table, recorded as R9e: five other passes' per-interaction
recognizers still build the dictionary chain at entry for the same reason rule0 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
