### PR TITLE
bench: CPU counters + a layout probe, and the fixpoint-cloning question settled

### DIFF
--- a/ApcOptimizer/Implementation/OptimizerPasses/CloneCS.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/CloneCS.lean
@@ -1,0 +1,38 @@
+import ApcOptimizer.Implementation.OptimizerPasses.Encoding
+
+set_option autoImplicit false
+
+/-! # Cloning the dense system — runtime definitions (impl-only)
+
+A structural rebuild of the dense system. Semantically the identity (`Proofs/CloneCS.lean`); it
+exists for its allocation behaviour, and it is a *diagnostic*, reached only from
+`profile --clone-probe`.
+
+It is deliberately not in `cleanupPasses`. `Circuit.clone` (`Implementation/Optimizer.lean`) is the
+same rebuild at the pipeline entry and is worth ~18% there, so the obvious next guess is that the
+dense system also decays as passes strip it down — the cleanup loop drops keccak from 28.6k
+constraints to 186. Measured, it does not: cloning once per cleanup iteration is a wash on keccak
+(1745→1769 ms, of which the clone is 38 ms) and clearly negative on sha256 (18.9→22.1 s, of which
+the clone is 0.4 s). The dense system is rebuilt by the passes themselves, so it never decays the
+way the parser's output has; and copying costs more than its own traversal, because it invalidates
+the `withPtrEq` identity shortcuts the degree guard and passes rely on (`Pass.lean`). Keep the probe
+so the question can be re-asked when the pipeline changes. -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+/-- Rebuild a dense expression node by node, so the result is freshly allocated. -/
+def DenseExpr.clone : DenseExpr p → DenseExpr p
+  | .const c => .const c
+  | .var i => .var i
+  | .add a b => .add a.clone b.clone
+  | .mul a b => .mul a.clone b.clone
+
+def DenseConstraintSystem.clone (d : DenseConstraintSystem p) : DenseConstraintSystem p :=
+  { algebraicConstraints := d.algebraicConstraints.map (fun e => e.clone),
+    busInteractions := d.busInteractions.map (fun bi =>
+      { bi with multiplicity := bi.multiplicity.clone,
+                payload := bi.payload.map (fun e => e.clone) }) }
+
+end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CloneCS.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/CloneCS.lean
@@ -1,0 +1,35 @@
+import ApcOptimizer.Implementation.OptimizerPasses.CloneCS
+import ApcOptimizer.Implementation.OptimizerPasses.Pass
+
+set_option autoImplicit false
+
+/-! # Cloning the dense system — the identity, and the pass that does it
+
+`DenseConstraintSystem.clone` is the identity, so the pass wrapping it is `DenseVerifiedPassW.id`
+with a different allocation behaviour (see `CloneCS.lean` for why that is worth a pass). -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+theorem DenseExpr.clone_eq (e : DenseExpr p) : e.clone = e := by
+  induction e with
+  | const n => rfl
+  | var i => rfl
+  | add a b iha ihb => simp [DenseExpr.clone, iha, ihb]
+  | mul a b iha ihb => simp [DenseExpr.clone, iha, ihb]
+
+theorem DenseConstraintSystem.clone_eq (d : DenseConstraintSystem p) : d.clone = d := by
+  simp [DenseConstraintSystem.clone, DenseExpr.clone_eq]
+
+/-- Rebuild the dense system, changing nothing but where its nodes live. -/
+def denseClonePass : DenseVerifiedPassW p :=
+  fun reg d hcov bs _ =>
+    { reg' := reg, out := d.clone, derivs := [], ext := VarRegistry.Extends.refl reg,
+      covered := by rw [DenseConstraintSystem.clone_eq]; exact hcov,
+      dcovered := by intro x hx; simp at hx,
+      correct := by
+        rw [DenseConstraintSystem.clone_eq]
+        exact PassCorrect.refl (reg.decodeCS d) bs }
+
+end ApcOptimizer.Dense

--- a/Benchmarks/runtime_bench.py
+++ b/Benchmarks/runtime_bench.py
@@ -8,6 +8,12 @@ For each case, run:
 and aggregate: total/mean/median optimizer time, the slowest cases, and where the time goes
 per pass across the whole set. Cases run *serially* so timings don't fight for cores.
 
