### PR TITLE
perf(recognizers): keep DenseExpr.const numerals off the entry path (xorEqExtract 0.64x, digitFold 0.70x)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DigitFold.lean
@@ -429,6 +429,25 @@ def densePairByteOps? (bs : BusSemantics p) (facts : BusFacts p bs)
       then some (o1, o2) else none
     | none => none
 
+/-- Dictionary-free twin: same structure, literals tested without the `ZMod.commRing` chain that
+    `DenseExpr.const 0`/`1` put at this recognizer's entry. -/
+def densePairByteOpsImpl? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p × DenseExpr p) :=
+  match facts.byteXorSpec bi.busId with
+  | none => none
+  | some spec =>
+    match spec.decode bi.payload with
+    | some (op, o1, o2, _r) =>
+      if spec.bound = 256 ∧ op = DenseExpr.const spec.pairOp ∧ _r.isConstZero = true
+          ∧ bi.multiplicity.isConstOne = true
+      then some (o1, o2) else none
+    | none => none
+
+@[csimp] theorem densePairByteOps_eq_impl : @densePairByteOps? = @densePairByteOpsImpl? := by
+  funext q bs facts bi
+  simp only [densePairByteOps?, densePairByteOpsImpl?, DenseExpr.isConstOne_eq_decide,
+    DenseExpr.isConstZero_eq_decide, decide_eq_true_eq]
+
 /-! ## The fold plan: the ladder forms to solve and the keys they will query -/
 
 /-- One operand's contribution: its ladder form (in reverse scan order) and its variables, when

--- a/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Encoding.lean
@@ -186,6 +186,28 @@ def DenseExpr.degree : DenseExpr p → Nat
   | .add a b => max a.degree b.degree
   | .mul a b => a.degree + b.degree
 
+/-! Mentioning `DenseExpr.const 0`/`1` anywhere in a function puts a `ZMod.commRing` chain at that
+function's *entry*, ahead of every branch test that would have rejected the input, so recognizers
+test literals through these instead. The `_eq_decide` bridges are their whole proof surface. -/
+
+/-- Is the dense expression the literal constant `0`? -/
+def DenseExpr.isConstZero : DenseExpr p → Bool
+  | .const n => zmodIsZero n
+  | _ => false
+
+/-- Is the dense expression the literal constant `1`? -/
+def DenseExpr.isConstOne : DenseExpr p → Bool
+  | .const n => zmodIsOne n
+  | _ => false
+
+theorem DenseExpr.isConstZero_eq_decide (e : DenseExpr p) :
+    e.isConstZero = decide (e = DenseExpr.const 0) := by
+  cases e <;> simp [DenseExpr.isConstZero]
+
+theorem DenseExpr.isConstOne_eq_decide (e : DenseExpr p) :
+    e.isConstOne = decide (e = DenseExpr.const 1) := by
+  cases e <;> simp [DenseExpr.isConstOne]
+
 /-- `eval` mentions `+`/`*`, so it derived the whole `CommRing` chain at *every node*. This twin
     routes both through the primitives; the `@[csimp]` below lives here, in the earliest dense
     module, so it fires for every pass. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/Rewrite.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Rewrite.lean
@@ -34,20 +34,4 @@ theorem DenseConstraintSystem.filterBus_covered {reg : VarRegistry}
     (d.filterBus keep).CoveredBy reg :=
   ⟨fun e he => hc.1 e he, fun bi hbi => hc.2 bi (List.mem_of_mem_filter hbi)⟩
 
-/-! ## Small dense expression predicates -/
-
-def DenseExpr.isConstZeroImpl : DenseExpr p → Bool
-  | .const n => zmodIsZero n
-  | _ => false
-
-/-- Is the dense expression the literal constant `0`? -/
-def DenseExpr.isConstZero : DenseExpr p → Bool
-  | .const n => zmodIsZero n
-  | _ => false
-
-@[csimp] theorem DenseExpr_isConstZero_eq_impl :
-    @DenseExpr.isConstZero = @DenseExpr.isConstZeroImpl := by
-  funext q e
-  simp [DenseExpr.isConstZero, DenseExpr.isConstZeroImpl]
-
 end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/SplitBytePair.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SplitBytePair.lean
