### PR TITLE
Simplify completeness definition

### DIFF
--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -259,6 +259,13 @@ theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars 
     fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
   unfold Derivations.witgen; split <;> simp_all
 
+/-- On output variables, `outputWitness` is exactly `witgen`. -/
+theorem Derivations.outputWitness_eq_witgen {ds : Derivations p} {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
+    (hv : v ∈ outputVars) :
+    ds.outputWitness h inputAssignment v = ds.witgen h inputAssignment v hv := by
+  simp [Derivations.outputWitness, hv]
+
 /-! ## Evaluation depends only on a system's variables
 
 Two assignments agreeing on `cs.vars` are interchangeable for `satisfies`/`admissible`/`sideEffects`.
@@ -395,13 +402,12 @@ theorem Derivations.safeMethod_eq {ds : Derivations p} {inputVars : List Variabl
     handed (`optimizerWithBusFacts_correct` transports this across the clone). -/
 theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : BusFacts p bs)
     (cs : Circuit p) :
-    (optimizerCore b facts cs).1.isSoundReplacementOf cs bs ∧
-      (optimizerCore b facts cs).1.isCompleteReplacementOf cs bs (optimizerCore b facts cs).2 := by
+    let r := pipeline b cs bs facts
+    let ds := r.derivs.forOutput cs.vars r.out.vars
+    r.out.isSoundReplacementOf cs bs ∧ r.out.isCompleteReplacementOf cs bs ds := by
+  dsimp
   refine ⟨(pipeline b cs bs facts).correct.toSound, ?_⟩
   intro hpow
-  -- Phrase the goal in `pipeline` terms up front: the coverage proof is one of its components, so
-  -- `refine` would otherwise have to bridge the `optimizerCore` projections by `whnf`.
-  simp only [optimizerCore]
   -- `PassCorrect` components (`Basic.lean`): no new powdr-ID column, and real-trace completeness.
   have hS := (pipeline b cs bs facts).correct.2.2.1
   have hcomp := (pipeline b cs bs facts).correct.2.2.2
@@ -421,20 +427,25 @@ theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : B
     rw [Derivations.forOutput_eq, List.mem_map] at hd
     obtain ⟨v, hv, rfl⟩ := hd
     exact List.mem_of_mem_filter (List.mem_eraseDups.mp hv)
-  intro env hadm hsat f hf
+  intro env hadm hsat
   obtain ⟨env', hsat', hadm', hse, hA, hR⟩ := hcomp env hadm hsat
   have hrec : (pipeline b cs bs facts).out.reconstructs cs.vars
       (pipeline b cs bs facts).derivs env' := by
     have hrec0 : cs.reconstructs cs.vars [] env :=
       fun u hu hunone => absurd (hpow u hu) (by simp [hunone])
     simpa using hR cs.vars (fun v hv _ => hv) [] hrec0
+  let f : Variable → ZMod p :=
+    ((pipeline b cs bs facts).derivs.forOutput cs.vars
+      (pipeline b cs bs facts).out.vars).outputWitness hcover env
   have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars, f v = env' v := by
     intro v hv
+    dsimp [f]
     -- Case first, rewrite second: `witgen`'s implicit `outputVars` is the pipeline output, so a
     -- goal mentioning the application makes `cases` reduce it — i.e. run the optimizer in `whnf`.
     cases hpw : v.powdrId? with
     | some w =>
-        rw [hf v hv, Derivations.witgen_powdrId hcover env hv hpw]
+        rw [Derivations.outputWitness_eq_witgen hcover env hv,
+          Derivations.witgen_powdrId hcover env hv hpw]
         exact (hA v (by simp [hpw])).symm
     | none =>
         obtain ⟨cm, hm, hxpow, hxinput, heq⟩ := hrec v hv hpw
@@ -444,7 +455,8 @@ theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : B
           (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
           (outputVars := (pipeline b cs bs facts).out.vars) hv hpw
         rw [hsafe] at hm'
-        rw [hf v hv, Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
+        rw [Derivations.outputWitness_eq_witgen hcover env hv,
+          Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
         exact ComputationMethod.eval_congr cm env env' (fun x hx => (hA x (hxpow x hx)).symm)
   exact ⟨(Circuit.satisfies_congr hagree).mpr hsat',
     (Circuit.admissible_congr hagree).mpr hadm',
@@ -466,8 +478,8 @@ theorem optimizerWithBusFacts_correct {bs : BusSemantics p} (b : DegreeBound)
     (optimizerWithBusFacts b facts cs).1.isSoundReplacementOf cs bs ∧
       (optimizerWithBusFacts b facts cs).1.isCompleteReplacementOf cs bs
         (optimizerWithBusFacts b facts cs).2 := by
-  simp only [optimizerWithBusFacts, Circuit.clone_eq]
-  exact optimizerCore_correct b facts cs
+  simpa [optimizerWithBusFacts, optimizerCore, Circuit.clone_eq] using
+    (optimizerCore_correct b facts cs.clone)
 
 /-- The fact-aware optimizer never pushes a within-bound circuit past the zkVM's degree
     bound (every pass is degree-guarded). -/

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -242,29 +242,18 @@ def optimizerWithBusFacts {bs : BusSemantics p} (b : DegreeBound) (facts : BusFa
 
 So the completeness proof never unfolds the spec's `Derivations.witgen`. -/
 
-/-- On an input variable, `witgen` passes the input assignment through. -/
-theorem Derivations.witgen_powdrId {ds : Derivations p} {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
-    {w : Nat} (hv : v ∈ outputVars) (hp : v.powdrId? = some w) :
-    ds.witgen h inputAssignment v hv = inputAssignment v := by
-  unfold Derivations.witgen; split <;> simp_all
+/-- Without a derivation method, `witgen` passes the input assignment through. -/
+theorem Derivations.witgen_none {ds : Derivations p} (inputAssignment : Variable → ZMod p)
+    {v : Variable} (hm : ds.methodFor v = none) :
+    ds.witgen inputAssignment v = inputAssignment v := by
+  simp [Derivations.witgen, hm]
 
-/-- On a derived variable, `witgen` evaluates the method `ds` records for it. -/
-theorem Derivations.witgen_methodFor {ds : Derivations p} {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
-    {cm : ComputationMethod p} (hv : v ∈ outputVars) (hp : v.powdrId? = none)
+/-- With a derivation method, `witgen` evaluates it. -/
+theorem Derivations.witgen_methodFor {ds : Derivations p} (inputAssignment : Variable → ZMod p)
+    {v : Variable} {cm : ComputationMethod p}
     (hm : ds.methodFor v = some cm) :
-    ds.witgen h inputAssignment v hv = cm.eval inputAssignment := by
-  have hg : ∀ hs : (ds.methodFor v).isSome, (ds.methodFor v).get hs = cm :=
-    fun hs => Option.get_of_mem hs (Option.mem_def.mpr hm)
-  unfold Derivations.witgen; split <;> simp_all
-
-/-- On output variables, `outputWitness` is exactly `witgen`. -/
-theorem Derivations.outputWitness_eq_witgen {ds : Derivations p} {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) {v : Variable}
-    (hv : v ∈ outputVars) :
-    ds.outputWitness h inputAssignment v = ds.witgen h inputAssignment v hv := by
-  simp [Derivations.outputWitness, hv]
+    ds.witgen inputAssignment v = cm.eval inputAssignment := by
+  simp [Derivations.witgen, hm]
 
 /-! ## Evaluation depends only on a system's variables
 
@@ -375,6 +364,21 @@ theorem Derivations.forOutput_methodFor {ds : Derivations p} {inputVars outputVa
   rw [Derivations.methodFor_map_same, if_pos]
   simp [hv, hpw]
 
+theorem Derivations.forOutput_methodFor_powdrId {ds : Derivations p}
+    {inputVars outputVars : List Variable} {v : Variable}
+    (hpw : v.powdrId?.isSome) :
+    (ds.forOutput inputVars outputVars).methodFor v = none := by
+  cases hpid : v.powdrId? with
+  | none =>
+      simp [hpid] at hpw
+  | some w =>
+      rw [Derivations.forOutput_eq, Derivations.methodFor_map_same]
+      apply if_neg
+      intro hv
+      have hv' := List.mem_eraseDups.mp hv
+      have hv'' := (List.mem_filter.mp hv').2
+      simp [hpid] at hv''
+
 theorem Derivations.safeMethod_vars (ds : Derivations p) (inputVars : List Variable) (v : Variable) :
     ∀ x ∈ (ds.safeMethod inputVars v).vars, x ∈ inputVars := by
   cases hm : ds.methodFor v with
@@ -411,16 +415,18 @@ theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : B
   -- `PassCorrect` components (`Basic.lean`): no new powdr-ID column, and real-trace completeness.
   have hS := (pipeline b cs bs facts).correct.2.2.1
   have hcomp := (pipeline b cs bs facts).correct.2.2.2
-  -- Every output variable is either reused from the input or has a safe method.
+  -- Every output variable either has no derivation method and is reused from the input, or it has
+  -- one whose variables all come from the input.
   have hcover : ((pipeline b cs bs facts).derivs.forOutput cs.vars
       (pipeline b cs bs facts).out.vars).cover cs.vars (pipeline b cs bs facts).out.vars := by
     intro v hv
     cases hpw : v.powdrId? with
-    | some w => exact hS v hv (by simp [hpw])
+    | some w =>
+        rw [Derivations.forOutput_methodFor_powdrId (by simp [hpw])]
+        exact hS v hv (by simp [hpw])
     | none =>
-        exact ⟨(pipeline b cs bs facts).derivs.safeMethod cs.vars v,
-          Derivations.forOutput_methodFor hv hpw,
-          Derivations.safeMethod_vars _ _ _⟩
+        rw [Derivations.forOutput_methodFor hv hpw]
+        exact Derivations.safeMethod_vars _ _ _
   refine ⟨?_, hcover, ?_⟩
   · -- `forOutput` records only no-ID variables occurring in the output.
     intro d hd
@@ -436,17 +442,16 @@ theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : B
     simpa using hR cs.vars (fun v hv _ => hv) [] hrec0
   let f : Variable → ZMod p :=
     ((pipeline b cs bs facts).derivs.forOutput cs.vars
-      (pipeline b cs bs facts).out.vars).outputWitness hcover env
+      (pipeline b cs bs facts).out.vars).witgen env
   have hagree : ∀ v ∈ (pipeline b cs bs facts).out.vars, f v = env' v := by
     intro v hv
     dsimp [f]
-    -- Case first, rewrite second: `witgen`'s implicit `outputVars` is the pipeline output, so a
-    -- goal mentioning the application makes `cases` reduce it — i.e. run the optimizer in `whnf`.
     cases hpw : v.powdrId? with
     | some w =>
-        rw [Derivations.outputWitness_eq_witgen hcover env hv,
-          Derivations.witgen_powdrId hcover env hv hpw]
-        exact (hA v (by simp [hpw])).symm
+        have hmnone := Derivations.forOutput_methodFor_powdrId
+          (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
+          (outputVars := (pipeline b cs bs facts).out.vars) (v := v) (by simp [hpw])
+        simpa [Derivations.witgen, hmnone] using (hA v (by simp [hpw])).symm
     | none =>
         obtain ⟨cm, hm, hxpow, hxinput, heq⟩ := hrec v hv hpw
         have hsafe : (pipeline b cs bs facts).derivs.safeMethod cs.vars v = cm :=
@@ -455,8 +460,7 @@ theorem optimizerCore_correct {bs : BusSemantics p} (b : DegreeBound) (facts : B
           (ds := (pipeline b cs bs facts).derivs) (inputVars := cs.vars)
           (outputVars := (pipeline b cs bs facts).out.vars) hv hpw
         rw [hsafe] at hm'
-        rw [Derivations.outputWitness_eq_witgen hcover env hv,
-          Derivations.witgen_methodFor hcover env hv hpw hm', ← heq]
+        rw [Derivations.witgen_methodFor env hm', ← heq]
         exact ComputationMethod.eval_congr cm env env' (fun x hx => (hA x (hxpow x hx)).symm)
   exact ⟨(Circuit.satisfies_congr hagree).mpr hsat',
     (Circuit.admissible_congr hagree).mpr hadm',

--- a/ApcOptimizer/Implementation/Optimizer.lean
+++ b/ApcOptimizer/Implementation/Optimizer.lean
@@ -242,12 +242,6 @@ def optimizerWithBusFacts {bs : BusSemantics p} (b : DegreeBound) (facts : BusFa
 
 So the completeness proof never unfolds the spec's `Derivations.witgen`. -/
 
-/-- Without a derivation method, `witgen` passes the input assignment through. -/
-theorem Derivations.witgen_none {ds : Derivations p} (inputAssignment : Variable → ZMod p)
-    {v : Variable} (hm : ds.methodFor v = none) :
-    ds.witgen inputAssignment v = inputAssignment v := by
-  simp [Derivations.witgen, hm]
-
 /-- With a derivation method, `witgen` evaluates it. -/
 theorem Derivations.witgen_methodFor {ds : Derivations p} (inputAssignment : Variable → ZMod p)
     {v : Variable} {cm : ComputationMethod p}

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -202,51 +202,28 @@ def Derivations.methodFor :
       | none => if u = v then some cm else none
 
 /-- Whether `ds` lets witness generation produce every element of `outputVars`
-    from `inputVars`: each output variable is either an input variable (reused)
-    or a derived variable with a method that reads only input variables. -/
+    from `inputVars`: if an output variable has no derivation method, it is a
+    reused input variable; if it has one, that method reads only input
+    variables. -/
 def Derivations.cover (ds : Derivations p)
     (inputVars outputVars : List Variable) : Prop :=
   ∀ v ∈ outputVars,
-    match v.powdrId? with
-    | some _ => v ∈ inputVars
-    | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
+    match ds.methodFor v with
+    | none => v ∈ inputVars
+    | some cm => ∀ x ∈ cm.vars, x ∈ inputVars
 -- ANCHOR_END: methodForCover
 
-omit [Fact p.Prime] in
-/- Support lemma, does not require audit. -/
-theorem Derivations.methodFor_isSome (ds : Derivations p)
-    {inputVars outputVars : List Variable} (h : ds.cover inputVars outputVars)
-    {v : Variable} (hv : v ∈ outputVars) (hp : v.powdrId? = none) :
-    (ds.methodFor v).isSome := by
-  have hc := h v hv
-  simp only [hp] at hc
-  obtain ⟨cm, hcm, -⟩ := hc
-  simp [hcm]
-
 -- ANCHOR: witgen
-/-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
-    variable passes through unchanged; every other variable is computed by the
-    method `ds` records for it. -/
-def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
-    (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
-  match hp : v.powdrId? with
-  -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
-  -- variable of the output circuit also exists in the input circuit.
-  | some _ => inputAssignment v
-  | none => ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
--- ANCHOR_END: witgen
-
-/-- The canonical total witness for the optimized circuit: on output variables,
-    it agrees with `witgen`; elsewhere, it reuses the input assignment. -/
-def Derivations.outputWitness (ds : Derivations p) {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) :
+/-- The canonical total witness for the optimized circuit: any variable with a
+    derivation method is computed by that method; all others reuse the input
+    assignment. -/
+def Derivations.witgen (ds : Derivations p) (inputAssignment : Variable → ZMod p) :
     Variable → ZMod p :=
   fun v =>
-    if hv : v ∈ outputVars then
-      ds.witgen h inputAssignment v hv
-    else
-      inputAssignment v
+    match ds.methodFor v with
+    | some cm => cm.eval inputAssignment
+    | none => inputAssignment v
+-- ANCHOR_END: witgen
 
 --------- Circuit implications ---------
 
@@ -312,7 +289,7 @@ def Circuit.isCompleteReplacementOf
 
   -- The optimized circuit variables can be derived from the original circuit
   -- variables, and the return derivations.
-  ∃ hcover : ds.cover originalCircuit.vars optimizedCircuit.vars,
+  ds.cover originalCircuit.vars optimizedCircuit.vars ∧
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
@@ -320,7 +297,7 @@ def Circuit.isCompleteReplacementOf
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    let assignment' := ds.outputWitness hcover assignment
+    let assignment' := ds.witgen assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/ApcOptimizer/Spec.lean
+++ b/ApcOptimizer/Spec.lean
@@ -237,6 +237,17 @@ def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variabl
   | none => ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
 -- ANCHOR_END: witgen
 
+/-- The canonical total witness for the optimized circuit: on output variables,
+    it agrees with `witgen`; elsewhere, it reuses the input assignment. -/
+def Derivations.outputWitness (ds : Derivations p) {inputVars outputVars : List Variable}
+    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p) :
+    Variable → ZMod p :=
+  fun v =>
+    if hv : v ∈ outputVars then
+      ds.witgen h inputAssignment v hv
+    else
+      inputAssignment v
+
 --------- Circuit implications ---------
 
 -- ANCHOR: admissible
@@ -309,9 +320,7 @@ def Circuit.isCompleteReplacementOf
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    ∀ assignment' : Variable → ZMod p,
-    (∀ v (hv : v ∈ optimizedCircuit.vars),
-      assignment' v = ds.witgen hcover assignment v hv) →
+    let assignment' := ds.outputWitness hcover assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =

--- a/docs/Docs.lean
+++ b/docs/Docs.lean
@@ -251,30 +251,29 @@ def Derivations.methodFor :
       | none => if u = v then some cm else none
 
 /-- Whether `ds` lets witness generation produce every element of `outputVars`
-    from `inputVars`: each output variable is either an input variable (reused)
-    or a derived variable with a method that reads only input variables. -/
+    from `inputVars`: if an output variable has no derivation method, it is a
+    reused input variable; if it has one, that method reads only input
+    variables. -/
 def Derivations.cover (ds : Derivations p)
     (inputVars outputVars : List Variable) : Prop :=
   ∀ v ∈ outputVars,
-    match v.powdrId? with
-    | some _ => v ∈ inputVars
-    | none => ∃ cm, ds.methodFor v = some cm ∧ ∀ x ∈ cm.vars, x ∈ inputVars
+    match ds.methodFor v with
+    | none => v ∈ inputVars
+    | some cm => ∀ x ∈ cm.vars, x ∈ inputVars
 ```
 
-Witness generation generates an assignment as described above. It is only defined on the output circuit's variables, and it is guaranteed to be well-defined by the `cover` property.
+Witness generation generates a total assignment: any variable with a derivation method is computed by that method; all others reuse the input assignment. The `cover` property is what says this total function is actually a legitimate witness generator for the optimized circuit.
 
 ```anchor witgen
-/-- Witness generation on a variable `ds` covers. Every powdr-ID (input)
-    variable passes through unchanged; every other variable is computed by the
-    method `ds` records for it. -/
-def Derivations.witgen (ds : Derivations p) {inputVars outputVars : List Variable}
-    (h : ds.cover inputVars outputVars) (inputAssignment : Variable → ZMod p)
-    (v : Variable) (hv : v ∈ outputVars) : ZMod p :=
-  match hp : v.powdrId? with
-  -- Well-defined: by the `some` branch of `Derivations.cover`, a powdr-ID
-  -- variable of the output circuit also exists in the input circuit.
-  | some _ => inputAssignment v
-  | none => ((ds.methodFor v).get (ds.methodFor_isSome h hv hp)).eval inputAssignment
+/-- The canonical total witness for the optimized circuit: any variable with a
+    derivation method is computed by that method; all others reuse the input
+    assignment. -/
+def Derivations.witgen (ds : Derivations p) (inputAssignment : Variable → ZMod p) :
+    Variable → ZMod p :=
+  fun v =>
+    match ds.methodFor v with
+    | some cm => cm.eval inputAssignment
+    | none => inputAssignment v
 ```
 
 ## The full completeness property
@@ -295,7 +294,7 @@ def Circuit.isCompleteReplacementOf
 
   -- The optimized circuit variables can be derived from the original circuit
   -- variables, and the return derivations.
-  ∃ hcover : ds.cover originalCircuit.vars optimizedCircuit.vars,
+  ds.cover originalCircuit.vars optimizedCircuit.vars ∧
 
   -- For any admissible satisfying assignment of the original circuit, the
   -- optimized circuit is also satisfied and admissible, with equal side
@@ -303,9 +302,7 @@ def Circuit.isCompleteReplacementOf
   ∀ assignment,
     originalCircuit.admissible busSemantics assignment →
     originalCircuit.satisfies busSemantics assignment →
-    ∀ assignment' : Variable → ZMod p,
-    (∀ v (hv : v ∈ optimizedCircuit.vars),
-      assignment' v = ds.witgen hcover assignment v hv) →
+    let assignment' := ds.witgen assignment
     optimizedCircuit.satisfies busSemantics assignment' ∧
       optimizedCircuit.admissible busSemantics assignment' ∧
       originalCircuit.sideEffects busSemantics assignment =


### PR DESCRIPTION
Currently, completeness says:
```
let the output assignment be any assignment which coincides with the input assignment on the input variables
```

This PR changes it to construct it explicitly
```
let the output assignment be the result of copying the input assignment for variables where it's defined and running column derivation otherwise
```

What we lose is that we do not prove anything about another satisfying output assignment, but that is not required for completeness.

Also, this seems to fit the comment better:

```
  -- For any admissible satisfying assignment of the original circuit, the
  -- optimized circuit is also satisfied and admissible, with equal side
  -- effects, under the assignment produced by witness generation.
```

This comment does not have the double \all, it reasons about the derived assignment directly.

As a result, we don't need the coverage proof, which simplifies the proposition even further.