+Where available, each case is also run once under the platform's CPU counters (`perf stat` on
+Linux, `/usr/bin/time -l` on macOS) to report cycles, instructions and IPC. That is what separates
+the two kinds of speedup: fewer *instructions* means less work (an algorithmic win), while flat
+instructions at fewer *cycles* means less stalling (a memory/layout win, invisible to per-pass
+timing because it taxes every pass alike). `--compare` classifies the change on that basis.
+
 This measures runtime only; effectiveness is benchmark.py's job.
 
     Benchmarks/runtime_bench.py                 # all openvm-eth cases
@@ -29,6 +35,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import statistics
 import subprocess
 import sys
@@ -83,6 +90,92 @@ RUN_MS_RE = re.compile(r"^\s*\((\d+) ms\)\s*$", re.M)
 PROFILE_HEAD_RE = re.compile(r": (\d+) cleanup iterations, (\d+) ms total")
 # `apc-optimizer profile` per-pass line, e.g. "  domainBatch: 258 ms".
 PROFILE_PASS_RE = re.compile(r"^\s+(\w+): (\d+) ms$", re.M)
+
+
+# CPU counters, read from whichever tool the platform has. Both report the whole process, so
+# parse/IO is included -- fine for classifying a change (the ratios move together), not for
+# attributing absolute counts to the optimizer.
+PERF_EVENTS = "cycles,instructions"
+# `/usr/bin/time -l`, e.g. "         26387451617  instructions retired".
+TIME_L_RE = re.compile(r"^\s*(\d+)\s+(instructions retired|cycles elapsed|"
+                       r"maximum resident set size)\s*$", re.M)
+TIME_L_KEY = {"instructions retired": "instructions", "cycles elapsed": "cycles",
+              "maximum resident set size": "max_rss"}
+
+
+def counter_backend():
+    """The available CPU-counter tool, or None (counters are then simply omitted)."""
+    if sys.platform.startswith("linux") and shutil.which("perf"):
+        return "perf"
+    if sys.platform == "darwin" and Path("/usr/bin/time").exists():
+        return "time-l"
+    return None
+
+
+def read_counters(cmd, backend):
+    """{cycles, instructions, max_rss?} for one run of `cmd`, or None if the tool refused (perf is
+    commonly blocked by perf_event_paranoid in containers)."""
+    if backend == "perf":
+        p = subprocess.run(["perf", "stat", "-x,", "-e", PERF_EVENTS, "--", *cmd],
+                           capture_output=True, text=True)
+        vals = {}
+        for line in p.stderr.splitlines():
+            f = line.split(",")
+            if len(f) >= 3:
+                try:
+                    vals[f[2]] = int(float(f[0]))
+                except ValueError:
+                    pass  # "<not counted>" / "<not supported>" / header noise
+        got = {k: vals[k] for k in ("cycles", "instructions") if k in vals}
+        return got if len(got) == 2 else None
+    if backend == "time-l":
+        p = subprocess.run(["/usr/bin/time", "-l", *cmd], capture_output=True, text=True)
+        got = {TIME_L_KEY[name]: int(v) for v, name in TIME_L_RE.findall(p.stderr)}
+        return got if "cycles" in got and "instructions" in got else None
+    return None
+
+
+def ipc(c):
+    return c["instructions"] / c["cycles"] if c and c.get("cycles") else None
+
+
+def sum_counters(per_case):
+    """Sum cycles/instructions over cases; max the peak RSS (it is a peak, not a total)."""
+    cs = [c for c in per_case.values() if c]
+    if not cs:
+        return None
+    out = {k: sum(c[k] for c in cs) for k in ("cycles", "instructions")}
+    rss = [c["max_rss"] for c in cs if "max_rss" in c]
+    if rss:
+        out["max_rss"] = max(rss)
+    return out
+
+
+def classify(base, target):
+    """One line saying whether a change moved work or stalls -- the diagnosis that per-pass timing
+    cannot give. Thresholds are deliberately loose; counters carry a few % of run-to-run noise."""
+    b, t = sum_counters(base), sum_counters(target)
+    if not b or not t:
+        return None
+    di = t["instructions"] / b["instructions"]
+    dc = t["cycles"] / b["cycles"]
+    if abs(di - 1) < 0.02 and dc < 0.98:
+        kind = ("**memory-bound win**: instructions are flat, so the same work now stalls less "
+                "(layout/locality, not algorithm)")
+    elif abs(di - 1) < 0.02 and dc > 1.02:
+        kind = ("**memory-bound regression**: instructions are flat but cycles rose -- the same "
+                "work stalls more")
+    elif di < 0.98:
+        kind = "**algorithmic win**: fewer instructions retired (less work)"
+    elif di > 1.02 and dc < 0.98:
+        kind = ("**net win despite more work**: instructions rose but cycles fell -- typically "
+                "trading a cheap traversal for better locality")
+    elif di > 1.02:
+        kind = "**more work**: instructions retired rose"
+    else:
+        kind = "no significant change in either counter"
+    return (f"Counters (whole process, summed): Δ instructions {di:.2f}×, Δ cycles {dc:.2f}×, "
+            f"IPC {ipc(b):.2f} → {ipc(t):.2f} — {kind}.")
 
 
 def best_of(cmd, repeat, parse):
