### PR TITLE
ci: post the PR bench report from a workflow_run job, so fork PRs get it too

### DIFF
--- a/.github/actions/report-bench/action.yml
+++ b/.github/actions/report-bench/action.yml
@@ -13,6 +13,12 @@ inputs:
   note:
     description: Trailing italic note appended to the PR comment (not to the job summary)
     default: ""
+  note-file:
+    description: >-
+      File holding the note, for callers whose note text comes from an artifact — passing such text
+      through an input would route it via GITHUB_ENV/GITHUB_OUTPUT, which its own content can spoof.
+      Takes precedence over `note`.
+    default: ""
   pr:
     description: PR number to comment on (empty = job summary only)
     default: ""
@@ -36,13 +42,18 @@ runs:
         MD: ${{ inputs.md-file }}
         MARKER: ${{ inputs.marker }}
         NOTE: ${{ inputs.note }}
+        NOTE_FILE: ${{ inputs.note-file }}
         PR: ${{ inputs.pr }}
       run: |
         body="$RUNNER_TEMP/sticky-comment-body.md"
         {
           echo "$MARKER"
           cat "$MD"
-          if [ -n "$NOTE" ]; then printf '\n_%s_\n' "$NOTE"; fi
+          if [ -n "$NOTE_FILE" ] && [ -s "$NOTE_FILE" ]; then
+            printf '\n_%s_\n' "$(cat "$NOTE_FILE")"
+          elif [ -n "$NOTE" ]; then
+            printf '\n_%s_\n' "$NOTE"
+          fi
         } > "$body"
         cid=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
           --jq '.[] | select(.body | startswith(env.MARKER)) | .id' | head -n 1)

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -264,8 +264,13 @@ jobs:
           path: rt-*.json
           if-no-files-found: ignore
 
-  # One sticky comment: per set an effectiveness table (with a report-only runtime row) and, for
-  # openvm-eth, the collapsed runtime detail from bench-runtime. Runs even if a job was skipped.
+  # One report: per set an effectiveness table (with a report-only runtime row) and, for openvm-eth,
+  # the collapsed runtime detail from bench-runtime. Runs even if a job was skipped.
+  #
+  # This job publishes -- it does not comment. A `pull_request` run of a fork gets a read-only
+  # GITHUB_TOKEN and public repos have no setting that changes that, so a comment step here is
+  # unpostable on exactly the PRs that most need the report. Instead the markdown goes to the job
+  # summary and to an artifact, and the `PR Report Comment` workflow posts it from base-repo context.
   report:
     if: always() && github.event_name == 'pull_request'
     needs: [baseline, effectiveness, bench-runtime]
@@ -273,7 +278,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       # Two artifacts per group cell (both sides, benched on that cell's runner); merge each side's
@@ -331,15 +335,9 @@ jobs:
             fi
             printf '\n' >> bench.md
           done
