### PR TITLE
perf: three no-op-prologue fixes (domainFold, carryBranch, reencode)

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CarryBranch.lean
@@ -115,10 +115,10 @@ def denseNeverZeroB (ops : DenseZModOps p) (B : Std.HashMap VarId Nat) (e : Dens
     becomes `x-5 = 0`. Recurses into the surviving factor. -/
 def denseResolveExpr (ops : DenseZModOps p) (B : Std.HashMap VarId Nat) :
     DenseExpr p → DenseExpr p
-  | .mul f g =>
+  | e@(.mul f g) =>
       if denseNeverZeroB ops B g then denseResolveExpr ops B f
       else if denseNeverZeroB ops B f then denseResolveExpr ops B g
-      else .mul f g
+      else e
   | e => e
 
 theorem denseResolveExpr_vars (ops : DenseZModOps p) (B : Std.HashMap VarId Nat) (e : DenseExpr p) :

--- a/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/DomainFoldRuntime.lean
@@ -498,7 +498,9 @@ termination_by i touched => touched.size - i
 decreasing_by all_goals omega
 
 /-- One target: domains, box gate, survivors, and the items it rewrites. Reads the system arrays
-    only — the caller applies the changes, so a rejected target costs no copy. -/
+    only — the caller applies the changes, so a rejected target costs no copy. A target that
+    touches nothing rewritable (no fold position, no touched interaction) skips the enumeration:
+    both collect results would be empty regardless of the survivors. -/
 def dfPlan (ix : DfIdx p) (keys : Array VarId) (cs : Array (DenseExpr p))
     (bis : Array (BusInteraction (DenseExpr p))) :
     List (Nat × DenseExpr p) × List (Nat × BusInteraction (DenseExpr p)) :=
@@ -508,12 +510,15 @@ def dfPlan (ix : DfIdx p) (keys : Array VarId) (cs : Array (DenseExpr p))
     if doms.foldl (fun n d => n * d.length) 1 > 256 then ([], [])
     else
       let fs := dfCovScan keys ix.src cs (dfTouched ix.csB keys) 0 [] []
-      let survs := dfEnumGo (zmodZeroP p)
-        (dfLevels keys.size fs.2 (Array.replicate keys.size [])) doms keys.size 0 #[[]]
-      if survs.isEmpty then ([], [])
+      let touchedBis := dfTouched ix.bisB keys
+      if fs.1.isEmpty && touchedBis.isEmpty then ([], [])
       else
-        let ctx : DfCtx p := ⟨keys, dfColRes survs keys.size⟩
-        (dfCollectCs ctx cs fs.1 [], dfCollectBis ctx bis 0 (dfTouched ix.bisB keys) [])
+        let survs := dfEnumGo (zmodZeroP p)
+          (dfLevels keys.size fs.2 (Array.replicate keys.size [])) doms keys.size 0 #[[]]
+        if survs.isEmpty then ([], [])
+        else
+          let ctx : DfCtx p := ⟨keys, dfColRes survs keys.size⟩
+          (dfCollectCs ctx cs fs.1 [], dfCollectBis ctx bis 0 touchedBis [])
 
 def dfApplyCs (cs : Array (DenseExpr p)) (ch : List (Nat × DenseExpr p)) : Array (DenseExpr p) :=
   match ch with

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/DomainFold.lean
@@ -1611,7 +1611,9 @@ theorem dfPlan_correct [Fact p.Prime] (bs : BusSemantics p) (isInput : VarId →
     · dsimp only
       split
       · exact DensePassCorrect_refl isInput _ bs
-      · rename_i hbox _
+      · split
+        · exact DensePassCorrect_refl isInput _ bs
+        rename_i hbox _ _
         set touched := dfTouched ix.csB keys with htouched
         set fs := dfCovScan keys ix.src cs touched 0 [] [] with hfs
         set survs := dfEnumGo (zmodZeroP p)
@@ -1801,7 +1803,9 @@ theorem dfLoop_covered (reg : VarRegistry) (csB bisB : Array (Array Nat))
             · dsimp only
               split
               · exact hcs
-              · exact dfApplyCs_covered reg _ (fun j => dfColRes_e? _ _ j) cs _ hcs
+              · split
+                · exact hcs
+                · exact dfApplyCs_covered reg _ (fun j => dfColRes_e? _ _ j) cs _ hcs
         · rw [dfPlan]
           split
           · exact hbis
@@ -1810,7 +1814,9 @@ theorem dfLoop_covered (reg : VarRegistry) (csB bisB : Array (Array Nat))
             · dsimp only
               split
               · exact hbis
-              · exact dfApplyBis_covered reg _ (fun j => dfColRes_e? _ _ j) bis _ hbis
+              · split
+                · exact hbis
+                · exact dfApplyBis_covered reg _ (fun j => dfColRes_e? _ _ j) bis _ hbis
 
 /-! ## The pass -/
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/Reencode.lean
@@ -3525,7 +3525,9 @@ theorem denseRncBuild_state (ctx : DenseRncCtx p) (reg : VarRegistry) (st : Dens
     (xs : List VarId) (fb : String) :
     (denseRncBuild ctx reg st xs fb).2.2 = (denseRncDoms ctx.ops st xs #[]).2 := by
   unfold denseRncBuild
-  split <;> next h => rw [h]
+  split
+  · next h => rw [h]
+  · next h => rw [h]; split <;> rfl
 
 theorem denseRncBuild_core (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (fb : String) : DenseRncCore st (denseRncBuild ctx reg st xs fb).2.2 := by
@@ -3570,9 +3572,16 @@ theorem denseRncBuild_spec (ctx : DenseRncCtx p) (reg : VarRegistry) (st : Dense
   split
   · exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, fun cd hcd => absurd hcd (by simp)⟩
   · next doms st' hd =>
-      obtain ⟨hext, hii, hcd⟩ := denseRncBuildCand_spec ctx reg st'
-        (denseCoveredIdxPos st.anchor st.cs xs) doms xs fb
-      exact ⟨hext, hii, hcd⟩
+      split
+      · exact ⟨VarRegistry.Extends.refl reg, fun _ => rfl, fun cd hcd => absurd hcd (by simp)⟩
+      · obtain ⟨hext, hii, hcd⟩ := denseRncBuildCand_spec ctx reg st'
+          (denseCoveredIdxPos st'.anchor st'.cs xs) doms xs fb
+        have hcore := denseRncCore_doms ctx.ops xs st #[]
+        rw [hd] at hcore
+        refine ⟨hext, hii, fun cd hc => ?_⟩
+        obtain ⟨h1, h2, h3, h4, h5⟩ := hcd cd hc
+        rw [hcore.anchor, hcore.cs] at h1
+        exact ⟨h1, h2, h3, h4, h5⟩
 
 /-! ### The write's freshness fields
 

--- a/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Reencode.lean
@@ -1294,17 +1294,22 @@ def denseRncBuildCand (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncSt
             (rb.1, some { bits := bits, k := k, vals := vals, hm := hm, patts := patts,
                           pattsA := pattsA, imgs := imgs, es := es, ces := ces, survs := survs })
 
-/-- Gather the covered set, look up the domains (updating the memo), then build the candidate.
-    Proof-free — `denseRncCert` re-verifies. -/
+/-- Look up the domains (updating the memo), gate on the box size, and only then gather the
+    covered set and build the candidate — an undomained or big-box group never pays the
+    `denseCoveredIdxPos` gather. The gather reads `st'` (whose `anchor`/`cs` equal `st`'s,
+    `denseRncCore_doms`), never `st`: a pending `st` use would un-share the memo arrays inside
+    `denseRncDoms`. Proof-free — `denseRncCert` re-verifies. -/
 def denseRncBuild (ctx : DenseRncCtx p) (reg : VarRegistry) (st : DenseRncState p)
     (xs : List VarId) (freshBase : String) :
     VarRegistry × Option (DenseRncCand p) × DenseRncState p :=
-  let planned := denseCoveredIdxPos st.anchor st.cs xs
   match denseRncDoms ctx.ops st xs #[] with
   | (none, st') => (reg, none, st')
   | (some doms, st') =>
-    let r := denseRncBuildCand ctx reg st' planned doms xs freshBase
-    (r.1, r.2, st')
+    if doms.foldl (fun n dd => n * dd.size) 1 > 256 then (reg, none, st')
+    else
+      let planned := denseCoveredIdxPos st'.anchor st'.cs xs
+      let r := denseRncBuildCand ctx reg st' planned doms xs freshBase
+      (r.1, r.2, st')
 
 /-! ### The checked certificate
 

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -1002,6 +1002,23 @@ are non-survivors" argument (`a·y + b = 0` has at most one root when `a ≠ 0`)
   pointer-word memcpys per run — **flat**. `copy_expand` is ~0.7 % of the run; its other sites are
   amortized doubling on small buckets.
 
+- **carryBranch candidate-restricted bounds build at per-invocation cost** (entry 182):
+  `denseBuildWith (some keep)` is behavior-identical for any keep ⊇ the certifiable factors'
+  variables, but *computing* keep per invocation loses on the big case however it is cut —
+  crude (all vars under mul roots): keccak pass 0.70x but sha256 1.11x (the set covers nearly
+  everything, ~1 M inserts of pure overhead); refined (affine-nonzero-const factors only):
+  sha256 1.32x (an `Option`-per-node classifier over the factor forest, factors re-walked
+  through nested spines). Viable only with the classification amortized once per run over
+  prepared interactions — the P1 static-tables substrate. The `e@` scrutinee return landed.
+- **reencode `denseRegisterBits` deferral past the degree pre-gate** (entry 182, spec):
+  rejected candidates register ~13.6 k × k phantom bit names per sha256 no-op invocation
+  (`Reencode.lean` `denseRncBuildCand`), growing `reg.byId.size` monotonically (which sizes
+  three `Array.replicate nVar` allocations per invocation) and making `denseRncNameTaken` force
+  the cross-cycle `varSeen` build. Deferring registration until after `denseRncDegPre` removes
+  all of it, but restructures `denseRncBuildCand`'s candidate record (bits feed the accept
+  thunks) and `denseRncStep`'s gate order, so `denseRncBuildCand_spec` and the `fun_cases` walk
+  in `denseRncStep_correct` need re-deriving. Real but bounded (~1 % sha256); do it if that
+  proof region is ever open for other reasons.
 - **Deferring a per-invocation index's force to its first query** (entry 174, busPairCancel's
   `cands`): the counters say it is queried 2 498 times in sha256 cycle 1, 0 times in cycles 8–10 and
   the coda, and **once in the whole keccak run**, so its 198 ms of build looks pure waste. Passing

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7252,3 +7252,46 @@ the walk's own `_self` lemma mid-recursion — no threaded proof, no framework t
 rebased on the same main): sha256 0.940 vs 0.948–0.956, apc_036 0.933 vs 0.959, keccak 0.931 vs
 0.954, apc_012 0.962 vs 0.922 (#281's one consistent edge — unexplained, noted in its close-out).
 #281 closed in favour of this branch with credit for both walk ideas.
+### 182. Runtime: three no-op-prologue fixes — domainFold skips empty-target enumeration, carryBranch stops rebuilding unresolved products, reencode gates its covered-set gather (0.94–1.00x per pass, small cases 0.990–0.995x)
+
+Three contained fixes to work passes do before discovering they have nothing to do, from a
+recognizer-level analysis of the no-op wall (~30 % of cleanup pass time is passes finding
+nothing; cross-pass gating and cross-cycle memoization of that wall were both prototyped and
+measured dead — the surviving lever is making each pass's own discovery cheaper).
+
+- **domainFold** (`dfPlan`): the ≤256-point box enumeration and `dfColRes` ran even when
+  `dfCovScan` had already produced no fold position and no touched interaction — the collects
+  were empty regardless of the survivors. Bail first. 0.94–0.97x on the pass.
+- **carryBranch** (`denseResolveExpr`): the unresolved-product fallthrough rebuilt `.mul f g`
+  — ~157 k reallocated roots per sha256 invocation, and no unchanged constraint ever
+  pointer-identical, so downstream per-item pointer shortcuts (the lockstep guard) can never
+  fire for this pass. `e@(.mul f g) => … else e` returns the original node. 0.97–0.99x now;
+  the guard-walk share lands when the lockstep guard does.
+- **reencode** (`denseRncBuild`): `denseCoveredIdxPos` (bucket union → `HashSet` → `mergeSort`
+  → a `denseCoveredBy` walk per candidate position) ran before the domain lookup and box gate
+  that reject a group for free. Reorder — with the gather reading `st'` (post-doms), because a
+  pending use of `st` un-shares the memo arrays inside `denseRncDoms` and turns its in-place
+  array updates into full `nVar`-sized copies: the first version read `st` and measured **2x
+  on the pass** (keccak 103 → 205 ms) before the aliasing was fixed. 0.97–1.00x on the pass.
+
+Corpus spot totals (interleaved, 3 reps): wasm apc_012 0.990x, apc_036 0.993x, keccak 0.995x,
+sha256 neutral. Output bit-identical on all four cases; proof-integrity clean. Proof cost: two
+extra `split` arms in `Proofs/DomainFold.lean`, an anchor/cs rewrite through `DenseRncCore` in
+`denseRncBuild_spec`, zero for carryBranch (the `@`-pattern is definitionally transparent).
+
+DROPPED, measured, do not retry as stated:
+- **carryBranch candidate-restricted bounds build** (`denseBuildWith (some keep)`): correct
+  (`denseAddAllWith`'s key-independence held — output identical) but the keep-set is the wrong
+  side of the trade at per-invocation cost. Crude keep (all vars under mul roots): keccak
+  carryBranch 0.70x but sha256 **1.11x** — 157 k of 200 k sha256 constraints are mul-rooted, so
+  the set covers nearly everything and its ~1 M-insert build is pure overhead. Refined keep
+  (affine-nonzero-const factors only): sha256 **1.32x** — the classifier walks the whole factor
+  forest with an `Option` per node and re-walks factors through nested spines. The restriction
+  only pays if the classification is computed once per run on prepared interactions (the P1
+  substrate), not per invocation.
+- **reencode `denseRegisterBits` deferral past the degree pre-gate** (rejected candidates mint
+  ~13.6 k × k phantom registry names per sha256 no-op invocation, grow the registry
+  monotonically, and force the cross-cycle `varSeen` build): not attempted here — it
+  restructures `denseRncStep`'s gate sequence and `denseRncBuildCand`'s candidate record, and
+  the `fun_cases` walk in `denseRncStep_correct` plus `denseRncBuildCand_spec` would need a
+  full re-derivation. Spec'd in ideas.md; the win is real but bounded (~1 % sha256).


### PR DESCRIPTION
Three contained fixes to work passes do before discovering they have nothing to do. From a recognizer-level analysis of the no-op wall (~30% of cleanup pass time is passes finding nothing; cross-pass gating and cross-cycle memoization of that wall were both prototyped and measured dead — the surviving lever is making each pass's own discovery cheaper). Log entry 181 has the full story including two measured dead ends recorded in ideas.md.

- **domainFold** (`dfPlan`): bail before the ≤256-point box enumeration when `dfCovScan` already found no fold position and no touched interaction — the collect results were empty regardless of the survivors. **0.94–0.97× on the pass.** Proof: two extra `split` arms.
- **carryBranch** (`denseResolveExpr`): the unresolved-product fallthrough rebuilt `.mul f g` — ~157k reallocated roots per sha256 invocation, so no unchanged constraint was ever pointer-identical to its input. `e@(.mul f g) => … else e` returns the original node; definitionally transparent, proofs untouched. **0.97–0.99× now**, and it re-enables per-item pointer shortcuts in the lockstep degree guard (#290) when that lands.
- **reencode** (`denseRncBuild`): the covered-set gather (`denseCoveredIdxPos`: bucket union → HashSet → mergeSort → per-position `denseCoveredBy` walk) ran before the domain lookup and box gate that reject a group for free. Reordered — with the gather reading the post-doms state: a pending use of the pre-state un-shares the memo arrays inside `denseRncDoms` and turns its in-place updates into full copies (the first version measured 2× on the pass before the aliasing fix). **0.97–1.00× on the pass.** Proof: `denseRncBuild_spec` rewrites through `DenseRncCore`'s anchor/cs preservation.

**Measured** (interleaved A/B, 3 reps + sha256 shots): wasm apc_012 **0.990×**, apc_036 **0.993×**, keccak **0.995×**, sha256 neutral. Output bit-identical on all four spot cases; `Scripts/check-proof-integrity.sh` clean. Effectiveness is unchanged by construction (every change only skips work whose results were provably discarded, or reuses a node the pass rebuilt identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)