@@ -151,13 +244,23 @@ def bench(args):
     if args.n is not None:
         cases = cases[: args.n]
 
+    backend = None if args.no_counters else counter_backend()
     run_ms = {}          # case name -> optimizer call wall time (ms)
     pass_ms = {}         # pass name -> cumulative ms across all cases
     iters = {}           # case name -> cleanup iterations
+    counters = {}        # case name -> {cycles, instructions, max_rss?}
     for i, case in enumerate(cases):
         (total,) = best_of([str(binary), "run", *vm_tok, str(case)], args.repeat, parse_run)
         _, its, passes = best_of([str(binary), "profile", *vm_tok, str(case)],
                                  args.repeat, parse_profile)
+        if backend:
+            c = read_counters([str(binary), "run", *vm_tok, str(case)], backend)
+            if c is None:
+                print(f"note: {backend} reported no counters; continuing without them",
+                      file=sys.stderr)
+                backend = None
+            else:
+                counters[case.name] = c
         run_ms[case.name] = total
         iters[case.name] = its
         for name, ms in passes.items():
@@ -165,7 +268,8 @@ def bench(args):
         print(f"[{i + 1}/{len(cases)}] {case.name}: {fmt_ms(total)}, {its} iterations",
               file=sys.stderr)
     return {"benchmark": benchmark, "vm": vm, "repeat": args.repeat,
-            "run_ms": run_ms, "pass_ms": pass_ms, "iters": iters}
+            "run_ms": run_ms, "pass_ms": pass_ms, "iters": iters,
+            "counters": counters, "counter_backend": backend}
 
 
 def summary_stats(run_ms):
@@ -221,6 +325,14 @@ def emit_md(data):
     lines.append(f"Cleanup iterations per case: "
                  f"min {min(iters.values())}, median {int(statistics.median(iters.values()))}, "
                  f"max {max(iters.values())}.")
+    tot = sum_counters(data.get("counters", {}))
+    if tot:
+        lines.append("")
+        lines.append(f"CPU counters (whole process, summed over cases, via "
+                     f"{data.get('counter_backend')}): "
+                     f"{tot['instructions'] / 1e9:.2f} G instructions, "
+                     f"{tot['cycles'] / 1e9:.2f} G cycles, IPC {ipc(tot):.2f}"
+                     + (f", peak RSS {tot['max_rss'] / 1e6:.0f} MB" if "max_rss" in tot else ""))
     return "\n".join(lines) + "\n"
 
 
@@ -240,6 +352,10 @@ def emit_compare_md(base, target):
     lines.append("")
     lines.append("Δ = target / baseline; below 1× means the target is faster.")
     lines.append("")