-      - name: Report
-        uses: ./.github/actions/report-bench
-        with:
-          md-file: bench.md
-          marker: "<!-- runtime-bench-quick -->"
-          # Comment on same-repo PRs only: fork PRs get a read-only token.
-          pr: ${{ github.event.pull_request.head.repo.full_name == github.repository
-                  && github.event.number || '' }}
-          note: >-
+      - name: Publish the report
+        env:
+          NOTE: >-
             openvm-eth + wasm-eth + keccak + sha256 + sp1/rsp + sp1/keccak,
             PR `${{ steps.note.outputs.pr_sha }}`
             ${{ steps.note.outputs.benched_sha
@@ -349,4 +347,13 @@ jobs:
             Effectiveness is exact. Each set's two sides are benched back to back on one runner, so
             the runtime row is comparable -- but coarse: benchmark.py runs cases in parallel. For
             per-pass detail: `gh workflow run "Runtime Bench" -f pr=${{ github.event.number }}`.
-          token: ${{ github.token }}
+        run: |
+          cat bench.md >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "$NOTE" > note.md
+      # Consumed by `PR Report Comment` (pr_report_comment.yml) via this run's id.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-bench-report
+          path: |
+            bench.md
+            note.md

--- a/.github/workflows/pr_report_comment.yml
+++ b/.github/workflows/pr_report_comment.yml
@@ -1,0 +1,74 @@
+name: PR Report Comment
+
+# Post the Lean Action CI bench report to its pull request as a sticky comment — one comment per
+# PR, updated in place on every push.
+#
+# The `report` job in Lean Action CI cannot post it itself. A `pull_request` run of a fork's branch
+# gets a read-only GITHUB_TOKEN, and on a public repository there is no setting that grants a write
+# token there (the "send write tokens to fork pull requests" option exists only for private repos).
+# So that job publishes the markdown as an artifact and this workflow — triggered by `workflow_run`,
+# which always runs in base-repo context, from the default branch's copy of this file, with the
+# permissions declared here — posts it. Same-repo and fork PRs go through the identical path.
+#
+# The trust boundary: this job holds a write token and must not run PR code. It checks out the
+# default branch (never the PR head), runs no build, and takes only markdown from the upstream run.
+# The PR number is resolved from the `workflow_run` payload's head repo and branch, both set by
+# GitHub, so a fork cannot aim the comment at another PR by writing a number into the artifact.
+# The report body itself is derived from PR code, as any bench result must be.
+
+on:
+  workflow_run:
+    workflows: ["Lean Action CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: pr-report-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      # Absent when `report` failed before uploading, or when the whole run was cancelled; then
+      # there is nothing to post and the job simply ends.
+      - name: Download the report
+        id: report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: pr-bench-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: report
+      - name: Resolve the PR
+        id: pr
+        if: steps.report.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # `<owner>:<branch>` of the run that produced the report — the `head` filter's format.
+          HEAD: ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
+        run: |
+          num=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&head=$HEAD" \
+            --jq '.[0].number // empty')
+          if [ -z "$num" ]; then
+            echo "::notice::no open PR for $HEAD; nothing to comment on"
+          fi
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+      - name: Sticky comment
+        if: steps.pr.outputs.number != ''
+        uses: ./.github/actions/report-bench
+        with:
+          md-file: report/bench.md
+          note-file: report/note.md
+          marker: "<!-- runtime-bench-quick -->"
+          pr: ${{ steps.pr.outputs.number }}
+          token: ${{ github.token }}


### PR DESCRIPTION
## What breaks today

On a fork's pull request the `report` job's comment step is **skipped**, not failed — the job still reports `pass`, and the bench report exists only in the job summary. #288 is the live example: [the step logged](https://github.com/powdr-labs/apc-optimizer/actions/runs/31020189840/job/92361115468) `outcome=skipped` while every check was green.

The gate was deliberate — `pull_request` runs from a fork get a read-only `GITHUB_TOKEN`, so `POST /issues/{n}/comments` would 403 — but it means the report is missing on exactly the PRs that most need it. There is no setting to fix: *"send write tokens to workflows from fork pull requests"* exists only for private repositories, and this repo is public.

## What this does

`report` stops commenting and starts publishing: job summary as before, plus the markdown as a `pr-bench-report` artifact. A new `PR Report Comment` workflow triggers on that run's completion and posts the sticky comment from base-repo context, where the token honors `pull-requests: write`.

Same-repo and fork PRs take the identical path, so there is no fork-only branch to rot, and `report` drops `pull-requests: write` altogether.

## Trust boundary

The new job holds a write token, so it must not run PR code:

- checkout is pinned to `github.event.repository.default_branch` — never the PR head;
- no build, no test, no benchmark: only markdown crosses over from the upstream run;
- the PR number is resolved from the `workflow_run` payload's head repo + branch (both set by GitHub) via the `pulls?head=` filter, so a fork cannot aim the comment at another PR by writing a number into its artifact;
- the note travels as a file (`note-file`) rather than an action input, keeping artifact-derived text out of `GITHUB_ENV`/`GITHUB_OUTPUT`, where its own content could otherwise spoof a delimiter.

The report body is derived from PR code, as any bench result must be.

## Verification

`workflow_run` only ever triggers from the **default branch's** copy of the workflow, so this cannot demonstrate itself on its own PR — the mechanism goes live on merge. What was checked up front:

- all three files parse as YAML;
- the resolution used by `Resolve the PR` returns #288 for that PR's fork branch: `gh api "repos/powdr-labs/apc-optimizer/pulls?state=open&head=1arie1:exp/order-free-admissibility"` → `288`;
- the `note-file` body assembly was run locally in both branches (file present / absent → falls back to `note`), confirming the marker stays the first line so `startswith(marker)` still updates existing sticky comments in place rather than posting duplicates.

Existing `runtime-bench-quick` comments are matched by the same marker, so PRs already carrying one get an update, not a second comment.

Note for open fork PRs: the upstream `pull_request` run uses the **PR branch's** copy of `lean_action_ci.yml`, so an already-open PR must be rebased onto the merged main before its run uploads the artifact.

No change to what is benched, to any audited file, or to the optimizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)