### PR TITLE
busForward: value forwarding through value-preserving memory accesses

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -26,6 +26,7 @@ import ApcOptimizer.Implementation.OptimizerPasses.DenseUmbrella
 import ApcOptimizer.Implementation.OptimizerPasses.HashedDedup
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.DomainBatch
 import ApcOptimizer.Implementation.OptimizerPasses.Proofs.FlagFold
+import ApcOptimizer.Implementation.OptimizerPasses.Proofs.BusForward
 
 set_option autoImplicit false
 
@@ -84,6 +85,7 @@ def cleanupPasses (b : DegreeBound) : List (String × DenseVerifiedPassW p) :=
     ("tautoBus", denseTautoBusDropPass),
     ("domainFold", denseDomainFoldPassV pw),
     ("busUnify", denseBusUnifyPass),
+    ("busForward", denseBusForwardPass),
     ("busPairCancel", denseBusPairCancelPass pw false),
     ("bytePack", denseByteCheckPackPass),
     ("disconnected", denseDisconnectedPass),

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusForward.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusForward.lean
@@ -105,68 +105,158 @@ def denseBFCheckCert (ops : DenseZModOps p) (nw : DenseNonzeroWits p)
 
 /-! ## The proposer sweep (untrusted) -/
 
-/-- An open forwarding window: the send's prepared record and position, the pending unmatched
-    receive of a forwarding pair (if any), the closed pairs (in reverse), and the slots every
-    closed pair has preserved so far. -/
+/-- The slot-only arms of `denseBUMidOk` (the zero-multiplicity arm is tested at the call site).
+    Depends only on the two address-slot lists, so the sweep memoizes it per class pair. -/
+def denseBFAddrExcl (nw : DenseNonzeroWits p) (a b : DenseBUPre p) : Bool :=
+  denseBUConstsNeq a b || denseBUAffineNeq a b || denseBUTwoRootNeq a b || denseBUNonzeroNeq nw a b
+
+/-- Positions whose address slots are syntactically identical (hash-gated). -/
+def denseBFSlotsIdent : List (Option (DenseBUSlot p)) → List (Option (DenseBUSlot p)) → Bool
+  | [], [] => true
+  | some a :: as, some b :: bs =>
+    a.eHash == b.eHash && decide (a.expr = b.expr) && denseBFSlotsIdent as bs
+  | none :: as, none :: bs => denseBFSlotsIdent as bs
+  | _, _ => false
+
+/-- Intern each position's address-slot list into a class id: syntactically identical slot lists
+    share a class, so their prepared records — and every `denseBFAddrExcl` verdict — coincide. -/
+def denseBFClasses (arr : Array (DenseBUPre p)) : Array Nat × Nat :=
+  let step := fun (acc : Array Nat × Std.HashMap UInt64 (List (Nat × List (Option (DenseBUSlot p)))) × Nat)
+      (a : DenseBUPre p) =>
+    let (ids, tbl, n) := acc
+    let h := a.slots.foldl (fun acc so =>
+      mixHash acc (match so with | some s => s.eHash | none => 13)) 7
+    let bucket := tbl.getD h []
+    match bucket.find? (fun e => denseBFSlotsIdent e.2 a.slots) with
+    | some e => (ids.push e.1, tbl, n)
+    | none => (ids.push n, tbl.insert h ((n, a.slots) :: bucket), n + 1)
+  let (ids, _, n) := arr.foldl step (#[], ∅, 0)
+  (ids, n)
+
+/-- An open forwarding window: the send's prepared record, position and address class, the pending
+    unmatched receive of a forwarding pair (if any), the closed pairs (in reverse), and the slots
+    every closed pair has preserved so far. -/
 structure DenseBFWin (p : ℕ) where
   pre : DenseBUPre p
   i : Nat
+  cls : Nat
   pending : Option (DenseBUPre p × Nat)
   pairs : List (Nat × Nat)
   mask : List Nat
 
-/-- One message against one window: keep (possibly updated), drop, or emit a proposal. -/
+/-- One message against one window: keep unchanged (excluded), keep updated (pending formed or
+    pair closed), drop, or emit a proposal. `keepSame` lets the sweep skip the map re-insert. -/
 inductive DenseBFStep (p : ℕ) where
+  | keepSame
   | keep (w : DenseBFWin p)
   | drop
   | propose (prop : Nat × List (Nat × Nat) × Nat)
 
+/-- `nCls`/`mcls` and `memo` memoize the `denseBUMidOk` slot arms per (window, message) class
+    pair; the verdict equals the unmemoized test, so the proposals are unchanged. -/
 def denseBFStep (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (setMult prevMult : ZMod p)
     (bis : Array (BusInteraction (DenseExpr p))) (mb : BusInteraction (DenseExpr p))
-    (mp : DenseBUPre p) (j : Nat) (w : DenseBFWin p) : DenseBFStep p :=
+    (mp : DenseBUPre p) (j nCls mcls : Nat) (w : DenseBFWin p)
+    (memo : Std.HashMap Nat Bool) : DenseBFStep p × Std.HashMap Nat Bool :=
+  let excl : Unit → Bool × Std.HashMap Nat Bool := fun _ =>
+    if decide (mp.mult = some ops.zero) then (true, memo)
+    else
+      let key := w.cls * nCls + mcls
+      match memo[key]? with
+      | some v => (v, memo)
+      | none => let v := denseBFAddrExcl nw w.pre mp; (v, memo.insert key v)
   match w.pending with
   | none =>
     if decide (mp.mult = some prevMult) && denseBUConstsEq w.pre mp then
       -- a receive back at the window's own address: `pairs = []` is `busUnify`'s case.
-      if w.pairs.isEmpty then .drop else .propose (w.i, w.pairs.reverse, j)
-    else if denseBUMidOk ops nw w.pre mp then .keep w
-    else if decide (mp.mult = some prevMult) then
-      .keep { w with pending := some (mp, j) }
-    else .drop
+      (if w.pairs.isEmpty then .drop else .propose (w.i, w.pairs.reverse, j), memo)
+    else
+      let (e, memo) := excl ()
+      if e then (.keepSame, memo)
+      else if decide (mp.mult = some prevMult) then
+        (.keep { w with pending := some (mp, j) }, memo)
+      else (.drop, memo)
   | some (ak, k) =>
     if decide (mp.mult = some setMult) && denseBUConstsEq ak mp then
       let mask := match bis[k]? with
         | some rb => w.mask.filter (fun t => denseBFSlotEq rb mb t)
         | none => []
-      if mask.isEmpty then .drop
-      else .keep { w with pending := none, pairs := (k, j) :: w.pairs, mask := mask }
-    else if denseBUMidOk ops nw w.pre mp then .keep w
-    else .drop
+      (if mask.isEmpty then .drop
+       else .keep { w with pending := none, pairs := (k, j) :: w.pairs, mask := mask }, memo)
+    else
+      let (e, memo) := excl ()
+      if e then (.keepSame, memo) else (.drop, memo)
 
-/-- The sweep: a send opens a window; each later message updates or drops every open window per
+/-- The sweep: a send opens a window; each later message updates or drops open windows per
     `denseBFStep`; a receive back at the window's own address with at least one closed pair yields
-    a proposal. One window per send, first-match. -/
+    a proposal. Windows split as in `denseBUSweep`: constant-address windows live in a map and an
+    all-constant message steps only the window at its own key — against any other constant window
+    it is excluded by `denseBUConstsNeq`, and it can never close a symbolic pending (syntactic
+    equality would const-fold both sides), so those windows step to `.keep` unchanged. Symbolic
+    windows, and every window on a symbolic message, are stepped one by one. -/
 def denseBFSweep (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (setMult prevMult : ZMod p)
     (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
-    (arr : Array (DenseBUPre p)) :
-    (fuel j : Nat) → (wins : List (DenseBFWin p)) →
+    (arr : Array (DenseBUPre p)) (cls : Array Nat) (nCls : Nat) :
+    (fuel j : Nat) →
+    (constOpen : Std.HashMap (DenseAddrKey p) (DenseBFWin p)) →
+    (symOpen : List (DenseBFWin p)) →
+    (memo : Std.HashMap Nat Bool) →
     (out : List (Nat × List (Nat × Nat) × Nat)) → List (Nat × List (Nat × Nat) × Nat)
-  | 0, _, _, out => out
-  | fuel + 1, j, wins, out =>
+  | 0, _, _, _, _, out => out
+  | fuel + 1, j, constOpen, symOpen, memo, out =>
     match arr[j]?, bis[j]? with
     | some mp, some mb =>
-      let (wins, out) := wins.foldr (init := (([] : List (DenseBFWin p)), out)) fun w acc =>
-        match denseBFStep ops nw setMult prevMult bis mb mp j w with
-        | .keep w' => (w' :: acc.1, acc.2)
-        | .drop => acc
-        | .propose pr => (acc.1, pr :: acc.2)
-      let wins :=
+      let mcls := cls[j]?.getD 0
+      let step := denseBFStep ops nw setMult prevMult bis mb mp j nCls mcls
+      let (constOpen, memo, out) :=
+        if mp.allConst then
+          match mp.key with
+          | some k =>
+            match constOpen[k]? with
+            | some w =>
+              match step w memo with
+              | (.keepSame, memo) => (constOpen, memo, out)
+              | (.keep w', memo) => (constOpen.insert k w', memo, out)
+              | (.drop, memo) => (constOpen.erase k, memo, out)
+              | (.propose pr, memo) => (constOpen.erase k, memo, pr :: out)
+            | none => (constOpen, memo, out)
+          | none => (constOpen, memo, out)
+        else
+          -- updates and drops are applied after the fold, once `toList`'s borrow is released,
+          -- so the map is mutated in place rather than copied per touched window.
+          let (upds, drops, memo, out) :=
+            constOpen.toList.foldl (init := (([] : List (DenseAddrKey p × DenseBFWin p)),
+                ([] : List (DenseAddrKey p)), memo, out)) fun acc kw =>
+              match step kw.2 acc.2.2.1 with
+              | (.keepSame, memo) => (acc.1, acc.2.1, memo, acc.2.2.2)
+              | (.keep w', memo) => ((kw.1, w') :: acc.1, acc.2.1, memo, acc.2.2.2)
+              | (.drop, memo) => (acc.1, kw.1 :: acc.2.1, memo, acc.2.2.2)
+              | (.propose pr, memo) => (acc.1, kw.1 :: acc.2.1, memo, pr :: acc.2.2.2)
+          let constOpen := drops.foldl (·.erase ·) constOpen
+          (upds.foldl (fun m kw => m.insert kw.1 kw.2) constOpen, memo, out)
+      let (symOpen, memo, out) :=
+        if symOpen.isEmpty then (symOpen, memo, out) else
+        symOpen.foldr (init := (([] : List (DenseBFWin p)), memo, out)) fun w acc =>
+          match step w acc.2.1 with
+          | (.keepSame, memo) => (w :: acc.1, memo, acc.2.2)
+          | (.keep w', memo) => (w' :: acc.1, memo, acc.2.2)
+          | (.drop, memo) => (acc.1, memo, acc.2.2)
+          | (.propose pr, memo) => (acc.1, memo, pr :: acc.2.2)
+      -- a same-key send steps the old window to `.drop` above, so the slot is already free.
+      let (constOpen, symOpen) :=
         if decide (mp.mult = some setMult) then
-          { pre := mp, i := j, pending := none, pairs := [],
-            mask := (List.range mb.payload.length).filter
-              (fun t => decide (t ∉ shape.addressFields)) } :: wins
-        else wins
-      denseBFSweep ops nw setMult prevMult shape bis arr fuel (j + 1) wins out
+          match mp.key with
+          | some k =>
+            let w : DenseBFWin p :=
+              { pre := mp, i := j, cls := mcls, pending := none, pairs := [],
+                mask := (List.range mb.payload.length).filter
+                  (fun t => decide (t ∉ shape.addressFields)) }
+            if k.allConst then (constOpen.insert k w, symOpen)
+            else (constOpen, w :: symOpen)
+          | none => (constOpen, symOpen)
+        else (constOpen, symOpen)
+      denseBFSweep ops nw setMult prevMult shape bis arr cls nCls fuel (j + 1) constOpen symOpen
+        memo out
     | _, _ => out
 
 /-! ## Verify and emit -/
@@ -190,7 +280,8 @@ def denseBFForBus (ops : DenseZModOps p) (T : DenseTwoRootMap p) (nw : DenseNonz
   let prevMult := denseGetPreviousMult ops shape
   let bis := bisL.toArray
   let arr := bis.map (denseBUPrep shape T)
-  let props := denseBFSweep ops nw setMult prevMult shape bis arr arr.size 0 [] []
+  let (cls, nCls) := denseBFClasses arr
+  let props := denseBFSweep ops nw setMult prevMult shape bis arr cls nCls arr.size 0 ∅ [] ∅ []
   denseBFCollect ops nw setMult prevMult shape bis arr props
 
 def denseBFEqsOf (busLists : List (Nat × MemoryBusShape × List (BusInteraction (DenseExpr p))))

--- a/ApcOptimizer/Implementation/OptimizerPasses/BusForward.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/BusForward.lean
@@ -1,0 +1,228 @@
+import ApcOptimizer.Implementation.OptimizerPasses.BusUnify
+
+set_option autoImplicit false
+
+/-! # Dense value forwarding through value-preserving memory accesses (runtime for `busForward`)
+
+Impl-only (no soundness lemma); the proof and wired pass live in `Proofs/BusForward.lean`.
+
+`busUnify` drops a send→receive window whenever an intervening access sits at an address whose
+aliasing with the window is undecidable. Per *slot*, more is entailed: if every undecided
+intervening access is a complete same-address receive→send pair carrying the same expression in a
+slot (a load's value slots), that slot survives the window whichever way the aliasing goes — a
+non-aliasing pair is excluded like any different-address message, an aliasing one has the value
+routed through it by the discipline, and preservation carries the slot across. The pass emits the
+surviving slot equalities `R[t] = S[t]` only; the interactions all stay (only `gauss` benefits,
+by merging the value variables).
+
+Engine shape as in `BusUnify.lean`: prepared records (`denseBUPrep`), an untrusted windowed
+sweep proposing `(sendPos, [(recvPos, sendPos), …], recvPos)` certificates, and a trusted
+verifier (`denseBFCheckCert`) re-checking every proposal. -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+/-! ## Preserved slots -/
+
+/-- Slot `t` is preserved by the pair `(r, s)`: the two payload entries are syntactically equal
+    expressions or equal constants (the slot test of `denseAddrConstsEq`). -/
+def denseBFSlotEq (r s : BusInteraction (DenseExpr p)) (t : Nat) : Bool :=
+  match r.payload[t]?, s.payload[t]? with
+  | some e, some e' =>
+    decide (e = e') ||
+    (match e.constValue?, e'.constValue? with
+     | some c, some c' => decide (c = c')
+     | _, _ => false)
+  | _, _ => false
+
+/-- Slot `t` is preserved by every proposed pair. -/
+def denseBFPairsPreserve (bis : Array (BusInteraction (DenseExpr p)))
+    (pairs : List (Nat × Nat)) (t : Nat) : Bool :=
+  pairs.all (fun kl =>
+    match bis[kl.1]?, bis[kl.2]? with
+    | some r, some s => denseBFSlotEq r s t
+    | _, _ => false)
+
+/-- The entailed conclusions of a verified proposal: the slot equalities `R[t] = S[t]` for the
+    non-address slots preserved by every forwarding pair (timestamp slots drop out on their own —
+    a real access never carries syntactically equal timestamps on its receive and send). -/
+def denseBFEmit (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
+    (pairs : List (Nat × Nat)) (S Rt : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
+  ((List.range S.payload.length).filter (fun t =>
+      decide (t ∉ shape.addressFields) && denseBFPairsPreserve bis pairs t)).map
+    (fun t => denseEqExpr ((Rt.payload[t]?).getD (.const 0)) ((S.payload[t]?).getD (.const 0)))
+
+/-- Boxed twin of `denseBFEmit` (see `denseMemEqConstraintsW`). -/
+def denseBFEmitW (negOne pad : DenseExpr p) (shape : MemoryBusShape)
+    (bis : Array (BusInteraction (DenseExpr p))) (pairs : List (Nat × Nat))
+    (S Rt : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
+  ((List.range S.payload.length).filter (fun t =>
+      decide (t ∉ shape.addressFields) && denseBFPairsPreserve bis pairs t)).map
+    (fun t => .add ((Rt.payload[t]?).getD pad) (.mul negOne ((S.payload[t]?).getD pad)))
+
+def denseBFEmitFast (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
+    (pairs : List (Nat × Nat)) (S Rt : BusInteraction (DenseExpr p)) : List (DenseExpr p) :=
+  denseBFEmitW (.const (-1)) (.const 0) shape bis pairs S Rt
+
+@[csimp] theorem denseBFEmit_eq_fast : @denseBFEmit = @denseBFEmitFast := by
+  funext p shape bis pairs S Rt; rfl
+
+/-! ## The verifier -/
+
+/-- Verify a proposal's pair list over `[q, j)`: each listed pair `(k, l)` in order — receive at
+    `k`, send at `l`, internally same-(syntactic/constant-)address — with every position outside
+    the pairs passing `denseBUMidOk` against the outer send `aS`. The strict ordering
+    `q ≤ k < l < j` is load-bearing: interleaved pairs would break the entailment (countermodel in
+    `Proofs/BusForward.lean`). -/
+def denseBFCheckPairs (ops : DenseZModOps p) (nw : DenseNonzeroWits p)
+    (setMult prevMult : ZMod p) (arr : Array (DenseBUPre p)) (aS : DenseBUPre p) (j : Nat) :
+    (pairs : List (Nat × Nat)) → (q : Nat) → Bool
+  | [], q => denseBUMidScan ops nw arr aS j (j - q) q
+  | (k, l) :: rest, q =>
+    decide (q ≤ k) && decide (k < l) && decide (l < j) &&
+    (match arr[k]?, arr[l]? with
+     | some ak, some al =>
+       decide (ak.mult = some prevMult) && decide (al.mult = some setMult) &&
+       denseBUConstsEq ak al &&
+       denseBUMidScan ops nw arr aS k (k - q) q &&
+       denseBUMidScan ops nw arr aS l (l - (k + 1)) (k + 1) &&
+       denseBFCheckPairs ops nw setMult prevMult arr aS j rest (l + 1)
+     | _, _ => false)
+
+/-- The verified certificate of one proposal `(i, pairs, j)`: send at `i`, receive at `j`, equal
+    addresses, and `denseBFCheckPairs` on the strictly-ordered forwarding pairs between them.
+    `pairs = []` is `busUnify`'s case and is not accepted here. -/
+def denseBFCheckCert (ops : DenseZModOps p) (nw : DenseNonzeroWits p)
+    (setMult prevMult : ZMod p) (arr : Array (DenseBUPre p)) (i : Nat)
+    (pairs : List (Nat × Nat)) (j : Nat) : Bool :=
+  match arr[i]?, arr[j]? with
+  | some aS, some aR =>
+    decide (i < j) && decide (aS.mult = some setMult) && decide (aR.mult = some prevMult) &&
+    denseBUConstsEq aS aR && !pairs.isEmpty &&
+    denseBFCheckPairs ops nw setMult prevMult arr aS j pairs (i + 1)
+  | _, _ => false
+
+/-! ## The proposer sweep (untrusted) -/
+
+/-- An open forwarding window: the send's prepared record and position, the pending unmatched
+    receive of a forwarding pair (if any), the closed pairs (in reverse), and the slots every
+    closed pair has preserved so far. -/
+structure DenseBFWin (p : ℕ) where
+  pre : DenseBUPre p
+  i : Nat
+  pending : Option (DenseBUPre p × Nat)
+  pairs : List (Nat × Nat)
+  mask : List Nat
+
+/-- One message against one window: keep (possibly updated), drop, or emit a proposal. -/
+inductive DenseBFStep (p : ℕ) where
+  | keep (w : DenseBFWin p)
+  | drop
+  | propose (prop : Nat × List (Nat × Nat) × Nat)
+
+def denseBFStep (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (setMult prevMult : ZMod p)
+    (bis : Array (BusInteraction (DenseExpr p))) (mb : BusInteraction (DenseExpr p))
+    (mp : DenseBUPre p) (j : Nat) (w : DenseBFWin p) : DenseBFStep p :=
+  match w.pending with
+  | none =>
+    if decide (mp.mult = some prevMult) && denseBUConstsEq w.pre mp then
+      -- a receive back at the window's own address: `pairs = []` is `busUnify`'s case.
+      if w.pairs.isEmpty then .drop else .propose (w.i, w.pairs.reverse, j)
+    else if denseBUMidOk ops nw w.pre mp then .keep w
+    else if decide (mp.mult = some prevMult) then
+      .keep { w with pending := some (mp, j) }
+    else .drop
+  | some (ak, k) =>
+    if decide (mp.mult = some setMult) && denseBUConstsEq ak mp then
+      let mask := match bis[k]? with
+        | some rb => w.mask.filter (fun t => denseBFSlotEq rb mb t)
+        | none => []
+      if mask.isEmpty then .drop
+      else .keep { w with pending := none, pairs := (k, j) :: w.pairs, mask := mask }
+    else if denseBUMidOk ops nw w.pre mp then .keep w
+    else .drop
+
+/-- The sweep: a send opens a window; each later message updates or drops every open window per
+    `denseBFStep`; a receive back at the window's own address with at least one closed pair yields
+    a proposal. One window per send, first-match. -/
+def denseBFSweep (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (setMult prevMult : ZMod p)
+    (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
+    (arr : Array (DenseBUPre p)) :
+    (fuel j : Nat) → (wins : List (DenseBFWin p)) →
+    (out : List (Nat × List (Nat × Nat) × Nat)) → List (Nat × List (Nat × Nat) × Nat)
+  | 0, _, _, out => out
+  | fuel + 1, j, wins, out =>
+    match arr[j]?, bis[j]? with
+    | some mp, some mb =>
+      let (wins, out) := wins.foldr (init := (([] : List (DenseBFWin p)), out)) fun w acc =>
+        match denseBFStep ops nw setMult prevMult bis mb mp j w with
+        | .keep w' => (w' :: acc.1, acc.2)
+        | .drop => acc
+        | .propose pr => (acc.1, pr :: acc.2)
+      let wins :=
+        if decide (mp.mult = some setMult) then
+          { pre := mp, i := j, pending := none, pairs := [],
+            mask := (List.range mb.payload.length).filter
+              (fun t => decide (t ∉ shape.addressFields)) } :: wins
+        else wins
+      denseBFSweep ops nw setMult prevMult shape bis arr fuel (j + 1) wins out
+    | _, _ => out
+
+/-! ## Verify and emit -/
+
+def denseBFCollect (ops : DenseZModOps p) (nw : DenseNonzeroWits p) (setMult prevMult : ZMod p)
+    (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
+    (arr : Array (DenseBUPre p)) : List (Nat × List (Nat × Nat) × Nat) → List (DenseExpr p)
+  | [] => []
+  | (i, pairs, j) :: rest =>
+    let acc := denseBFCollect ops nw setMult prevMult shape bis arr rest
+    if denseBFCheckCert ops nw setMult prevMult arr i pairs j then
+      match bis[i]?, bis[j]? with
+      | some S, some R => denseBFEmit shape bis pairs S R ++ acc
+      | _, _ => acc
+    else acc
+
+/-- The entailed value-forwarding equalities of one bus: prepare, sweep, verify. -/
+def denseBFForBus (ops : DenseZModOps p) (T : DenseTwoRootMap p) (nw : DenseNonzeroWits p)
+    (shape : MemoryBusShape) (bisL : List (BusInteraction (DenseExpr p))) : List (DenseExpr p) :=
+  let setMult := denseSetNewMult ops shape
+  let prevMult := denseGetPreviousMult ops shape
+  let bis := bisL.toArray
+  let arr := bis.map (denseBUPrep shape T)
+  let props := denseBFSweep ops nw setMult prevMult shape bis arr arr.size 0 [] []
+  denseBFCollect ops nw setMult prevMult shape bis arr props
+
+def denseBFEqsOf (busLists : List (Nat × MemoryBusShape × List (BusInteraction (DenseExpr p))))
+    (d : DenseConstraintSystem p) : List (DenseExpr p) :=
+  let T := denseBUTable busLists d
+  let nw := denseBUWits d
+  (busLists.map (fun sl => denseBFForBus denseZModOps T nw sl.2.1 sl.2.2)).flatten
+
+def denseBFEqs (memShape : Nat → Option MemoryBusShape) (d : DenseConstraintSystem p) :
+    List (DenseExpr p) :=
+  let busLists := denseBUBusLists memShape d.busInteractions
+  if busLists.isEmpty then [] else denseBFEqsOf busLists d
+
+/-- The constraints `denseBusForwardF` appends, minus those identically zero or already present. -/
+def denseBusForwardNewCs (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) : List (DenseExpr p) :=
+  let _ := bs
+  let eqs := denseBFEqs facts.memShape d
+  if eqs.isEmpty then [] else denseBUFilterNew d eqs
+
+/-- For a memory-bus send `S` and a later receive `R` at the same address, with every message
+    between them either provably different-address/inactive or part of a strictly-ordered
+    same-address receive→send pair, every payload slot carried unchanged through all such pairs is
+    equal on `R` and `S` — e.g. `mload a; mstore a, v; mload b (aliasing unknown); mload a -> u`
+    entails `u = v`, the stored value forwarded to the second load through the value-preserving
+    `mload b` pair. Emits those value-slot equalities only; no interaction is touched. -/
+def denseBusForwardF (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p) :
+    DenseConstraintSystem p :=
+  if (1 : ZMod p) ≠ 0 then
+    let new := denseBusForwardNewCs bs facts d
+    if new.isEmpty then d
+    else { d with algebraicConstraints := d.algebraicConstraints ++ new }
+  else d
+
+end ApcOptimizer.Dense

--- a/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusForward.lean
+++ b/ApcOptimizer/Implementation/OptimizerPasses/Proofs/BusForward.lean
@@ -1,0 +1,530 @@
+import ApcOptimizer.Implementation.OptimizerPasses.BusForward
+import ApcOptimizer.Implementation.OptimizerPasses.Proofs.BusUnify
+
+set_option autoImplicit false
+
+/-! # Soundness for the dense `busForward` pass
+
+`DensePassCorrect` for `denseBusForwardF` (`BusForward.lean`). The pass only adds constraints, so
+soundness is a constraint superset (`DensePassCorrect.denseAddConstraints`); the substance is the
+chain lemma `memFwdChain`: through strictly-ordered, internally same-address receive→send pairs, a
+payload slot preserved by every pair is forwarded from the send to the receive whatever the pairs'
+aliasing. Per assignment, a pair either aliases the window address — then the discipline routes
+the value through it and preservation carries the slot — or it does not and is excluded like any
+different-address message; the syntactic certificate never decides which.
+
+The strict ordering of the pairs is load-bearing. With interleaved pairs `r_A r_B s_A s_B` the
+both-alias case only forces `S = r_A` and `s_B = R`, leaving `r_B` (hence `R`) unconstrained, so
+an assignment exploiting that satisfies `admissibleMemoryBus` while violating the would-be
+equality. `denseBFCheckPairs` verifies the ordering positionally. -/
+
+namespace ApcOptimizer.Dense
+
+variable {p : ℕ}
+
+/-! ## Local copies of `Proofs/BusUnify.lean`'s private helpers -/
+
+private theorem bfConstValueEval (e : DenseExpr p) (c : ZMod p) (h : e.constValue? = some c)
+    (denv : VarId → ZMod p) : e.eval denv = c := by
+  rw [← DenseExpr.fold_eval e denv]
+  grind [DenseExpr.constValue?, DenseExpr.eval]
+
+private theorem bf_list_at {γ : Type} {l : List γ} {i : Nat} {x : γ} (h : l[i]? = some x) :
+    l = l.take i ++ x :: l.drop (i + 1) ∧ (l.take i).length = i := by
+  obtain ⟨hi, hx⟩ := List.getElem?_eq_some_iff.1 h
+  refine ⟨?_, by simp [Nat.min_eq_left hi.le]⟩
+  conv_lhs => rw [← List.take_append_drop i l]
+  rw [List.drop_eq_getElem_cons hi, hx]
+
+private theorem bf_arr_get {γ β : Type} (l : List γ) (f : γ → β) {k : Nat} {x : γ}
+    (h : l[k]? = some x) : (l.toArray.map f)[k]? = some (f x) := by
+  simp [h]
+
+private theorem bf_arr_get_inv {γ β : Type} (l : List γ) (f : γ → β) {k : Nat} {y : β}
+    (h : (l.toArray.map f)[k]? = some y) : ∃ x, l[k]? = some x ∧ y = f x := by
+  have h' : (l[k]?).map f = some y := by simpa using h
+  cases hx : l[k]? <;> rw [hx] at h' <;> simp_all
+
+private theorem bf_mem_of_filter_get {d : DenseConstraintSystem p} {busId k : Nat}
+    {S : BusInteraction (DenseExpr p)}
+    (h : (d.busInteractions.filter (fun bi => bi.busId = busId))[k]? = some S) :
+    S ∈ d.busInteractions :=
+  List.mem_of_mem_filter (List.mem_of_getElem? h)
+
+/-! ## Segment plumbing -/
+
+/-- Splitting the segment `[q, j)` of `l` at a position `q ≤ k < j`. -/
+private theorem bf_seg_split {γ : Type} (l : List γ) (q k j : Nat) (x : γ)
+    (hqk : q ≤ k) (hkj : k < j) (hk : l[k]? = some x) :
+    (l.drop q).take (j - q)
+      = (l.drop q).take (k - q) ++ x :: (l.drop (k + 1)).take (j - (k + 1)) := by
+  obtain ⟨hklen, hx⟩ := List.getElem?_eq_some_iff.1 hk
+  rw [show j - q = (k - q) + (j - k) by omega, List.take_add, List.drop_drop,
+    show q + (k - q) = k by omega, List.drop_eq_getElem_cons hklen, hx,
+    show j - k = (j - (k + 1)) + 1 by omega, List.take_succ_cons]
+
+private theorem bf_mem_seg {γ : Type} {l : List γ} {a n : Nat} {x : γ}
+    (h : x ∈ (l.drop a).take n) : ∃ r, a ≤ r ∧ r < a + n ∧ l[r]? = some x := by
+  obtain ⟨t, ht⟩ := List.getElem?_of_mem h
+  rw [List.getElem?_take] at ht
+  split at ht
+  · rename_i htlt
+    rw [List.getElem?_drop] at ht
+    exact ⟨a + t, by omega, by omega, ht⟩
+  · exact absurd ht (by simp)
+
+/-! ## Slot-wise value lemmas -/
+
+/-- Slot-wise form of `densePayloadSlot_eval_eq`. -/
+private theorem bf_slot_getD_eq (P Q : List (DenseExpr p)) (denv : VarId → ZMod p) (t : Nat)
+    (h : (P.map (fun e => e.eval denv))[t]? = (Q.map (fun e => e.eval denv))[t]?) :
+    ((P[t]?).getD (.const 0)).eval denv = ((Q[t]?).getD (.const 0)).eval denv := by
+  simp only [List.getElem?_map] at h
+  cases hP : P[t]? <;> cases hQ : Q[t]? <;> rw [hP, hQ] at h <;> simp_all
+
+/-- A syntactically preserved slot is preserved on the evaluated messages. -/
+theorem denseBFSlotEq_sound (r s : BusInteraction (DenseExpr p)) (t : Nat)
+    (h : denseBFSlotEq r s t = true) (denv : VarId → ZMod p) :
+    (denseBIEval r denv).payload[t]? = (denseBIEval s denv).payload[t]? := by
+  show (r.payload.map (fun e => e.eval denv))[t]? = (s.payload.map (fun e => e.eval denv))[t]?
+  unfold denseBFSlotEq at h
+  simp only [List.getElem?_map]
+  cases hr : r.payload[t]? with
+  | none => rw [hr] at h; simp at h
+  | some e =>
+    rw [hr] at h
+    cases hs : s.payload[t]? with
+    | none => rw [hs] at h; simp at h
+    | some e' =>
+      rw [hs] at h
+      simp only [Option.map_some, Option.some.injEq]
+      rcases (Bool.or_eq_true _ _).mp h with he | hc
+      · rw [of_decide_eq_true he]
+      · cases hce : e.constValue? with
+        | none => rw [hce] at hc; simp at hc
+        | some c =>
+          cases hce' : e'.constValue? with
+          | none => rw [hce, hce'] at hc; simp at hc
+          | some c' =>
+            rw [hce, hce'] at hc
+            rw [bfConstValueEval e c hce denv, bfConstValueEval e' c' hce' denv,
+              of_decide_eq_true hc]
+
+/-! ## The chain lemma -/
+
+/-- `mid` splits into messages excluded at the window address `av` (inactive or evaluated-address
+    `≠ av`) and, in strict left-to-right order, the given internally same-address receive→send
+    forwarding pairs. -/
+inductive MemFwdMid (shape : MemoryBusShape) (av : List (Option (ZMod p))) :
+    List (BusInteraction (ZMod p) × BusInteraction (ZMod p)) →
+    List (BusInteraction (ZMod p)) → Prop
+  | nil (mid : List (BusInteraction (ZMod p)))
+      (hexcl : ∀ m ∈ mid, m.multiplicity ≠ 0 → shape.address m = av → False) :
+      MemFwdMid shape av [] mid
+  | cons (r s : BusInteraction (ZMod p))
+      (pairs : List (BusInteraction (ZMod p) × BusInteraction (ZMod p)))
+      (excl0 excl1 mid2 : List (BusInteraction (ZMod p)))
+      (hexcl0 : ∀ m ∈ excl0, m.multiplicity ≠ 0 → shape.address m = av → False)
+      (hexcl1 : ∀ m ∈ excl1, m.multiplicity ≠ 0 → shape.address m = av → False)
+      (hr : r.multiplicity = -shape.setNewMult) (hs : s.multiplicity = shape.setNewMult)
+      (hrs : shape.address r = shape.address s)
+      (hrest : MemFwdMid shape av pairs mid2) :
+      MemFwdMid shape av ((r, s) :: pairs) (excl0 ++ r :: excl1 ++ s :: mid2)
+
+theorem MemFwdMid.prepend_excl {shape : MemoryBusShape} {av : List (Option (ZMod p))}
+    {pairs : List (BusInteraction (ZMod p) × BusInteraction (ZMod p))}
+    {mid : List (BusInteraction (ZMod p))} (E : List (BusInteraction (ZMod p)))
+    (hE : ∀ m ∈ E, m.multiplicity ≠ 0 → shape.address m = av → False)
+    (h : MemFwdMid shape av pairs mid) : MemFwdMid shape av pairs (E ++ mid) := by
+  cases h with
+  | nil mid hexcl =>
+    exact .nil _ (fun m hm => (List.mem_append.1 hm).elim (hE m) (hexcl m))
+  | cons r s pairs excl0 excl1 mid2 hexcl0 hexcl1 hr hs hrs hrest =>
+    rw [show E ++ (excl0 ++ r :: excl1 ++ s :: mid2) = (E ++ excl0) ++ r :: excl1 ++ s :: mid2
+      by simp]
+    exact .cons r s pairs (E ++ excl0) excl1 mid2
+      (fun m hm => (List.mem_append.1 hm).elim (hE m) (hexcl0 m)) hexcl1 hr hs hrs hrest
+
+/-- The chain lemma. `S` (send) and `R` (receive) sit at the same evaluated address `av`; the
+    messages between them split per `MemFwdMid`. A payload slot preserved by every forwarding pair
+    reaches `R` from `S`: per assignment, the head pair either aliases `av` — the discipline pairs
+    `S` with its receive, preservation carries the slot to its send, and the recursion continues
+    from that send — or it does not alias and joins the excluded set (`prepend_excl`). -/
+theorem memFwdChain (shape : MemoryBusShape) (hp1 : (1 : ZMod p) ≠ 0)
+    (Lraw : List (BusInteraction (ZMod p)))
+    (hadm : admissibleMemoryBus shape (Lraw.filter (fun m => decide (m.multiplicity ≠ 0))))
+    (av : List (Option (ZMod p))) :
+    ∀ (pairs : List (BusInteraction (ZMod p) × BusInteraction (ZMod p)))
+      (mid : List (BusInteraction (ZMod p))), MemFwdMid shape av pairs mid →
+      ∀ (pre post : List (BusInteraction (ZMod p))) (S R : BusInteraction (ZMod p)),
+        Lraw = pre ++ S :: mid ++ R :: post →
+        S.multiplicity = shape.setNewMult → R.multiplicity = -shape.setNewMult →
+        shape.address S = av → shape.address R = av →
+        ∀ t : Nat, (∀ pr ∈ pairs, pr.1.payload[t]? = pr.2.payload[t]?) →
+        S.payload[t]? = R.payload[t]?
+  | [], mid, hmid, pre, post, S, R, hL, hS, hR, hSav, hRav, t, _ => by
+    cases hmid with
+    | nil _ hexcl =>
+      have hpay : S.payload = R.payload :=
+        admissibleMemoryBus.consecutive shape Lraw hp1 hadm pre mid post S R hL hS hR
+          (hSav.trans hRav.symm) (fun m hm hne haddr => hexcl m hm hne (haddr.trans hSav))
+      exact congrArg (fun P => P[t]?) hpay
+  | (r, s) :: rest, mid, hmid, pre, post, S, R, hL, hS, hR, hSav, hRav, t, hpres => by
+    cases hmid with
+    | cons _ _ _ excl0 excl1 mid2 hexcl0 hexcl1 hr hs hrs hrest =>
+      by_cases hral : shape.address r = av
+      · -- the pair aliases: `S` pairs with `r`; preservation carries the slot to `s`; recurse.
+        have hSr : S.payload = r.payload :=
+          admissibleMemoryBus.consecutive shape Lraw hp1 hadm pre excl0
+            (excl1 ++ s :: mid2 ++ R :: post) S r
+            (by rw [hL]; simp) hS hr (hSav.trans hral.symm)
+            (fun m hm hne haddr => hexcl0 m hm hne (haddr.trans hSav))
+        have hsR : s.payload[t]? = R.payload[t]? :=
+          memFwdChain shape hp1 Lraw hadm av rest mid2 hrest
+            (pre ++ S :: excl0 ++ r :: excl1) post s R
+            (by rw [hL]; simp) hs hR (hrs.symm.trans hral) hRav t
+            (fun pr hpr => hpres pr (List.mem_cons_of_mem _ hpr))
+        calc S.payload[t]? = r.payload[t]? := congrArg (fun P => P[t]?) hSr
+          _ = s.payload[t]? := hpres (r, s) (List.mem_cons_self ..)
+          _ = R.payload[t]? := hsR
+      · -- the pair does not alias: both halves join the excluded set; recurse on `rest`.
+        have hmid' : MemFwdMid shape av rest (excl0 ++ r :: excl1 ++ s :: mid2) := by
+          have h1 : MemFwdMid shape av rest (s :: mid2) :=
+            MemFwdMid.prepend_excl [s] (by
+              intro m hm _ haddr
+              rw [List.mem_singleton.1 hm] at haddr
+              exact hral (hrs.trans haddr)) hrest
+          have h2 := MemFwdMid.prepend_excl (excl0 ++ r :: excl1) (by
+              intro m hm hne haddr
+              rcases List.mem_append.1 hm with hm0 | hm1
+              · exact hexcl0 m hm0 hne haddr
+              · rcases List.mem_cons.1 hm1 with rfl | hm1'
+                · exact hral haddr
+                · exact hexcl1 m hm1' hne haddr) h1
+          simpa using h2
+        exact memFwdChain shape hp1 Lraw hadm av rest _ hmid' pre post S R hL hS hR hSav hRav t
+          (fun pr hpr => hpres pr (List.mem_cons_of_mem _ hpr))
+
+/-! ## The verifier: from the certificate to `MemFwdMid` -/
+
+/-- A `denseBUMidScan`-cleared range `[a, b)` of the bus list is excluded, message-wise. -/
+private theorem bf_seg_excl (d : DenseConstraintSystem p) (reg : VarRegistry)
+    (hcov : d.CoveredBy reg) (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (hT : T.Sound d.algebraicConstraints)
+    (bisL : List (BusInteraction (DenseExpr p)))
+    (hsub : ∀ m ∈ bisL, m ∈ d.busInteractions)
+    (S : BusInteraction (DenseExpr p)) (hScov : denseBICovered reg S)
+    (denv : VarId → ZMod p) (hcon : ∀ c ∈ d.algebraicConstraints, c.eval denv = 0)
+    (a b : Nat)
+    (hscan : denseBUMidScan denseZModOps (denseBUWits d)
+        (bisL.toArray.map (denseBUPrep shape T)) (denseBUPrep shape T S) b (b - a) a = true) :
+    ∀ m ∈ ((bisL.drop a).take (b - a)).map (fun bi => denseBIEval bi denv),
+      m.multiplicity ≠ 0 → shape.address m = shape.address (denseBIEval S denv) → False := by
+  intro m hm
+  obtain ⟨m0, hm0, rfl⟩ := List.mem_map.1 hm
+  obtain ⟨r, har, hrb, hr⟩ := bf_mem_seg hm0
+  have hok := denseBUMidScan_sound denseZModOps (denseBUWits d)
+    (bisL.toArray.map (denseBUPrep shape T)) (denseBUPrep shape T S) b (b - a) a hscan
+    r (denseBUPrep shape T m0) har (by omega) (by omega)
+    (bf_arr_get bisL (denseBUPrep shape T) hr)
+  exact denseBUMidOk_sound d reg hcov shape T hT S m0 hScov
+    (hcov.2 m0 (hsub m0 (List.mem_of_getElem? hr))) hok denv hcon
+
+/-- A verified pair list yields the evaluated `MemFwdMid` decomposition of the segment `[q, j)`,
+    with the syntactic per-slot preservation test carrying over to the evaluated pairs. -/
+private theorem denseBFCheckPairs_sound (d : DenseConstraintSystem p) (reg : VarRegistry)
+    (hcov : d.CoveredBy reg) (shape : MemoryBusShape) (T : DenseTwoRootMap p)
+    (hT : T.Sound d.algebraicConstraints)
+    (bisL : List (BusInteraction (DenseExpr p)))
+    (hsub : ∀ m ∈ bisL, m ∈ d.busInteractions)
+    (S : BusInteraction (DenseExpr p)) (hScov : denseBICovered reg S)
+    (denv : VarId → ZMod p) (hcon : ∀ c ∈ d.algebraicConstraints, c.eval denv = 0) :
+    ∀ (pairs : List (Nat × Nat)) (q j : Nat),
+      denseBFCheckPairs denseZModOps (denseBUWits d) (denseSetNewMult denseZModOps shape)
+          (denseGetPreviousMult denseZModOps shape)
+          (bisL.toArray.map (denseBUPrep shape T)) (denseBUPrep shape T S) j pairs q = true →
+      ∃ evPairs, MemFwdMid shape (shape.address (denseBIEval S denv)) evPairs
+          (((bisL.drop q).take (j - q)).map (fun bi => denseBIEval bi denv)) ∧
+        ∀ t : Nat, denseBFPairsPreserve bisL.toArray pairs t = true →
+          ∀ pr ∈ evPairs, pr.1.payload[t]? = pr.2.payload[t]?
+  | [], q, j, hchk => by
+    refine ⟨[], MemFwdMid.nil _
+      (bf_seg_excl d reg hcov shape T hT bisL hsub S hScov denv hcon q j hchk), ?_⟩
+    intro t _ pr hpr
+    simp at hpr
+  | (k, l) :: rest, q, j, hchk => by
+    rw [denseBFCheckPairs] at hchk
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at hchk
+    obtain ⟨⟨⟨hqk, hkl⟩, hlj⟩, hmatch⟩ := hchk
+    cases hak : (bisL.toArray.map (denseBUPrep shape T))[k]? with
+    | none => rw [hak] at hmatch; cases (bisL.toArray.map (denseBUPrep shape T))[l]? <;>
+        simp at hmatch
+    | some ak =>
+      rw [hak] at hmatch
+      cases hal : (bisL.toArray.map (denseBUPrep shape T))[l]? with
+      | none => rw [hal] at hmatch; simp at hmatch
+      | some al =>
+        rw [hal] at hmatch
+        simp only [Bool.and_eq_true, decide_eq_true_eq] at hmatch
+        obtain ⟨⟨⟨⟨⟨hakm, halm⟩, haddrkl⟩, hscan0⟩, hscan1⟩, hrestchk⟩ := hmatch
+        obtain ⟨rk, hrk, rfl⟩ := bf_arr_get_inv bisL (denseBUPrep shape T) hak
+        obtain ⟨sl, hsl, rfl⟩ := bf_arr_get_inv bisL (denseBUPrep shape T) hal
+        rw [denseBUPrep_mult, denseGetPreviousMult_eq] at hakm
+        rw [denseBUPrep_mult, denseSetNewMult_eq] at halm
+        have hrkm : (denseBIEval rk denv).multiplicity = -shape.setNewMult :=
+          bfConstValueEval rk.multiplicity _ hakm denv
+        have hslm : (denseBIEval sl denv).multiplicity = shape.setNewMult :=
+          bfConstValueEval sl.multiplicity _ halm denv
+        have haddrEv : shape.address (denseBIEval rk denv)
+            = shape.address (denseBIEval sl denv) :=
+          denseAddrConstsEq_sound shape rk sl
+            (by rw [← denseBUConstsEq_eq shape T rk sl]; exact haddrkl) denv
+        obtain ⟨evRest, hmidRest, hpresRest⟩ := denseBFCheckPairs_sound d reg hcov shape T hT
+          bisL hsub S hScov denv hcon rest (l + 1) j hrestchk
+        have hsplit : (bisL.drop q).take (j - q)
+            = (bisL.drop q).take (k - q)
+              ++ (rk :: (bisL.drop (k + 1)).take (l - (k + 1)))
+              ++ sl :: (bisL.drop (l + 1)).take (j - (l + 1)) := by
+          rw [bf_seg_split bisL q k j rk hqk (by omega) hrk,
+            bf_seg_split bisL (k + 1) l j sl (by omega) hlj hsl]
+          simp
+        refine ⟨(denseBIEval rk denv, denseBIEval sl denv) :: evRest, ?_, ?_⟩
+        · rw [hsplit]
+          simp only [List.map_append, List.map_cons]
+          exact MemFwdMid.cons _ _ _ _ _ _
+            (bf_seg_excl d reg hcov shape T hT bisL hsub S hScov denv hcon q k hscan0)
+            (bf_seg_excl d reg hcov shape T hT bisL hsub S hScov denv hcon (k + 1) l hscan1)
+            hrkm hslm haddrEv hmidRest
+        · intro t hpt pr hpr
+          have hbk : bisL.toArray[k]? = some rk := by simpa using hrk
+          have hbl : bisL.toArray[l]? = some sl := by simpa using hsl
+          simp only [denseBFPairsPreserve, List.all_cons, Bool.and_eq_true, hbk, hbl] at hpt
+          rcases List.mem_cons.1 hpr with rfl | hpr'
+          · exact denseBFSlotEq_sound rk sl t hpt.1 denv
+          · exact hpresRest t hpt.2 pr hpr'
+
+/-- The engine's verifier entails the chain lemma's conclusion: every slot equality it emits
+    vanishes on every admissible satisfying assignment. -/
+theorem denseBFCheckCert_sound (d : DenseConstraintSystem p) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (hp1 : (1 : ZMod p) ≠ 0) (reg : VarRegistry) (hcov : d.CoveredBy reg)
+    (T : DenseTwoRootMap p) (hT : T.Sound d.algebraicConstraints)
+    (busId : Nat) (shape : MemoryBusShape) (hshape : facts.memShape busId = some shape)
+    (bisL : List (BusInteraction (DenseExpr p)))
+    (hbis : bisL = d.busInteractions.filter (fun bi => bi.busId = busId))
+    (i : Nat) (pairs : List (Nat × Nat)) (j : Nat) (S R : BusInteraction (DenseExpr p))
+    (hS : bisL[i]? = some S) (hR : bisL[j]? = some R)
+    (hchk : denseBFCheckCert denseZModOps (denseBUWits d) (denseSetNewMult denseZModOps shape)
+        (denseGetPreviousMult denseZModOps shape) (bisL.toArray.map (denseBUPrep shape T))
+        i pairs j = true)
+    (denv : VarId → ZMod p) (hadm : d.admissible bs denv) (hsat : d.satisfies bs denv) :
+    ∀ c ∈ denseBFEmit shape bisL.toArray pairs S R, c.eval denv = 0 := by
+  have hai := bf_arr_get bisL (denseBUPrep shape T) hS
+  have haj := bf_arr_get bisL (denseBUPrep shape T) hR
+  unfold denseBFCheckCert at hchk
+  rw [hai, haj] at hchk
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at hchk
+  obtain ⟨⟨⟨⟨⟨hij, hSm⟩, hRm⟩, haddrEq⟩, -⟩, hpairs⟩ := hchk
+  rw [denseBUPrep_mult, denseSetNewMult_eq] at hSm
+  rw [denseBUPrep_mult, denseGetPreviousMult_eq] at hRm
+  subst hbis
+  set bisL := d.busInteractions.filter (fun bi => bi.busId = busId) with hbisL
+  have hsub : ∀ m ∈ bisL, m ∈ d.busInteractions := fun m hm => List.mem_of_mem_filter hm
+  have hScov : denseBICovered reg S := hcov.2 S (hsub S (List.mem_of_getElem? hS))
+  have hcon : ∀ c ∈ d.algebraicConstraints, c.eval denv = 0 := hsat.1
+  have hSev : (denseBIEval S denv).multiplicity = shape.setNewMult :=
+    bfConstValueEval S.multiplicity _ hSm denv
+  have hRev : (denseBIEval R denv).multiplicity = -shape.setNewMult :=
+    bfConstValueEval R.multiplicity _ hRm denv
+  have haddrSR : shape.address (denseBIEval S denv) = shape.address (denseBIEval R denv) :=
+    denseAddrConstsEq_sound shape S R
+      (by rw [← denseBUConstsEq_eq shape T S R]; exact haddrEq) denv
+  -- the evaluated-list admissibility (as in `denseConsecutivePayloadEq`)
+  have hadm' : bs.admissible ((d.busInteractions.map (fun bi => denseBIEval bi denv)).filter
+      (fun m => decide (m.multiplicity ≠ 0) && bs.isStateful m.busId)) := hadm
+  have hb := facts.admissible_sound (d.busInteractions.map (fun bi => denseBIEval bi denv)) hadm'
+    busId shape hshape
+  rw [dense_map_eval_filter_busId] at hb
+  -- the split at the endpoints
+  obtain ⟨hsplitS, hlenS⟩ := bf_list_at hS
+  obtain ⟨hsplitR, hlenR⟩ := bf_list_at hR
+  have hsplit : bisL = bisL.take i ++ S :: (bisL.drop (i + 1)).take (j - i - 1)
+      ++ R :: bisL.drop (j + 1) :=
+    dense_split_of_positions hlenS hsplitS hlenR hsplitR hij
+  -- the pairs
+  obtain ⟨evPairs, hmid, hpres⟩ := denseBFCheckPairs_sound d reg hcov shape T hT bisL hsub S
+    hScov denv hcon pairs (i + 1) j hpairs
+  rw [Nat.sub_sub] at hsplit
+  -- the chain
+  have hchain : ∀ t : Nat, denseBFPairsPreserve bisL.toArray pairs t = true →
+      (denseBIEval S denv).payload[t]? = (denseBIEval R denv).payload[t]? := by
+    intro t hpt
+    exact memFwdChain shape hp1 (bisL.map (fun bi => denseBIEval bi denv)) hb
+      (shape.address (denseBIEval S denv)) evPairs _ hmid
+      ((bisL.take i).map (fun bi => denseBIEval bi denv))
+      ((bisL.drop (j + 1)).map (fun bi => denseBIEval bi denv))
+      (denseBIEval S denv) (denseBIEval R denv)
+      (by conv_lhs => rw [hsplit]
+          simp)
+      hSev hRev rfl haddrSR.symm t (hpres t hpt)
+  -- the emitted equalities
+  intro c hc
+  unfold denseBFEmit at hc
+  obtain ⟨t, htmem, rfl⟩ := List.mem_map.1 hc
+  have htf := List.mem_filter.1 htmem
+  simp only [Bool.and_eq_true] at htf
+  rw [denseEqExpr_eval]
+  rw [bf_slot_getD_eq R.payload S.payload denv t (hchain t htf.2.2).symm, sub_self]
+
+/-! ## From the emitted equalities back to a verified certificate -/
+
+theorem denseBFCollect_mem (ops : DenseZModOps p) (nw : DenseNonzeroWits p)
+    (setMult prevMult : ZMod p) (shape : MemoryBusShape)
+    (bis : Array (BusInteraction (DenseExpr p))) (arr : Array (DenseBUPre p)) :
+    ∀ (props : List (Nat × List (Nat × Nat) × Nat)) (c : DenseExpr p),
+      c ∈ denseBFCollect ops nw setMult prevMult shape bis arr props →
+      ∃ i pairs j S R, denseBFCheckCert ops nw setMult prevMult arr i pairs j = true ∧
+        bis[i]? = some S ∧ bis[j]? = some R ∧ c ∈ denseBFEmit shape bis pairs S R
+  | [], c, hc => by simp [denseBFCollect] at hc
+  | (i, pairs, j) :: rest, c, hc => by
+      rw [denseBFCollect] at hc
+      split at hc
+      · rename_i hchk
+        split at hc
+        · rename_i S R hSi hRj
+          rcases List.mem_append.1 hc with h | h
+          · exact ⟨i, pairs, j, S, R, hchk, hSi, hRj, h⟩
+          · exact denseBFCollect_mem ops nw setMult prevMult shape bis arr rest c h
+        · exact denseBFCollect_mem ops nw setMult prevMult shape bis arr rest c hc
+      · exact denseBFCollect_mem ops nw setMult prevMult shape bis arr rest c hc
+
+theorem denseBFForBus_mem (ops : DenseZModOps p) (T : DenseTwoRootMap p)
+    (nw : DenseNonzeroWits p) (shape : MemoryBusShape)
+    (bisL : List (BusInteraction (DenseExpr p))) (c : DenseExpr p)
+    (hc : c ∈ denseBFForBus ops T nw shape bisL) :
+    ∃ i pairs j S R,
+      denseBFCheckCert ops nw (denseSetNewMult ops shape) (denseGetPreviousMult ops shape)
+        (bisL.toArray.map (denseBUPrep shape T)) i pairs j = true ∧
+      bisL[i]? = some S ∧ bisL[j]? = some R ∧ c ∈ denseBFEmit shape bisL.toArray pairs S R := by
+  obtain ⟨i, pairs, j, S, R, hchk, hSi, hRj, hmem⟩ :=
+    denseBFCollect_mem ops nw _ _ shape bisL.toArray _ _ c hc
+  exact ⟨i, pairs, j, S, R, hchk, by simpa using hSi, by simpa using hRj, hmem⟩
+
+/-- The structure of an emitted equality: a declared bus, positions in that bus's interaction
+    list, and the verifier's verdict on the certificate. -/
+theorem denseBFEqs_mem (bs : BusSemantics p) (facts : BusFacts p bs) (d : DenseConstraintSystem p)
+    {c : DenseExpr p} (hc : c ∈ denseBFEqs facts.memShape d) :
+    ∃ busId shape i pairs j S R,
+      facts.memShape busId = some shape ∧
+      (d.busInteractions.filter (fun bi => bi.busId = busId))[i]? = some S ∧
+      (d.busInteractions.filter (fun bi => bi.busId = busId))[j]? = some R ∧
+      denseBFCheckCert denseZModOps (denseBUWits d) (denseSetNewMult denseZModOps shape)
+        (denseGetPreviousMult denseZModOps shape)
+        ((d.busInteractions.filter (fun bi => bi.busId = busId)).toArray.map
+          (denseBUPrep shape (denseBUTable (denseBUBusLists facts.memShape d.busInteractions) d)))
+        i pairs j = true ∧
+      c ∈ denseBFEmit shape (d.busInteractions.filter (fun bi => bi.busId = busId)).toArray
+        pairs S R := by
+  rw [show denseBFEqs facts.memShape d
+      = (if (denseBUBusLists facts.memShape d.busInteractions).isEmpty then []
+         else denseBFEqsOf (denseBUBusLists facts.memShape d.busInteractions) d) from rfl] at hc
+  split at hc
+  · simp at hc
+  · rw [show denseBFEqsOf (denseBUBusLists facts.memShape d.busInteractions) d
+        = ((denseBUBusLists facts.memShape d.busInteractions).map (fun sl =>
+            denseBFForBus denseZModOps
+              (denseBUTable (denseBUBusLists facts.memShape d.busInteractions) d)
+              (denseBUWits d) sl.2.1 sl.2.2)).flatten from rfl,
+      List.mem_flatten] at hc
+    obtain ⟨l, hl, hcl⟩ := hc
+    obtain ⟨e, he, rfl⟩ := List.mem_map.1 hl
+    obtain ⟨hms, hfilter⟩ := denseBUBusLists_mem he
+    obtain ⟨i, pairs, j, S, R, hchk, hSi, hRj, hmem⟩ := denseBFForBus_mem _ _ _ _ _ c hcl
+    rw [hfilter] at hSi hRj hchk hmem
+    exact ⟨e.1, e.2.1, i, pairs, j, S, R, hms, hSi, hRj, hchk, hmem⟩
+
+/-! ## The appended constraints -/
+
+/-- Every var of an emitted slot equality comes from the send's or receive's payload. -/
+theorem denseBFEmit_vars (shape : MemoryBusShape) (bis : Array (BusInteraction (DenseExpr p)))
+    (pairs : List (Nat × Nat)) (S Rt : BusInteraction (DenseExpr p))
+    {c : DenseExpr p} (hc : c ∈ denseBFEmit shape bis pairs S Rt) {z : VarId} (hz : z ∈ c.vars) :
+    (∃ e ∈ Rt.payload, z ∈ e.vars) ∨ (∃ e ∈ S.payload, z ∈ e.vars) := by
+  grind [denseBFEmit, denseEqExpr, DenseExpr.vars, List.mem_of_getElem?]
+
+theorem denseBusForwardNewCs_subset (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) {c : DenseExpr p} (h : c ∈ denseBusForwardNewCs bs facts d) :
+    c ∈ denseBFEqs facts.memShape d := by
+  rw [show denseBusForwardNewCs bs facts d
+      = (if (denseBFEqs facts.memShape d).isEmpty then []
+         else denseBUFilterNew d (denseBFEqs facts.memShape d)) from rfl] at h
+  split at h
+  · simp at h
+  · exact denseBUFilterNew_subset d _ h
+
+theorem denseBusForwardNewCs_vars (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) :
+    ∀ c ∈ denseBusForwardNewCs bs facts d, ∀ z ∈ c.vars, z ∈ d.occ := by
+  intro c hc z hz
+  obtain ⟨busId, shape, i, pairs, j, S, R, _, hSi, hRj, _, hmem⟩ :=
+    denseBFEqs_mem bs facts d (denseBusForwardNewCs_subset bs facts d hc)
+  rcases denseBFEmit_vars shape _ pairs S R hmem hz with ⟨e, he, hze⟩ | ⟨e, he, hze⟩
+  · exact DenseConstraintSystem.mem_occ_of_payload (bf_mem_of_filter_get hRj) he hze
+  · exact DenseConstraintSystem.mem_occ_of_payload (bf_mem_of_filter_get hSi) he hze
+
+theorem denseBusForwardNewCs_sound (bs : BusSemantics p) (facts : BusFacts p bs)
+    (reg : VarRegistry) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg)
+    (hp1 : (1 : ZMod p) ≠ 0) (denv : VarId → ZMod p) (hadm : d.admissible bs denv)
+    (hsat : d.satisfies bs denv) :
+    ∀ c ∈ denseBusForwardNewCs bs facts d, c.eval denv = 0 := by
+  intro c hc
+  obtain ⟨busId, shape, i, pairs, j, S, R, hms, hSi, hRj, hchk, hmem⟩ :=
+    denseBFEqs_mem bs facts d (denseBusForwardNewCs_subset bs facts d hc)
+  exact denseBFCheckCert_sound d bs facts hp1 reg hcov _
+    (denseBUTable_sound (denseBUBusLists facts.memShape d.busInteractions) d) busId shape hms
+    _ rfl i pairs j S R hSi hRj hchk denv hadm hsat c hmem
+
+/-! ## The pass -/
+
+/-- The `let`-bound body, unfolded (definitionally). -/
+theorem denseBusForwardF_eq (bs : BusSemantics p) (facts : BusFacts p bs)
+    (d : DenseConstraintSystem p) :
+    denseBusForwardF bs facts d =
+      (if (1 : ZMod p) ≠ 0 then
+        (if (denseBusForwardNewCs bs facts d).isEmpty then d
+         else { d with algebraicConstraints :=
+                  d.algebraicConstraints ++ denseBusForwardNewCs bs facts d })
+       else d) := rfl
+
+theorem denseBusForwardF_covered (reg : VarRegistry) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
+    (denseBusForwardF bs facts d).CoveredBy reg := by
+  rw [denseBusForwardF_eq]
+  split_ifs with hp1 _hempty
+  · exact hcov
+  · refine ⟨fun e he => ?_, hcov.2⟩
+    rcases List.mem_append.1 he with h | h
+    · exact hcov.1 e h
+    · intro i hi
+      exact DenseConstraintSystem.occ_valid hcov i
+        (denseBusForwardNewCs_vars bs facts d e h i hi)
+  · exact hcov
+
+theorem denseBusForwardF_correct (reg : VarRegistry) (bs : BusSemantics p)
+    (facts : BusFacts p bs) (d : DenseConstraintSystem p) (hcov : d.CoveredBy reg) :
+    DensePassCorrect reg.isInput d (denseBusForwardF bs facts d) [] bs := by
+  rw [denseBusForwardF_eq]
+  split_ifs with hp1 _hempty
+  · exact DensePassCorrect.refl reg.isInput d bs
+  · exact DensePassCorrect.denseAddConstraints d bs (denseBusForwardNewCs bs facts d)
+      (denseBusForwardNewCs_vars bs facts d)
+      (fun denv hadm hsat => denseBusForwardNewCs_sound bs facts reg d hcov hp1 denv hadm hsat)
+  · exact DensePassCorrect.refl reg.isInput d bs
+
+/-- The dense `busForward` pass (see `denseBusForwardF`). -/
+def denseBusForwardPass : DenseVerifiedPassW p :=
+  DenseVerifiedPassW.of denseBusForwardF (fun _ _ _ => [])
+    (fun reg bs facts d hcov => denseBusForwardF_covered reg bs facts d hcov)
+    (fun _ _ _ _ _ => by intro x hx; simp at hx)
+    (fun reg bs facts d hcov => denseBusForwardF_correct reg bs facts d hcov)
+
+end ApcOptimizer.Dense

--- a/agent-docs/ideas.md
+++ b/agent-docs/ideas.md
@@ -26,7 +26,25 @@ this session (`intervalForce`, `basisJustified`, the OR-identity byte-check arms
 442 → 55 and bus gap 765 → 319 with 0 per-case regressions; the mechanisms are general (each also
 improved wasm-eth and/or OpenVM keccak).
 
+**Update (entry 182, `busForward`)**: value forwarding through value-preserving memory accesses
+moved several rows — OpenVM keccak vars 14.981× vs powdr 13.618× and bus **flipped to ahead**
+(7.838× vs 7.648×), sha256 14.430×/8.793× both ahead, wasm-eth vars 7.260×, openvm-eth 4.557×,
+sp1/rsp 3.930× (W/L 17/41), sp1/keccak 5.178×. 13/303 cases improved, 0 regressions.
+
 ## Open ideas, priority order
+
+### 0b. busForward v2: constraint-entailed slot preservation  ·  *vars*  ·  unknown value — census first
+
+`busForward` (entry 182) accepts a forwarding pair's slot only when the receive/send entries are
+*syntactically* equal (or equal constants). A store pair preserves nothing syntactically, but its
+value slots may still be forced equal by an existing algebraic constraint (`u − v = 0` present,
+e.g. a load-and-store of the same register between the window's endpoints), and more windows may
+die on blockers a hash lookup would clear. Before building: instrument the sweep and report the
+census — how many windows die on (a) empty mask (store pairs / value vars not yet merged — the
+fixpoint re-run after `gauss` already recovers the "not yet merged" half), (b) undecided non-pair
+blockers, (c) unmatched pending receives. Only if (a) dominates, extend `denseBFSlotEq` with a
+`denseBUFilterNew`-style hash lookup of `r[t] − s[t]` among `d.algebraicConstraints`. Do not
+build speculatively.
 
 ### 1. Quadratic root domains as bounds (`x·(x − c) = 0 → x ∈ {0, c}`)  ·  *bus + vars, sp1*  ·  high value / medium effort
 

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7320,3 +7320,30 @@ If #288 lands, the runtime transform survives unchanged; `memFwdChain` must be r
 `admissibleMemoryBusM` via that branch's counting lemmas (same case-split argument).
 
 **Worked: yes.**
+
+### 183. busForward sweep: address-class memoized exclusion + const-keyed windows (pass 0.5× on SP1, rsp case total −15%)
+
+Runtime-only follow-up to entry 182 after review feedback that rsp's end-to-end +17 % was too
+high. Two changes, both confined to the untrusted sweep (`denseBFSweep`/`denseBFStep`); the
+trusted verifier, the emitted constraints and every proof are untouched, and all six suites
+reproduce entry 182's effectiveness numbers exactly.
+
+1. **Const-keyed windows** (`busUnify`'s `constOpen` map): an all-constant message steps only the
+   window at its own address key. Valid for busForward because against any other constant window
+   it is excluded by `denseBUConstsNeq`, and it can never `constsEq`-close a symbolic pending —
+   syntactic equality would const-fold both sides. Helps OpenVM shapes; SP1's three symbolic
+   address fields (`[2,3,4]`) never take this path.
+2. **Address-class memo**: intern each position's address-slot list by syntactic equality
+   (`denseBFClasses`), then memoize the slot-only exclusion arms (`denseBFAddrExcl` =
+   `denseBUMidOk` minus the zero-mult arm) per class pair. SP1 basic blocks touch the same few
+   dozen addresses over and over, so the quadratic window×message sweep collapses to a few
+   hundred distinct verdicts. A `keepSame` step variant plus busUnify's collect-then-apply
+   map-update pattern avoids the RC-2 full-map copies a naive fold-with-insert incurs.
+
+Measured (profile CLI, per pass): rsp apc_060 busForward 42 → 21 ms (case 146 → 125 ms),
+sp1/keccak 197 → 110 ms (now cheaper than busUnify's 189), wasm-eth apc_012 at parity
+(184 vs busUnify 199), OpenVM keccak/eth within noise. busForward now costs ~busUnify
+everywhere, which is the floor for the shared engine shape without cross-pass prep sharing
+(`denseBUTable`/`denseBUWits` are rebuilt per pass — a separate, pass-independent idea).
+
+**Worked: yes.**

--- a/agent-docs/log.md
+++ b/agent-docs/log.md
@@ -7252,3 +7252,71 @@ the walk's own `_self` lemma mid-recursion — no threaded proof, no framework t
 rebased on the same main): sha256 0.940 vs 0.948–0.956, apc_036 0.933 vs 0.959, keccak 0.931 vs
 0.954, apc_012 0.962 vs 0.922 (#281's one consistent edge — unexplained, noted in its close-out).
 #281 closed in favour of this branch with credit for both walk ideas.
+
+### 182. busForward — value forwarding through value-preserving memory accesses (keccak −184 vars/−56 bus, sha256 −197/−63, wins on all six suites, 0 regressions)
+
+**Idea.** `busUnify` drops a send→receive window whenever an intervening access sits at an
+address whose aliasing with the window is undecidable (a symbolic pointer). Per *slot*, more is
+entailed: if every undecided intervening access is a complete same-address receive→send pair that
+carries the *same expression* in a slot (a load's value slots — its receive and send both carry
+`v`), that slot survives the window whichever way the aliasing goes. Per assignment, a
+non-aliasing pair is excluded like any provably-different-address message; an aliasing one has
+the value routed through it by the memory discipline, and slot preservation carries it across.
+So for `mstore a, v; mload b (aliasing unknown); mload a -> u` the pass emits `u − v = 0` —
+the value slots only; the timestamp slot is genuinely undetermined (it depends on the aliasing)
+and drops out automatically because no real access carries syntactically equal ts expressions on
+its receive and send. Interactions are left alone; only `gauss` benefits, by merging the value
+variables — the top-priority metric.
+
+**Runtime** (`OptimizerPasses/BusForward.lean`): `busUnify`'s untrusted-proposer /
+trusted-verifier split over the same prepared records (`denseBUPrep`) and exclusion arms
+(`denseBUMidOk`). A proposal is `(i, [(k₁,l₁),…,(kₘ,lₘ)], j)` on one bus's interaction array:
+send at `i`, receive at `j`, `denseBUConstsEq` addresses, `m ≥ 1` pairs (the `m = 0` case is
+`busUnify`'s), each pair an internally-`ConstsEq` receive→send, every other index in `(i, j)`
+passing `denseBUMidOk` against `i` — with the strict ordering `i < k₁ < l₁ < … < lₘ < j`
+verified positionally (`denseBFCheckPairs`). The sweep keeps one window per send with at most one
+pending receive; a pair closes on the first `ConstsEq` send, intersecting the window's preserved
+slot mask (syntactic/constant slot equality, `denseBFSlotEq`); an empty mask, a second undecided
+message, or an undecided non-receive drops the window. Emission is the masked
+`denseMemEqConstraints` twin (`denseBFEmit`), filtered by `denseBUFilterNew`.
+
+**Proof** (`Proofs/BusForward.lean`): the chain lemma `memFwdChain` against `main`'s positional
+`admissibleMemoryBus`, by induction on the pair list with a per-assignment case split on
+`eval(addr(r₁)) = α` — *no*: the pair joins the excluded set (`MemFwdMid.prepend_excl`) and the
+induction proceeds with the same list; *yes*: `admissibleMemoryBus.consecutive` forces
+`S.payload = r₁.payload`, preservation gives slot equality to `s₁`, and the induction continues
+with `s₁` as the send. **The strict ordering is load-bearing**: interleaved pairs
+(`r_A r_B s_A s_B`) leave `r_B` unconstrained in the both-alias case, so a verifier accepting
+them would emit a non-entailed constraint and break completeness. Wired with
+`DenseVerifiedPassW.of` + `DensePassCorrect.denseAddConstraints` (not `ofAddConstraints`:
+`denseBUMidOk`'s nonzero-witness arm needs the registry/coverage, exactly as in `busUnify`).
+Scheduled immediately after `busUnify`; the mask is syntactic, so the pass mostly fires after
+`gauss` has merged value variables of earlier-derived equalities — the cleanup fixpoint re-runs
+it each cycle, which is exactly what it needs.
+
+MEASURED (A/B against this branch minus the pass entry, all 303 cases across the six suites;
+sizes deterministic, so the diff is exact): **13 cases improve, 0 regress on any axis**.
+
+| suite | cases changed | Δvars | Δbus | aggregate vars (after) |
+|---|---:|---:|---:|---|
+| OpenVM keccak | 1/1 | **−184** (2021→1837) | **−56** (1748→1692) | 14.981× vs powdr 13.618×; bus now **ahead** 7.838× vs 7.648× |
+| OpenVM sha256 | 1/1 | **−197** (11903→11706) | **−63** (9567→9504) | 14.430× vs 14.036× |
+| openvm-eth | 3/100 | −24 | 0 | 4.557× vs 4.092× |
+| wasm-eth | 2/100 | −12 | 0 | 7.260× vs 6.273× |
+| sp1/rsp | 5/100 | −20 | 0 | 3.930× vs 3.980× (W/L 17/41) |
+| sp1/keccak | 1/1 | −8 | 0 | 5.178× vs 4.809× |
+
+The keccak/sha256 bus-interaction drops are downstream: the forwarded equalities let
+`busPairCancel`/`gauss` retire pairs that were previously blocked. OpenVM keccak's bus axis flips
+from behind powdr (7.587× vs 7.648× in the ideas-file table) to ahead.
+
+Runtime (4-core box, median of 3, end-to-end): sha256 41.6 → 36.7 s (the shrink pays for the
+pass), keccak 3.93 → 4.23 s, wasm-eth apc_012 4.68 → 5.02 s, apc_036 4.47 → 4.30 s. Per-pass
+profile: busForward 254–291 ms per run — parity with busUnify (223–277 ms), as expected from the
+shared engine shape.
+
+Relation to PR #288 (order-free multiset rely): built on `main`'s positional rely, deliberately.
+If #288 lands, the runtime transform survives unchanged; `memFwdChain` must be restated against
+`admissibleMemoryBusM` via that branch's counting lemmas (same case-split argument).
+
+**Worked: yes.**


### PR DESCRIPTION
On the memory bus, each access is a **receive** of the cell's current record followed by a **send** of its new one: a load receives `(a, v, t)` and sends `(a, v, T)` — the same value `v` on both sides — while a store receives the old value and sends the stored one. The memory discipline (`admissibleMemoryBus`) guarantees that a send's payload equals the payload of the *next* receive at the same address, provided no active message in between is at that address.

`busUnify` uses this to equate the payloads of send→receive pairs where everything in between is provably inactive or at a different address. It gives up when an access in between sits at an address that can be proven neither equal nor different:

```
i1: mstore a, v      recv (a, u₁, t₁)   send (a, v, T₁)
i2: mload  b -> w    recv (b, w, t₂)    send (b, w, T₂)     b = a? unknown
i3: mload  a -> u    recv (a, u, t₃)    send (a, u, T₃)
```

Whether `i1`'s send pairs with `i3`'s receive depends on whether `b = a`, so no whole-payload equality can be emitted. But the **value** slots connect either way:

- `b ≠ a`: `i2` doesn't touch `a`, so `i1`'s send pairs with `i3`'s receive directly → `u = v`;
- `b = a`: `i1`'s send pairs with `i2`'s receive → `w = v`, and `i2`'s send carries that same `w`, pairing with `i3`'s receive → `u = w = v`.

So `u = v` holds unconditionally, while the timestamp slot genuinely differs between the two cases.

The new `busForward` pass emits exactly these entailed slot equalities: for a send and a later same-address receive, with every message in between provably excluded or part of a strictly-ordered same-address receive→send pair, each payload slot carried syntactically unchanged through all pairs is equal on both ends (chain lemma `memFwdChain`; the strict ordering of the pairs is required for soundness and is verified). No interaction is added or removed — `gauss` merges the value variables.

Local A/B: 13/303 cases improve, 0 regressions; OpenVM keccak −184 vars/−56 bus, sha256 −197/−63, remaining wins spread over openvm-eth, wasm-eth, sp1/rsp, sp1/keccak. Built on `main`'s positional rely; conflicts with #288's multiset rely (chain lemma would need restating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9vcejdvqcXmqHuXtjmYgg