+    verdict = classify(base.get("counters", {}), target.get("counters", {}))
+    if verdict:
+        lines.append(verdict)
+        lines.append("")
     lines.append("| | target | baseline | Δ |")
     lines.append("|---|---|---|---|")
     for label, t, b in (("total", tt, bt), ("mean", tmean, bmean),
@@ -278,8 +394,12 @@ def emit_detail_compare_md(base, target):
     this branch = target, for embedding under the effectiveness table. Δ = this branch / main."""
     common = sorted(set(base["run_ms"]) & set(target["run_ms"]))
     b_run, t_run = base["run_ms"], target["run_ms"]
-    lines = ["<details><summary>Slowest cases (out of top 10)</summary>", "",
-             "| case | main | this branch | Δ |", "|---|---|---|---|"]
+    lines = []
+    verdict = classify(base.get("counters", {}), target.get("counters", {}))
+    if verdict:
+        lines += [verdict, ""]
+    lines += ["<details><summary>Slowest cases (out of top 10)</summary>", "",
+              "| case | main | this branch | Δ |", "|---|---|---|---|"]
     for name in sorted(common, key=lambda n: -t_run[n])[:10]:
         lines.append(f"| {name} | {fmt_ms(b_run[name])} | {fmt_ms(t_run[name])} "
                      f"| {fmt_ratio(t_run[name], b_run[name])} |")
@@ -309,6 +429,9 @@ def main():
                     help="only the top N cases by cost rank (default: all)")
     ap.add_argument("--repeat", type=int, default=1,
                     help="runs per case; the fastest is kept (default: 1)")
+    ap.add_argument("--no-counters", action="store_true",
+                    help="skip the CPU-counter run per case (perf / /usr/bin/time -l); counters "
+                         "are used automatically when the platform provides them")
     ap.add_argument("--no-build", action="store_true",
                     help="skip `lake build` (the binary must already exist)")
     ap.add_argument("--binary", type=Path, default=None, metavar="EXE",

--- a/Main.lean
+++ b/Main.lean
@@ -1,6 +1,7 @@
 import ApcOptimizer.Implementation.JsonParser
 import ApcOptimizer.Optimizer
 import ApcOptimizer.Implementation.Optimizer
+import ApcOptimizer.Implementation.OptimizerPasses.Proofs.CloneCS
 import ApcOptimizer.Utils.Size
 import ApcOptimizer.Utils.Dsl
 import ApcOptimizer.OpenVmSemantics
@@ -338,9 +339,19 @@ def denseProfileLoop {p : ℕ} (passes : List (String × DenseVerifiedPassW p))
     run, nor drift out of sync. It mirrors the pipeline's dense structure: encode once at entry, step
     the dense prelude list once, iterate the dense `cleanupPasses` list to its fixpoint, step the
     dense coda list once, decode once at output. Encode and decode are reported on their own lines and
-    never charged to any pass. -/
+    never charged to any pass.
+
+    `cloneProbe` inserts a `denseClonePass` -- a proven no-op -- at the head of the cleanup cycle,
+    so any time it moves is attributable to allocation alone: it tests whether the dense system's
+    heap layout degrades as the passes strip it down.
+
+    Caveat, measured: this loop stepping allocates and prints per pass, which perturbs allocation
+    enough to hide *entry*-boundary layout effects (cloning the input circuit here reads as 0 ms
+    while the same clone inside `optimizerWithBusFacts` is worth ~18% of `run`). Probe layout
+    effects at the pipeline entry by A/B-ing `run`, not here. -/
 def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : Circuit p)
-    (bs : BusSemantics p) (facts : BusFacts p bs) (verbose : Bool := false) : IO Unit := do
+    (bs : BusSemantics p) (facts : BusFacts p bs) (verbose : Bool := false)
+    (cloneProbe : Bool := false) : IO Unit := do
   let t0 ← IO.monoMsNow
   -- Encode once at the pipeline entry (reported on its own line, never charged to a pass).
   let tEnc0 ← IO.monoMsNow
@@ -356,8 +367,10 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : Circuit p)
   let (st0, acc) ← denseRunCycleTimed (preludePasses (p := p) b) st0 bs facts ∅
   -- Step the dense cleanup fixpoint (the SAME `cleanupPasses` list the optimizer runs), threading
   -- the registry / dense system / coverage from pass to pass and iteration to iteration.
+  let cleanup := if cloneProbe then ("clone", denseClonePass) :: cleanupPasses (p := p) b
+                 else cleanupPasses (p := p) b
   let (stF, acc, iters) ←
-    denseProfileLoop (cleanupPasses (p := p) b) st0 bs facts acc 0 st0.2.1.sizeKey verbose
+    denseProfileLoop cleanup st0 bs facts acc 0 st0.2.1.sizeKey verbose
   -- Coda (dense, run once).
   let (stF, acc) ← denseRunCycleTimed (codaPasses (p := p) b) stF bs facts acc
   -- Decode once at the pipeline output (reported on its own line).
@@ -374,20 +387,23 @@ def profileRun {p : ℕ} (b : DegreeBound) (fileName : String) (cs : Circuit p)
     IO.println s!"  {name}: {ms} ms"
 
 /-- `profile [vm] <file>`: per-pass optimizer timing for the selected VM. -/
-def cmdProfile (vm fileName : String) (verbose : Bool := false) : IO Unit := do
+def cmdProfile (vm fileName : String) (verbose : Bool := false)
+    (cloneProbe : Bool := false) : IO Unit := do
   if isSp1 vm then
     let (cs, busMap) ← parseFileWith parseSp1 fileName
     profileRun ApcOptimizer.SP1.defaultDegreeBound fileName cs
       (ApcOptimizer.SP1.sp1BusSemantics ApcOptimizer.SP1.koalaBear busMap)
-      (ApcOptimizer.SP1.sp1Facts ApcOptimizer.SP1.koalaBear busMap) verbose
+      (ApcOptimizer.SP1.sp1Facts ApcOptimizer.SP1.koalaBear busMap) verbose cloneProbe
   else
     let (cs, busMap) ← parseFileWith parseOpenVm fileName
     profileRun defaultDegreeBound fileName cs
-      (openVmBusSemantics babyBear busMap) (openVmFacts babyBear busMap) verbose
+      (openVmBusSemantics babyBear busMap) (openVmFacts babyBear busMap) verbose cloneProbe
 
 def usage : String :=
   "usage: apc-optimizer run [vm] <file.json[.gz]>\n" ++
   "       apc-optimizer profile [vm] <file.json[.gz]>  (per-pass optimizer timing)\n" ++
+  "       apc-optimizer profile [vm] --clone-probe <file.json[.gz]>  (same, with a proven no-op\n" ++
+  "                                clone in the cleanup cycle: tests heap-layout sensitivity)\n" ++
   "       apc-optimizer compare [vm] <unopt.json[.gz]> <opt.json[.gz]>\n" ++
   "       apc-optimizer report  [vm] <unopt.json[.gz]> <opt.json[.gz]>  (JSON: stats + render x3)\n" ++
   "       apc-optimizer opt-export [vm] <in.json[.gz]> <out.json>  (optimize and write the result\n" ++
@@ -410,6 +426,7 @@ def main (args : List String) : IO Unit := do
   | ["run", fileName] => cmdRun vm fileName
   | ["profile", fileName] => cmdProfile vm fileName
   | ["profile", "-v", fileName] => cmdProfile vm fileName (verbose := true)
+  | ["profile", "--clone-probe", fileName] => cmdProfile vm fileName (cloneProbe := true)
   | ["report", unoptFile, optFile] => cmdReport vm unoptFile optFile
   | ["opt-export", inFile, outFile] => cmdOptExport vm inFile outFile
   | ["compare", unoptFile, optFile] => cmdCompare vm unoptFile optFile

--- a/Scripts/unused-theorems.txt
+++ b/Scripts/unused-theorems.txt
@@ -15,10 +15,16 @@ simpleOptimizer_maintainsCorrectness
 ApcOptimizer.OpenVM.openVmOptimizer_maintainsCorrectness
 ApcOptimizer.SP1.sp1Optimizer_maintainsCorrectness
 
-# Theorems the closure cannot see are used, so they must be listed by hand. The only class so far:
+# Theorems the closure cannot see are used, so they must be listed by hand. Two classes so far:
 # a `rfl`-lemma named in a `simp only`/`rw` list whose rewrite step collapses to `Eq.refl`, leaving
-# no reference to the lemma in the resulting proof term.
+# no reference to the lemma in the resulting proof term; and lemmas reached only from the CLI, which
+# is not a correctness root.
 [ignore]
+# The layout probe (`profile --clone-probe`): `denseClonePass` is built from these, and the pass is
+# reached from `Main.lean` rather than from the correctness theorems. Deliberately not wired into
+# `cleanupPasses` -- cloning inside the loop measures as neutral-to-harmful (see `CloneCS.lean`).
+ApcOptimizer.Dense.DenseExpr.clone_eq
+ApcOptimizer.Dense.DenseConstraintSystem.clone_eq
 # `(Task.spawn f).get = f ()`, used in `denseCollectForcedV_eq_serial` (Proofs/DomainBatch.lean);
 # `Task.get` is opaque, so the `simp only` needs the lemma even though it rewrites by `rfl`.
 ApcOptimizer.Dense.get_spawn


### PR DESCRIPTION
Follow-up to #299: tooling to find layout wins like that one on purpose, plus the answer to the
obvious next question. No change to the optimizer's behaviour — effectiveness is untouched and the
new pass is a diagnostic, not part of the pipeline.

### 1. CPU counters in `runtime_bench.py`, with a verdict

Per-pass wall time structurally cannot see a memory-layout effect: fragmentation taxes every pass
alike, so the relative table stays flat while the total moves. That is exactly what #299 looked
like — a per-pass table reading 1.00× across the board next to a 36% drop in the total.

Each case now also runs once under the platform's counters (`perf stat` on Linux, `/usr/bin/time -l`
on macOS), and `--compare` classifies the change:

> Counters (whole process, summed): Δ instructions 1.01×, Δ cycles 0.83×, IPC 2.84 → 3.47 —
> **memory-bound win**: instructions are flat, so the same work now stalls less (layout/locality,
> not algorithm).

Flat instructions with fewer cycles is a locality win; fewer instructions is an algorithmic win.
Counters are whole-process (parse/IO included), which is fine for the ratio-based verdict but not for
absolute attribution. Missing or blocked counter tools degrade to the previous output.

### 2. A layout probe, and its (negative) result

`profile --clone-probe` inserts `denseClonePass` — a proven no-op that only reallocates — at the head
of the cleanup cycle, so any time it moves is attributable to allocation alone.

It settles the natural follow-up to #299: the entry clone is worth ~18%, and the cleanup loop strips
keccak from 28.6k constraints to 186, so surely the dense system decays the same way and wants
periodic re-cloning? **It does not.**

| case | baseline | clone per cleanup iteration | clone's own cost |
|---|---|---|---|
| keccak | 1745 ms | 1769 ms | 38 ms |
| sha256 | 18.9 s | 22.1 s | 0.4 s |

A wash on keccak, clearly negative on sha256 — and note sha256 loses ~2.8 s *beyond* the clone's own
cost. Two reasons: the passes rebuild the system themselves, so it never decays the way the parser's
output does; and copying invalidates the `withPtrEq` identity shortcuts the degree guard and passes
rely on (#290). Constraint *removal* does not fragment the survivors — what fragmented the input was
being allocated alongside the `Lean.Json` graph.

The probe stays so the question can be re-asked cheaply when the pipeline changes. Its two `clone_eq`
lemmas are reached from the CLI rather than a correctness root, so they are listed in
`unused-theorems.txt`'s `[ignore]` section.

### Caveat found while building this

The profiler's per-pass stepping allocates and prints between passes, which perturbs allocation
enough to **hide entry-boundary layout effects**: cloning the input circuit inside `profile` reads as
0 ms, while the same clone inside `optimizerWithBusFacts` is worth ~18% of `run`. So `--clone-probe`
is trustworthy for the dense interior (a within-binary A/B) but the profiler must not be used to
probe the entry boundary — use `run`. This is recorded in `profileRun`'s docstring; I dropped a
`--clone-input` flag I had written for that job rather than ship a probe that answers wrongly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