@@ -24,6 +24,25 @@ def denseAsBytePair (bs : BusSemantics p) (facts : BusFacts p bs)
             ∧ r = DenseExpr.const 0 then some (bi.busId, spec, o1, o2) else none
     | none => none
 
+/-- Dictionary-free twin: same structure, literals tested without the `ZMod.commRing` chain that
+    `DenseExpr.const 0`/`1` put at this recognizer's entry. -/
+def denseAsBytePairImpl (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) :
+    Option (Nat × ByteXorSpec p × DenseExpr p × DenseExpr p) :=
+  match facts.byteXorSpec bi.busId with
+  | none => none
+  | some spec =>
+    match spec.decode bi.payload with
+    | some (op, o1, o2, r) =>
+        if bi.multiplicity.isConstOne = true ∧ op = DenseExpr.const spec.pairOp
+            ∧ r.isConstZero = true then some (bi.busId, spec, o1, o2) else none
+    | none => none
+
+@[csimp] theorem denseAsBytePair_eq_impl : @denseAsBytePair = @denseAsBytePairImpl := by
+  funext q bs facts bi
+  simp only [denseAsBytePair, denseAsBytePairImpl, DenseExpr.isConstOne_eq_decide,
+    DenseExpr.isConstZero_eq_decide, decide_eq_true_eq]
+
 /-- Split one interaction: a recognized packed pair becomes its two single-value checks (in
     decode order `a` then `b`); anything else passes through unchanged. -/
 def denseSplitOne (bs : BusSemantics p) (facts : BusFacts p bs)

--- a/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/SubsumedCheck.lean
@@ -26,6 +26,29 @@ def denseSubsumedCheckOf (bs : BusSemantics p) (facts : BusFacts p bs)
     else none
   | none => none
 
+/-- Dictionary-free twin: the literal-`1` gate runs first, so a non-unit multiplicity no longer
+    builds the `constValue?` pattern that `facts.rangeCheckAt` would discard. -/
+def denseSubsumedCheckOfImpl (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (VarId × Nat) :=
+  if bi.multiplicity.isConstOne then
+    match facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+    | some (valSlot, bound) =>
+      match bi.payload[valSlot]? with
+      | some (DenseExpr.var x) => some (x, bound)
+      | _ => none
+    | none => none
+  else none
+
+@[csimp] theorem denseSubsumedCheckOf_eq_impl :
+    @denseSubsumedCheckOf = @denseSubsumedCheckOfImpl := by
+  funext q bs facts bi
+  unfold denseSubsumedCheckOf denseSubsumedCheckOfImpl
+  rw [DenseExpr.isConstOne_eq_decide]
+  cases facts.rangeCheckAt bi.busId (bi.payload.map DenseExpr.constValue?) with
+  | none => simp
+  | some vb => obtain ⟨valSlot, bound⟩ := vb; by_cases hm : bi.multiplicity = DenseExpr.const 1 <;>
+      simp [hm]
+
 /-- Recognise a single-variable range check `[x, width]` (multiplicity `1`) on a `varRangeBus`
     bus whose width is a *satisfiable* constant (`width.val ≤ 17`): the checked variable and the
     bound `2 ^ width`. -/

--- a/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/XorEqExtract.lean
@@ -34,6 +34,47 @@ def denseXorEq? (bs : BusSemantics p) (facts : BusFacts p bs)
       | none => none
     else none
 
+/-- The `255` literal behind a call, so it stays out of the recognizers' entry. -/
+def denseIsConst255 (e : DenseExpr p) : Bool := decide (e = DenseExpr.const 255)
+
+/-- Dictionary-free twin: the literal-`1` multiplicity gate runs first (a tag test, ahead of the
+    `byteXorSpec` lookup), the `0` tests go through `isConstZero`, and `255` sits behind
+    `denseIsConst255`, which the hot path never reaches. -/
+def denseXorEqImpl? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p) :=
+  if bi.multiplicity.isConstOne then
+    match facts.byteXorSpec bi.busId with
+    | none => none
+    | some spec =>
+      match spec.decode bi.payload with
+      | some (op, o1, o2, r) =>
+        if op = DenseExpr.const spec.xorOp then
+          if o1.isConstZero then some (denseEqExpr r o2)
+          else if o2.isConstZero then some (denseEqExpr r o1)
+          else if 256 ≤ p ∧ spec.bound = 256 ∧ denseIsConst255 o1 = true then
+            some (denseEqExpr r (denseComplExpr o2))
+          else if 256 ≤ p ∧ spec.bound = 256 ∧ denseIsConst255 o2 = true then
+            some (denseEqExpr r (denseComplExpr o1))
+          else none
+        else none
+      | none => none
+  else none
+
+@[csimp] theorem denseXorEq_eq_impl : @denseXorEq? = @denseXorEqImpl? := by
+  funext q bs facts bi
+  unfold denseXorEq? denseXorEqImpl?
+  rw [DenseExpr.isConstOne_eq_decide]
+  by_cases hm : bi.multiplicity = DenseExpr.const 1
+  · simp only [hm, decide_true, if_true, DenseExpr.isConstZero_eq_decide, decide_eq_true_eq,
+      denseIsConst255, decide_eq_true_eq]
+  · simp only [hm, decide_false, Bool.false_eq_true, if_false]
+    cases facts.byteXorSpec bi.busId with
+    | none => rfl
+    | some spec =>
+      cases spec.decode bi.payload with
+      | none => rfl
+      | some t => obtain ⟨op, o1, o2, r⟩ := t; rfl
+
 /-- A substitution target Gauss can inline freely: a constant. -/
 def denseSimpleTarget (e : DenseExpr p) : Bool := e.constValue?.isSome
 
