### PR TITLE
perf(guard): lockstep degree check with withPtrEq identity shortcuts (0.94-0.96x end-to-end)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
@@ -86,13 +86,151 @@ def DenseRespectsDeg (b : DegreeBound) (f : DenseVerifiedPassW p) : Prop :=
     (reg.decodeCS d).withinDegree b →
     ((f reg d hcov bs facts).reg'.decodeCS (f reg d hcov bs facts).out).withinDegree b
 
+/-! ### The lockstep degree check
+
+The guard's degree walk runs against the pass *input* in lockstep: an output item that *is* the
+aligned input item (the same object, `withPtrEq`) is skipped without walking either tree. What each
+paired position checks is `outOk || !inOk` — `true` whenever the two items are equal
+(`bool_or_not_self`, which is exactly `withPtrEq`'s contract) and equal to the plain check whenever
+the input side is within the bound, which the guarded pipeline maintains
+(`denseWithinDegreeLK_sound`). Unpaired output items (appends, length changes) get the plain
+check. -/
+
+private theorem bool_or_not_self (b : Bool) : (b || !b) = true := by cases b <;> rfl
+
+/-- One lockstep item check: `outOk || !inOk`, with the identity shortcut. -/
+def denseDegItemLK (bnd : Nat) (cIn cOut : DenseExpr p) : Bool :=
+  withPtrEq cOut cIn
+    (fun _ => decide (cOut.degree ≤ bnd) || !decide (cIn.degree ≤ bnd))
+    (fun h => by subst h; exact bool_or_not_self _)
+
+private theorem denseDegItemLK_eq (bnd : Nat) (cIn cOut : DenseExpr p) :
+    denseDegItemLK bnd cIn cOut
+      = (decide (cOut.degree ≤ bnd) || !decide (cIn.degree ≤ bnd)) := rfl
+
+/-- One lockstep interaction check (multiplicity and payload together); see `denseDegItemLK`. -/
+def denseDegBiLK (bnd : Nat) (bIn bOut : BusInteraction (DenseExpr p)) : Bool :=
+  withPtrEq bOut bIn
+    (fun _ =>
+      (decide (bOut.multiplicity.degree ≤ bnd)
+          && bOut.payload.all (fun e => decide (e.degree ≤ bnd)))
+        || !(decide (bIn.multiplicity.degree ≤ bnd)
+          && bIn.payload.all (fun e => decide (e.degree ≤ bnd))))
+    (fun h => by subst h; exact bool_or_not_self _)
+
+private theorem denseDegBiLK_eq (bnd : Nat) (bIn bOut : BusInteraction (DenseExpr p)) :
+    denseDegBiLK bnd bIn bOut
+      = ((decide (bOut.multiplicity.degree ≤ bnd)
+            && bOut.payload.all (fun e => decide (e.degree ≤ bnd)))
+          || !(decide (bIn.multiplicity.degree ≤ bnd)
+            && bIn.payload.all (fun e => decide (e.degree ≤ bnd)))) := rfl
+
+def denseDegItemsLK (bnd : Nat) : List (DenseExpr p) → List (DenseExpr p) → Bool
+  | cIn :: din, cOut :: dout => denseDegItemLK bnd cIn cOut && denseDegItemsLK bnd din dout
+  | _, dout => dout.all (fun c => decide (c.degree ≤ bnd))
+
+def denseDegBisLK (bnd : Nat) :
+    List (BusInteraction (DenseExpr p)) → List (BusInteraction (DenseExpr p)) → Bool
+  | bIn :: din, bOut :: dout => denseDegBiLK bnd bIn bOut && denseDegBisLK bnd din dout
+  | _, dout =>
+      dout.all (fun bi => decide (bi.multiplicity.degree ≤ bnd)
+        && bi.payload.all (fun e => decide (e.degree ≤ bnd)))
+
+private theorem denseDegItemsLK_self (bnd : Nat) (l : List (DenseExpr p)) :
+    denseDegItemsLK bnd l l = true := by
+  induction l with
+  | nil => rfl
+  | cons c rest ih =>
+      show (denseDegItemLK bnd c c && denseDegItemsLK bnd rest rest) = true
+      rw [denseDegItemLK_eq, bool_or_not_self, ih, Bool.and_self]
+
+private theorem denseDegBisLK_self (bnd : Nat) (l : List (BusInteraction (DenseExpr p))) :
+    denseDegBisLK bnd l l = true := by
+  induction l with
+  | nil => rfl
+  | cons bi rest ih =>
+      show (denseDegBiLK bnd bi bi && denseDegBisLK bnd rest rest) = true
+      rw [denseDegBiLK_eq, bool_or_not_self, ih, Bool.and_self]
+
+private theorem denseDegItemsLK_sound (bnd : Nat) (din dout : List (DenseExpr p))
+    (hin : din.all (fun c => decide (c.degree ≤ bnd)) = true)
+    (h : denseDegItemsLK bnd din dout = true) :
+    dout.all (fun c => decide (c.degree ≤ bnd)) = true := by
+  induction dout generalizing din with
+  | nil => rfl
+  | cons c rest ih =>
+      cases din with
+      | nil => exact h
+      | cons i irest =>
+          rw [List.all_cons, Bool.and_eq_true] at hin
+          have h' : (denseDegItemLK bnd i c && denseDegItemsLK bnd irest rest) = true := h
+          rw [Bool.and_eq_true, denseDegItemLK_eq] at h'
+          rw [List.all_cons, Bool.and_eq_true]
+          refine ⟨?_, ih irest hin.2 h'.2⟩
+          have hc := h'.1
+          rw [hin.1] at hc
+          simpa using hc
+
+private theorem denseDegBisLK_sound (bnd : Nat) (din dout : List (BusInteraction (DenseExpr p)))
+    (hin : din.all (fun bi => decide (bi.multiplicity.degree ≤ bnd)
+        && bi.payload.all (fun e => decide (e.degree ≤ bnd))) = true)
+    (h : denseDegBisLK bnd din dout = true) :
+    dout.all (fun bi => decide (bi.multiplicity.degree ≤ bnd)
+      && bi.payload.all (fun e => decide (e.degree ≤ bnd))) = true := by
+  induction dout generalizing din with
+  | nil => rfl
+  | cons bi rest ih =>
+      cases din with
+      | nil => exact h
+      | cons i irest =>
+          rw [List.all_cons, Bool.and_eq_true] at hin
+          have h' : (denseDegBiLK bnd i bi && denseDegBisLK bnd irest rest) = true := h
+          rw [Bool.and_eq_true, denseDegBiLK_eq] at h'
+          rw [List.all_cons, Bool.and_eq_true]
+          refine ⟨?_, ih irest hin.2 h'.2⟩
+          have hc := h'.1
+          rw [hin.1] at hc
+          simpa using hc
+
+/-- The guard's degree check: the lockstep walks with a whole-system identity shortcut. On a
+    within-bound input this decides exactly `dOut.withinDegreeB b`
+    (`denseWithinDegreeLK_sound` / `denseWithinDegreeLK_complete`). -/
+def denseWithinDegreeLK (dIn dOut : DenseConstraintSystem p) (b : DegreeBound) : Bool :=
+  withPtrEq dOut dIn
+    (fun _ =>
+      denseDegItemsLK b.identities dIn.algebraicConstraints dOut.algebraicConstraints
+        && denseDegBisLK b.busInteractions dIn.busInteractions dOut.busInteractions)
+    (fun h => by
+      subst h
+      rw [denseDegItemsLK_self, denseDegBisLK_self, Bool.and_self])
+
+private theorem denseWithinDegreeLK_def (dIn dOut : DenseConstraintSystem p) (b : DegreeBound) :
+    denseWithinDegreeLK dIn dOut b
+      = (denseDegItemsLK b.identities dIn.algebraicConstraints dOut.algebraicConstraints
+          && denseDegBisLK b.busInteractions dIn.busInteractions dOut.busInteractions) := rfl
+
+/-- A `true` lockstep verdict on a within-bound input puts the output within the bound. -/
+private theorem denseWithinDegreeLK_sound (dIn dOut : DenseConstraintSystem p) (b : DegreeBound)
+    (hin : dIn.withinDegreeB b = true) (h : denseWithinDegreeLK dIn dOut b = true) :
+    dOut.withinDegreeB b = true := by
+  rw [denseWithinDegreeLK_def, Bool.and_eq_true] at h
+  rw [DenseConstraintSystem.withinDegreeB, Bool.and_eq_true] at hin
+  rw [DenseConstraintSystem.withinDegreeB, Bool.and_eq_true]
+  exact ⟨denseDegItemsLK_sound _ _ _ hin.1 h.1, denseDegBisLK_sound _ _ _ hin.2 h.2⟩
+
+attribute [irreducible] denseWithinDegreeLK
+
 /-- Degree guard on the dense system (no decode): if the output would exceed `b`, keep the input.
-    The dense check equals the spec check (`decodeCS_withinDegreeB`). -/
+    The check runs in lockstep with the input (`denseWithinDegreeLK`), so an unchanged output —
+    whole-system or item-wise — skips the degree walk; per item it tests `outOk || !inOk`, which
+    never rejects a within-bound output (`outOk` alone suffices) and, on the within-bound inputs
+    the guarded pipeline maintains, accepts exactly the within-bound outputs
+    (`denseWithinDegreeLK_sound`, used by `guardDegree_respectsDeg`). -/
 def DenseVerifiedPassW.guardDegree (b : DegreeBound) (f : DenseVerifiedPassW p) :
     DenseVerifiedPassW p :=
   fun reg d hcov bs facts =>
     let r := f reg d hcov bs facts
-    if r.out.withinDegreeB b then r
+    if denseWithinDegreeLK d r.out b then r
     else { reg' := reg, out := d, derivs := [], ext := VarRegistry.Extends.refl reg,
            covered := hcov, dcovered := by intro x hx; simp at hx,
            correct := PassCorrect.refl (reg.decodeCS d) bs }
@@ -100,12 +238,15 @@ def DenseVerifiedPassW.guardDegree (b : DegreeBound) (f : DenseVerifiedPassW p) 
 theorem DenseVerifiedPassW.guardDegree_respectsDeg {b : DegreeBound} (f : DenseVerifiedPassW p) :
     DenseRespectsDeg b (f.guardDegree b) := by
   intro reg d hcov bs facts hin
+  have hdIn : d.withinDegreeB b = true := by
+    rw [← reg.decodeCS_withinDegreeB]
+    exact (Circuit.withinDegreeB_iff _ _).2 hin
   simp only [DenseVerifiedPassW.guardDegree]
-  by_cases hok : (f reg d hcov bs facts).out.withinDegreeB b = true
+  by_cases hok : denseWithinDegreeLK d (f reg d hcov bs facts).out b = true
   · rw [if_pos hok]
     refine (Circuit.withinDegreeB_iff _ _).1 ?_
     rw [(f reg d hcov bs facts).reg'.decodeCS_withinDegreeB]
-    exact hok
+    exact denseWithinDegreeLK_sound d _ b hdIn hok
   · rw [if_neg hok]
     exact hin
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Pass.lean
@@ -108,14 +108,23 @@ private theorem denseDegItemLK_eq (bnd : Nat) (cIn cOut : DenseExpr p) :
     denseDegItemLK bnd cIn cOut
       = (decide (cOut.degree ≤ bnd) || !decide (cIn.degree ≤ bnd)) := rfl
 
+/-- The payload degree check without the closure `List.all` allocates per interaction. -/
+def denseDegExprsOk (bnd : Nat) : List (DenseExpr p) → Bool
+  | [] => true
+  | e :: rest => decide (e.degree ≤ bnd) && denseDegExprsOk bnd rest
+
+private theorem denseDegExprsOk_eq (bnd : Nat) (l : List (DenseExpr p)) :
+    denseDegExprsOk bnd l = l.all (fun e => decide (e.degree ≤ bnd)) := by
+  induction l with
+  | nil => rfl
+  | cons e rest ih => rw [denseDegExprsOk, ih, List.all_cons]
+
 /-- One lockstep interaction check (multiplicity and payload together); see `denseDegItemLK`. -/
 def denseDegBiLK (bnd : Nat) (bIn bOut : BusInteraction (DenseExpr p)) : Bool :=
   withPtrEq bOut bIn
     (fun _ =>
-      (decide (bOut.multiplicity.degree ≤ bnd)
-          && bOut.payload.all (fun e => decide (e.degree ≤ bnd)))
-        || !(decide (bIn.multiplicity.degree ≤ bnd)
-          && bIn.payload.all (fun e => decide (e.degree ≤ bnd))))
+      (decide (bOut.multiplicity.degree ≤ bnd) && denseDegExprsOk bnd bOut.payload)
+        || !(decide (bIn.multiplicity.degree ≤ bnd) && denseDegExprsOk bnd bIn.payload))
     (fun h => by subst h; exact bool_or_not_self _)
 
 private theorem denseDegBiLK_eq (bnd : Nat) (bIn bOut : BusInteraction (DenseExpr p)) :
@@ -123,7 +132,10 @@ private theorem denseDegBiLK_eq (bnd : Nat) (bIn bOut : BusInteraction (DenseExp
       = ((decide (bOut.multiplicity.degree ≤ bnd)
             && bOut.payload.all (fun e => decide (e.degree ≤ bnd)))
           || !(decide (bIn.multiplicity.degree ≤ bnd)
-            && bIn.payload.all (fun e => decide (e.degree ≤ bnd)))) := rfl
+            && bIn.payload.all (fun e => decide (e.degree ≤ bnd)))) := by
+  show ((decide (bOut.multiplicity.degree ≤ bnd) && denseDegExprsOk bnd bOut.payload)
+      || !(decide (bIn.multiplicity.degree ≤ bnd) && denseDegExprsOk bnd bIn.payload)) = _
+  rw [denseDegExprsOk_eq, denseDegExprsOk_eq]
 
 def denseDegItemsLK (bnd : Nat) : List (DenseExpr p) → List (DenseExpr p) → Bool
   | cIn :: din, cOut :: dout => denseDegItemLK bnd cIn cOut && denseDegItemsLK bnd din dout
@@ -151,6 +163,39 @@ private theorem denseDegBisLK_self (bnd : Nat) (l : List (BusInteraction (DenseE
   | cons bi rest ih =>
       show (denseDegBiLK bnd bi bi && denseDegBisLK bnd rest rest) = true
       rw [denseDegBiLK_eq, bool_or_not_self, ih, Bool.and_self]
+
+/-- `denseDegItemsLK` with a remaining-list identity shortcut at every step: a shared tail is
+    retired by one pointer compare (`denseDegItemsLK_self` is `withPtrEq`'s obligation there).
+    The `Subtype` carries the walk's own specification so that obligation can be discharged while
+    the recursion is elaborated; its only runtime field is the `Bool`. -/
+def denseDegItemsFast (bnd : Nat) : (din dout : List (DenseExpr p)) →
+    { r : Bool // r = denseDegItemsLK bnd din dout }
+  | cIn :: din, cOut :: dout =>
+      have hval : (denseDegItemLK bnd cIn cOut && (denseDegItemsFast bnd din dout).1)
+          = denseDegItemsLK bnd (cIn :: din) (cOut :: dout) := by
+        rw [(denseDegItemsFast bnd din dout).2]; rfl
+      ⟨withPtrEq (cOut :: dout) (cIn :: din)
+        (fun _ => denseDegItemLK bnd cIn cOut && (denseDegItemsFast bnd din dout).1)
+        (fun h => by
+          rw [hval, show cIn :: din = cOut :: dout from h.symm]
+          exact denseDegItemsLK_self bnd _),
+       hval⟩
+  | din, dout => ⟨denseDegItemsLK bnd din dout, rfl⟩
+
+/-- `denseDegItemsFast` for the interaction lists. -/
+def denseDegBisFast (bnd : Nat) : (din dout : List (BusInteraction (DenseExpr p))) →
+    { r : Bool // r = denseDegBisLK bnd din dout }
+  | bIn :: din, bOut :: dout =>
+      have hval : (denseDegBiLK bnd bIn bOut && (denseDegBisFast bnd din dout).1)
+          = denseDegBisLK bnd (bIn :: din) (bOut :: dout) := by
+        rw [(denseDegBisFast bnd din dout).2]; rfl
+      ⟨withPtrEq (bOut :: dout) (bIn :: din)
+        (fun _ => denseDegBiLK bnd bIn bOut && (denseDegBisFast bnd din dout).1)
+        (fun h => by
+          rw [hval, show bIn :: din = bOut :: dout from h.symm]
+          exact denseDegBisLK_self bnd _),
+       hval⟩
+  | din, dout => ⟨denseDegBisLK bnd din dout, rfl⟩
 
 private theorem denseDegItemsLK_sound (bnd : Nat) (din dout : List (DenseExpr p))
     (hin : din.all (fun c => decide (c.degree ≤ bnd)) = true)
@@ -198,16 +243,20 @@ private theorem denseDegBisLK_sound (bnd : Nat) (din dout : List (BusInteraction
 def denseWithinDegreeLK (dIn dOut : DenseConstraintSystem p) (b : DegreeBound) : Bool :=
   withPtrEq dOut dIn
     (fun _ =>
-      denseDegItemsLK b.identities dIn.algebraicConstraints dOut.algebraicConstraints
-        && denseDegBisLK b.busInteractions dIn.busInteractions dOut.busInteractions)
+      (denseDegItemsFast b.identities dIn.algebraicConstraints dOut.algebraicConstraints).1
+        && (denseDegBisFast b.busInteractions dIn.busInteractions dOut.busInteractions).1)
     (fun h => by
       subst h
-      rw [denseDegItemsLK_self, denseDegBisLK_self, Bool.and_self])
+      rw [(denseDegItemsFast ..).2, (denseDegBisFast ..).2,
+        denseDegItemsLK_self, denseDegBisLK_self, Bool.and_self])
 
 private theorem denseWithinDegreeLK_def (dIn dOut : DenseConstraintSystem p) (b : DegreeBound) :
     denseWithinDegreeLK dIn dOut b
       = (denseDegItemsLK b.identities dIn.algebraicConstraints dOut.algebraicConstraints
-          && denseDegBisLK b.busInteractions dIn.busInteractions dOut.busInteractions) := rfl
+          && denseDegBisLK b.busInteractions dIn.busInteractions dOut.busInteractions) := by
+  show ((denseDegItemsFast b.identities dIn.algebraicConstraints dOut.algebraicConstraints).1
+      && (denseDegBisFast b.busInteractions dIn.busInteractions dOut.busInteractions).1) = _
+  rw [(denseDegItemsFast ..).2, (denseDegBisFast ..).2]
 
 /-- A `true` lockstep verdict on a within-bound input puts the output within the bound. -/
 private theorem denseWithinDegreeLK_sound (dIn dOut : DenseConstraintSystem p) (b : DegreeBound)

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -454,6 +454,13 @@ where a pass has already been rebuilt to a cheap sweep: zeroMultBus **76 %**, on
 hintCollapse 39 %, bytePack 34 %, xorEqExtract 26 %, degenRange 16 %, carryBranch 14 %, and 3–8 % for
 the big passes. `DenseExpr.degree` is 5.4 % of whole-run samples and `guardDegree` is 21 % of all
 `lean_dec_ref_cold` callers (`List.all` boxes a closure and a `Bool` per item).
+**The guard half landed (entry 181): `guardDegree` now checks in lockstep against the pass input,
+with axiom-free `withPtrEq` identity shortcuts** — 0.94–0.96x end-to-end on every representative
+and sha256, output-identical. What remains of R5 — the `unchanged` field, the fixpoint `sizeKey`
+skip, the guard's `inc_ref`/restore branch — is sub-bar alone; treat it as the substrate of the
+R15 cross-cycle skip memo (with R14's state channel) and size the three together. Note the guard's
+`dec_ref` attribution was mostly the old-generation free cascade landing in its frame, not
+`List.all` boxing — de-boxing alone measured flat (entry 181's DROPPED list).
 
 **R6. Cross-cycle dirtiness (the real fix for no-op rescans)**  ·  *large refactor; the cheap
 slice is now a measured dead end*. **Do not build a cross-cycle negative-memo for domainBatch**:
@@ -977,6 +984,23 @@ instead of 256 (~30× on those scans). It needs a per-item degree analysis and a
 are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`).
 
 ### Runtime dead ends (measured; do not re-propose without new evidence)
+
+- **A shrink-first pre-cycle** (entry 181: a `gauss → normalize → constFold → dedup →
+  trivialConstr` fixpoint between prelude and cleanup, so the heavy passes see a smaller system):
+  effectiveness-identical, but sha256 is a wash — the heavy passes get 20–30 % cheaper and the
+  pre-stage consumes exactly what they save — and wasm-eth `apc_012` regresses **2.0x**, its
+  main-cycle gauss exploding 215 ms → 2.7 s on the pre-shrunk system (basis/shape sensitivity, the
+  entry-134 hazard). First-time shrink work costs the same wherever it runs; any revival needs a
+  pre-stage strictly cheaper than the passes themselves (a fused-sweep shape) with gauss kept out.
+- **De-boxing the guard loop without lockstep** (entry 181: monomorphic `all` loops + a capped
+  allocation-free degree walk, proven csimp, verified live in the C): **flat** — the guard's cost
+  is the tree walk's memory latency, not closures/`lean_apply_1`/Bool boxing. A variant returning
+  `Option Nat` per node was 4–7 % *slower* everywhere: never introduce a per-node ctor return on a
+  hot walk.
+- **Capacity slack for reencode's `pushBool` seeds** (entry 181): the first push onto a
+  `toArray`-seeded array copies it whole (24 % of `Array.push` samples), but that is ~11
+  pointer-word memcpys per run — **flat**. `copy_expand` is ~0.7 % of the run; its other sites are
+  amortized doubling on small buckets.
 
 - **Deferring a per-invocation index's force to its first query** (entry 174, busPairCancel's
   `cands`): the counters say it is queried 2 498 times in sha256 cycle 1, 0 times in cycles 8–10 and

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7238,3 +7238,17 @@ DROPPED, measured the same session, do not retry as stated (details in the dead-
   `pushBool`): **flat** — ~11 pointer-word memcpys per run; `copy_expand` is ~0.7 % of the run.
 
 **Worked: yes** (the lockstep guard); the three DROPPED items are recorded dead ends.
+
+**Addendum (same session): the walk upgraded with PR #281's two refinements, certificate-free.**
+A parallel draft (#281) had independently built the same guard idea around a threaded degree
+certificate (`DenseGuardedPassW`, 4 files). A three-way A/B on current main showed its edge over
+the plain lockstep guard (sha256 0.94x vs 0.97x) came from its *walk*, not its certificate: a
+remaining-list `withPtrEq` at every step (one compare retires a shared tail — 35–45 % of guard
+nodes sit in one, per #281's probe) and monomorphic per-item walkers (no closure per interaction).
+Both fit the certificate-free design: `denseDegItemsFast`/`denseDegBisFast` return
+`{ r : Bool // r = denseDegItemsLK … }` so the list-level `withPtrEq` obligation is discharged by
+the walk's own `_self` lemma mid-recursion — no threaded proof, no framework type change,
+`denseWithinDegreeLK`'s interface and everything downstream unchanged. Hybrid vs #281 (medians,
+rebased on the same main): sha256 0.940 vs 0.948–0.956, apc_036 0.933 vs 0.959, keccak 0.931 vs
+0.954, apc_012 0.962 vs 0.922 (#281's one consistent edge — unexplained, noted in its close-out).
+#281 closed in favour of this branch with credit for both walk ideas.

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7187,3 +7187,54 @@ unused theorem. All six twins verified live and chain-free in the C — the `Imp
 
 **Worked: yes** (xorEqExtract, digitFold, subsumedCheck, splitBytePair); **no** for subsumedRange and
 IdentitySubst, both dropped.
+
+### 181. Runtime: lockstep degree guard with `withPtrEq` identity shortcuts (0.94–0.96x end-to-end)
+
+R5's guard half — the lockstep design the 2026-08-04 profiling session called for. `guardDegree`
+re-ran `withinDegreeB` (a full degree walk, three closure allocations per call, a boxed `Bool` per
+item) on every pass output, including the ~62 % of invocations that return their input untouched.
+The check now runs in lockstep against the pass *input*: `withPtrEq` identity shortcuts at the
+whole-system and per-item level skip the walk for anything that *is* the input object, and each
+paired position tests `outOk || !inOk` — `true` on identical items by Bool excluded middle, which
+is exactly `withPtrEq`'s proof obligation, so the change is axiom-free (no `unsafe`, no
+`implemented_by`; the integrity script still reports the three standard axioms). On the
+within-bound inputs the guarded pipeline maintains, `outOk || !inOk` decides exactly `outOk`
+(`denseWithinDegreeLK_sound`), which is what `guardDegree_respectsDeg` consumes; unpaired output
+items (appends, length changes) get the plain check, so the guard never rejects a within-bound
+output.
+
+Two implementation notes that will bite anyone touching this:
+- **`denseWithinDegreeLK` must stay `@[irreducible]`.** `optimizerWithBusFacts_correct`'s `change`
+  tactics whnf through the folded 40-pass pipeline; with the fatter guard body that reduction blew
+  past 16x the heartbeat budget. Irreducible makes the reducer stop at the guard's `if` instead of
+  evaluating the check against the whole pipeline prefix; no `maxHeartbeats` change anywhere.
+- The unfolding lemmas (`denseWithinDegreeLK_def`, the `_eq` pair) are proven *before* the
+  attribute flips; everything downstream goes through them, never through delta.
+
+LANDED (interleaved, 3 reps + one sha256 shot, 20-core box, serial): sha256 `apc_001`
+**20.79 → 20.01 s (0.962x)**, wasm-eth `apc_012` **0.940x**, keccak `apc_001` **0.963x**, wasm-eth
+`apc_036` ~0.95x. Per-pass, the rebuilt cheap sweeps that were mostly guard collapse: degenRange
+22 → 7 ms, hintCollapse 15 → 9, bytePack 18 → 10 on the representatives; sha256 flagFold
+1094 → 1028, domainFold 1191 → 1124. Output identical on wasm-eth `apc_012`/`apc_036`, OpenVM
+keccak and SP1 keccak, and sha256's final sizes.
+
+What this does NOT cover of R5: the `unchanged : Option (out = d ∧ derivs = [])` field — the
+fixpoint's per-cycle `sizeKey` skip and the guard's `inc_ref`/restore branch. Alone it is now
+sub-bar (the guard walk it mostly existed to skip is skipped); it is the substrate for R15's
+cross-cycle skip memo (per-pass verdicts + a pass state channel, R14) and should be sized as one
+unit with that.
+
+DROPPED, measured the same session, do not retry as stated (details in the dead-ends list):
+- **Shrink-first pre-cycle**: effectiveness-identical but sha256 a wash (the heavy passes got
+  20–30 % cheaper on the pre-shrunk system and the pre-stage consumed exactly what they saved) and
+  wasm-eth `apc_012` **2.0x** — its main-cycle gauss exploded 215 ms → 2.7 s (basis/shape
+  sensitivity, the entry-134 hazard). Rescheduling relocates first-time shrink work; it does not
+  shrink it.
+- **De-boxing the guard loop without lockstep** (proven csimp, verified live in the C): **flat**
+  (±1–2 % representatives, sha256 +1.5 %). The guard's cost is the walk's memory latency, not the
+  loop machinery. A first variant returning `Option Nat` was **4–7 % slower everywhere** — an
+  allocation per tree node dwarfs any dispatch it saves.
+- **Reencode seed capacity slack** (`toArray`-seeded `cs`/`cvs` pay a full copy on the first
+  `pushBool`): **flat** — ~11 pointer-word memcpys per run; `copy_expand` is ~0.7 % of the run.
+
+**Worked: yes** (the lockstep guard); the three DROPPED items are recorded dead ends.


### PR DESCRIPTION
## What

`guardDegree` re-ran `withinDegreeB` — a full degree walk over every item of the system — on every pass output, including the ~62% of invocations that return their input untouched (the R5/R15 measurements). The check now runs **in lockstep against the pass input**:

- `withPtrEq` identity shortcuts at the whole-system and per-item level skip the walk for anything that *is* the input object (a no-op pass costs one pointer compare; a rebuilt-spine pass with preserved items costs one pointer compare per item).
- Each paired position tests `outOk || !inOk`. That is `true` on identical items by Bool excluded middle — which is exactly `withPtrEq`'s proof obligation, so the change is **axiom-free**: no `unsafe`, no `@[implemented_by]`, and the integrity script still reports `[propext, Classical.choice, Quot.sound]` on the correctness theorems.
- On the within-bound inputs the guarded pipeline maintains, `outOk || !inOk` decides exactly `outOk` (`denseWithinDegreeLK_sound`, consumed by `guardDegree_respectsDeg`). Unpaired output items (appends, length changes) get the plain check, so the guard never rejects a within-bound output.

`denseWithinDegreeLK` is `@[irreducible]`: without it, `optimizerWithBusFacts_correct`'s `change` tactics whnf through the folded 40-pass pipeline into the guard check and blow past 16x the heartbeat budget; with it, no options change anywhere.

## Measured (interleaved A/B vs main, 3 reps + one sha256 shot, serial)

| case | main | this PR | ratio |
|---|---:|---:|---|
| sha256 apc_001 | 20.79 s | 20.01 s | **0.962x** |
| wasm-eth apc_012 | ~2.43 s | ~2.29 s | **0.940x** |
| keccak apc_001 | ~2.05 s | ~1.97 s | **0.963x** |
| wasm-eth apc_036 | ~2.13 s | ~2.02 s | ~0.95x |

Per-pass, the rebuilt cheap sweeps that were mostly guard collapse: degenRange 22→7 ms, hintCollapse 15→9, bytePack 18→10 on the representatives; sha256 flagFold 1094→1028, domainFold 1191→1124.

**Effectiveness:** expected unchanged — the check is weaker-or-equal per item and never rejects a within-bound output, so decisions are identical on invariant-respecting runs. Output verified identical on wasm-eth apc_012/apc_036, OpenVM keccak, SP1 keccak, and sha256's final sizes; the CI matrix is the full verdict.

## Bookkeeping

`agent-docs/log.md` entry 181 records this change plus three dead ends measured in the same session (shrink-first pre-cycle: negative, gauss basis-sensitivity; guard de-boxing without lockstep: flat — the guard's cost is the walk's memory latency, not the loop machinery; reencode seed capacity slack: flat). `ideas.md` R5 and the dead-ends list updated accordingly. The remaining half of R5 (the `unchanged` field, fixpoint `sizeKey` skip) is deliberately out of scope: sub-bar alone now, and the substrate for the R15 cross-cycle skip memo to be sized with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)