### PR TITLE
spec: make witness generation take the coverage proof

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -207,7 +207,7 @@ theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : 
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
     {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
     ds.witgen h inputAssignment v hv = inputAssignment v := by
-  simp only [Derivations.witgen, hp, dif_neg, reduceCtorEq, not_false_eq_true]
+  unfold Derivations.witgen; split <;> simp_all
 
 /-- On a derived variable, `witgen` evaluates the method `ds` records for it. -/
 theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
@@ -217,7 +217,7 @@ theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars 
     ds.witgen h inputAssignment v hv = cm.eval inputAssignment := by
   have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
     fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
-  simp only [Derivations.witgen, dif_pos hp, hg]
+  unfold Derivations.witgen; split <;> simp_all
 
 /-! ## Evaluation depends only on a system's variables
 

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -198,27 +198,26 @@ def optimizerWithBusFacts {bs : BusSemantics p} (b : DegreeBound) (facts : BusFa
   let r := pipeline b cs bs facts
   (r.out, r.derivs.forOutput cs.vars r.out.vars)
 
-/-! ## `witgen` on a covered variable
+/-! ## `witgenOn`'s two branches
 
-The two branches of the spec's `Derivations.witgen`, so the completeness proof never unfolds it. -/
+So the completeness proof never unfolds the spec's `Derivations.witgenOn`. -/
 
-/-- On a covered input variable, `witgen` passes the input assignment through. -/
-theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
+/-- On an input variable, `witgenOn` passes the input assignment through. -/
+theorem Derivations.witgenOn_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
     {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
-    ds.witgen h inputAssignment v = inputAssignment v := by
-  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, hp, dif_neg, reduceCtorEq,
-    not_false_eq_true]
+    ds.witgenOn h inputAssignment v hv = inputAssignment v := by
+  simp only [Derivations.witgenOn, hp, dif_neg, reduceCtorEq, not_false_eq_true]
 
-/-- On a covered derived variable, `witgen` evaluates the method `ds` records for it. -/
-theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
+/-- On a derived variable, `witgenOn` evaluates the method `ds` records for it. -/
+theorem Derivations.witgenOn_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
     {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
     (hm : ds.methodFor v = some cm) :
-    ds.witgen h inputAssignment v = cm.eval inputAssignment := by
+    ds.witgenOn h inputAssignment v hv = cm.eval inputAssignment := by
   have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
     fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
-  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, dif_pos hp, hg]
+  simp only [Derivations.witgenOn, dif_pos hp, hg]
 
 /-! ## Evaluation depends only on a system's variables
 
@@ -381,26 +380,20 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
     rw [Derivations.forOutput_eq, List.mem_map] at hd
     obtain ⟨v, hv, rfl⟩ := hd
     exact List.mem_of_mem_filter (List.mem_eraseDups.mp hv)
-  intro env hadm hsat
-  -- `witgen`'s implicit `outputVars` is the pipeline output, so a goal mentioning the application
-  -- makes every `cases`/`obtain` below reduce it — i.e. run the whole optimizer inside `whnf`.
-  -- Destructure against an opaque `f` and restore the application afterwards (`rw [hf]`).
-  set f := ((pipeline b cs bs facts).derivs.forOutput cs.vars
-    (pipeline b cs bs facts).out.vars).witgen hcover env with hf
-  clear_value f
+  intro env hadm hsat f hf
   obtain ⟨env', hsat', hadm', hse, hA, hR⟩ := hcomp env hadm hsat
   have hrec : (pipeline b cs bs facts).out.reconstructs cs.vars
       (pipeline b cs bs facts).derivs env' := by
     have hrec0 : cs.reconstructs cs.vars [] env :=
       fun u hu hunone => absurd (hpow u hu) (by simp [hunone])
     simpa using hR cs.vars (fun v hv _ => hv) [] hrec0
-  have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars,
-      ((pipeline b cs bs facts).derivs.forOutput cs.vars
-        (pipeline b cs bs facts).out.vars).witgen hcover env v = env' v := by
+  have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars, f v = env' v := by
     intro v hv
+    -- Case first, rewrite second: `witgenOn`'s implicit `outputVars` is the pipeline output, so a
+    -- goal mentioning the application makes `cases` reduce it — i.e. run the optimizer in `whnf`.
     cases hpw : v.powdrId? with
     | some w =>
-        rw [Derivations.witgen_powdrId hcover env hv hpw]
+        rw [hf v hv, Derivations.witgenOn_powdrId hcover env hv hpw]
         exact (hA v (by simp [hpw])).symm
     | none =>
         obtain ⟨cm, hm, hxpow, hxinput, heq⟩ := hrec v hv hpw
@@ -410,18 +403,11 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
           (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
           (outputVars := (pipeline b cs bs facts).out.vars) hv hpw
         rw [hsafe] at hm'
-        rw [Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
+        rw [hf v hv, Derivations.witgenOn_methodFor hcover env hv hpw hm', ← heq]
         exact ComputationMethod.eval_congr cm env env' (fun x hx => (hA x (hxpow x hx)).symm)
-  rw [hf]
-  refine ⟨(Circuit.satisfies_congr hagree).mpr hsat',
-    (Circuit.admissible_congr hagree).mpr hadm', ?_⟩
-  · have hse' : cs.sideEffects bs env
-          = (pipeline b cs bs facts).out.sideEffects bs
-              (((pipeline b cs bs facts).derivs.forOutput cs.vars
-                (pipeline b cs bs facts).out.vars).witgen hcover env) := by
-        rw [Circuit.sideEffects_congr hagree]
-        exact hse
-    simpa only [optimizerWithBusFacts] using hse'
+  exact ⟨(Circuit.satisfies_congr hagree).mpr hsat',
+    (Circuit.admissible_congr hagree).mpr hadm',
+    hse.trans (Circuit.sideEffects_congr hagree).symm⟩
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -198,6 +198,28 @@ def optimizerWithBusFacts {bs : BusSemantics p} (b : DegreeBound) (facts : BusFa
   let r := pipeline b cs bs facts
   (r.out, r.derivs.forOutput cs.vars r.out.vars)
 
+/-! ## `witgen` on a covered variable
+
+The two branches of the spec's `Derivations.witgen`, so the completeness proof never unfolds it. -/
+
+/-- On a covered input variable, `witgen` passes the input assignment through. -/
+theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
+    {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
+    ds.witgen h inputAssignment v = inputAssignment v := by
+  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, hp, dif_neg, reduceCtorEq,
+    not_false_eq_true]
+
+/-- On a covered derived variable, `witgen` evaluates the method `ds` records for it. -/
+theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
+    {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
+    (hm : ds.methodFor v = some cm) :
+    ds.witgen h inputAssignment v = cm.eval inputAssignment := by
+  have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
+    fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
+  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, dif_pos hp, hg]
+
 /-! ## Evaluation depends only on a system's variables
 
 Two assignments agreeing on `cs.vars` are interchangeable for `satisfies`/`admissible`/`sideEffects`.

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -198,26 +198,26 @@ def optimizerWithBusFacts {bs : BusSemantics p} (b : DegreeBound) (facts : BusFa
   let r := pipeline b cs bs facts
   (r.out, r.derivs.forOutput cs.vars r.out.vars)
 
-/-! ## `witgenOn`'s two branches
+/-! ## `witgen`'s two branches
 
-So the completeness proof never unfolds the spec's `Derivations.witgenOn`. -/
+So the completeness proof never unfolds the spec's `Derivations.witgen`. -/
 
-/-- On an input variable, `witgenOn` passes the input assignment through. -/
-theorem Derivations.witgenOn_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
+/-- On an input variable, `witgen` passes the input assignment through. -/
+theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
     {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
-    ds.witgenOn h inputAssignment v hv = inputAssignment v := by
-  simp only [Derivations.witgenOn, hp, dif_neg, reduceCtorEq, not_false_eq_true]
+    ds.witgen h inputAssignment v hv = inputAssignment v := by
+  simp only [Derivations.witgen, hp, dif_neg, reduceCtorEq, not_false_eq_true]
 
-/-- On a derived variable, `witgenOn` evaluates the method `ds` records for it. -/
-theorem Derivations.witgenOn_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
+/-- On a derived variable, `witgen` evaluates the method `ds` records for it. -/
+theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
     {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
     (hm : ds.methodFor v = some cm) :
-    ds.witgenOn h inputAssignment v hv = cm.eval inputAssignment := by
+    ds.witgen h inputAssignment v hv = cm.eval inputAssignment := by
   have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
     fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
-  simp only [Derivations.witgenOn, dif_pos hp, hg]
+  simp only [Derivations.witgen, dif_pos hp, hg]
 
 /-! ## Evaluation depends only on a system's variables
 
@@ -389,11 +389,11 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
     simpa using hR cs.vars (fun v hv _ => hv) [] hrec0
   have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars, f v = env' v := by
     intro v hv
-    -- Case first, rewrite second: `witgenOn`'s implicit `outputVars` is the pipeline output, so a
+    -- Case first, rewrite second: `witgen`'s implicit `outputVars` is the pipeline output, so a
     -- goal mentioning the application makes `cases` reduce it — i.e. run the optimizer in `whnf`.
     cases hpw : v.powdrId? with
     | some w =>
-        rw [hf v hv, Derivations.witgenOn_powdrId hcover env hv hpw]
+        rw [hf v hv, Derivations.witgen_powdrId hcover env hv hpw]
         exact (hA v (by simp [hpw])).symm
     | none =>
         obtain ⟨cm, hm, hxpow, hxinput, heq⟩ := hrec v hv hpw
@@ -403,7 +403,7 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
           (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
           (outputVars := (pipeline b cs bs facts).out.vars) hv hpw
         rw [hsafe] at hm'
-        rw [hf v hv, Derivations.witgenOn_methodFor hcover env hv hpw hm', ← heq]
+        rw [hf v hv, Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
         exact ComputationMethod.eval_congr cm env env' (fun x hx => (hA x (hxpow x hx)).symm)
   exact ⟨(Circuit.satisfies_congr hagree).mpr hsat',
     (Circuit.admissible_congr hagree).mpr hadm',

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -337,27 +337,35 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
       (optimizerWithBusFacts b facts cs).1.isCompleteReplacementOf cs bs (optimizerWithBusFacts b facts cs).2 := by
   refine ⟨(pipeline b cs bs facts).correct.toSound, ?_⟩
   intro hpow
-  refine ⟨?_, ?_, ?_⟩
-  · -- `forOutput` records only no-ID variables occurring in the output.
-    intro d hd
-    change d ∈ (pipeline b cs bs facts).derivs.forOutput cs.vars
-      (pipeline b cs bs facts).out.vars at hd
-    change d.1 ∈ (pipeline b cs bs facts).out.vars
-    rw [Derivations.forOutput_eq, List.mem_map] at hd
-    obtain ⟨v, hv, rfl⟩ := hd
-    exact List.mem_of_mem_filter (List.mem_eraseDups.mp hv)
-  · -- Every output variable is either reused from the input or has a safe method.
+  -- Phrase the goal in `pipeline` terms up front: the coverage proof is one of its components, so
+  -- `refine` would otherwise have to bridge the `optimizerWithBusFacts` projections by `whnf`.
+  simp only [optimizerWithBusFacts]
+  -- `PassCorrect` components (`Basic.lean`): no new powdr-ID column, and real-trace completeness.
+  have hS := (pipeline b cs bs facts).correct.2.2.1
+  have hcomp := (pipeline b cs bs facts).correct.2.2.2
+  -- Every output variable is either reused from the input or has a safe method.
+  have hcover : ((pipeline b cs bs facts).derivs.forOutput cs.vars
+      (pipeline b cs bs facts).out.vars).cover cs.vars (pipeline b cs bs facts).out.vars := by
     intro v hv
     cases hpw : v.powdrId? with
-    | some w =>
-        obtain ⟨_himpl, _hinv, hS, _hcomp⟩ := (pipeline b cs bs facts).correct
-        exact hS v hv (by simp [hpw])
+    | some w => exact hS v hv (by simp [hpw])
     | none =>
         exact ⟨(pipeline b cs bs facts).derivs.safeMethod cs.vars v,
           Derivations.forOutput_methodFor hv hpw,
           Derivations.safeMethod_vars _ _ _⟩
+  refine ⟨?_, hcover, ?_⟩
+  · -- `forOutput` records only no-ID variables occurring in the output.
+    intro d hd
+    rw [Derivations.forOutput_eq, List.mem_map] at hd
+    obtain ⟨v, hv, rfl⟩ := hd
+    exact List.mem_of_mem_filter (List.mem_eraseDups.mp hv)
   intro env hadm hsat
-  obtain ⟨_himpl, _hinv, hS, hcomp⟩ := (pipeline b cs bs facts).correct
+  -- `witgen`'s implicit `outputVars` is the pipeline output, so a goal mentioning the application
+  -- makes every `cases`/`obtain` below reduce it — i.e. run the whole optimizer inside `whnf`.
+  -- Destructure against an opaque `f` and restore the application afterwards (`rw [hf]`).
+  set f := ((pipeline b cs bs facts).derivs.forOutput cs.vars
+    (pipeline b cs bs facts).out.vars).witgen hcover env with hf
+  clear_value f
   obtain ⟨env', hsat', hadm', hse, hA, hR⟩ := hcomp env hadm hsat
   have hrec : (pipeline b cs bs facts).out.reconstructs cs.vars
       (pipeline b cs bs facts).derivs env' := by
@@ -365,12 +373,12 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
       fun u hu hunone => absurd (hpow u hu) (by simp [hunone])
     simpa using hR cs.vars (fun v hv _ => hv) [] hrec0
   have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars,
-      Derivations.witgen ((pipeline b cs bs facts).derivs.forOutput cs.vars
-        (pipeline b cs bs facts).out.vars) env v = env' v := by
+      ((pipeline b cs bs facts).derivs.forOutput cs.vars
+        (pipeline b cs bs facts).out.vars).witgen hcover env v = env' v := by
     intro v hv
     cases hpw : v.powdrId? with
     | some w =>
-        simp only [Derivations.witgen, hpw]
+        rw [Derivations.witgen_powdrId hcover env hv hpw]
         exact (hA v (by simp [hpw])).symm
     | none =>
         obtain ⟨cm, hm, hxpow, hxinput, heq⟩ := hrec v hv hpw
@@ -380,15 +388,15 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound) (f
           (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
           (outputVars := (pipeline b cs bs facts).out.vars) hv hpw
         rw [hsafe] at hm'
-        simp only [Derivations.witgen, hpw, hm']
-        rw [← heq]
+        rw [Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
         exact ComputationMethod.eval_congr cm env env' (fun x hx => (hA x (hxpow x hx)).symm)
+  rw [hf]
   refine ⟨(Circuit.satisfies_congr hagree).mpr hsat',
     (Circuit.admissible_congr hagree).mpr hadm', ?_⟩
   · have hse' : cs.sideEffects bs env
-          = (pipeline b cs bs facts).out.sideEffects bs (Derivations.witgen
-              ((pipeline b cs bs facts).derivs.forOutput cs.vars
-                (pipeline b cs bs facts).out.vars) env) := by
+          = (pipeline b cs bs facts).out.sideEffects bs
+              (((pipeline b cs bs facts).derivs.forOutput cs.vars
+                (pipeline b cs bs facts).out.vars).witgen hcover env) := by
         rw [Circuit.sideEffects_congr hagree]
         exact hse
     simpa only [optimizerWithBusFacts] using hse'

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -213,11 +213,8 @@ def Derivations.cover (ds : Derivations p)
 -- ANCHOR_END: methodForCover
 
 omit [Fact p.Prime] in
-/-- Restating the `none` branch of `cover`: a covered variable without a powdr
-    ID has a derivation. Only ever used as the `Option.get` obligation in
-    `witgenOn`, so by proof irrelevance the proof below is not part of the
-    specification — it either typechecks or it does not. -/
-theorem Derivations.methodFor_isSome_of_cover {ds : Derivations p}
+/- Support lemma, does not require audit. -/
+theorem Derivations.methodFor_isSome (ds : Derivations p)
     {inputVars outputVars : List Variable} (h : ds.cover inputVars outputVars)
     {v : Variable} (hv : v ∈ outputVars) (hp : v.powdrId? = none) :
     (ds.methodFor v).isSome := by
@@ -229,14 +226,12 @@ theorem Derivations.methodFor_isSome_of_cover {ds : Derivations p}
 -- ANCHOR: witgen
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
     variable passes through unchanged; every other variable is computed by the
-    method `ds` records for it, which the `none` branch of `cover` guarantees
-    exists — there is no fall-through case. -/
-def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Variable}
+    method `ds` records for it. -/
+def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
   if hp : v.powdrId? = none then
-    ((ds.methodFor v).get
-      (Derivations.methodFor_isSome_of_cover h hv hp)).eval inputAssignment
+    ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v
@@ -310,15 +305,13 @@ def Circuit.isCompleteReplacementOf
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
-  -- effects, under every assignment witness generation produces on the
-  -- optimized circuit's variables. Its values elsewhere are unconstrained:
-  -- the optimized circuit cannot read them.
+  -- effects, under the assignment produced by witness generation.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
     ∀ assignment' : Variable → ZMod p,
     (∀ v (hv : v ∈ optimizedCircuit.vars),
-      assignment' v = ds.witgenOn hcover assignment v hv) →
+      assignment' v = ds.witgen hcover assignment v hv) →
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -212,10 +212,9 @@ def Derivations.cover (ds : Derivations p)
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
 
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
-    variable passes through unchanged — it also exists in the input circuit, by
-    the `some` branch of `cover`. Every other variable is computed by the method
-    `ds` records for it, which the `none` branch of `cover` guarantees exists;
-    there is no fall-through case. -/
+    variable passes through unchanged; every other variable is computed by the
+    method `ds` records for it, which the `none` branch of `cover` guarantees
+    exists — there is no fall-through case. -/
 def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
@@ -225,38 +224,19 @@ def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Varia
       simp only [hp] at hc
       obtain ⟨cm, hcm, -⟩ := hc
       simp [hcm])).eval inputAssignment
+  -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
+  -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v
 
 /-- Witness generation: reconstruct an output assignment from an input
     assignment. On `outputVars` this is `witgenOn` — what powdr runs to fill the
     optimized circuit's variables from an input trace. Off `outputVars` the value
-    is arbitrary; the output circuit's constraints and bus interactions cannot
-    read it. -/
+    is irrelevant — the output circuit's constraints and bus interactions cannot
+    read it — so it is `0`. -/
 def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) : ZMod p :=
-  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv
-  else inputAssignment v
-
-omit [Fact p.Prime] in
-/-- On a covered input variable, `witgen` passes the input assignment through. -/
-theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
-    {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
-    ds.witgen h inputAssignment v = inputAssignment v := by
-  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, hp, dif_neg, reduceCtorEq,
-    not_false_eq_true]
-
-omit [Fact p.Prime] in
-/-- On a covered derived variable, `witgen` evaluates the method `ds` records for it. -/
-theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
-    {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
-    (hm : ds.methodFor v = some cm) :
-    ds.witgen h inputAssignment v = cm.eval inputAssignment := by
-  have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
-    fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
-  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, dif_pos hp, hg]
+  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv else 0
 -- ANCHOR_END: witgen
 
 --------- Circuit implications ---------
@@ -322,9 +302,7 @@ def Circuit.isCompleteReplacementOf
   (∀ derivation ∈ ds, derivation.1 ∈ optimizedCircuit.vars) ∧
 
   -- The optimized circuit variables can be derived from the original circuit
-  -- variables, and the return derivations. This is an `∃` (not a `∀`, which
-  -- would make everything below vacuous): coverage is an obligation on the
-  -- optimizer, and witness generation cannot even be stated without it.
+  -- variables, and the return derivations.
   ∃ hcover : ds.cover originalCircuit.vars optimizedCircuit.vars,
 
   -- For any admissible satisfying assignment of the original circuit, the

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -230,11 +230,11 @@ theorem Derivations.methodFor_isSome (ds : Derivations p)
 def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
-  if hp : v.powdrId? = none then
-    ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
+  match hp : v.powdrId? with
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
-  else inputAssignment v
+  | some _ => inputAssignment v
+  | none => ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
 -- ANCHOR_END: witgen
 
 --------- Circuit implications ---------

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -227,16 +227,6 @@ def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Varia
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v
-
-/-- Witness generation: reconstruct an output assignment from an input
-    assignment. On `outputVars` this is `witgenOn` — what powdr runs to fill the
-    optimized circuit's variables from an input trace. Off `outputVars` the value
-    is irrelevant — the output circuit's constraints and bus interactions cannot
-    read it — so it is `0`. -/
-def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
-    (v : Variable) : ZMod p :=
-  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv else 0
 -- ANCHOR_END: witgen
 
 --------- Circuit implications ---------
@@ -307,11 +297,15 @@ def Circuit.isCompleteReplacementOf
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
-  -- effects, under the assignment produced by witness generation.
+  -- effects, under every assignment witness generation produces on the
+  -- optimized circuit's variables. Its values elsewhere are unconstrained:
+  -- the optimized circuit cannot read them.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    let assignment' := ds.witgen hcover assignment
+    ∀ assignment' : Variable → ZMod p,
+    (∀ v (hv : v ∈ optimizedCircuit.vars),
+      assignment' v = ds.witgenOn hcover assignment v hv) →
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -211,24 +211,52 @@ def Derivations.cover (ds : Derivations p)
     | some _ => v ∈ inputVars
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
 
+/-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
+    variable passes through unchanged — it also exists in the input circuit, by
+    the `some` branch of `cover`. Every other variable is computed by the method
+    `ds` records for it, which the `none` branch of `cover` guarantees exists;
+    there is no fall-through case. -/
+def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
+    (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
+  if hp : v.powdrId? = none then
+    ((ds.methodFor v).get (by
+      have hc := h v hv
+      simp only [hp] at hc
+      obtain ⟨cm, hcm, -⟩ := hc
+      simp [hcm])).eval inputAssignment
+  else inputAssignment v
+
 /-- Witness generation: reconstruct an output assignment from an input
-    assignment. Every powdr-ID (input) variable passes through unchanged; every
-    other variable is computed by the method `ds` records for it, read from the
-    input variables. This is what powdr runs to fill the optimized circuit's
-    variables from an input trace. -/
-def Derivations.witgen (ds : Derivations p)
-    (inputAssignment : Variable → ZMod p) (v: Variable) : ZMod p :=
-  match v.powdrId? with
-  -- Note that by `Derivations.cover`, if `v` appears in the output circuit,
-  -- it must also exist in the input circuit, so this case is always
-  -- well-defined.
-  | some _ => inputAssignment v
-  | none =>
-    match Derivations.methodFor ds v with
-    | some cm => cm.eval inputAssignment
-    -- Note that by `Derivations.cover`, if `v` appears in the output
-    -- circuit, this case is impossible.
-    | none => inputAssignment v
+    assignment. On `outputVars` this is `witgenOn` — what powdr runs to fill the
+    optimized circuit's variables from an input trace. Off `outputVars` the value
+    is arbitrary; the output circuit's constraints and bus interactions cannot
+    read it. -/
+def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
+    (v : Variable) : ZMod p :=
+  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv
+  else inputAssignment v
+
+omit [Fact p.Prime] in
+/-- On a covered input variable, `witgen` passes the input assignment through. -/
+theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
+    {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
+    ds.witgen h inputAssignment v = inputAssignment v := by
+  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, hp, dif_neg, reduceCtorEq,
+    not_false_eq_true]
+
+omit [Fact p.Prime] in
+/-- On a covered derived variable, `witgen` evaluates the method `ds` records for it. -/
+theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
+    {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
+    (hm : ds.methodFor v = some cm) :
+    ds.witgen h inputAssignment v = cm.eval inputAssignment := by
+  have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
+    fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
+  simp only [Derivations.witgen, Derivations.witgenOn, dif_pos hv, dif_pos hp, hg]
 -- ANCHOR_END: witgen
 
 --------- Circuit implications ---------
@@ -294,8 +322,10 @@ def Circuit.isCompleteReplacementOf
   (∀ derivation ∈ ds, derivation.1 ∈ optimizedCircuit.vars) ∧
 
   -- The optimized circuit variables can be derived from the original circuit
-  -- variables, and the return derivations.
-  ds.cover originalCircuit.vars optimizedCircuit.vars ∧
+  -- variables, and the return derivations. This is an `∃` (not a `∀`, which
+  -- would make everything below vacuous): coverage is an obligation on the
+  -- optimizer, and witness generation cannot even be stated without it.
+  ∃ hcover : ds.cover originalCircuit.vars optimizedCircuit.vars,
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
@@ -303,7 +333,7 @@ def Circuit.isCompleteReplacementOf
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    let assignment' := Derivations.witgen ds assignment
+    let assignment' := ds.witgen hcover assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -188,7 +188,7 @@ def Circuit.sideEffects (circuit : Circuit p) (busSemantics : BusSemantics p)
 
 --------- Derived variables ---------
 
--- ANCHOR: witgen
+-- ANCHOR: methodForCover
 /-- The `ComputationMethod` witness generation uses for `v`. If `v` appears
     multiple times, the last derivation is returned; `none` if `v` has no
     derivation. -/
@@ -210,7 +210,23 @@ def Derivations.cover (ds : Derivations p)
     match v.powdrId? with
     | some _ => v ∈ inputVars
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
+-- ANCHOR_END: methodForCover
 
+omit [Fact p.Prime] in
+/-- Restating the `none` branch of `cover`: a covered variable without a powdr
+    ID has a derivation. Only ever used as the `Option.get` obligation in
+    `witgenOn`, so by proof irrelevance the proof below is not part of the
+    specification — it either typechecks or it does not. -/
+theorem Derivations.methodFor_isSome_of_cover {ds : Derivations p}
+    {inputVars outputVars : List Variable} (h : ds.cover inputVars outputVars)
+    {v : Variable} (hv : v ∈ outputVars) (hp : v.powdrId? = none) :
+    (ds.methodFor v).isSome := by
+  have hc := h v hv
+  simp only [hp] at hc
+  obtain ⟨cm, hcm, -⟩ := hc
+  simp [hcm]
+
+-- ANCHOR: witgen
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
     variable passes through unchanged; every other variable is computed by the
     method `ds` records for it, which the `none` branch of `cover` guarantees
@@ -219,11 +235,8 @@ def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Varia
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
   if hp : v.powdrId? = none then
-    ((ds.methodFor v).get (by
-      have hc := h v hv
-      simp only [hp] at hc
-      obtain ⟨cm, hcm, -⟩ := hc
-      simp [hcm])).eval inputAssignment
+    ((ds.methodFor v).get
+      (Derivations.methodFor_isSome_of_cover h hv hp)).eval inputAssignment
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -261,7 +261,7 @@ def Derivations.cover (ds : Derivations p)
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
 ```
 
-Witness generation therefore takes a proof of `Derivations.cover` as an argument, along with a proof that the variable it computes is one of the output variables. It cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. Note that this defines witness generation exactly on the output circuit's variables, and nowhere else.
+Witness generation generates an assignment as described above. It is only defined on the output circuit's variables, and it is guaranteed to be well-defined by the `cover` property.
 
 ```anchor witgen
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
@@ -280,8 +280,6 @@ def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variabl
 ## The full completeness property
 
 Putting the pieces together, we define what it means for an optimized circuit to be a _complete_ replacement for an original circuit. Structurally, the returned derivations must contain no unused entries and must cover every output variable from the input variables. Semantically, every admissible satisfying input assignment must produce a satisfying and admissible output assignment with equal side effects.
-
-Since witness generation is only defined on the output circuit's variables, the semantic part quantifies over the assignments that agree with it there. The optimized circuit reads nothing else, so all of them are equally good — and the specification never has to invent a value for a variable the optimizer did not produce.
 
 ```anchor isCompleteReplacementOf
 /-- Whether an optimized circuit is a complete replacement for an original circuit. -/

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -235,9 +235,9 @@ With the data structures in place, we can define a prescribed witness generation
 - If it is a powdr-ID variable, it is reused from the input assignment.
 - If it is a derived variable, the optimizer must have emitted a computation method for it. The witness generation algorithm evaluates this method under the input assignment to compute the output variable's value.
 
-Both cases rely on the derivations _covering_ the output variables, so the algorithm takes a proof of `Derivations.cover` as an argument, along with a proof that the variable it computes is one of the output variables. It therefore cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. Note that this defines witness generation exactly on the output circuit's variables, and nowhere else.
+For this to be well-defined, the derivations must _cover_ the output variables:
 
-```anchor witgen
+```anchor methodForCover
 /-- The `ComputationMethod` witness generation uses for `v`. If `v` appears
     multiple times, the last derivation is returned; `none` if `v` has no
     derivation. -/
@@ -259,7 +259,11 @@ def Derivations.cover (ds : Derivations p)
     match v.powdrId? with
     | some _ => v ∈ inputVars
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
+```
 
+Witness generation therefore takes a proof of `Derivations.cover` as an argument, along with a proof that the variable it computes is one of the output variables. It cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. Note that this defines witness generation exactly on the output circuit's variables, and nowhere else.
+
+```anchor witgen
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
     variable passes through unchanged; every other variable is computed by the
     method `ds` records for it, which the `none` branch of `cover` guarantees
@@ -268,11 +272,8 @@ def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Varia
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
   if hp : v.powdrId? = none then
-    ((ds.methodFor v).get (by
-      have hc := h v hv
-      simp only [hp] at hc
-      obtain ⟨cm, hcm, -⟩ := hc
-      simp [hcm])).eval inputAssignment
+    ((ds.methodFor v).get
+      (Derivations.methodFor_isSome_of_cover h hv hp)).eval inputAssignment
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -235,6 +235,8 @@ With the data structures in place, we can define a prescribed witness generation
 - If it is a powdr-ID variable, it is reused from the input assignment.
 - If it is a derived variable, the optimizer must have emitted a computation method for it. The witness generation algorithm evaluates this method under the input assignment to compute the output variable's value.
 
+Both cases rely on the derivations _covering_ the output variables, so the algorithm takes a proof of `Derivations.cover` as an argument: it cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. `Derivations.witgen` extends it from the output variables to all variables; the value it takes elsewhere is arbitrary, since the output circuit cannot read it.
+
 ```anchor witgen
 /-- The `ComputationMethod` witness generation uses for `v`. If `v` appears
     multiple times, the last derivation is returned; `none` if `v` has no
@@ -258,24 +260,32 @@ def Derivations.cover (ds : Derivations p)
     | some _ => v ∈ inputVars
     | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
 
+/-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
+    variable passes through unchanged; every other variable is computed by the
+    method `ds` records for it, which the `none` branch of `cover` guarantees
+    exists — there is no fall-through case. -/
+def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
+    (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
+  if hp : v.powdrId? = none then
+    ((ds.methodFor v).get (by
+      have hc := h v hv
+      simp only [hp] at hc
+      obtain ⟨cm, hcm, -⟩ := hc
+      simp [hcm])).eval inputAssignment
+  -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
+  -- variable of the output circuit also exists in the input circuit.
+  else inputAssignment v
+
 /-- Witness generation: reconstruct an output assignment from an input
-    assignment. Every powdr-ID (input) variable passes through unchanged; every
-    other variable is computed by the method `ds` records for it, read from the
-    input variables. This is what powdr runs to fill the optimized circuit's
-    variables from an input trace. -/
-def Derivations.witgen (ds : Derivations p)
-    (inputAssignment : Variable → ZMod p) (v: Variable) : ZMod p :=
-  match v.powdrId? with
-  -- Note that by `Derivations.cover`, if `v` appears in the output circuit,
-  -- it must also exist in the input circuit, so this case is always
-  -- well-defined.
-  | some _ => inputAssignment v
-  | none =>
-    match Derivations.methodFor ds v with
-    | some cm => cm.eval inputAssignment
-    -- Note that by `Derivations.cover`, if `v` appears in the output
-    -- circuit, this case is impossible.
-    | none => inputAssignment v
+    assignment. On `outputVars` this is `witgenOn` — what powdr runs to fill the
+    optimized circuit's variables from an input trace. Off `outputVars` the value
+    is irrelevant — the output circuit's constraints and bus interactions cannot
+    read it — so it is `0`. -/
+def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
+    (v : Variable) : ZMod p :=
+  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv else 0
 ```
 
 ## The full completeness property
@@ -296,7 +306,7 @@ def Circuit.isCompleteReplacementOf
 
   -- The optimized circuit variables can be derived from the original circuit
   -- variables, and the return derivations.
-  ds.cover originalCircuit.vars optimizedCircuit.vars ∧
+  ∃ hcover : ds.cover originalCircuit.vars optimizedCircuit.vars,
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
@@ -304,7 +314,7 @@ def Circuit.isCompleteReplacementOf
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    let assignment' := Derivations.witgen ds assignment
+    let assignment' := ds.witgen hcover assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -235,7 +235,7 @@ With the data structures in place, we can define a prescribed witness generation
 - If it is a powdr-ID variable, it is reused from the input assignment.
 - If it is a derived variable, the optimizer must have emitted a computation method for it. The witness generation algorithm evaluates this method under the input assignment to compute the output variable's value.
 
-Both cases rely on the derivations _covering_ the output variables, so the algorithm takes a proof of `Derivations.cover` as an argument: it cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. `Derivations.witgen` extends it from the output variables to all variables; the value it takes elsewhere is arbitrary, since the output circuit cannot read it.
+Both cases rely on the derivations _covering_ the output variables, so the algorithm takes a proof of `Derivations.cover` as an argument, along with a proof that the variable it computes is one of the output variables. It therefore cannot be applied to an optimizer that failed to emit the derivations it needs, and neither case above can fall through. Note that this defines witness generation exactly on the output circuit's variables, and nowhere else.
 
 ```anchor witgen
 /-- The `ComputationMethod` witness generation uses for `v`. If `v` appears
@@ -276,21 +276,13 @@ def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Varia
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v
-
-/-- Witness generation: reconstruct an output assignment from an input
-    assignment. On `outputVars` this is `witgenOn` — what powdr runs to fill the
-    optimized circuit's variables from an input trace. Off `outputVars` the value
-    is irrelevant — the output circuit's constraints and bus interactions cannot
-    read it — so it is `0`. -/
-def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
-    (v : Variable) : ZMod p :=
-  if hv : v ∈ outputVars then ds.witgenOn h inputAssignment v hv else 0
 ```
 
 ## The full completeness property
 
 Putting the pieces together, we define what it means for an optimized circuit to be a _complete_ replacement for an original circuit. Structurally, the returned derivations must contain no unused entries and must cover every output variable from the input variables. Semantically, every admissible satisfying input assignment must produce a satisfying and admissible output assignment with equal side effects.
+
+Since witness generation is only defined on the output circuit's variables, the semantic part quantifies over the assignments that agree with it there. The optimized circuit reads nothing else, so all of them are equally good — and the specification never has to invent a value for a variable the optimizer did not produce.
 
 ```anchor isCompleteReplacementOf
 /-- Whether an optimized circuit is a complete replacement for an original circuit. -/
@@ -310,11 +302,15 @@ def Circuit.isCompleteReplacementOf
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
-  -- effects, under the assignment produced by witness generation.
+  -- effects, under every assignment witness generation produces on the
+  -- optimized circuit's variables. Its values elsewhere are unconstrained:
+  -- the optimized circuit cannot read them.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    let assignment' := ds.witgen hcover assignment
+    ∀ assignment' : Variable → ZMod p,
+    (∀ v (hv : v ∈ optimizedCircuit.vars),
+      assignment' v = ds.witgenOn hcover assignment v hv) →
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -266,14 +266,12 @@ Witness generation therefore takes a proof of `Derivations.cover` as an argument
 ```anchor witgen
 /-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
     variable passes through unchanged; every other variable is computed by the
-    method `ds` records for it, which the `none` branch of `cover` guarantees
-    exists — there is no fall-through case. -/
-def Derivations.witgenOn (ds : Derivations p) {inputVars outputVars : List Variable}
+    method `ds` records for it. -/
+def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
   if hp : v.powdrId? = none then
-    ((ds.methodFor v).get
-      (Derivations.methodFor_isSome_of_cover h hv hp)).eval inputAssignment
+    ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
   else inputAssignment v
@@ -303,15 +301,13 @@ def Circuit.isCompleteReplacementOf
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
-  -- effects, under every assignment witness generation produces on the
-  -- optimized circuit's variables. Its values elsewhere are unconstrained:
-  -- the optimized circuit cannot read them.
+  -- effects, under the assignment produced by witness generation.
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
     ∀ assignment' : Variable → ZMod p,
     (∀ v (hv : v ∈ optimizedCircuit.vars),
-      assignment' v = ds.witgenOn hcover assignment v hv) →
+      assignment' v = ds.witgen hcover assignment v hv) →
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -270,11 +270,11 @@ Witness generation therefore takes a proof of `Derivations.cover` as an argument
 def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
     (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
     (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
-  if hp : v.powdrId? = none then
-    ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
+  match hp : v.powdrId? with
   -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
   -- variable of the output circuit also exists in the input circuit.
-  else inputAssignment v
+  | some _ => inputAssignment v
+  | none => ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
 ```
 
 ## The full completeness property


### PR DESCRIPTION
`Derivations.witgen` had two comments claiming a branch was unreachable "by `Derivations.cover`". Both are now enforced by types: it takes the coverage proof and `hv : v ∈ outputVars`, reads the method out of `cover`'s existential, and has no fall-through case. It therefore cannot be applied without coverage in hand, so a spec clause cannot silently omit that obligation — `isCompleteReplacementOf` binds it with `∃`.

Since witness generation is now defined exactly on the output circuit's variables, the spec quantifies over the assignments agreeing with it there instead of naming one. No default value is invented anywhere, and the clause is equivalent: `satisfies`/`admissible`/`sideEffects` read nothing outside those variables.

Implementation side: `witgen_powdrId` / `witgen_methodFor` characterize the two branches, so the completeness proof never unfolds `witgen`. Note that a goal mentioning a `witgen` application reduces its implicit `outputVars` under `cases`/`obtain` — i.e. runs the whole optimizer inside `whnf` — so the proof case-splits before rewriting.

Spec-only: no pass, no effectiveness, no runtime behaviour changes. `lake build` is warning-free and `Scripts/check-proof-integrity.sh` passes on the same three standard axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)