@@ -65,5 +106,42 @@ def denseBoolEq? (bs : BusSemantics p) (facts : BusFacts p bs)
         else none
       | none => none
     else none
+
+/-- Dictionary-free twin of `denseBoolEq?`; see `denseXorEqImpl?`. -/
+def denseBoolEqImpl? (bs : BusSemantics p) (facts : BusFacts p bs)
+    (bi : BusInteraction (DenseExpr p)) : Option (DenseExpr p) :=
+  if bi.multiplicity.isConstOne then
+    match facts.byteXorSpec bi.busId with
+    | none => none
+    | some spec =>
+      match spec.decode bi.payload with
+      | some (op, o1, o2, r) =>
+        if denseOpIs spec.orOp op then
+          if o1.isConstZero then
+            (if denseSimpleTarget o2 then some (denseEqExpr r o2) else none)
+          else if o2.isConstZero then
+            (if denseSimpleTarget o1 then some (denseEqExpr r o1) else none)
+          else none
+        else if denseOpIs spec.andOp op then
+          if o1.isConstZero || o2.isConstZero then some r
+          else none
+        else none
+      | none => none
+  else none
+
+@[csimp] theorem denseBoolEq_eq_impl : @denseBoolEq? = @denseBoolEqImpl? := by
+  funext q bs facts bi
+  unfold denseBoolEq? denseBoolEqImpl?
+  rw [DenseExpr.isConstOne_eq_decide]
+  by_cases hm : bi.multiplicity = DenseExpr.const 1
+  · simp only [hm, decide_true, if_true, DenseExpr.isConstZero_eq_decide, decide_eq_true_eq,
+      Bool.or_eq_true, decide_eq_true_eq]
+  · simp only [hm, decide_false, Bool.false_eq_true, if_false]
+    cases facts.byteXorSpec bi.busId with
+    | none => rfl
+    | some spec =>
+      cases spec.decode bi.payload with
+      | none => rfl
+      | some t => obtain ⟨op, o1, o2, r⟩ := t; rfl
 
 end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -547,14 +547,29 @@ group (subsumedRange 418 ms of corpus; digitFold 583 but only `densePairByteOps?
 identitySubst 127, redundantByteDrop 360, splitBytePair 47), so the rest are worth batching behind
 it rather than one PR each.
 
-**R9b. What is left, and why it is expensive.** Its `rootPairUnify` half is **superseded by entry
-170**, which rebuilt the pass (0.13–0.53×): the per-candidate chain builders are gone with the
-per-candidate work itself, and the surviving `⁻¹` is one call per distinct coefficient value.
-Still open for `HintCollapse`, `SeqzCollapse`, `ByteCheckPack` and `BoxRewrite`: landing these means
-restating the affected `…With_eq` bridges to rewrite through `zmodZeroP_eq`/`zmodOneP_eq` rather than
-`rfl` — mechanical, but ~25 proof sites for a few percent. Note also `Affine.trySolve`/`trySolveUnit`
-and `denseScaledSlotBound` need the ring for `⁻¹`/`scale` regardless, so converting only their guards
-would not empty their entries.
+~~**R9b. What is left, and why it is expensive.**~~ · **retired as a dead end 2026-08-05: its targets
+do not execute.** Its `rootPairUnify` half was already **superseded by entry 170**, which rebuilt the
+pass (0.13–0.53×). The remainder — convert the construction sites in `HintCollapse`, `SeqzCollapse`,
+`ByteCheckPack`, `BoxRewrite`, at ~25 `…With_eq` bridge restatements off `rfl` — was measured by
+attribution on sha256 `apc_001` (131 271 LBR samples, 21.3 s) and **every named construction site is
+cold**: `denseSumExpr` 0 frame appearances, `denseCoeffVar` 0, `denseExtractLinear` 0, `densePolyOf`
+0, `denseComplExpr` 0, `denseSeqzE*` 2. Not a naming artifact — `denseHintCollapse` itself appears
+1021 times, so the pass is sampled and its R9b functions simply never run. Whole-item ceiling
+**1.07 % of the run** charging *all* alloc+refcount inside those functions to the dictionary (a large
+over-count: they exist to allocate expression trees), **0.18 %** at the direct chain-walk leaves —
+either way consistent with R9's own measured `+0.4 %, not worth it`, and R9b's "a few percent" was
+never supported. Do not re-open it without a case where one of those symbols is hot.
+
+**What was actually hot there is R9e, not R9b.** The two groups carrying samples carry them in their
+*comparison* logic: `denseXorEq?` (4100 appearances; XorEqExtract 342 ms on sha256, 851 ms corpus)
+opens with `bi.multiplicity = DenseExpr.const 1` then `op = DenseExpr.const spec.xorOp` /
+`o1 = DenseExpr.const 0` / `o1 = DenseExpr.const 255` — the degenRange rule0 pattern exactly, so
+tag-matching fixes it with no proof movement. That makes **XorEqExtract the largest R9e target**,
+ahead of SubsumedCheck. Its size is genuinely open: ~7 % of the pass at the direct leaves, ~39 % at
+the generous ceiling, so size it (`@[implemented_by]`) before promising the ≥ 10 % per-pass clause.
+The one true R9b-shaped hot site left is `denseIsByteCompl`'s own `.const (-1)` — one function, 1–2
+bridges, not 25. Note also `Affine.trySolve`/`trySolveUnit` and `denseScaledSlotBound` need the ring
+for `⁻¹`/`scale` regardless, so converting only their guards would never empty their entries.
 
 **R9d (partly done, entry 170). The bound path is what is left of `rootPairUnify`** (sha256 918 ms:
 preparation 274, `denseVarBucket` build 125, ~900 bound queries 122, `substF` 259). A

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -520,20 +520,32 @@ per corpus**. Three things worth carrying forward:
 - **Where a twin already exists, edit only the twin**; the in-place edit costs proof work and buys
   no runtime.
 
-**R9e (new, found in entry 179; cheap, several passes).** A recognizer that compares an expression
+**R9e (new, found in entry 179; cheap, several passes).** A recognizer that *compares* an expression
 against a `DenseExpr.const` numeral pays the dictionary chain at its **entry**, not at the
 comparison: `denseRangeEq?___redArg`'s first two statements were `ZMod_commRing` +
 `Ring_toAddGroupWithOne`, *ahead* of the `[v, c]` payload-shape test that rejects most interactions —
-so the gate written first is not the gate that runs first. The fix is mechanical: match the
-constructor as a tag (`| .const c =>`) and test the literal with `zmodIsOne`/`zmodIsZero`. Scan the
-first ~14 lines of each `___redArg` body in the IR for `ZMod_commRing`; that finds, still live,
-`denseSubsumedCheckOf` / `denseSubsumedRangeCheck?` (SubsumedCheck), `denseIdentityPairAt` /
-`denseOrIdentityOperand` / `denseIdentitySubstF` (IdentitySubst), `denseIsByteCompl` /
-`denseSvCheckWith?` / `denseComplExpr` (ByteCheckPack), `denseAsBytePair` / `denseSplitBytePairF`
-(SplitBytePair) and `densePairByteOps?` / `denseSlotBoundAt` / `denseInteractionBound` (DigitFold) —
-every one of them a per-interaction recognizer. Corpus stakes are small per pass (subsumedRange 418
-ms, digitFold 583, identitySubst 127, redundantByteDrop 360, splitBytePair 47), so batch them rather
-than opening one PR each.
+so the gate written first is not the gate that runs first, and this is invisible in the Lean source.
+The fix is mechanical and moves no proof: match the constructor as a tag (`| .const c =>`) and test
+the literal with `zmodIsOne`/`zmodIsZero`.
+
+**Comparison is R9e; construction is R9b — do not batch them.** A site that has to *build* a numeral
+(`denseComplExpr`'s `.add (.const 255) (.mul (.const (-1)) e)`) cannot be tag-matched out of it; it
+needs the primitive and therefore R9b's ~25 `…With_eq` bridge restatements. Scanning the first ~14
+lines of each `___redArg` body in the IR for `ZMod_commRing` mixes the two, so classify each hit
+before costing it. Still live, and comparison-shaped (i.e. actually R9e): `denseSubsumedCheckOf` /
+`denseSubsumedRangeCheck?` (SubsumedCheck), `denseIdentityPairAt` / `denseOrIdentityOperand` /
+`denseIdentitySubstF` (IdentitySubst), `denseAsBytePair` / `denseSplitBytePairF` (SplitBytePair),
+`densePairByteOps?` (DigitFold). Construction-shaped, i.e. **R9b, not this item**: `denseComplExpr`
+and its callers `denseIsByteCompl` / `denseSvCheckWith?` (ByteCheckPack).
+
+**Start with `SubsumedCheck.denseSubsumedCheckOf`: it is nearly a verbatim copy of the
+`denseBoolCheck?` that entry 179 fixed** — the same `payload.map constValue?` handed to
+`facts.rangeCheckAt` (constantly `none` on OpenVM, so the pattern is built and discarded), the same
+`bi.multiplicity = DenseExpr.const 1`, and the same `payload[valSlot]? = some (.var x)` emit
+condition, so `denseHasBareVar` transfers as a pre-filter unchanged. It is also the largest of the
+group (subsumedRange 418 ms of corpus; digitFold 583 but only `densePairByteOps?` is this shape,
+identitySubst 127, redundantByteDrop 360, splitBytePair 47), so the rest are worth batching behind
+it rather than one PR each.
 
 **R9b. What is left, and why it is expensive.** Its `rootPairUnify` half is **superseded by entry
 170**, which rebuilt the pass (0.13–0.53×): the per-candidate chain builders are gone with the

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -520,32 +520,28 @@ per corpus**. Three things worth carrying forward:
 - **Where a twin already exists, edit only the twin**; the in-place edit costs proof work and buys
   no runtime.
 
-**R9e (new, found in entry 179; cheap, several passes).** A recognizer that *compares* an expression
-against a `DenseExpr.const` numeral pays the dictionary chain at its **entry**, not at the
-comparison: `denseRangeEq?___redArg`'s first two statements were `ZMod_commRing` +
-`Ring_toAddGroupWithOne`, *ahead* of the `[v, c]` payload-shape test that rejects most interactions —
-so the gate written first is not the gate that runs first, and this is invisible in the Lean source.
-The fix is mechanical and moves no proof: match the constructor as a tag (`| .const c =>`) and test
-the literal with `zmodIsOne`/`zmodIsZero`.
+~~**R9e. Recognizer numerals on the entry path.**~~ · **done (entry 180)**, and the residual is
+measured. A recognizer that *compares* an expression against a `DenseExpr.const` numeral pays the
+`ZMod.commRing` chain at its **entry**, ahead of the branch test that would have rejected the
+interaction — invisible in the Lean source, so read the C. Fixed with one `@[csimp]` twin per
+recognizer testing literals through `DenseExpr.isConstZero`/`isConstOne` (`Encoding.lean`, the common
+ancestor of both halves of the import graph; its two `_eq_decide` bridges are the whole proof
+surface). **xorEqExtract 0.61–0.66x, digitFold 0.68–0.74x, subsumedCheck 0.66–0.78x, splitBytePair
+0.55–0.74x; corpus wall ~0.983x.**
 
-**Comparison is R9e; construction is R9b — do not batch them.** A site that has to *build* a numeral
-(`denseComplExpr`'s `.add (.const 255) (.mul (.const (-1)) e)`) cannot be tag-matched out of it; it
-needs the primitive and therefore R9b's ~25 `…With_eq` bridge restatements. Scanning the first ~14
-lines of each `___redArg` body in the IR for `ZMod_commRing` mixes the two, so classify each hit
-before costing it. Still live, and comparison-shaped (i.e. actually R9e): `denseSubsumedCheckOf` /
-`denseSubsumedRangeCheck?` (SubsumedCheck), `denseIdentityPairAt` / `denseOrIdentityOperand` /
-`denseIdentitySubstF` (IdentitySubst), `denseAsBytePair` / `denseSplitBytePairF` (SplitBytePair),
-`densePairByteOps?` (DigitFold). Construction-shaped, i.e. **R9b, not this item**: `denseComplExpr`
-and its callers `denseIsByteCompl` / `denseSvCheckWith?` (ByteCheckPack).
+Measured and dropped — do not re-propose as stated: **`denseSubsumedRangeCheck?`** (flat, 0.993x:
+subsumedRange's 417 ms is not in its recognizer) and **`IdentitySubst`** (flat, 0.967–1.085x). The
+IdentitySubst result is the informative one: a variant that *also* hoisted the literal-`1`
+multiplicity gate ahead of the `facts.byteXorSpec` lookup measured **0.761x**, so there the cost is
+the *lookup ordering*, not the numeral — worth ~15 ms of corpus, which does not repay the
+`if`-past-`match` commutation proof the hoist needs. Two twin shapes, very different proof costs:
+structure-preserving (swap comparisons only) closes as a congruence with one `simp only`; hoisting a
+gate out of a nested match must commute `if` past `match` by hand — `grind` fails and `cases` on the
+scrutinee will not substitute under the twin's `if`.
 
-**Start with `SubsumedCheck.denseSubsumedCheckOf`: it is nearly a verbatim copy of the
-`denseBoolCheck?` that entry 179 fixed** — the same `payload.map constValue?` handed to
-`facts.rangeCheckAt` (constantly `none` on OpenVM, so the pattern is built and discarded), the same
-`bi.multiplicity = DenseExpr.const 1`, and the same `payload[valSlot]? = some (.var x)` emit
-condition, so `denseHasBareVar` transfers as a pre-filter unchanged. It is also the largest of the
-group (subsumedRange 418 ms of corpus; digitFold 583 but only `densePairByteOps?` is this shape,
-identitySubst 127, redundantByteDrop 360, splitBytePair 47), so the rest are worth batching behind
-it rather than one PR each.
+Still unconverted, and now known to be **not worth converting on this evidence**: the construction
+sites of R9b (below) and the `if (1 : ZMod p) ≠ 0` guard at the top of each pass transform
+(`denseSplitBytePairF`, `denseIdentitySubstF`, …) — once per invocation, not per interaction.
 
 ~~**R9b. What is left, and why it is expensive.**~~ · **retired as a dead end 2026-08-05: its targets
 do not execute.** Its `rootPairUnify` half was already **superseded by entry 170**, which rebuilt the

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7142,3 +7142,48 @@ allocation-free tag-check pass that returns the input on a miss, no cheaper nece
 beats it, so the gate and the pass are the same code.
 
 **Worked: yes.**
+
+### 180. Runtime: recognizer numerals off the entry path in four passes (xorEqExtract 0.64x, digitFold 0.70x)
+
+R9e, found while doing entry 179: a recognizer that compares an expression against a
+`DenseExpr.const` numeral pays the `ZMod.commRing` chain at its **entry**, ahead of the branch test
+that would have rejected the interaction, and this is invisible in the Lean source. Six functions in
+five passes still had it. The fix is one `@[csimp]` twin each testing literals with
+`DenseExpr.isConstZero`/`isConstOne` instead — `Proofs/*` untouched everywhere.
+
+`DenseExpr.isConstOne` is new and `isConstZero` moved from `Rewrite.lean` to `Encoding.lean`: the
+recognizers live on both sides of the import graph (`IdentitySubst` and `SubsumedCheck` never see
+`Rewrite`), and `Encoding.lean` — where `DenseExpr` itself is declared — is the common ancestor. The
+whole proof surface is the two `_eq_decide` bridges.
+
+LANDED, and what each measured (three interleaved corpus reps, 303 APCs): **xorEqExtract 0.61–0.66x**
+(852 → 548 ms), **digitFold 0.68–0.74x** (570 → 387), subsumedCheck 0.66–0.78x (77 → 51),
+splitBytePair 0.55–0.74x (47 → 33). Corpus wall **0.976 / 0.991 / 0.981x**, so ~0.983x; both VMs
+improve (OpenVM 0.975x, SP1 0.978x). sha256 `apc_001` 21 134 → 20 616 ms with xorEqExtract 340 → 251
+and digitFold 182 → 117.
+
+DROPPED, measured, do not retry as stated:
+- **`denseSubsumedRangeCheck?` — flat (0.993x).** subsumedRange's 417 ms is not in its recognizer, so
+  removing the chain there buys nothing; the twin was deleted rather than landed.
+- **`IdentitySubst` — flat (0.967 / 0.984 / 1.085x) once the twin kept the original structure.** The
+  interesting part: an earlier version that *also* hoisted the literal-`1` multiplicity gate ahead of
+  the `facts.byteXorSpec` lookup measured **0.761x**. So in this pass the numeral was not the cost —
+  the lookup ordering was — and it is worth ~15 ms of corpus, which does not repay the proof. The
+  hoist is what needs an `if`-past-`match` commutation argument; that is exactly the proof that
+  `grind` would not do and that made the structure-preserving twin the right shape for the two passes
+  where the numeral *was* the cost.
+
+THE PROOF LESSON. Two twin shapes, very different costs. Keeping the original's structure and
+swapping only the comparisons makes the equality a congruence: `simp only [defs, isConstOne_eq_decide,
+isConstZero_eq_decide, decide_eq_true_eq]` closes it outright. Hoisting a gate *out* of a nested match
+instead needs the `if`/`match` commutation by hand — `grind` failed on both attempts, and `cases` on
+the match scrutinee does not substitute under the twin's `if`. Reach for the hoist only where it is
+what pays (xorEqExtract and SubsumedCheck's own recognizer, both of which kept it).
+
+VERIFIED: per-cycle `vars / bus / constraints` identical on all 303 corpus APCs in every rep; `lake
+build` clean with no warnings; `check-proof-integrity` passes on the three standard axioms with no
+unused theorem. All six twins verified live and chain-free in the C — the `Impl` bodies carry no
+`ZMod_commRing` in their first 16 lines, and each slow body's only caller is its own dead wrapper.
+
+**Worked: yes** (xorEqExtract, digitFold, subsumedCheck, splitBytePair); **no** for subsumedRange and
+IdentitySubst, both dropped.


### PR DESCRIPTION
This is R9e, found while doing entry 179 (#286). A recognizer that compares an expression against a
`DenseExpr.const` numeral pays the `ZMod.commRing` chain at its **entry**, not at the comparison —
Lean floats the construction ahead of every branch test, so `denseXorEq?` built a dictionary before
even the `facts.byteXorSpec` lookup that rejects most interactions. **The gate you wrote first is not
the gate that runs first, and this is invisible in the Lean source.**

## The change

One `@[csimp]` twin per recognizer, testing literals through `DenseExpr.isConstZero` / `isConstOne`
instead of the `DenseExpr` equality. **`Proofs/*` is untouched everywhere.**

`isConstOne` is new and `isConstZero` moves from `Rewrite.lean` to `Encoding.lean`: the recognizers
live on both sides of the import graph (`IdentitySubst` and `SubsumedCheck` never see `Rewrite`), and
`Encoding.lean` — where `DenseExpr` is declared — is the common ancestor. Its two `_eq_decide` bridges
are the entire proof surface.

`denseIsConst255` keeps XorEqExtract's `255` behind a call the hot path never reaches. `denseXorEq?`
and `denseSubsumedCheckOf` additionally run the literal-1 gate first, which also stops
`denseSubsumedCheckOf` from building a `constValue?` pattern that `rangeCheckAt` discards.

## Numbers

Three interleaved corpus reps, 303 APCs (OpenVM 202, SP1 101), local 20-core box, serial:

| pass | before | after | ratio (3 reps) |
|---|---:|---:|---|
| **xorEqExtract** | 852 ms | 548 ms | **0.61 / 0.64 / 0.66x** |
| **digitFold** | 570 | 387 | **0.68 / 0.70 / 0.74x** |
| subsumedCheck | 77 | 51 | 0.66 / 0.74 / 0.78x |
| splitBytePair | 47 | 33 | 0.55 / 0.70 / 0.74x |
| corpus wall | 45 914 | 44 793 | 0.976 / 0.981 / 0.991x |

Both VMs improve (OpenVM 0.975x, SP1 0.978x). sha256 `apc_001` 21 134 → 20 616 ms, with
xorEqExtract 340 → 251 and digitFold 182 → 117.

This clears the land bar on the per-pass clause (xorEqExtract 0.64x, digitFold 0.70x), not the
≥ 5 % end-to-end one.

## Measured and deliberately dropped

Both were implemented, measured, and deleted rather than landed:

- **`denseSubsumedRangeCheck?` — flat (0.993x).** subsumedRange's 417 ms is not in its recognizer.
- **`IdentitySubst` — flat (0.967 / 0.984 / 1.085x).** The informative one: a variant that *also*
  hoisted the literal-1 gate ahead of the `byteXorSpec` lookup measured **0.761x**, so there the cost
  is the lookup ordering, not the numeral — worth ~15 ms of corpus, which does not repay the
  `if`-past-`match` commutation proof the hoist needs.

The two docs commits also retire **R9b** as a dead end: attribution on sha256 `apc_001` (131k LBR
samples) shows every construction site it names has **zero** frame appearances (`denseSumExpr`,
`denseCoeffVar`, `denseExtractLinear`, `densePolyOf`, `denseComplExpr`; `denseSeqzE*` at 2), while
`denseHintCollapse` itself appears 1021 times — the item would have spent ~25 proof-bridge
restatements on code that does not execute.

## Verified

- Per-cycle `vars / bus / constraints` identical on all 303 corpus APCs, in every rep.
- `lake build` clean with no warnings; `Scripts/check-proof-integrity.sh` passes on the three standard
  axioms with no unused theorem.
- All twins live and chain-free in the C: no `ZMod_commRing` in the first 16 lines of any `Impl` body,
  and each slow body's only caller is its own dead wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)